### PR TITLE
Improvements to fix Oltu AbstractValidator design issues

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
+++ b/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
@@ -106,6 +106,9 @@ public final class OAuthConstants {
     //Oauth Event Interceptor Proxy Name
     public static final String OAUTH_INTERCEPTOR_PROXY = "OauthDataInterceptorHandlerProxy";
 
+    public static final String RESPONSE_HEADERS_PROPERTY = "RESPONSE_HEADERS";
+
+
     //Constants used for multiple scopes
     public static final String OIDC_SCOPE_CONFIG_PATH = "oidc-scope-config.xml";
     public static final String SCOPE_RESOURCE_PATH = "/oidc";

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuer.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuer.java
@@ -410,8 +410,8 @@ public class AccessTokenIssuer {
     private void setResponseHeaders(OAuthTokenReqMessageContext tokReqMsgCtx,
                                     OAuth2AccessTokenRespDTO tokenRespDTO) {
 
-        if (tokReqMsgCtx.getProperty("RESPONSE_HEADERS") != null) {
-            tokenRespDTO.setResponseHeaders((ResponseHeader[]) tokReqMsgCtx.getProperty("RESPONSE_HEADERS"));
+        if (tokReqMsgCtx.getProperty(OAuthConstants.RESPONSE_HEADERS_PROPERTY) != null) {
+            tokenRespDTO.setResponseHeaders((ResponseHeader[]) tokReqMsgCtx.getProperty(OAuthConstants.RESPONSE_HEADERS_PROPERTY));
         }
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AbstractValidator.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AbstractValidator.java
@@ -1,6 +1,6 @@
 /*
  *
- *   Copyright (c) ${year}, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *   Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  *   WSO2 Inc. licenses this file to you under the Apache License,
  *   Version 2.0 (the "License"); you may not use this file except

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AbstractValidator.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AbstractValidator.java
@@ -1,0 +1,104 @@
+/*
+ *
+ *   Copyright (c) ${year}, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *   WSO2 Inc. licenses this file to you under the Apache License,
+ *   Version 2.0 (the "License"); you may not use this file except
+ *   in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing,
+ *   software distributed under the License is distributed on an
+ *   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *   KIND, either express or implied.  See the License for the
+ *   specific language governing permissions and limitations
+ *   under the License.
+ * /
+ */
+
+package org.wso2.carbon.identity.oauth2.token.handlers.grant;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * AbstractValidator class is extended from Apache Oltu's
+ * org.apache.oltu.oauth2.common.validators.AbstractValidator AbstractValidator class and provide
+ * number of additional helper methods for custom grant type Validators.
+ *
+ * @since 5.4.10
+ */
+public abstract class AbstractValidator
+		extends org.apache.oltu.oauth2.common.validators.AbstractValidator {
+
+	public AbstractValidator() {
+		super();
+		configureParams();
+	}
+
+	/*
+
+	Custom grant type Validator implementations should  implement this method to add or remove
+	required, optional and not-allowed  parameters.
+	 */
+	abstract protected void configureParams();
+
+	protected List<String> getRequiredParams() {
+		return requiredParams;
+	}
+
+	protected void setRequiredParams(List<String> requiredParams) {
+		this.requiredParams = requiredParams;
+	}
+
+	protected void addRequiredParam(String requiredParam) {
+		this.requiredParams.add(requiredParam);
+	}
+
+	protected void removeRequiredParam(String requiredParam) {
+		this.requiredParams.remove(requiredParam);
+	}
+
+	protected Map<String, String> getOptionalParams() {
+		return optionalParams;
+	}
+
+	protected void setOptionalParams(Map<String, String> optionalParams) {
+		this.optionalParams = optionalParams;
+	}
+
+	protected void addOptionalParam(String key, String optionalParam) {
+		this.optionalParams.put(key, optionalParam);
+	}
+
+	protected void removeOptionalParam(String optionalParamKey) {
+		this.optionalParams.remove(optionalParamKey);
+	}
+
+	protected List<String> getNotAllowedParamsParams() {
+		return notAllowedParams;
+	}
+
+	protected void setNotAllowedParamsParams(List<String> params) {
+		this.notAllowedParams = notAllowedParams;
+	}
+
+	protected void addNotAllowedParamsParam(String param) {
+		this.notAllowedParams.add(param);
+	}
+
+	protected void removeNotAllowedParamsParam(String param) {
+		this.notAllowedParams.remove(param);
+	}
+
+	public boolean isEnforceClientAuthentication() {
+		return enforceClientAuthentication;
+	}
+
+	public void setEnforceClientAuthentication(boolean enforceClientAuthentication) {
+		this.enforceClientAuthentication = enforceClientAuthentication;
+	}
+
+}

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AbstractValidator.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AbstractValidator.java
@@ -15,7 +15,7 @@
  *   KIND, either express or implied.  See the License for the
  *   specific language governing permissions and limitations
  *   under the License.
- * /
+ * 
  */
 
 package org.wso2.carbon.identity.oauth2.token.handlers.grant;

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AbstractValidator.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AbstractValidator.java
@@ -15,7 +15,7 @@
  *   KIND, either express or implied.  See the License for the
  *   specific language governing permissions and limitations
  *   under the License.
- * 
+ *
  */
 
 package org.wso2.carbon.identity.oauth2.token.handlers.grant;
@@ -39,7 +39,6 @@ public abstract class AbstractValidator
 	}
 
 	/*
-
 	Custom grant type Validator implementations should  implement this method to add or remove
 	required, optional and not-allowed  parameters.
 	 */

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/RefreshGrantHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/RefreshGrantHandler.java
@@ -360,7 +360,7 @@ public class RefreshGrantHandler extends AbstractAuthorizationGrantHandler {
         header.setValue(oldAccessToken.getAccessToken());
         respHeaders.add(header);
 
-        tokReqMsgCtx.addProperty("RESPONSE_HEADERS", respHeaders.toArray(
+        tokReqMsgCtx.addProperty(OAuthConstants.RESPONSE_HEADERS_PROPERTY, respHeaders.toArray(
                 new ResponseHeader[respHeaders.size()]));
 
         return tokenRespDTO;

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/iwa/ntlm/NTLMAuthenticationGrantHandlerWithHandshake.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/iwa/ntlm/NTLMAuthenticationGrantHandlerWithHandshake.java
@@ -20,6 +20,7 @@ package org.wso2.carbon.identity.oauth2.token.handlers.grant.iwa.ntlm;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.oauth.common.OAuthConstants;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.ResponseHeader;
 import org.wso2.carbon.identity.oauth2.token.OAuthTokenReqMessageContext;
@@ -37,7 +38,6 @@ public class NTLMAuthenticationGrantHandlerWithHandshake extends AbstractAuthori
     private static final String SCHEME_NTLM = "NTLM";
     private static final String SERVER_CONNECTION = "server-connection";
     private static final String SECURITY_PACKAGE = "Negotiate";
-    private static final String RESPONSE_HEADERS_PROPERTY = "RESPONSE_HEADERS";
 
     //This is the index of the byte which represents the NTLM token type.
     private static final int MESSAGE_TYPE_BYTE_INDEX = 8;
@@ -100,7 +100,7 @@ public class NTLMAuthenticationGrantHandlerWithHandshake extends AbstractAuthori
                 responseHeaders[0] = new ResponseHeader();
                 responseHeaders[0].setKey(HEADER_WWW_AUTHENTICATE);
                 responseHeaders[0].setValue(SCHEME_NTLM + " " + type2Token);
-                tokReqMsgCtx.addProperty(RESPONSE_HEADERS_PROPERTY, responseHeaders);
+                tokReqMsgCtx.addProperty(OAuthConstants.RESPONSE_HEADERS_PROPERTY, responseHeaders);
                 return false;
             } else if (tokenType == NTLM_TYPE_3_TOKEN) {
                 serverContext = provider.acceptSecurityToken(SERVER_CONNECTION, bytesToken, SECURITY_PACKAGE);


### PR DESCRIPTION
Apache Oltu's AbstractValidator class use several  protected  member variables. When extending from AbstractValidator, a concrete class has to access above  protected  member variables  directly, according to OOP principles  this is a very bad design. This fix introduce  a new AbstractValidator class with proper methods to  access/modify above variables.  OAuth2 grant type validator implementations   should use this newly introduced  AbstractValidator class. 