### PR TITLE
Improvement to handling tenantDomain in OIDC Requests

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/AuthorizationHandlerManager.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/AuthorizationHandlerManager.java
@@ -93,8 +93,10 @@ public class AuthorizationHandlerManager {
 
         // loading the stored application data
         OAuthAppDO oAuthAppDO = getAppInformation(authzReqDTO);
-
         authzReqMsgCtx.addProperty("OAuthAppDO", oAuthAppDO);
+
+        // load the SP tenant domain from the OAuth App info
+        authzReqMsgCtx.getAuthorizationReqDTO().setTenantDomain(OAuth2Util.getTenantDomainOfOauthApp(oAuthAppDO));
 
         boolean isAuthorizedClient = authzHandler.isAuthorizedClient(authzReqMsgCtx);
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/DefaultIDTokenBuilder.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/DefaultIDTokenBuilder.java
@@ -71,7 +71,6 @@ import org.wso2.carbon.idp.mgt.IdentityProviderManager;
 import org.wso2.carbon.user.core.UserStoreException;
 import org.wso2.carbon.user.core.UserStoreManager;
 
-import javax.xml.namespace.QName;
 import java.security.Key;
 import java.security.KeyStore;
 import java.security.MessageDigest;
@@ -83,10 +82,11 @@ import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.LinkedHashSet;
+import javax.xml.namespace.QName;
 
 /**
  * This is the IDToken generator for the OpenID Connect Implementation. This
@@ -140,9 +140,10 @@ public class DefaultIDTokenBuilder implements org.wso2.carbon.identity.openidcon
             if (log.isDebugEnabled()) {
                 log.debug("Error while getting Federated Identity Provider ", e);
             }
+            throw new IdentityOAuth2Exception("Error getting Federated Identity Provider", e);
         }
-        FederatedAuthenticatorConfig[] fedAuthnConfigs =
-                identityProvider.getFederatedAuthenticatorConfigs();
+
+        FederatedAuthenticatorConfig[] fedAuthnConfigs = identityProvider.getFederatedAuthenticatorConfigs();
 
         // Get OIDC authenticator
         FederatedAuthenticatorConfig samlAuthenticatorConfig =
@@ -311,9 +312,9 @@ public class DefaultIDTokenBuilder implements org.wso2.carbon.identity.openidcon
             if (log.isDebugEnabled()) {
                 log.debug("Error while getting Federated Identity Provider ", e);
             }
+            throw new IdentityOAuth2Exception("Error getting Federated Identity Provider", e);
         }
-        FederatedAuthenticatorConfig[] fedAuthnConfigs =
-                identityProvider.getFederatedAuthenticatorConfigs();
+        FederatedAuthenticatorConfig[] fedAuthnConfigs = identityProvider.getFederatedAuthenticatorConfigs();
 
         // Get OIDC authenticator
         FederatedAuthenticatorConfig samlAuthenticatorConfig =


### PR DESCRIPTION
OIDC authorization and implicit flow derive the tenantDomain from the query parameter.
 This improvement is to derive the tenantDomain using the client_id value.

We did a similar improvement to OAuth in [IDENTITY-4531](https://wso2.org/jira/browse/IDENTITY-4531?focusedCommentId=119456&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-119456). Looks like we have missed this one.
