### PR TITLE
IDENTITY-5210 : SSO does not work among two OIDC applications with different subject identifiers

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
@@ -1126,28 +1126,14 @@ public class OAuth2AuthzEndpoint {
                         OIDCSessionManagementUtil.getSessionManager()
                                                  .getOIDCSessionState(opBrowserStateCookie.getValue());
                 if (previousSessionState != null) {
-                    if (previousSessionState.getAuthenticatedUser().equals(authenticatedUser)) {
-
-                        if (!previousSessionState.getSessionParticipants().contains(oAuth2Parameters.getClientId())) {
-                            // User is authenticated to a new client. Restore browser session state
-                            String oldOPBrowserStateCookieId = opBrowserStateCookie.getValue();
-                            opBrowserStateCookie = OIDCSessionManagementUtil.addOPBrowserStateCookie(response);
-                            String newOPBrowserStateCookieId = opBrowserStateCookie.getValue();
-                            previousSessionState.addSessionParticipant(oAuth2Parameters.getClientId());
-                            OIDCSessionManagementUtil.getSessionManager()
-                                                     .restoreOIDCSessionState(oldOPBrowserStateCookieId,
-                                                                              newOPBrowserStateCookieId,
-                                                                              previousSessionState);
-                        }
-                    } else {
-                        if (log.isDebugEnabled()) {
-                            log.debug("Existing session is not authenticated for the given user " + authenticatedUser);
-                        }
-                        redirectURL = EndpointUtil.getErrorPageURL(OAuth2ErrorCodes.ACCESS_DENIED,
-                                                                   "No valid session found for the authenticated user " +
-                                                                   authenticatedUser,
-                                                                   oAuth2Parameters.getApplicationName());
-                        sessionStateObj.setAddSessionState(false);
+                    if (!previousSessionState.getSessionParticipants().contains(oAuth2Parameters.getClientId())) {
+                        // User is authenticated to a new client. Restore browser session state
+                        String oldOPBrowserStateCookieId = opBrowserStateCookie.getValue();
+                        opBrowserStateCookie = OIDCSessionManagementUtil.addOPBrowserStateCookie(response);
+                        String newOPBrowserStateCookieId = opBrowserStateCookie.getValue();
+                        previousSessionState.addSessionParticipant(oAuth2Parameters.getClientId());
+                        OIDCSessionManagementUtil.getSessionManager().restoreOIDCSessionState
+                                (oldOPBrowserStateCookieId, newOPBrowserStateCookieId, previousSessionState);
                     }
                 } else {
                     log.warn("No session state found for the received Session ID : " + opBrowserStateCookie.getValue());


### PR DESCRIPTION
Cause:
When another application participates in the browser session of the user for OIDC applications, the authenticated subject identifier that was there is the session was validated against the subject identifier received for the same browser session. This validation breaks the flow if subject identifiers are different.

Fix:
As the cookie bounds the authenticated user browser session, and as the user session is already validated from the authentication framework against the 'commonauthId' cookie, when another application participates in the user session, validating the user in the session again, does not make sense, as it is the browser session of the respective user. And the user may be participating in the same session with different identifiers, accounts and authentication sequences with respect to the applications. Therefore, the unnecessary check that validates the subject identifier in the session was removed.