### PR TITLE
Fix IDENTITY-4928 / IDENTITY-4970 [master branch]

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dao/TokenMgtDAO.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dao/TokenMgtDAO.java
@@ -630,8 +630,11 @@ public class TokenMgtDAO {
                         String tokenId = resultSet.getString(9);
                         revokeToken(tokenId, authorizedUser);
                     }
-
+                } else {
+                    // this means we were not able to find the authorization code in the database table.
+                    return null;
                 }
+
             } else {
                 prepStmt = connection.prepareStatement(SQLQueries.VALIDATE_AUTHZ_CODE);
                 prepStmt.setString(1, persistenceProcessor.getProcessedClientId(consumerKey));
@@ -664,13 +667,18 @@ public class TokenMgtDAO {
                         String tokenId = resultSet.getString(9);
                         revokeToken(tokenId, authorizedUser);
                     }
+                } else {
+                    // this means we were not able to find the authorization code in the database table.
+                    return null;
                 }
+
             }
 
             connection.commit();
+
             return new AuthzCodeDO(user, OAuth2Util.buildScopeArray(scopeString), issuedTime, validityPeriod,
-                    callbackUrl, consumerKey, authorizationKey, codeId, codeState, pkceCodeChallenge,
-                    pkceCodeChallengeMethod);
+                        callbackUrl, consumerKey, authorizationKey, codeId, codeState, pkceCodeChallenge,
+                        pkceCodeChallengeMethod);
 
         } catch (SQLException e) {
             throw new IdentityOAuth2Exception("Error when validating an authorization code", e);

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AuthorizationCodeGrantHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AuthorizationCodeGrantHandler.java
@@ -128,7 +128,9 @@ public class AuthorizationCodeGrantHandler extends AbstractAuthorizationGrantHan
         if (authzCodeDO == null) {
             if (log.isDebugEnabled()) {
                 log.debug("Invalid access token request with " +
-                        "Client Id : " + clientId);
+                        "Client Id : " + clientId +
+                        ", Invalid authorization code provided."
+                );
             }
             return false;
         }
@@ -139,14 +141,14 @@ public class AuthorizationCodeGrantHandler extends AbstractAuthorizationGrantHan
                 if (log.isDebugEnabled()) {
                     log.debug("Invalid access token request with " +
                             "Client Id : " + clientId +
-                            "redirect_uri not present in request");
+                            " redirect_uri not present in request");
                 }
                 return false;
             } else if (!oAuth2AccessTokenReqDTO.getCallbackURI().equals(authzCodeDO.getCallbackUrl())) {
                 if (log.isDebugEnabled()) {
                     log.debug("Invalid access token request with " +
                             "Client Id : " + clientId +
-                            "redirect_uri does not match previously presented redirect_uri to authorization endpoint");
+                            " redirect_uri does not match previously presented redirect_uri to authorization endpoint");
                 }
                 return false;
             }


### PR DESCRIPTION
* Returning null when an authorization code is not found in the database table instead of an empty AuthzCodeDO object.
* Formatting an improving debug logs.