### PR TITLE
Invalid Refresh Token Error Handling

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuer.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuer.java
@@ -254,12 +254,11 @@ public class AccessTokenIssuer {
             OAuth2Util.setTokenRequestContext(tokReqMsgCtx);
             tokenRespDTO = authzGrantHandler.issue(tokReqMsgCtx);
             if (tokenRespDTO.isError()) {
-	    	    setResponseHeaders(tokReqMsgCtx, tokenRespDTO);
-                triggerPostListeners(tokenReqDTO, tokenRespDTO, tokReqMsgCtx, isRefreshRequest);
-	    	    return tokenRespDTO;
-	        }
-            triggerPostListeners(tokenReqDTO, tokenRespDTO, tokReqMsgCtx, isRefreshRequest);
+                setResponseHeaders(tokReqMsgCtx, tokenRespDTO);
+                return tokenRespDTO;
+            }    
         } finally {
+            triggerPostListeners(tokenReqDTO, tokenRespDTO, tokReqMsgCtx, isRefreshRequest);
             // clears the token request context.
             OAuth2Util.clearTokenRequestContext();
         }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuer.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuer.java
@@ -253,6 +253,11 @@ public class AccessTokenIssuer {
             // IDENTITY-4111.
             OAuth2Util.setTokenRequestContext(tokReqMsgCtx);
             tokenRespDTO = authzGrantHandler.issue(tokReqMsgCtx);
+            if (tokenRespDTO.isError()) {
+	    	    setResponseHeaders(tokReqMsgCtx, tokenRespDTO);
+                triggerPostListeners(tokenReqDTO, tokenRespDTO, tokReqMsgCtx, isRefreshRequest);
+	    	    return tokenRespDTO;
+	        }
             triggerPostListeners(tokenReqDTO, tokenRespDTO, tokReqMsgCtx, isRefreshRequest);
         } finally {
             // clears the token request context.

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/RefreshGrantHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/RefreshGrantHandler.java
@@ -180,7 +180,7 @@ public class RefreshGrantHandler extends AbstractAuthorizationGrantHandler {
             }
         } else {
             // todo add proper error message/error code
-            return handleError(OAuthError.TokenResponse.INVALID_REQUEST, "Refresh token is expired.");
+            return handleError(OAuthError.TokenResponse.INVALID_REQUEST, "Refresh token is expired.", oauth2AccessTokenReqDTO);
         }
 
         Timestamp timestamp = new Timestamp(new Date().getTime());
@@ -335,7 +335,13 @@ public class RefreshGrantHandler extends AbstractAuthorizationGrantHandler {
         return tokenRespDTO;
     }
 
-    private OAuth2AccessTokenRespDTO handleError(String errorCode, String errorMsg) {
+    private OAuth2AccessTokenRespDTO handleError(String errorCode, String errorMsg,
+            OAuth2AccessTokenReqDTO tokenReqDTO) {
+        if (log.isDebugEnabled()) {
+            log.debug("OAuth-Error-Code=" + errorCode + " client-id=" + tokenReqDTO.getClientId()
+                + " grant-type=" + tokenReqDTO.getGrantType()
+                + " scope=" + OAuth2Util.buildScopeString(tokenReqDTO.getScope()));
+    	}
         OAuth2AccessTokenRespDTO tokenRespDTO;
         tokenRespDTO = new OAuth2AccessTokenRespDTO();
         tokenRespDTO.setError(true);


### PR DESCRIPTION
We are using wso2 identity server 5.1.0 and came across the following situation:

-- client possesses refresh token generated with access token
-- access token is now beyond validity period, but is still in 'ACTIVE' state in database
-- refresh token is now beyond validity period as well
-- client posts refresh token and rather than getting a 400 bad request, a 500 internal server error is returned

Our testing shows that this is because the refresh grant handler is returning a response token data transfer object with error information and a null access token.  The access token issuer is not checking whether the response is in error and instead proceeds as if the access token was assigned.

The addition of the few lines of code in my commits below cause the proper 400 bad request response to be sent back to the client, and also update the refresh grant handler to log consistent with the access token issuer.

Apologies if I have compared to the wrong branch, etc, as I am not sure where you are in your release cycle or how you would prefer to receive these types of suggestions.
