### PR TITLE
Fix IDENTITY-5019 [master]

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AuthorizationCodeGrantHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AuthorizationCodeGrantHandler.java
@@ -83,7 +83,8 @@ public class AuthorizationCodeGrantHandler extends AbstractAuthorizationGrantHan
             authzCodeDO = (AuthzCodeDO) oauthCache.getValueFromCache(cacheKey);
         }
         oAuthAppDO = appInfoCache.getValueFromCache(clientId);
-        if (oAuthAppDO != null) {
+        if (oAuthAppDO == null) {
+            // we need to pull App info from the DB since it was not found in the cache.
             try {
                 oAuthAppDO = new OAuthAppDAO().getAppInformation(clientId);
             } catch (InvalidOAuthClientException e) {


### PR DESCRIPTION
fixing the incorrect if condition that causes AppInfoDO not to be retrieved from DB when it is not found in the cache. This leads to an NPE.