### PR TITLE
fixing NPE thrown when POST request comes without queryString

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
@@ -303,7 +303,9 @@ public class EndpointUtil {
                 }
             } else {
                 sessionDataCache.addToCache(new SessionDataCacheKey(sessionDataKeyConsent),entry);
-                queryString = URLEncoder.encode(entry.getQueryString(), "UTF-8");
+                if (entry.getQueryString() != null) {
+                    queryString = URLEncoder.encode(entry.getQueryString(), "UTF-8");
+                }
             }
 
 


### PR DESCRIPTION
a NullPointerException is thrown at the changed line when a POST request (eg: using CURL) which does not have a queryString