### PR TITLE
Fix IDENTITY-4435

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.ui/src/main/resources/web/oauth/add.jsp
+++ b/components/org.wso2.carbon.identity.oauth.ui/src/main/resources/web/oauth/add.jsp
@@ -88,7 +88,10 @@
                 function validate() {
                     var callbackUrl = document.getElementById('callback').value;
                     if ($(jQuery("#grant_code"))[0].checked || $(jQuery("#grant_implicit"))[0].checked) {
-                        if (!isWhiteListed(callbackUrl, ["url"]) || !isNotBlackListed(callbackUrl,
+                        // This is to support providing regex patterns for callback URLs
+                        if (callbackUrl.startsWith("regexp=")) {
+                            // skip validation
+                        } else if (!isWhiteListed(callbackUrl, ["url"]) || !isNotBlackListed(callbackUrl,
                                         ["uri-unsafe-exists"])) {
                             CARBON.showWarningDialog('<fmt:message key="callback.is.not.url"/>');
                             return false;

--- a/components/org.wso2.carbon.identity.oauth.ui/src/main/resources/web/oauth/edit.jsp
+++ b/components/org.wso2.carbon.identity.oauth.ui/src/main/resources/web/oauth/edit.jsp
@@ -178,7 +178,10 @@
                         if (!$(jQuery("#grant_code"))[0].checked && !$(jQuery("#grant_implicit"))[0].checked) {
                             document.getElementsByName("callback")[0].value = '';
                         } else {
-                            if (!isWhiteListed(callbackUrl, ["url"]) || !isNotBlackListed(callbackUrl,
+                            // This is to support providing regex patterns for callback URLs
+                            if (callbackUrl.startsWith("regexp=")) {
+                                // skip validation
+                            }else if (!isWhiteListed(callbackUrl, ["url"]) || !isNotBlackListed(callbackUrl,
                                             ["uri-unsafe-exists"])) {
                                 CARBON.showWarningDialog('<fmt:message key="callback.is.not.url"/>');
                                 return false;


### PR DESCRIPTION
Remove validation if the callback url is preceeded with regexp to allow configuring multiple callback uris with regexes.