### PR TITLE
Fixing Identity_4814

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/user/impl/UserInforRequestDefaultValidator.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/user/impl/UserInforRequestDefaultValidator.java
@@ -25,7 +25,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.HttpHeaders;
 
 /**
- * Validates the schema and authorization header according to the specification
+ * Validates authorization header according to the specification
  *
  * @see http://openid.net/specs/openid-connect-basic-1_0-22.html#anchor6
  */
@@ -34,13 +34,7 @@ public class UserInforRequestDefaultValidator implements UserInfoRequestValidato
     @Override
     public String validateRequest(HttpServletRequest request) throws UserInfoEndpointException {
 
-        String schema = request.getParameter("schema");
         String authzHeaders = request.getHeader(HttpHeaders.AUTHORIZATION);
-
-        if (!"openid".equals(schema)) {
-            throw new UserInfoEndpointException(UserInfoEndpointException.ERROR_CODE_INVALID_SCHEMA,
-                    "Schema should be openid");
-        }
 
         if (authzHeaders == null) {
             throw new UserInfoEndpointException(OAuthError.ResourceResponse.INVALID_REQUEST,


### PR DESCRIPTION
Removing "schema" parameter since [1] does not specify such parameter to the user info request.

[1] http://openid.net/specs/openid-connect-core-1_0.html#UserInfo
