### PR TITLE
Improve fix-IDENTITY-5015 [master]

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
+++ b/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
@@ -108,7 +108,7 @@ public final class OAuthConstants {
 
     //Constants used for multiple scopes
     public static final String OIDC_SCOPE_CONFIG_PATH = "oidc-scope-config.xml";
-    public static final String SCOPE_RESOURCE_PATH = "/oidc/";
+    public static final String SCOPE_RESOURCE_PATH = "/oidc";
 
     public static class GrantTypes {
         public static final String IMPLICIT = "implicit";

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/user/OpenIDConnectUserEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/user/OpenIDConnectUserEndpoint.java
@@ -25,9 +25,12 @@ import org.apache.oltu.oauth2.as.response.OAuthASResponse;
 import org.apache.oltu.oauth2.common.exception.OAuthSystemException;
 import org.apache.oltu.oauth2.common.message.OAuthResponse;
 import org.wso2.carbon.identity.oauth.IdentityOAuthAdminException;
+import org.wso2.carbon.identity.oauth.OAuthUtil;
 import org.wso2.carbon.identity.oauth.common.OAuth2ErrorCodes;
 import org.wso2.carbon.identity.oauth.common.OAuthConstants;
+import org.wso2.carbon.identity.oauth.common.exception.InvalidOAuthClientException;
 import org.wso2.carbon.identity.oauth.dao.OAuthAppDAO;
+import org.wso2.carbon.identity.oauth.dao.OAuthAppDO;
 import org.wso2.carbon.identity.oauth.endpoint.user.impl.UserInfoEndpointConfig;
 import org.wso2.carbon.identity.oauth.user.UserInfoAccessTokenValidator;
 import org.wso2.carbon.identity.oauth.user.UserInfoEndpointException;
@@ -37,6 +40,7 @@ import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.dao.TokenMgtDAO;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2TokenValidationResponseDTO;
 import org.wso2.carbon.identity.oauth2.model.AccessTokenDO;
+import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -94,6 +98,15 @@ public class OpenIDConnectUserEndpoint {
             // validate the access token
             UserInfoAccessTokenValidator tokenValidator = UserInfoEndpointConfig.getInstance().getUserInfoAccessTokenValidator();
             OAuth2TokenValidationResponseDTO tokenResponse = tokenValidator.validateToken(accessToken);
+
+            /*
+               We need to pass the SP's tenantId to the UserInfoResponseBuilder to retrieve the correct OIDC scope
+               configurations. We can't do this currently as OAuth2TokenValidationResponseDTO does not contain any
+               contextual information that could be used to derive the tenantId of the SP. Therefore we are setting
+               the tenantId in a thread local variable.
+             */
+            setServiceProviderTenantId(accessToken);
+
             // build the claims
             //ToDO - Validate the grant type to be implicit or authorization_code before retrieving claims
             UserInfoResponseBuilder userInfoResponseBuilder = UserInfoEndpointConfig.getInstance().getUserInfoResponseBuilder();
@@ -151,6 +164,29 @@ public class OpenIDConnectUserEndpoint {
             return Response.status(response.getResponseStatus()).entity(response.getBody()).build();
         }
         return Response.status(res.getResponseStatus()).entity(res.getBody()).build();
+    }
+
+    /**
+     * Derive the tenantId of the SP from the accessToken identifier and set a threadLocal variable to be used by
+     * the UserInfoResponseBuilder.
+     *
+     * @param accessToken
+     * @throws OAuthSystemException
+     */
+    private void setServiceProviderTenantId(String accessToken) throws OAuthSystemException {
+        try {
+            // get client id of OAuth app from the introspection
+            String clientId = OAuth2Util.getClientIdForAccessToken(accessToken);
+            if (StringUtils.isBlank(clientId)) {
+                throw new OAuthSystemException("Cannot find the clientID of the SP that issued the token.");
+            }
+            OAuthAppDO appDO = OAuth2Util.getAppInformationByClientId(clientId);
+            int spTenantId = OAuth2Util.getTenantId(OAuth2Util.getTenantDomainOfOauthApp(appDO));
+            // set the tenant id in the thread local variable
+            OAuth2Util.setClientTenatId(spTenantId);
+        } catch (IdentityOAuth2Exception | InvalidOAuthClientException e) {
+            throw new OAuthSystemException("Error when obtaining the tenant information of SP.", e);
+        }
     }
 
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/TokenValidationHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/TokenValidationHandler.java
@@ -24,10 +24,6 @@ import java.util.TreeMap;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.identity.application.common.model.User;
-import org.wso2.carbon.identity.oauth.cache.CacheEntry;
-import org.wso2.carbon.identity.oauth.cache.CacheKey;
-import org.wso2.carbon.identity.oauth.cache.OAuthCache;
-import org.wso2.carbon.identity.oauth.cache.OAuthCacheKey;
 import org.wso2.carbon.identity.oauth.common.OAuthConstants;
 import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
@@ -458,40 +454,7 @@ public class TokenValidationHandler {
      * @throws IdentityOAuth2Exception
      */
     private AccessTokenDO findAccessToken(String tokenIdentifier) throws IdentityOAuth2Exception {
-
-	boolean cacheHit = false;
-	AccessTokenDO accessTokenDO = null;
-	// check the cache, if caching is enabled.
-	if (OAuthServerConfiguration.getInstance().isCacheEnabled()) {
-	    OAuthCache oauthCache = OAuthCache.getInstance();
-        OAuthCacheKey cacheKey = new OAuthCacheKey(tokenIdentifier);
-	    CacheEntry result = oauthCache.getValueFromCache(cacheKey);
-	    // cache hit, do the type check.
-	    if (result instanceof AccessTokenDO) {
-		accessTokenDO = (AccessTokenDO) result;
-		cacheHit = true;
-	    }
-	}
-	// cache miss, load the access token info from the database.
-	if (accessTokenDO == null) {
-	    accessTokenDO = tokenMgtDAO.retrieveAccessToken(tokenIdentifier, false);
-	}
-	
-	if (accessTokenDO == null) {
-	    throw new IllegalArgumentException("Invalid access token");
-	}
-
-	// add the token back to the cache in the case of a cache miss
-	if (OAuthServerConfiguration.getInstance().isCacheEnabled() && !cacheHit) {
-	    OAuthCache oauthCache = OAuthCache.getInstance();
-        OAuthCacheKey cacheKey = new OAuthCacheKey(tokenIdentifier);
-	    oauthCache.addToCache(cacheKey, accessTokenDO);
-	    if (log.isDebugEnabled()) {
-		log.debug("Access Token Info object was added back to the cache.");
-	    }
-	}
-
-	return accessTokenDO;
+		return OAuth2Util.getAccessTokenDOfromTokenIdentifier(tokenIdentifier);
     }
     
 }


### PR DESCRIPTION
* Get the clientId of the SP OAuth app, then derive the SP tenantId and set it in a threadLocal variable at the UserInfo endpoint.

* Use the SP tenantID set in threadLocal to retrieve correct OIDC scope config at the UserInfoResponseBuilder.