### PR TITLE
Fixed IDENTITY-5936: OAuth application allowed grant types are not updating without restarting the server.

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/cache/AppInfoCache.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/cache/AppInfoCache.java
@@ -19,6 +19,7 @@
 package org.wso2.carbon.identity.oauth.cache;
 
 import org.wso2.carbon.identity.application.common.cache.BaseCache;
+import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
 import org.wso2.carbon.identity.oauth.dao.OAuthAppDO;
 import org.wso2.carbon.utils.CarbonUtils;
 
@@ -50,5 +51,10 @@ public class AppInfoCache extends BaseCache<String, OAuthAppDO> {
             }
         }
         return instance;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return super.isEnabled() && OAuthServerConfiguration.getInstance().isCacheEnabled();
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -1117,7 +1117,12 @@ public class OAuth2Util {
     public static OAuthAppDO getAppInformationByClientId(String clientId)
             throws IdentityOAuth2Exception, InvalidOAuthClientException {
 
-        OAuthAppDO oAuthAppDO = AppInfoCache.getInstance().getValueFromCache(clientId);
+        OAuthAppDO oAuthAppDO = null;
+
+        if (OAuthServerConfiguration.getInstance().isCacheEnabled()) {
+            oAuthAppDO = AppInfoCache.getInstance().getValueFromCache(clientId);
+        }
+
         if (oAuthAppDO != null) {
             return oAuthAppDO;
         } else {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -1117,12 +1117,7 @@ public class OAuth2Util {
     public static OAuthAppDO getAppInformationByClientId(String clientId)
             throws IdentityOAuth2Exception, InvalidOAuthClientException {
 
-        OAuthAppDO oAuthAppDO = null;
-
-        if (OAuthServerConfiguration.getInstance().isCacheEnabled()) {
-            oAuthAppDO = AppInfoCache.getInstance().getValueFromCache(clientId);
-        }
-
+        OAuthAppDO oAuthAppDO = AppInfoCache.getInstance().getValueFromCache(clientId);
         if (oAuthAppDO != null) {
             return oAuthAppDO;
         } else {


### PR DESCRIPTION
Added a condition to check whether the cache is enabled before getting the OAuth app from cache.