### PR TITLE
Fixed IDENTITY-5344 : Returns refresh tokens for SAML bearer grant type.

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
+++ b/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
@@ -115,6 +115,10 @@ public final class OAuthConstants {
     public static class GrantTypes {
         public static final String IMPLICIT = "implicit";
         public static final String TOKEN = "token";
+        public static final String CLIENT_CREDENTIALS = "client_credentials";
+        public static final String IWA_NTLM = "iwa:ntlm";
+        public static final String PASSWORD = "password";
+        public static final String AUTHORIZATION_CODE = "authorization_code";
 
         private GrantTypes() {
         }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
@@ -122,6 +122,7 @@ public class OAuthServerConfiguration {
     private TokenPersistenceProcessor persistenceProcessor = null;
     private Set<OAuthCallbackHandlerMetaData> callbackHandlerMetaData = new HashSet<>();
     private Map<String, String> supportedGrantTypeClassNames = new HashMap<>();
+    private Map<String, Boolean> refreshTokenAllowedGrantTypes = new HashMap<>();
     private Map<String, AuthorizationGrantHandler> supportedGrantTypes;
     private Map<String, String> supportedGrantTypeValidatorNames = new HashMap<>();
     private Map<String, Class<? extends OAuthValidator<HttpServletRequest>>> supportedGrantTypeValidators;
@@ -821,6 +822,17 @@ public class OAuthServerConfiguration {
         return isImplicitErrorFragment;
     }
 
+    /**
+     * Return the value of whether the refresh token is allowed for this grant type. Null will be returned if there is
+     * no tag or empty tag.
+     * @param grantType Name of the Grant type.
+     * @return True or False if there is a value. Null otherwise.
+     */
+    public Boolean getValueForIsRefreshTokenAllowed(String grantType) {
+
+        return refreshTokenAllowedGrantTypes.get(grantType);
+    }
+
     private void parseOAuthCallbackHandlers(OMElement callbackHandlersElem) {
         if (callbackHandlersElem == null) {
             warnOnFaultyConfiguration("OAuthCallbackHandlers element is not available.");
@@ -1261,6 +1273,13 @@ public class OAuthServerConfiguration {
                     if (!StringUtils.isEmpty(authzGrantValidatorImplClass)) {
                         supportedGrantTypeValidatorNames.put(grantTypeName, authzGrantValidatorImplClass);
                     }
+                    
+                    OMElement refreshTokenAllowed = supportedGrantTypeElement
+                            .getFirstChildWithName(getQNameWithIdentityNS(ConfigElements.REFRESH_TOKEN_ALLOWED));
+                    if (refreshTokenAllowed != null && StringUtils.isNotBlank(refreshTokenAllowed.getText())) {
+                        boolean isRefreshAllowed = Boolean.parseBoolean(refreshTokenAllowed.getText());
+                        refreshTokenAllowedGrantTypes.put(grantTypeName, isRefreshAllowed);
+                    }
                 }
             }
         } else {
@@ -1685,6 +1704,7 @@ public class OAuthServerConfiguration {
         private static final String SAML2_GRANT = "SAML2Grant";
         private static final String SAML2_TOKEN_HANDLER = "SAML2TokenHandler";
 
+        public static final String REFRESH_TOKEN_ALLOWED = "IsRefreshTokenAllowed";
     }
 
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AuthorizationCodeGrantHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AuthorizationCodeGrantHandler.java
@@ -277,4 +277,19 @@ public class AuthorizationCodeGrantHandler extends AbstractAuthorizationGrantHan
         }
     }
 
+    @Override
+    public boolean issueRefreshToken() throws IdentityOAuth2Exception {
+
+        Boolean isRefreshTokenAllowed = OAuthServerConfiguration.getInstance()
+                .getValueForIsRefreshTokenAllowed(OAuthConstants.GrantTypes.AUTHORIZATION_CODE);
+
+        // If no tag present. We'll be sending no refresh token.
+        if (isRefreshTokenAllowed == null) {
+            // Default behaviour should be return false. For backward compatibility reasons,
+            // we are sending true instead.
+            return true;
+        }
+
+        return isRefreshTokenAllowed;
+    }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/ClientCredentialsGrantHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/ClientCredentialsGrantHandler.java
@@ -20,6 +20,8 @@ package org.wso2.carbon.identity.oauth2.token.handlers.grant;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.oauth.common.OAuthConstants;
+import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.token.OAuthTokenReqMessageContext;
 
@@ -34,7 +36,7 @@ public class ClientCredentialsGrantHandler extends AbstractAuthorizationGrantHan
     public boolean validateGrant(OAuthTokenReqMessageContext tokReqMsgCtx)
             throws IdentityOAuth2Exception {
 
-        if(!super.validateGrant(tokReqMsgCtx)){
+        if (!super.validateGrant(tokReqMsgCtx)){
             return false;
         }
 
@@ -44,12 +46,21 @@ public class ClientCredentialsGrantHandler extends AbstractAuthorizationGrantHan
     }
 
     @Override
-    public boolean issueRefreshToken() throws IdentityOAuth2Exception {
+    public boolean isOfTypeApplicationUser() throws IdentityOAuth2Exception {
         return false;
     }
 
     @Override
-    public boolean isOfTypeApplicationUser() throws IdentityOAuth2Exception {
-        return false;
+    public boolean issueRefreshToken() throws IdentityOAuth2Exception {
+
+        Boolean isRefreshTokenAllowed = OAuthServerConfiguration.getInstance()
+                .getValueForIsRefreshTokenAllowed(OAuthConstants.GrantTypes.CLIENT_CREDENTIALS);
+
+        // If no tag present. We'll be sending no refresh token.
+        if (isRefreshTokenAllowed == null) {
+            return false;
+        }
+
+        return isRefreshTokenAllowed;
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/PasswordGrantHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/PasswordGrantHandler.java
@@ -28,6 +28,8 @@ import org.wso2.carbon.identity.application.common.IdentityApplicationManagement
 import org.wso2.carbon.identity.application.common.model.ServiceProvider;
 import org.wso2.carbon.identity.base.IdentityRuntimeException;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.oauth.common.OAuthConstants;
+import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
 import org.wso2.carbon.identity.oauth.internal.OAuthComponentServiceHolder;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2AccessTokenReqDTO;
@@ -122,5 +124,21 @@ public class PasswordGrantHandler extends AbstractAuthorizationGrantHandler {
             throw new IdentityOAuth2Exception("Authentication failed for " + username);
         }
         return authStatus;
+    }
+
+    @Override
+    public boolean issueRefreshToken() throws IdentityOAuth2Exception {
+
+        Boolean isRefreshTokenAllowed = OAuthServerConfiguration.getInstance()
+                .getValueForIsRefreshTokenAllowed(OAuthConstants.GrantTypes.PASSWORD);
+
+        // If no tag present. We'll be sending no refresh token.
+        if (isRefreshTokenAllowed == null) {
+            // Default behaviour should be return false. For backward compatibility reasons,
+            // we are sending true instead.
+            return true;
+        }
+
+        return isRefreshTokenAllowed;
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/iwa/ntlm/NTLMAuthenticationGrantHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/iwa/ntlm/NTLMAuthenticationGrantHandler.java
@@ -23,6 +23,8 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.identity.base.IdentityConstants;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.oauth.common.OAuthConstants;
+import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.token.OAuthTokenReqMessageContext;
 import org.wso2.carbon.identity.oauth2.token.handlers.grant.AbstractAuthorizationGrantHandler;
@@ -138,4 +140,17 @@ public class NTLMAuthenticationGrantHandler extends AbstractAuthorizationGrantHa
 
     }
 
+    @Override
+    public boolean issueRefreshToken() throws IdentityOAuth2Exception {
+
+        Boolean isRefreshTokenAllowed = OAuthServerConfiguration.getInstance()
+                .getValueForIsRefreshTokenAllowed(OAuthConstants.GrantTypes.IWA_NTLM);
+
+        // If no tag present. We'll be sending no refresh token.
+        if (isRefreshTokenAllowed == null) {
+            return false;
+        }
+
+        return isRefreshTokenAllowed;
+    }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/saml/SAML1BearerGrantHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/saml/SAML1BearerGrantHandler.java
@@ -534,4 +534,18 @@ public class SAML1BearerGrantHandler extends AbstractAuthorizationGrantHandler {
     public boolean authorizeAccessDelegation(OAuthTokenReqMessageContext tokReqMsgCtx) throws IdentityOAuth2Exception {
         return true;
     }
+
+    @Override
+    public boolean issueRefreshToken() throws IdentityOAuth2Exception {
+
+        Boolean isRefreshTokenAllowed = OAuthServerConfiguration.getInstance()
+                .getValueForIsRefreshTokenAllowed(OAuthConstants.OAUTH_SAML1_BEARER_METHOD);
+
+        // If no tag present. We'll be sending no refresh token.
+        if (isRefreshTokenAllowed == null) {
+            return false;
+        }
+
+        return isRefreshTokenAllowed;
+    }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/saml/SAML2BearerGrantHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/saml/SAML2BearerGrantHandler.java
@@ -53,7 +53,6 @@ import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.token.OAuthTokenReqMessageContext;
 import org.wso2.carbon.identity.oauth2.token.handlers.grant.AbstractAuthorizationGrantHandler;
-import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 import org.wso2.carbon.identity.oauth2.util.X509CredentialImpl;
 import org.wso2.carbon.idp.mgt.IdentityProviderManagementException;
 import org.wso2.carbon.idp.mgt.IdentityProviderManager;
@@ -546,5 +545,19 @@ public class SAML2BearerGrantHandler extends AbstractAuthorizationGrantHandler {
         }
 
         return true;
+    }
+
+    @Override
+    public boolean issueRefreshToken() throws IdentityOAuth2Exception {
+
+        Boolean isRefreshTokenAllowed = OAuthServerConfiguration.getInstance()
+                .getValueForIsRefreshTokenAllowed(OAuthConstants.OAUTH_SAML2_BEARER_METHOD);
+
+        // If no tag present. We'll be sending no refresh token.
+        if (isRefreshTokenAllowed == null) {
+            return false;
+        }
+
+        return isRefreshTokenAllowed;
     }
 }


### PR DESCRIPTION
https://wso2.org/jira/browse/IDENTITY-5344

Added the tag <IsRefreshTokenAllowed> to identity.xml SupportedGrantTypes/SupportedGrantType to enable the refresh token individually for allowed grant types.