### PR TITLE
Fixing Identity-5019

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -816,7 +816,7 @@ public class OAuth2Util {
         if(!isPKCESupportEnabled()) {
             return true;
         }
-        if(oAuthAppDO.isPkceMandatory() || referenceCodeChallenge != null){
+        if (oAuthAppDO != null && oAuthAppDO.isPkceMandatory() || referenceCodeChallenge != null) {
 
             //As per RFC 7636 Fallback to 'plain' if no code_challenge_method parameter is sent
             if(challenge_method == null || challenge_method.trim().length() == 0) {


### PR DESCRIPTION
When we disable the cache oAuthAppDO becomes null. So this null pointer occurs