### PR TITLE
Fix  Identity-4915:'sub' claim not returned in id_tokens generated with Client credential grant type

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/user/OpenIDConnectUserEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/user/OpenIDConnectUserEndpoint.java
@@ -95,10 +95,6 @@ public class OpenIDConnectUserEndpoint {
         } catch (OAuthSystemException e) {
             log.error("UserInfoEndpoint Failed", e);
             throw new OAuthSystemException("UserInfoEndpoint Failed");
-        } catch (IdentityOAuthAdminException e) {
-            if (log.isDebugEnabled()) {
-                log.debug("Error in getting grant type.", e);
-            }
         }
 
         ResponseBuilder respBuilder =

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dao/OAuthAppDAO.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dao/OAuthAppDAO.java
@@ -582,7 +582,7 @@ public class OAuthAppDAO {
                         + SQLQueries.OAuthConsumerDAOSQLQueries.GET_GRANT_TYPE_BY_TOKEN, e);
             } catch (IdentityOAuthAdminException e1) {
                 log.error("Error when executing the SQL : "
-                        + SQLQueries.OAuthConsumerDAOSQLQueries.GET_GRANT_TYPE_BY_TOKEN, e);
+                        + SQLQueries.OAuthConsumerDAOSQLQueries.GET_GRANT_TYPE_BY_TOKEN, e1);
             }
         } finally {
             IdentityDatabaseUtil.closeAllConnections(connection, null, prepStmt);

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dao/OAuthAppDAO.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dao/OAuthAppDAO.java
@@ -54,6 +54,7 @@ public class OAuthAppDAO {
 
     public static final Log log = LogFactory.getLog(OAuthAppDAO.class);
     private TokenPersistenceProcessor persistenceProcessor;
+    private String GRANT_TYPE = "GRANT_TYPE";
 
     public OAuthAppDAO() {
 
@@ -551,6 +552,36 @@ public class OAuthAppDAO {
             IdentityDatabaseUtil.closeAllConnections(connection, rSet, prepStmt);
         }
         return isDuplicateConsumer;
+    }
+
+    /**
+     * Get the grant type.
+     *
+     * @param accessToken Access token
+     * @throws IdentityOAuthAdminException
+     */
+    public String getGrantType(String accessToken) throws IdentityOAuthAdminException {
+
+        PreparedStatement prepStmt = null;
+        Connection connection = null;
+        ResultSet rSet = null;
+        String grantType = null;
+
+        try {
+            connection = IdentityDatabaseUtil.getDBConnection();
+            prepStmt = connection.prepareStatement(SQLQueries.OAuthConsumerDAOSQLQueries.RETRIEVE_GRANT_TYPE_BY_TOKEN);
+            prepStmt.setString(1, accessToken);
+            rSet = prepStmt.executeQuery();
+            if (rSet != null && rSet.next()) {
+                grantType = rSet.getString(GRANT_TYPE);
+            }
+            connection.commit();
+        } catch (SQLException e) {
+            throw new IdentityOAuthAdminException("Error while executing the SQL prepStmt.", e);
+        } finally {
+            IdentityDatabaseUtil.closeAllConnections(connection, null, prepStmt);
+        }
+        return grantType;
     }
 
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dao/OAuthAppDAO.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dao/OAuthAppDAO.java
@@ -558,9 +558,9 @@ public class OAuthAppDAO {
      * Get the grant type.
      *
      * @param accessToken Access token
-     * @throws IdentityOAuthAdminException
+     * @return grant type
      */
-    public String getGrantType(String accessToken) throws IdentityOAuthAdminException {
+    public String getGrantType(String accessToken) {
 
         PreparedStatement prepStmt = null;
         Connection connection = null;
@@ -569,7 +569,7 @@ public class OAuthAppDAO {
 
         try {
             connection = IdentityDatabaseUtil.getDBConnection();
-            prepStmt = connection.prepareStatement(SQLQueries.OAuthConsumerDAOSQLQueries.RETRIEVE_GRANT_TYPE_BY_TOKEN);
+            prepStmt = connection.prepareStatement(SQLQueries.OAuthConsumerDAOSQLQueries.GET_GRANT_TYPE_BY_TOKEN);
             prepStmt.setString(1, accessToken);
             rSet = prepStmt.executeQuery();
             if (rSet != null && rSet.next()) {
@@ -577,7 +577,13 @@ public class OAuthAppDAO {
             }
             connection.commit();
         } catch (SQLException e) {
-            throw new IdentityOAuthAdminException("Error while executing the SQL prepStmt.", e);
+            try {
+                throw new IdentityOAuthAdminException("Error when executing the SQL : "
+                        + SQLQueries.OAuthConsumerDAOSQLQueries.GET_GRANT_TYPE_BY_TOKEN, e);
+            } catch (IdentityOAuthAdminException e1) {
+                log.error("Error when executing the SQL : "
+                        + SQLQueries.OAuthConsumerDAOSQLQueries.GET_GRANT_TYPE_BY_TOKEN, e);
+            }
         } finally {
             IdentityDatabaseUtil.closeAllConnections(connection, null, prepStmt);
         }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dao/SQLQueries.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dao/SQLQueries.java
@@ -119,6 +119,9 @@ public class SQLQueries {
         public static final String GET_ACCESS_TOKEN = "SELECT SCOPE, AUTHZ_USER FROM IDN_OAUTH1A_ACCESS_TOKEN " +
                 "WHERE ACCESS_TOKEN=?";
 
+        public static final String RETRIEVE_GRANT_TYPE_BY_TOKEN = "SELECT GRANT_TYPE FROM " +
+                "IDN_OAUTH2_ACCESS_TOKEN WHERE ACCESS_TOKEN = ?";
+
         public static final String GET_ACCESS_TOKEN_SECRET = "SELECT ACCESS_TOKEN_SECRET FROM IDN_OAUTH1A_ACCESS_TOKEN " +
                 "WHERE ACCESS_TOKEN=?";
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dao/SQLQueries.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dao/SQLQueries.java
@@ -119,7 +119,7 @@ public class SQLQueries {
         public static final String GET_ACCESS_TOKEN = "SELECT SCOPE, AUTHZ_USER FROM IDN_OAUTH1A_ACCESS_TOKEN " +
                 "WHERE ACCESS_TOKEN=?";
 
-        public static final String RETRIEVE_GRANT_TYPE_BY_TOKEN = "SELECT GRANT_TYPE FROM " +
+        public static final String GET_GRANT_TYPE_BY_TOKEN = "SELECT GRANT_TYPE FROM " +
                 "IDN_OAUTH2_ACCESS_TOKEN WHERE ACCESS_TOKEN = ?";
 
         public static final String GET_ACCESS_TOKEN_SECRET = "SELECT ACCESS_TOKEN_SECRET FROM IDN_OAUTH1A_ACCESS_TOKEN " +

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuer.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuer.java
@@ -284,10 +284,11 @@ public class AccessTokenIssuer {
             log.debug("Access token issued to client Id: " + tokenReqDTO.getClientId() + " username: " +
                     tokReqMsgCtx.getAuthorizedUser() + " and scopes: " + tokenRespDTO.getAuthorizedScopes());
         }
-
-        if (tokReqMsgCtx.getScope() != null && OAuth2Util.isOIDCAuthzRequest(tokReqMsgCtx.getScope())) {
-            IDTokenBuilder builder = OAuthServerConfiguration.getInstance().getOpenIDConnectIDTokenBuilder();
-            tokenRespDTO.setIDToken(builder.buildIDToken(tokReqMsgCtx, tokenRespDTO));
+        if (!GrantType.CLIENT_CREDENTIALS.toString().equals(tokenReqDTO.getGrantType())) {
+            if (tokReqMsgCtx.getScope() != null && OAuth2Util.isOIDCAuthzRequest(tokReqMsgCtx.getScope())) {
+                IDTokenBuilder builder = OAuthServerConfiguration.getInstance().getOpenIDConnectIDTokenBuilder();
+                tokenRespDTO.setIDToken(builder.buildIDToken(tokReqMsgCtx, tokenRespDTO));
+            }
         }
 
         if (tokenReqDTO.getGrantType().equals(GrantType.AUTHORIZATION_CODE.toString())) {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuer.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuer.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.oauth2.token;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.oltu.oauth2.common.error.OAuthError;
@@ -284,10 +285,12 @@ public class AccessTokenIssuer {
             log.debug("Access token issued to client Id: " + tokenReqDTO.getClientId() + " username: " +
                     tokReqMsgCtx.getAuthorizedUser() + " and scopes: " + tokenRespDTO.getAuthorizedScopes());
         }
-        if (!GrantType.CLIENT_CREDENTIALS.toString().equals(tokenReqDTO.getGrantType())) {
-            if (tokReqMsgCtx.getScope() != null && OAuth2Util.isOIDCAuthzRequest(tokReqMsgCtx.getScope())) {
+        if (!GrantType.CLIENT_CREDENTIALS.toString().equals(tokenReqDTO.getGrantType()) && scopes != null) {
+            if (StringUtils.isNotBlank(scopes.toString()) && OAuth2Util.isOIDCAuthzRequest(scopes)) {
                 IDTokenBuilder builder = OAuthServerConfiguration.getInstance().getOpenIDConnectIDTokenBuilder();
-                tokenRespDTO.setIDToken(builder.buildIDToken(tokReqMsgCtx, tokenRespDTO));
+                if (builder != null) {
+                    tokenRespDTO.setIDToken(builder.buildIDToken(tokReqMsgCtx, tokenRespDTO));
+                }
             }
         }
 


### PR DESCRIPTION
Remove ID Token issuing and claims returning from User info endpoint in client credential grant type.