### PR TITLE
Fixing IDENTITY-5423 : Adding "temporarily_unavailable" OAuth2 Error Code

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuth2ErrorCodes.java
+++ b/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuth2ErrorCodes.java
@@ -28,6 +28,7 @@ public class OAuth2ErrorCodes {
     public static final String INVALID_CLIENT = "invalid_client";
     public static final String UNSUPPORTED_GRANT_TYPE = "unsupported_grant_type";
     public static final String LOGIN_REQUIRED = "login_required";
+    public static final String TEMPORARY_UNAVAILABLE = "temporarily_unavailable";
 
     private OAuth2ErrorCodes(){
 


### PR DESCRIPTION
According to specification [1] there should be an error code as "temporarily_unavailable" for 503 errors. Hence it's better to keep it defined.