### PR TITLE
IDENTITY-6261: Adding capability to add multiple scope validators.

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/DefaultOAuth2TokenValidator.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/DefaultOAuth2TokenValidator.java
@@ -23,9 +23,7 @@ import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2TokenValidationRequestDTO;
 import org.wso2.carbon.identity.oauth2.model.AccessTokenDO;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
+import java.util.Set;
 
 /**
  * Default OAuth2 access token validator that supports "bearer" token type.
@@ -35,7 +33,6 @@ public class DefaultOAuth2TokenValidator implements OAuth2TokenValidator {
 
     public static final String TOKEN_TYPE = "bearer";
     private static final String ACCESS_TOKEN_DO = "AccessTokenDO";
-    private static final String OIDC_SCOPE_VALIDATOR_CLASS = "org.wso2.carbon.identity.oauth2.validators.OIDCScopeValidator";
 
     @Override
     public boolean validateAccessDelegation(OAuth2TokenValidationMessageContext messageContext)
@@ -49,30 +46,11 @@ public class DefaultOAuth2TokenValidator implements OAuth2TokenValidator {
     public boolean validateScope(OAuth2TokenValidationMessageContext messageContext)
             throws IdentityOAuth2Exception {
 
-        OAuth2ScopeValidator scopeValidator = OAuthServerConfiguration.getInstance().getoAuth2ScopeValidator();
-        if (scopeValidator != null && scopeValidator.getClass() != null && messageContext.getRequestDTO() != null) {
-            //if OIDC scope validator is engaged through the configuration
-            if (scopeValidator.getClass().getName().equals(OIDC_SCOPE_VALIDATOR_CLASS)) {
-                List<String> idTokenAllowedGrantTypesList = new ArrayList();
-                Map<String, String> idTokenAllowedGrantTypesMap = OAuthServerConfiguration.getInstance().
-                        getIdTokenAllowedForGrantTypesMap();
-                if (!idTokenAllowedGrantTypesMap.isEmpty()) {
-                    for (Map.Entry<String, String> entry : idTokenAllowedGrantTypesMap.entrySet()) {
-                        if (Boolean.parseBoolean(entry.getValue())) {
-                            idTokenAllowedGrantTypesList.add(entry.getKey());
-                        }
-                    }
-                }
-                if (!idTokenAllowedGrantTypesList.isEmpty()) {
-                    return scopeValidator.validateScope((AccessTokenDO) messageContext.getProperty(ACCESS_TOKEN_DO),
-                            idTokenAllowedGrantTypesList.toString());
-                } else {
-                    return scopeValidator.validateScope((AccessTokenDO) messageContext.getProperty(ACCESS_TOKEN_DO),
-                            null);
-                }
-            }
-            //If any other scope validator is engaged through the configuration
-            else {
+        Set<OAuth2ScopeValidator> oAuth2ScopeValidators = OAuthServerConfiguration.getInstance()
+                .getOAuth2ScopeValidators();
+        for (OAuth2ScopeValidator validator: oAuth2ScopeValidators) {
+
+            if (validator != null && validator.canHandle(messageContext)) {
                 String resource = null;
                 if (messageContext.getRequestDTO().getContext() != null) {
                     //Iterate the array of context params to find the 'resource' context param.
@@ -85,12 +63,12 @@ public class DefaultOAuth2TokenValidator implements OAuth2TokenValidator {
                         }
                     }
                 }
+                boolean isValid = validator.validateScope((AccessTokenDO) messageContext.getProperty
+                        (ACCESS_TOKEN_DO), resource);
 
-                //Return True if there is no resource to validate the token against
-                //OR if the token has a valid scope to access the resource. False otherwise.
-                return resource == null ||
-                        scopeValidator.validateScope((AccessTokenDO) messageContext.getProperty(ACCESS_TOKEN_DO),
-                                resource);
+                if (!isValid) {
+                    return false;
+                }
             }
         }
         return true;

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/JDBCScopeValidator.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/JDBCScopeValidator.java
@@ -63,6 +63,11 @@ public class JDBCScopeValidator extends OAuth2ScopeValidator {
     @Override
     public boolean validateScope(AccessTokenDO accessTokenDO, String resource) throws IdentityOAuth2Exception {
 
+        // Return true if there is no resource to validate the token against.
+        if (resource == null) {
+            return true;
+        }
+
         //Get the list of scopes associated with the access token
         String[] scopes = accessTokenDO.getScope();
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/OAuth2ScopeValidator.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/OAuth2ScopeValidator.java
@@ -21,6 +21,8 @@ package org.wso2.carbon.identity.oauth2.validators;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.model.AccessTokenDO;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -29,6 +31,7 @@ import java.util.Set;
 public abstract class OAuth2ScopeValidator {
 
     protected Set<String> scopesToSkip;
+    protected Map<String, String> properties = new HashMap<>();
 
     /**
      * Method to validate the scopes associated with the access token against the resource that is being accessed.
@@ -48,4 +51,21 @@ public abstract class OAuth2ScopeValidator {
         this.scopesToSkip = scopesToSkip;
     }
 
+    public Map<String, String> getProperties() {
+        return properties;
+    }
+
+    public void setProperties(Map<String, String> properties) {
+        this.properties = properties;
+    }
+
+    /**
+     * Checks whether a given scopes can be handled by the validator.
+     *
+     * @param messageContext OAuth2TokenValidationMessageContext for the request.
+     * @return true if the given scopes can be validated, otherwise false.
+     */
+    public boolean canHandle(OAuth2TokenValidationMessageContext messageContext) {
+        return true;
+    }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/OIDCScopeValidator.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/OIDCScopeValidator.java
@@ -18,35 +18,17 @@
 
 package org.wso2.carbon.identity.oauth2.validators;
 
-import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.oltu.oauth2.common.message.types.GrantType;
-import org.wso2.carbon.base.MultitenantConstants;
-import org.wso2.carbon.context.PrivilegedCarbonContext;
-import org.wso2.carbon.identity.application.common.model.User;
-import org.wso2.carbon.identity.base.IdentityConstants;
-import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
-import org.wso2.carbon.identity.core.util.IdentityUtil;
-import org.wso2.carbon.identity.oauth.cache.CacheEntry;
-import org.wso2.carbon.identity.oauth.cache.OAuthCache;
-import org.wso2.carbon.identity.oauth.cache.OAuthCacheKey;
 import org.wso2.carbon.identity.oauth.common.OAuthConstants;
 import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
-import org.wso2.carbon.identity.oauth.internal.OAuthComponentServiceHolder;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
-import org.wso2.carbon.identity.oauth2.dao.TokenMgtDAO;
 import org.wso2.carbon.identity.oauth2.model.AccessTokenDO;
-import org.wso2.carbon.identity.oauth2.model.ResourceScopeCacheEntry;
-import org.wso2.carbon.user.api.UserStoreException;
-import org.wso2.carbon.user.api.UserStoreManager;
-import org.wso2.carbon.user.core.service.RealmService;
-import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
-import java.util.Set;
+import java.util.Map;
 
 
 /**
@@ -60,51 +42,59 @@ public class OIDCScopeValidator extends OAuth2ScopeValidator {
     /**
      * Returns whether the grant types are validated with "openid" scope.
      *
-     * @param accessTokenDO            - The access token data object
-     * @param idTokenAllowedGrantTypes grant types expected sample value "[implicit,password]"
-     * @return true if the grant type is valid
+     * @param accessTokenDO The access token data object.
+     * @param resource The resource that is being accessed.
+     * @return true if the grant type is valid.
      * @throws IdentityOAuth2Exception
      */
     @Override
-    public boolean validateScope(AccessTokenDO accessTokenDO, String idTokenAllowedGrantTypes) throws IdentityOAuth2Exception {
+    public boolean validateScope(AccessTokenDO accessTokenDO, String resource) throws IdentityOAuth2Exception {
 
-        //Get the list of scopes associated with the access token
-        String[] scopes = accessTokenDO.getScope();
         List<String> idTokenAllowedGrantList = new ArrayList<>();
-        if (StringUtils.isNotBlank(idTokenAllowedGrantTypes)) {
-            idTokenAllowedGrantList = Arrays.asList(idTokenAllowedGrantTypes.substring(1,
-                    idTokenAllowedGrantTypes.length() - 1).split(", "));
-        }
-        //If no scopes are associated with the token
-        if (scopes != null && scopes.length > 0) {
-            String grantTypeValue = accessTokenDO.getGrantType();
+        Map<String, String> idTokenAllowedGrantTypesMap = OAuthServerConfiguration.getInstance().
+                getIdTokenAllowedForGrantTypesMap();
 
-            for (String scope : scopes) {
-                if (scope.trim().equals(OAuthConstants.Scope.OPENID)) {
-                    //validating the authorization_code grant type with open id scope ignoring the IdTokenAllowed element
-                    // defined in the identity.xml
-                    if (GrantType.AUTHORIZATION_CODE.toString().equals(grantTypeValue)) {
+        if (!idTokenAllowedGrantTypesMap.isEmpty()) {
+            for (Map.Entry<String, String> entry : idTokenAllowedGrantTypesMap.entrySet()) {
+                if (Boolean.parseBoolean(entry.getValue())) {
+                    idTokenAllowedGrantList.add(entry.getKey());
+                }
+            }
+        }
+
+        String grantTypeValue = accessTokenDO.getGrantType();
+
+        // validating the authorization_code grant type with open id scope ignoring the IdTokenAllowed element defined
+        // in the identity.xml
+        if (GrantType.AUTHORIZATION_CODE.toString().equals(grantTypeValue)) {
+            return true;
+        } else if (idTokenAllowedGrantList.contains(grantTypeValue)) {
+            // if id_token is allowed for requested grant type.
+            return true;
+        } else {
+            if (log.isDebugEnabled()) {
+                log.debug("id_token is not allowed for requested grant type: " + grantTypeValue);
+            }
+            return false;
+        }
+    }
+
+    @Override
+    public boolean canHandle(OAuth2TokenValidationMessageContext messageContext) {
+
+        AccessTokenDO accessTokenDO = (AccessTokenDO) messageContext.getProperty("AccessTokenDO");
+        if (accessTokenDO != null) {
+            //Get the list of scopes associated with the access token
+            String[] scopes = accessTokenDO.getScope();
+
+            if (scopes != null && scopes.length > 0) {
+                for (String scope : scopes) {
+                    if (scope.trim().equals(OAuthConstants.Scope.OPENID)) {
                         return true;
-                    }
-                    //if id token is allowed for requested grant type
-                    if (idTokenAllowedGrantList.contains(grantTypeValue)) {
-                        return true;
-                    } else {
-                        if (log.isDebugEnabled()) {
-                            log.debug("Id Token is not allowed for requested grant type.");
-                        }
-                        return false;
                     }
                 }
-                return true;
             }
-            if (log.isDebugEnabled()) {
-                log.debug("No requested scope is defined in accessTokenDO.");
-            }
-            return false;
-
-        } else {
-            return false;
         }
+        return false;
     }
 }


### PR DESCRIPTION
With this improvement, multiple `OAuth2ScopeValidator` implementations can be registered in `identity.xml`. A sample configuration is as follows.

```xml
<OAuth>
    ....
    <ScopeValidators>
        <ScopeValidator class="org.fully.qualified.class.name.ExtendedScopeValidator" scopesToSkip="scope1 scope2">
            <Property name="foo-property">foo-value</Property>
        
        </ScopeValidators>
```