### PR TITLE
IDENTITY-6774: Decouple OAuth2 grant handling from client_id, client_secret authentication

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
@@ -27,11 +27,8 @@ import org.apache.oltu.oauth2.as.issuer.OAuthIssuer;
 import org.apache.oltu.oauth2.as.issuer.OAuthIssuerImpl;
 import org.apache.oltu.oauth2.as.issuer.UUIDValueGenerator;
 import org.apache.oltu.oauth2.as.issuer.ValueGenerator;
-import org.apache.oltu.oauth2.as.validator.AuthorizationCodeValidator;
 import org.apache.oltu.oauth2.as.validator.ClientCredentialValidator;
 import org.apache.oltu.oauth2.as.validator.CodeValidator;
-import org.apache.oltu.oauth2.as.validator.PasswordValidator;
-import org.apache.oltu.oauth2.as.validator.RefreshTokenValidator;
 import org.apache.oltu.oauth2.as.validator.TokenValidator;
 import org.apache.oltu.oauth2.common.message.types.GrantType;
 import org.apache.oltu.oauth2.common.message.types.ResponseType;
@@ -53,8 +50,11 @@ import org.wso2.carbon.identity.oauth2.token.OauthTokenIssuerImpl;
 import org.wso2.carbon.identity.oauth2.token.handlers.clientauth.ClientAuthenticationHandler;
 import org.wso2.carbon.identity.oauth2.token.handlers.grant.AuthorizationGrantHandler;
 import org.wso2.carbon.identity.oauth2.token.handlers.grant.saml.SAML2TokenCallbackHandler;
+import org.wso2.carbon.identity.oauth2.validators.grant.AuthorizationCodeGrantValidator;
 import org.wso2.carbon.identity.oauth2.validators.OAuth2ScopeHandler;
 import org.wso2.carbon.identity.oauth2.validators.OAuth2ScopeValidator;
+import org.wso2.carbon.identity.oauth2.validators.grant.PasswordGrantValidator;
+import org.wso2.carbon.identity.oauth2.validators.grant.RefreshTokenGrantValidator;
 import org.wso2.carbon.identity.openidconnect.CustomClaimsCallbackHandler;
 import org.wso2.carbon.identity.openidconnect.IDTokenBuilder;
 import org.wso2.carbon.utils.CarbonUtils;
@@ -558,13 +558,13 @@ public class OAuthServerConfiguration {
                             new Hashtable<>();
                     // Load default grant type validators
                     supportedGrantTypeValidatorsTemp
-                            .put(GrantType.PASSWORD.toString(), PasswordValidator.class);
+                            .put(GrantType.PASSWORD.toString(), PasswordGrantValidator.class);
                     supportedGrantTypeValidatorsTemp.put(GrantType.CLIENT_CREDENTIALS.toString(),
                             ClientCredentialValidator.class);
                     supportedGrantTypeValidatorsTemp.put(GrantType.AUTHORIZATION_CODE.toString(),
-                            AuthorizationCodeValidator.class);
+                            AuthorizationCodeGrantValidator.class);
                     supportedGrantTypeValidatorsTemp.put(GrantType.REFRESH_TOKEN.toString(),
-                            RefreshTokenValidator.class);
+                            RefreshTokenGrantValidator.class);
                     supportedGrantTypeValidatorsTemp.put(
                             org.wso2.carbon.identity.oauth.common.GrantType.SAML20_BEARER
                                     .toString(), SAML2GrantValidator.class);

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AbstractValidator.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AbstractValidator.java
@@ -31,11 +31,14 @@ import java.util.Map;
  *
  * @since 5.4.10
  */
-public abstract class AbstractValidator
-		extends org.apache.oltu.oauth2.common.validators.AbstractValidator {
+public abstract class AbstractValidator extends org.apache.oltu.oauth2.common.validators.AbstractValidator {
 
 	public AbstractValidator() {
 		super();
+		// Client Authentication is handled by
+		// org.wso2.carbon.identity.oauth2.token.handlers.clientauth.ClientAuthenticationHandler extensions point.
+		// Therefore client_id and client_secret are not mandatory since client can authenticate with other means.
+		setEnforceClientAuthentication(false);
 		configureParams();
 	}
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/grant/AuthorizationCodeGrantValidator.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/grant/AuthorizationCodeGrantValidator.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.carbon.identity.oauth2.validators.grant;
+
+import org.apache.oltu.oauth2.as.validator.AuthorizationCodeValidator;
+
+/**
+ * Grant validator for Authorization Code Grant Type
+ */
+public class AuthorizationCodeGrantValidator extends AuthorizationCodeValidator {
+
+    public AuthorizationCodeGrantValidator() {
+        super();
+        // Client Authentication is handled by
+        // org.wso2.carbon.identity.oauth2.token.handlers.clientauth.ClientAuthenticationHandler extensions point.
+        // Therefore client_id and client_secret are not mandatory since client can authenticate with other means.
+        enforceClientAuthentication = false;
+    }
+}

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/grant/PasswordGrantValidator.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/grant/PasswordGrantValidator.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.carbon.identity.oauth2.validators.grant;
+
+import org.apache.oltu.oauth2.as.validator.PasswordValidator;
+
+/**
+ * Grant validator for Resource Owner Password Grant Type
+ */
+public class PasswordGrantValidator extends PasswordValidator {
+
+    public PasswordGrantValidator() {
+        super();
+        // Client Authentication is handled by
+        // org.wso2.carbon.identity.oauth2.token.handlers.clientauth.ClientAuthenticationHandler extensions point.
+        // Therefore client_id and client_secret are not mandatory since client can authenticate with other means.
+        enforceClientAuthentication = false;
+    }
+}

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/grant/PasswordGrantValidator.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/grant/PasswordGrantValidator.java
@@ -19,7 +19,7 @@ package org.wso2.carbon.identity.oauth2.validators.grant;
 import org.apache.oltu.oauth2.as.validator.PasswordValidator;
 
 /**
- * Grant validator for Resource Owner Password Grant Type
+ * Grant validator for Resource Owner Password Grant Type.
  */
 public class PasswordGrantValidator extends PasswordValidator {
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/grant/RefreshTokenGrantValidator.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/grant/RefreshTokenGrantValidator.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.carbon.identity.oauth2.validators.grant;
+
+import org.apache.oltu.oauth2.as.validator.RefreshTokenValidator;
+
+/**
+ * Grant validator for Refresh Token Grant Type
+ */
+public class RefreshTokenGrantValidator extends RefreshTokenValidator {
+
+    public RefreshTokenGrantValidator() {
+        super();
+        // Client Authentication is handled by
+        // org.wso2.carbon.identity.oauth2.token.handlers.clientauth.ClientAuthenticationHandler extensions point.
+        // Therefore client_id and client_secret are not mandatory since client can authenticate with other means.
+        enforceClientAuthentication = false;
+    }
+}


### PR DESCRIPTION
### Proposed changes in this pull request
- Remove client_id, client_secret authentication enforced by Oltu since it is already handled by another layer in OAuth2 component.

https://www.wso2.org/jira/browse/IDENTITY-6774