### PR TITLE
Integrate DB backed Service Provider public certs with Request Object Signature validation

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
@@ -236,8 +236,17 @@ public class EndpointUtil {
 
         String errorPageUrl = OAuth2Util.OAuthURL.getOAuth2ErrorPageUrl();
         try {
-            errorPageUrl += "?" + OAuthConstants.OAUTH_ERROR_CODE + "=" + URLEncoder.encode(errorCode, UTF_8) +
-                    "&" + OAuthConstants.OAUTH_ERROR_MESSAGE + "=" + URLEncoder.encode(errorMessage, UTF_8);
+
+            if (StringUtils.isNotBlank(errorCode)) {
+                errorPageUrl = FrameworkUtils.appendQueryParamsStringToUrl(errorPageUrl,
+                        OAuthConstants.OAUTH_ERROR_CODE + "=" + URLEncoder.encode(errorCode, UTF_8));
+            }
+
+            if (StringUtils.isNotBlank(errorMessage)) {
+                errorPageUrl = FrameworkUtils.appendQueryParamsStringToUrl(errorPageUrl,
+                        OAuthConstants.OAUTH_ERROR_MESSAGE + "=" + URLEncoder.encode(errorMessage, UTF_8));
+            }
+
         } catch (UnsupportedEncodingException e) {
             //ignore
             if (log.isDebugEnabled()){

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpointTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpointTest.java
@@ -114,6 +114,7 @@ import static org.mockito.Matchers.anySet;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.MockitoAnnotations.initMocks;
 import static org.powermock.api.mockito.PowerMockito.doAnswer;
+import static org.powermock.api.mockito.PowerMockito.doCallRealMethod;
 import static org.powermock.api.mockito.PowerMockito.doNothing;
 import static org.powermock.api.mockito.PowerMockito.doReturn;
 import static org.powermock.api.mockito.PowerMockito.doThrow;
@@ -1238,6 +1239,7 @@ public class OAuth2AuthzEndpointTest extends TestOAuthEndpointBase {
 
         mockStatic(FrameworkUtils.class);
         when(FrameworkUtils.getRequestCoordinator()).thenReturn(requestCoordinator);
+        when(FrameworkUtils.appendQueryParamsStringToUrl(anyString(), anyString())).thenCallRealMethod();
 
         doAnswer(new Answer<Object>() {
             @Override

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/RequestObjectException.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/RequestObjectException.java
@@ -37,7 +37,8 @@ public class RequestObjectException extends FrameworkException {
 
     public RequestObjectException(String errorMessage) {
         super(errorMessage);
-        this.errorCode = null;
+        // By default we set the invalid_request error code.
+        this.errorCode = ERROR_CODE_INVALID_REQUEST;
         this.errorMessage = errorMessage;
     }
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/RequestObjectException.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/RequestObjectException.java
@@ -26,28 +26,31 @@ public class RequestObjectException extends FrameworkException {
 
     public static final String ERROR_CODE_INVALID_REQUEST = "invalid_request";
     private static final long serialVersionUID = -4449780649560053452L;
-    private final String errorCode;
-    private final String errorMessage;
+    private String errorMessage;
 
     public RequestObjectException(String errorCode, String errorMessage) {
-        super(errorMessage);
-        this.errorCode = errorCode;
+        super(errorCode, errorMessage);
+        this.errorMessage = errorMessage;
+    }
+
+    public RequestObjectException(String errorCode, String errorMessage, Throwable cause) {
+        super(errorCode, errorMessage, cause);
         this.errorMessage = errorMessage;
     }
 
     public RequestObjectException(String errorMessage) {
-        super(errorMessage);
         // By default we set the invalid_request error code.
-        this.errorCode = ERROR_CODE_INVALID_REQUEST;
+        super(ERROR_CODE_INVALID_REQUEST, errorMessage);
         this.errorMessage = errorMessage;
     }
 
-    public String getErrorCode() {
-        return errorCode;
+    public RequestObjectException(String errorMessage, Throwable cause) {
+        // By default we set the invalid_request error code.
+        super(ERROR_CODE_INVALID_REQUEST, errorMessage, cause);
+        this.errorMessage = errorMessage;
     }
 
     public String getErrorMessage() {
         return errorMessage;
     }
 }
-

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -2068,10 +2068,10 @@ public class OAuth2Util {
 
         try {
             ServiceProvider serviceProvider = OAuth2Util.getServiceProvider(clientId, tenantDomain);
-            // Get the certificate content
+            // Get the certificate content.
             String certificateContent = serviceProvider.getCertificateContent();
             if (StringUtils.isNotBlank(certificateContent)) {
-                // Get the cert and return
+                // Build the Certificate object from cert content.
                 return IdentityUtil.convertPEMEncodedContentToCertificate(certificateContent);
             } else {
                 throw new IdentityOAuth2Exception("Public certificate not configured for Service Provider with " +

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -45,6 +45,10 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.wso2.carbon.core.util.KeyStoreManager;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
+import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
+import org.wso2.carbon.identity.application.common.model.ServiceProvider;
+import org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants;
+import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.base.IdentityConstants;
 import org.wso2.carbon.identity.base.IdentityException;
 import org.wso2.carbon.identity.core.util.IdentityConfigParser;
@@ -70,10 +74,8 @@ import org.wso2.carbon.identity.oauth2.config.SpOAuth2ExpiryTimeConfiguration;
 import org.wso2.carbon.identity.oauth2.dao.OAuthTokenPersistenceFactory;
 import org.wso2.carbon.identity.oauth2.internal.OAuth2ServiceComponentHolder;
 import org.wso2.carbon.identity.oauth2.model.AccessTokenDO;
-import org.wso2.carbon.identity.oauth2.model.AuthzCodeDO;
 import org.wso2.carbon.identity.oauth2.model.ClientCredentialDO;
 import org.wso2.carbon.identity.oauth2.token.OAuthTokenReqMessageContext;
-import org.wso2.carbon.identity.openidconnect.OIDCConstants;
 import org.wso2.carbon.identity.openidconnect.model.RequestedClaim;
 import org.wso2.carbon.registry.core.Registry;
 import org.wso2.carbon.registry.core.Resource;
@@ -2046,5 +2048,18 @@ public class OAuth2Util {
         return isExplicitlyFederatedUser && isFederatedUserNotMappedToLocalUser;
     }
 
+
+    public static ServiceProvider getServiceProvider(String clientId,
+                                                     String tenantDomain) throws IdentityOAuth2Exception {
+        ApplicationManagementService applicationMgtService = OAuth2ServiceComponentHolder.getApplicationMgtService();
+        try {
+            // Get the Service Provider.
+            return applicationMgtService.getServiceProviderByClientId(
+                    clientId, IdentityApplicationConstants.OAuth2.NAME, tenantDomain);
+        } catch (IdentityApplicationManagementException e) {
+            throw new IdentityOAuth2Exception("Error while obtaining the service provider for client_id: " +
+                    clientId + " of tenantDomain: " + tenantDomain, e);
+        }
+    }
 }
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -2050,6 +2050,14 @@ public class OAuth2Util {
         return isExplicitlyFederatedUser && isFederatedUserNotMappedToLocalUser;
     }
 
+    /**
+     * Returns the service provider associated with the OAuth clientId.
+     *
+     * @param clientId OAuth2/OIDC Client Identifier
+     * @param tenantDomain
+     * @return
+     * @throws IdentityOAuth2Exception
+     */
     public static ServiceProvider getServiceProvider(String clientId,
                                                      String tenantDomain) throws IdentityOAuth2Exception {
         ApplicationManagementService applicationMgtService = OAuth2ServiceComponentHolder.getApplicationMgtService();
@@ -2063,6 +2071,15 @@ public class OAuth2Util {
         }
     }
 
+    /**
+     *  Returns the public certificate of the service provider associated with the OAuth consumer app as
+     *  an X509 @{@link Certificate} object.
+     *
+     * @param clientId OAuth2/OIDC Client Identifier
+     * @param tenantDomain
+     * @return
+     * @throws IdentityOAuth2Exception
+     */
     public static Certificate getX509CertOfOAuthApp(String clientId,
                                                     String tenantDomain) throws IdentityOAuth2Exception {
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -2064,7 +2064,7 @@ public class OAuth2Util {
     }
 
     public static Certificate getPublicCertOfOAuthApp(String clientId,
-                                                         String tenantDomain) throws IdentityOAuth2Exception {
+                                                      String tenantDomain) throws IdentityOAuth2Exception {
 
         try {
             ServiceProvider serviceProvider = OAuth2Util.getServiceProvider(clientId, tenantDomain);

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -2063,8 +2063,8 @@ public class OAuth2Util {
         }
     }
 
-    public static Certificate getPublicCertOfOAuthApp(String clientId,
-                                                      String tenantDomain) throws IdentityOAuth2Exception {
+    public static Certificate getX509CertOfOAuthApp(String clientId,
+                                                    String tenantDomain) throws IdentityOAuth2Exception {
 
         try {
             ServiceProvider serviceProvider = OAuth2Util.getServiceProvider(clientId, tenantDomain);
@@ -2079,7 +2079,7 @@ public class OAuth2Util {
             }
         } catch (CertificateException e) {
             throw new IdentityOAuth2Exception("Error while building X509 cert of oauth app with client_id: "
-                    + clientId + " of tenantDomain: " + tenantDomain);
+                    + clientId + " of tenantDomain: " + tenantDomain, e);
         }
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/RequestObjectValidatorImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/RequestObjectValidatorImpl.java
@@ -204,45 +204,45 @@ public class RequestObjectValidatorImpl implements RequestObjectValidator {
                 + currentAudience);
     }
 
-    /**
-     * Get the X509CredentialImpl object for a particular tenant and alias
-     *
-     * @param tenantDomain tenant domain of the issuer
-     * @param alias        alias of cert
-     * @return X509Certificate object containing the public certificate in the primary keystore of the tenantDOmain
-     * with alias
-     */
-    @Deprecated
-    protected Certificate getCertificateForAlias(String tenantDomain, String alias) throws RequestObjectException {
-
-        int tenantId;
-        String error = "Unable to Validate the Signature of Request Object";
-        tenantId = IdentityTenantUtil.getTenantId(tenantDomain);
-        KeyStoreManager keyStoreManager;
-        // get an instance of the corresponding Key Store Manager instance
-        keyStoreManager = KeyStoreManager.getInstance(tenantId);
-        KeyStore keyStore;
-        try {
-            // for tenants, load key from their generated key store
-            if (tenantId != MultitenantConstants.SUPER_TENANT_ID) {
-                keyStore = keyStoreManager.getKeyStore(generateKSNameFromDomainName(tenantDomain));
-            } else {
-                // for super tenant, load the default pub. cert using the config. in carbon.xml
-                keyStore = keyStoreManager.getPrimaryKeyStore();
-            }
-            return keyStore.getCertificate(alias);
-
-        } catch (KeyStoreException e) {
-            String errorMsg = "Error instantiating an X509Certificate object for the certificate alias:" + alias +
-                    " in tenant:" + tenantDomain;
-            log.error(errorMsg, e);
-            throw new RequestObjectException(OAuth2ErrorCodes.SERVER_ERROR, error);
-        } catch (Exception e) {
-            //keyStoreManager throws Exception
-            log.error("Unable to load key store manager for the tenant domain:" + tenantDomain, e);
-            throw new RequestObjectException(OAuth2ErrorCodes.SERVER_ERROR, error);
-        }
-    }
+//    /**
+//     * Get the X509CredentialImpl object for a particular tenant and alias
+//     *
+//     * @param tenantDomain tenant domain of the issuer
+//     * @param alias        alias of cert
+//     * @return X509Certificate object containing the public certificate in the primary keystore of the tenantDOmain
+//     * with alias
+//     */
+//    @Deprecated
+//    protected Certificate getCertificateForAlias(String tenantDomain, String alias) throws RequestObjectException {
+//
+//        int tenantId;
+//        String error = "Unable to Validate the Signature of Request Object";
+//        tenantId = IdentityTenantUtil.getTenantId(tenantDomain);
+//        KeyStoreManager keyStoreManager;
+//        // get an instance of the corresponding Key Store Manager instance
+//        keyStoreManager = KeyStoreManager.getInstance(tenantId);
+//        KeyStore keyStore;
+//        try {
+//            // for tenants, load key from their generated key store
+//            if (tenantId != MultitenantConstants.SUPER_TENANT_ID) {
+//                keyStore = keyStoreManager.getKeyStore(generateKSNameFromDomainName(tenantDomain));
+//            } else {
+//                // for super tenant, load the default pub. cert using the config. in carbon.xml
+//                keyStore = keyStoreManager.getPrimaryKeyStore();
+//            }
+//            return keyStore.getCertificate(alias);
+//
+//        } catch (KeyStoreException e) {
+//            String errorMsg = "Error instantiating an X509Certificate object for the certificate alias:" + alias +
+//                    " in tenant:" + tenantDomain;
+//            log.error(errorMsg, e);
+//            throw new RequestObjectException(OAuth2ErrorCodes.SERVER_ERROR, error);
+//        } catch (Exception e) {
+//            //keyStoreManager throws Exception
+//            log.error("Unable to load key store manager for the tenant domain:" + tenantDomain, e);
+//            throw new RequestObjectException(OAuth2ErrorCodes.SERVER_ERROR, error);
+//        }
+//    }
 
     /**
      * Get the X509CredentialImpl object for a particular tenant and alias
@@ -260,16 +260,16 @@ public class RequestObjectValidatorImpl implements RequestObjectValidator {
         }
     }
 
-    /**
-     * Generate the key store name from the domain name
-     *
-     * @param tenantDomain tenant domain name
-     * @return key store file name
-     */
-    protected static String generateKSNameFromDomainName(String tenantDomain) {
-        String ksName = tenantDomain.trim().replace(FULL_STOP_DELIMITER, DASH_DELIMITER);
-        return ksName + KEYSTORE_FILE_EXTENSION;
-    }
+//    /**
+//     * Generate the key store name from the domain name
+//     *
+//     * @param tenantDomain tenant domain name
+//     * @return key store file name
+//     */
+//    protected static String generateKSNameFromDomainName(String tenantDomain) {
+//        String ksName = tenantDomain.trim().replace(FULL_STOP_DELIMITER, DASH_DELIMITER);
+//        return ksName + KEYSTORE_FILE_EXTENSION;
+//    }
 
     /**
      * Validate the signedJWT signature with given certificate

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/RequestObjectValidatorImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/RequestObjectValidatorImpl.java
@@ -25,15 +25,11 @@ import com.nimbusds.jwt.SignedJWT;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.wso2.carbon.base.MultitenantConstants;
-import org.wso2.carbon.core.util.KeyStoreManager;
 import org.wso2.carbon.identity.application.common.model.FederatedAuthenticatorConfig;
 import org.wso2.carbon.identity.application.common.model.IdentityProvider;
-import org.wso2.carbon.identity.application.common.model.ServiceProvider;
 import org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants;
 import org.wso2.carbon.identity.application.common.util.IdentityApplicationManagementUtil;
 import org.wso2.carbon.identity.base.IdentityConstants;
-import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.oauth.common.OAuth2ErrorCodes;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
@@ -45,19 +41,12 @@ import org.wso2.carbon.identity.openidconnect.model.RequestObject;
 import org.wso2.carbon.idp.mgt.IdentityProviderManagementException;
 import org.wso2.carbon.idp.mgt.IdentityProviderManager;
 
-import java.security.KeyStore;
-import java.security.KeyStoreException;
 import java.security.PublicKey;
 import java.security.cert.Certificate;
-import java.security.cert.CertificateException;
 import java.security.interfaces.RSAPublicKey;
 import java.util.List;
 
-import static org.apache.commons.lang.StringUtils.getCommonPrefix;
 import static org.apache.commons.lang.StringUtils.isEmpty;
-import static org.wso2.carbon.identity.openidconnect.model.Constants.DASH_DELIMITER;
-import static org.wso2.carbon.identity.openidconnect.model.Constants.FULL_STOP_DELIMITER;
-import static org.wso2.carbon.identity.openidconnect.model.Constants.KEYSTORE_FILE_EXTENSION;
 import static org.wso2.carbon.identity.openidconnect.model.Constants.RS;
 
 /**
@@ -81,7 +70,7 @@ public class RequestObjectValidatorImpl implements RequestObjectValidator {
 
         SignedJWT jwt = requestObject.getSignedJWT();
         Certificate certificate =
-                getPublicCertOfOAuthApp(oAuth2Parameters.getClientId(), oAuth2Parameters.getTenantDomain());
+                getX509CertOfOAuthApp(oAuth2Parameters.getClientId(), oAuth2Parameters.getTenantDomain());
         boolean isVerified = isSignatureVerified(jwt, certificate);
         requestObject.setIsSignatureValid(isVerified);
         return isVerified;
@@ -204,6 +193,16 @@ public class RequestObjectValidatorImpl implements RequestObjectValidator {
                 + currentAudience);
     }
 
+
+    /**
+     * @deprecated use @{@link RequestObjectValidatorImpl#getX509CertOfOAuthApp(String, String)}} instead
+     * to retrieve the public certificate of the Service Provider in X509 format.
+     */
+    @Deprecated
+    protected Certificate getCertificateForAlias(String tenantDomain, String alias) throws RequestObjectException {
+        return getX509CertOfOAuthApp(alias, tenantDomain);
+    }
+
     /**
      * Get the X509Certificate object containing the public key of the OAuth client.
      *
@@ -211,12 +210,12 @@ public class RequestObjectValidatorImpl implements RequestObjectValidator {
      * @param tenantDomain tenant domain of Service Provider.
      * @return X509Certificate object containing the public certificate of the Service Provider.
      */
-    protected Certificate getPublicCertOfOAuthApp(String clientId, String tenantDomain) throws RequestObjectException {
+    protected Certificate getX509CertOfOAuthApp(String clientId, String tenantDomain) throws RequestObjectException {
         try {
-            return OAuth2Util.getPublicCertOfOAuthApp(clientId, tenantDomain);
+            return OAuth2Util.getX509CertOfOAuthApp(clientId, tenantDomain);
         } catch (IdentityOAuth2Exception e) {
             throw new RequestObjectException("Error retrieving public certificate of OAuth app with client_id: "
-                    + clientId + " of tenantDomain: " + tenantDomain);
+                    + clientId + " of tenantDomain: " + tenantDomain, e);
         }
     }
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/RequestObjectValidatorImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/RequestObjectValidatorImpl.java
@@ -29,6 +29,7 @@ import org.wso2.carbon.base.MultitenantConstants;
 import org.wso2.carbon.core.util.KeyStoreManager;
 import org.wso2.carbon.identity.application.common.model.FederatedAuthenticatorConfig;
 import org.wso2.carbon.identity.application.common.model.IdentityProvider;
+import org.wso2.carbon.identity.application.common.model.ServiceProvider;
 import org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants;
 import org.wso2.carbon.identity.application.common.util.IdentityApplicationManagementUtil;
 import org.wso2.carbon.identity.base.IdentityConstants;
@@ -38,6 +39,7 @@ import org.wso2.carbon.identity.oauth.common.OAuth2ErrorCodes;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.RequestObjectException;
 import org.wso2.carbon.identity.oauth2.model.OAuth2Parameters;
+import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 import org.wso2.carbon.identity.openidconnect.model.Constants;
 import org.wso2.carbon.identity.openidconnect.model.RequestObject;
 import org.wso2.carbon.idp.mgt.IdentityProviderManagementException;
@@ -47,9 +49,11 @@ import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.PublicKey;
 import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
 import java.security.interfaces.RSAPublicKey;
 import java.util.List;
 
+import static org.apache.commons.lang.StringUtils.getCommonPrefix;
 import static org.apache.commons.lang.StringUtils.isEmpty;
 import static org.wso2.carbon.identity.openidconnect.model.Constants.DASH_DELIMITER;
 import static org.wso2.carbon.identity.openidconnect.model.Constants.FULL_STOP_DELIMITER;
@@ -67,6 +71,7 @@ public class RequestObjectValidatorImpl implements RequestObjectValidator {
 
     @Override
     public boolean isSigned(RequestObject requestObject) {
+
         return requestObject.getSignedJWT() != null;
     }
 
@@ -75,13 +80,12 @@ public class RequestObjectValidatorImpl implements RequestObjectValidator {
             RequestObjectException {
 
         SignedJWT jwt = requestObject.getSignedJWT();
-        Certificate certificate = getCertificateForAlias(oAuth2Parameters.getTenantDomain(), oAuth2Parameters
-                .getClientId());
+        Certificate certificate =
+                getPublicCertOfOAuthApp(oAuth2Parameters.getClientId(), oAuth2Parameters.getTenantDomain());
         boolean isVerified = isSignatureVerified(jwt, certificate);
         requestObject.setIsSignatureValid(isVerified);
         return isVerified;
     }
-
 
     /**
      * Decide whether this request object is a signed object encrypted object or a nested object.
@@ -133,6 +137,7 @@ public class RequestObjectValidatorImpl implements RequestObjectValidator {
     }
 
     protected boolean isValidParameter(String authParam, String requestObjParam) {
+
         return StringUtils.isEmpty(requestObjParam) || requestObjParam.equals(authParam);
     }
 
@@ -170,14 +175,15 @@ public class RequestObjectValidatorImpl implements RequestObjectValidator {
     }
 
     protected boolean isValidIssuer(RequestObject requestObject, OAuth2Parameters oAuth2Parameters) {
+
         String issuer = requestObject.getClaimsSet().getIssuer();
         return StringUtils.isNotEmpty(issuer) && issuer.equals(oAuth2Parameters.getClientId());
     }
 
     private boolean isParamPresent(RequestObject requestObject, String claim) {
+
         return StringUtils.isNotEmpty(requestObject.getClaimValue(claim));
     }
-
 
     /**
      * Check whether the Token is indented for the server
@@ -206,6 +212,7 @@ public class RequestObjectValidatorImpl implements RequestObjectValidator {
      * @return X509Certificate object containing the public certificate in the primary keystore of the tenantDOmain
      * with alias
      */
+    @Deprecated
     protected Certificate getCertificateForAlias(String tenantDomain, String alias) throws RequestObjectException {
 
         int tenantId;
@@ -234,6 +241,36 @@ public class RequestObjectValidatorImpl implements RequestObjectValidator {
             //keyStoreManager throws Exception
             log.error("Unable to load key store manager for the tenant domain:" + tenantDomain, e);
             throw new RequestObjectException(OAuth2ErrorCodes.SERVER_ERROR, error);
+        }
+    }
+
+    /**
+     * Get the X509CredentialImpl object for a particular tenant and alias
+     *
+     * @param tenantDomain tenant domain of the issuer
+     * @return X509Certificate object containing the public certificate in the primary keystore of the tenantDOmain
+     * with alias
+     */
+    protected Certificate getPublicCertOfOAuthApp(String clientId, String tenantDomain) throws RequestObjectException {
+
+        try {
+            ServiceProvider serviceProvider = OAuth2Util.getServiceProvider(clientId, tenantDomain);
+            // Get the certificate content
+            String certificateContent = serviceProvider.getCertificateContent();
+            if (StringUtils.isNotBlank(certificateContent)) {
+                // Get the cert and return
+                return IdentityUtil.convertPEMEncodedContentToCertificate(certificateContent);
+            } else {
+                // Go for backward compatibility approach.
+                // TODO: throw an exception, no need of the backward compatible behaviour....
+                return getCertificateForAlias(tenantDomain, clientId);
+            }
+        } catch (IdentityOAuth2Exception e) {
+            throw new RequestObjectException("Error while retrieving public cert of oauth app with client_id: "
+                    + clientId + " of tenantDomain: " + tenantDomain);
+        } catch (CertificateException e) {
+            throw new RequestObjectException("Error while building X509 cert of oauth app with client_id: "
+                    + clientId + " of tenantDomain: " + tenantDomain);
         }
     }
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/RequestObjectValidatorImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/RequestObjectValidatorImpl.java
@@ -70,7 +70,7 @@ public class RequestObjectValidatorImpl implements RequestObjectValidator {
 
         SignedJWT jwt = requestObject.getSignedJWT();
         Certificate certificate =
-                getX509CertOfOAuthApp(oAuth2Parameters.getClientId(), oAuth2Parameters.getTenantDomain());
+                getCertificateForAlias(oAuth2Parameters.getTenantDomain(), oAuth2Parameters.getClientId());
         boolean isVerified = isSignatureVerified(jwt, certificate);
         requestObject.setIsSignatureValid(isVerified);
         return isVerified;

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/RequestObjectValidatorImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/RequestObjectValidatorImpl.java
@@ -205,11 +205,11 @@ public class RequestObjectValidatorImpl implements RequestObjectValidator {
     }
 
     /**
-     * Get the X509CredentialImpl object for a particular tenant and alias
+     * Get the X509Certificate object containing the public key of the OAuth client.
      *
-     * @param tenantDomain tenant domain of the issuer
-     * @return X509Certificate object containing the public certificate in the primary keystore of the tenantDOmain
-     * with alias
+     * @param clientId clientID of the OAuth client (Service Provider).
+     * @param tenantDomain tenant domain of Service Provider.
+     * @return X509Certificate object containing the public certificate of the Service Provider.
      */
     protected Certificate getPublicCertOfOAuthApp(String clientId, String tenantDomain) throws RequestObjectException {
         try {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/RequestObjectValidatorImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/RequestObjectValidatorImpl.java
@@ -252,24 +252,10 @@ public class RequestObjectValidatorImpl implements RequestObjectValidator {
      * with alias
      */
     protected Certificate getPublicCertOfOAuthApp(String clientId, String tenantDomain) throws RequestObjectException {
-
         try {
-            ServiceProvider serviceProvider = OAuth2Util.getServiceProvider(clientId, tenantDomain);
-            // Get the certificate content
-            String certificateContent = serviceProvider.getCertificateContent();
-            if (StringUtils.isNotBlank(certificateContent)) {
-                // Get the cert and return
-                return IdentityUtil.convertPEMEncodedContentToCertificate(certificateContent);
-            } else {
-                // Go for backward compatibility approach.
-                // TODO: throw an exception, no need of the backward compatible behaviour....
-                return getCertificateForAlias(tenantDomain, clientId);
-            }
+            return OAuth2Util.getPublicCertOfOAuthApp(clientId, tenantDomain);
         } catch (IdentityOAuth2Exception e) {
-            throw new RequestObjectException("Error while retrieving public cert of oauth app with client_id: "
-                    + clientId + " of tenantDomain: " + tenantDomain);
-        } catch (CertificateException e) {
-            throw new RequestObjectException("Error while building X509 cert of oauth app with client_id: "
+            throw new RequestObjectException("Error retrieving public certificate of OAuth app with client_id: "
                     + clientId + " of tenantDomain: " + tenantDomain);
         }
     }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/RequestObjectValidatorImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/RequestObjectValidatorImpl.java
@@ -204,46 +204,6 @@ public class RequestObjectValidatorImpl implements RequestObjectValidator {
                 + currentAudience);
     }
 
-//    /**
-//     * Get the X509CredentialImpl object for a particular tenant and alias
-//     *
-//     * @param tenantDomain tenant domain of the issuer
-//     * @param alias        alias of cert
-//     * @return X509Certificate object containing the public certificate in the primary keystore of the tenantDOmain
-//     * with alias
-//     */
-//    @Deprecated
-//    protected Certificate getCertificateForAlias(String tenantDomain, String alias) throws RequestObjectException {
-//
-//        int tenantId;
-//        String error = "Unable to Validate the Signature of Request Object";
-//        tenantId = IdentityTenantUtil.getTenantId(tenantDomain);
-//        KeyStoreManager keyStoreManager;
-//        // get an instance of the corresponding Key Store Manager instance
-//        keyStoreManager = KeyStoreManager.getInstance(tenantId);
-//        KeyStore keyStore;
-//        try {
-//            // for tenants, load key from their generated key store
-//            if (tenantId != MultitenantConstants.SUPER_TENANT_ID) {
-//                keyStore = keyStoreManager.getKeyStore(generateKSNameFromDomainName(tenantDomain));
-//            } else {
-//                // for super tenant, load the default pub. cert using the config. in carbon.xml
-//                keyStore = keyStoreManager.getPrimaryKeyStore();
-//            }
-//            return keyStore.getCertificate(alias);
-//
-//        } catch (KeyStoreException e) {
-//            String errorMsg = "Error instantiating an X509Certificate object for the certificate alias:" + alias +
-//                    " in tenant:" + tenantDomain;
-//            log.error(errorMsg, e);
-//            throw new RequestObjectException(OAuth2ErrorCodes.SERVER_ERROR, error);
-//        } catch (Exception e) {
-//            //keyStoreManager throws Exception
-//            log.error("Unable to load key store manager for the tenant domain:" + tenantDomain, e);
-//            throw new RequestObjectException(OAuth2ErrorCodes.SERVER_ERROR, error);
-//        }
-//    }
-
     /**
      * Get the X509CredentialImpl object for a particular tenant and alias
      *
@@ -259,17 +219,6 @@ public class RequestObjectValidatorImpl implements RequestObjectValidator {
                     + clientId + " of tenantDomain: " + tenantDomain);
         }
     }
-
-//    /**
-//     * Generate the key store name from the domain name
-//     *
-//     * @param tenantDomain tenant domain name
-//     * @return key store file name
-//     */
-//    protected static String generateKSNameFromDomainName(String tenantDomain) {
-//        String ksName = tenantDomain.trim().replace(FULL_STOP_DELIMITER, DASH_DELIMITER);
-//        return ksName + KEYSTORE_FILE_EXTENSION;
-//    }
 
     /**
      * Validate the signedJWT signature with given certificate

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/openidconnect/OIDCRequestObjectUtilTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/openidconnect/OIDCRequestObjectUtilTest.java
@@ -39,6 +39,7 @@ import org.wso2.carbon.identity.oauth2.model.OAuth2Parameters;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 import org.wso2.carbon.identity.openidconnect.model.Constants;
 import org.wso2.carbon.identity.openidconnect.model.RequestObject;
+import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
 import java.nio.file.Paths;
 import java.security.Key;
@@ -109,17 +110,11 @@ public class OIDCRequestObjectUtilTest extends PowerMockTestCase {
         mockStatic(OAuth2Util.class);
         when(OAuth2Util.getTenantId("carbon.super")).thenReturn(-1234);
         when((OAuth2Util.getPrivateKey(anyString(), anyInt()))).thenReturn(rsaPrivateKey);
+        when(OAuth2Util.getPublicCertOfOAuthApp(TEST_CLIENT_ID_1, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME))
+                .thenReturn(clientKeyStore.getCertificate("wso2carbon"));
 
         mockStatic(IdentityTenantUtil.class);
         when(IdentityTenantUtil.getTenantId(anyString())).thenReturn(-1234);
-
-        KeyStoreManager keyStoreManager = Mockito.mock(KeyStoreManager.class);
-        ConcurrentHashMap<String, KeyStoreManager> mtKeyStoreManagers = new ConcurrentHashMap();
-        mtKeyStoreManagers.put(String.valueOf(SUPER_TENANT_ID), keyStoreManager);
-        WhiteboxImpl.setInternalState(KeyStoreManager.class, "mtKeyStoreManagers", mtKeyStoreManagers);
-        Mockito.when(keyStoreManager.getPrimaryKeyStore()).thenReturn(wso2KeyStore);
-        Mockito.when(keyStoreManager.getKeyStore("wso2carbon.jks")).thenReturn(wso2KeyStore);
-
 
         RequestObjectValidator requestObjectValidator = PowerMockito.spy(new RequestObjectValidatorImpl());
         when((oauthServerConfigurationMock.getRequestObjectValidator())).thenReturn(requestObjectValidator);
@@ -138,8 +133,6 @@ public class OIDCRequestObjectUtilTest extends PowerMockTestCase {
         } catch (RequestObjectException e) {
             Assert.assertFalse(exceptionNotExpected, errorMsg + "Request Object Building failed due to " + e.getErrorMessage());
         }
-
-
     }
 
     @Test(expectedExceptions = {RequestObjectException.class})

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/openidconnect/OIDCRequestObjectUtilTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/openidconnect/OIDCRequestObjectUtilTest.java
@@ -110,7 +110,7 @@ public class OIDCRequestObjectUtilTest extends PowerMockTestCase {
         mockStatic(OAuth2Util.class);
         when(OAuth2Util.getTenantId("carbon.super")).thenReturn(-1234);
         when((OAuth2Util.getPrivateKey(anyString(), anyInt()))).thenReturn(rsaPrivateKey);
-        when(OAuth2Util.getPublicCertOfOAuthApp(TEST_CLIENT_ID_1, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME))
+        when(OAuth2Util.getX509CertOfOAuthApp(TEST_CLIENT_ID_1, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME))
                 .thenReturn(clientKeyStore.getCertificate("wso2carbon"));
 
         mockStatic(IdentityTenantUtil.class);

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/openidconnect/RequestObjectValidatorImplTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/openidconnect/RequestObjectValidatorImplTest.java
@@ -19,18 +19,15 @@
 package org.wso2.carbon.identity.openidconnect;
 
 import com.nimbusds.jose.JWSAlgorithm;
-import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.testng.PowerMockTestCase;
-import org.powermock.reflect.internal.WhiteboxImpl;
 import org.testng.Assert;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.wso2.carbon.base.CarbonBaseConstants;
-import org.wso2.carbon.core.util.KeyStoreManager;
 import org.wso2.carbon.identity.common.testng.WithAxisConfiguration;
 import org.wso2.carbon.identity.common.testng.WithCarbonHome;
 import org.wso2.carbon.identity.common.testng.WithH2Database;
@@ -51,12 +48,10 @@ import java.security.KeyStore;
 import java.security.PublicKey;
 import java.security.interfaces.RSAPrivateKey;
 import java.util.HashMap;
-import java.util.concurrent.ConcurrentHashMap;
 
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.mock;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.when;
@@ -143,7 +138,7 @@ public class RequestObjectValidatorImplTest extends PowerMockTestCase {
         when((OAuth2Util.getPrivateKey(anyString(), anyInt()))).thenReturn(rsaPrivateKey);
 
         // Mock OAuth2Util returning public cert of the service provider
-        when(OAuth2Util.getPublicCertOfOAuthApp(TEST_CLIENT_ID_1, SUPER_TENANT_DOMAIN_NAME))
+        when(OAuth2Util.getX509CertOfOAuthApp(TEST_CLIENT_ID_1, SUPER_TENANT_DOMAIN_NAME))
                 .thenReturn(clientKeyStore.getCertificate(CLIENT_PUBLIC_CERT_ALIAS));
 
         RequestObjectValidatorImpl requestObjectValidator = PowerMockito.spy(new RequestObjectValidatorImpl());

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/openidconnect/RequestObjectValidatorImplTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/openidconnect/RequestObjectValidatorImplTest.java
@@ -77,6 +77,7 @@ import static org.wso2.carbon.utils.multitenancy.MultitenantConstants.SUPER_TENA
 @PowerMockIgnore({"javax.crypto.*"})
 public class RequestObjectValidatorImplTest extends PowerMockTestCase {
     public static final String SOME_SERVER_URL = "some-server-url";
+    public static final String CLIENT_PUBLIC_CERT_ALIAS = "wso2carbon";
     private RSAPrivateKey rsaPrivateKey;
     private KeyStore clientKeyStore;
     private KeyStore wso2KeyStore;
@@ -86,7 +87,8 @@ public class RequestObjectValidatorImplTest extends PowerMockTestCase {
     public void setUp() throws Exception {
         System.setProperty(CarbonBaseConstants.CARBON_HOME,
                 Paths.get(System.getProperty("user.dir"), "src", "test", "resources").toString());
-        clientKeyStore = getKeyStoreFromFile("testkeystore.jks", "wso2carbon", System.getProperty(CarbonBaseConstants.CARBON_HOME));
+        clientKeyStore =
+                getKeyStoreFromFile("testkeystore.jks", CLIENT_PUBLIC_CERT_ALIAS, System.getProperty(CarbonBaseConstants.CARBON_HOME));
         wso2KeyStore = getKeyStoreFromFile("wso2carbon.jks", "wso2carbon", System.getProperty(CarbonBaseConstants
                 .CARBON_HOME));
     }
@@ -97,7 +99,7 @@ public class RequestObjectValidatorImplTest extends PowerMockTestCase {
         PublicKey publicKey = wso2KeyStore.getCertificate("wso2carbon").getPublicKey();
         String audience = SOME_SERVER_URL;
 
-        HashMap claims1 = new HashMap<>();
+        HashMap<String, Object> claims1 = new HashMap<>();
         claims1.put(Constants.STATE, "af0ifjsldkj");
         String jsonWebToken1 = buildJWT(TEST_CLIENT_ID_1, TEST_CLIENT_ID_1, "1000", audience, "RSA265", privateKey, 0,
                 claims1);
@@ -111,11 +113,15 @@ public class RequestObjectValidatorImplTest extends PowerMockTestCase {
                 {jsonWebToken1, true, false, true, "Valid Request Object, signed not encrypted."},
                 {jsonWebToken2, false, false, true, "Valid Request Object, signed not encrypted."},
                 {jsonWebEncryption1, false, true, true, "Valid Request Object, signed and encrypted."},
-                {jsonWebEncryption2, true, true, true, "Valid Request Object, signed and encrypted."}};
+                {jsonWebEncryption2, true, true, true, "Valid Request Object, signed and encrypted."}
+        };
     }
 
     @Test(dataProvider = "provideJWT")
-    public void testValidateRequestObj(String jwt, boolean isSigned, boolean isEncrypted, boolean exceptionNotExpected,
+    public void testValidateRequestObj(String jwt,
+                                       boolean isSigned,
+                                       boolean isEncrypted,
+                                       boolean exceptionNotExpected,
                                        String errorMsg) throws Exception {
         OAuth2Parameters oAuth2Parameters = new OAuth2Parameters();
         oAuth2Parameters.setTenantDomain(SUPER_TENANT_DOMAIN_NAME);
@@ -131,37 +137,30 @@ public class RequestObjectValidatorImplTest extends PowerMockTestCase {
         mockStatic(OAuthServerConfiguration.class);
         when(OAuthServerConfiguration.getInstance()).thenReturn(oauthServerConfigurationMock);
 
-//        mockStatic(RequestObjectValidatorImpl.class);
-//        PowerMockito.spy(RequestObjectValidatorImpl.class);
-
         rsaPrivateKey = (RSAPrivateKey) wso2KeyStore.getKey("wso2carbon", "wso2carbon".toCharArray());
         mockStatic(OAuth2Util.class);
         when(OAuth2Util.getTenantId(SUPER_TENANT_DOMAIN_NAME)).thenReturn(SUPER_TENANT_ID);
         when((OAuth2Util.getPrivateKey(anyString(), anyInt()))).thenReturn(rsaPrivateKey);
+
+        // Mock OAuth2Util returning public cert of the service provider
+        when(OAuth2Util.getPublicCertOfOAuthApp(TEST_CLIENT_ID_1, SUPER_TENANT_DOMAIN_NAME))
+                .thenReturn(clientKeyStore.getCertificate(CLIENT_PUBLIC_CERT_ALIAS));
 
         RequestObjectValidatorImpl requestObjectValidator = PowerMockito.spy(new RequestObjectValidatorImpl());
 
         RequestParamRequestObjectBuilder requestParamRequestObjectBuilder = new RequestParamRequestObjectBuilder();
         when((oauthServerConfigurationMock.getRequestObjectValidator())).thenReturn(requestObjectValidator);
 
-        KeyStoreManager keyStoreManager = Mockito.mock(KeyStoreManager.class);
-        ConcurrentHashMap<String, KeyStoreManager> mtKeyStoreManagers = new ConcurrentHashMap();
-        mtKeyStoreManagers.put(String.valueOf(SUPER_TENANT_ID), keyStoreManager);
-        WhiteboxImpl.setInternalState(KeyStoreManager.class, "mtKeyStoreManagers", mtKeyStoreManagers);
-        Mockito.when(keyStoreManager.getPrimaryKeyStore()).thenReturn(wso2KeyStore);
-        Mockito.when(keyStoreManager.getKeyStore("wso2carbon.jks")).thenReturn(wso2KeyStore);
-
         PowerMockito.doReturn(SOME_SERVER_URL).when(requestObjectValidator, "getTokenEpURL",
                 anyString());
 
-        String requestObjectString = jwt;
-        RequestObject requestObject = requestParamRequestObjectBuilder.buildRequestObject(requestObjectString,
-                oAuth2Parameters);
+        RequestObject requestObject = requestParamRequestObjectBuilder.buildRequestObject(jwt, oAuth2Parameters);
 
-        Assert.assertEquals(requestParamRequestObjectBuilder.isEncrypted(requestObjectString), isEncrypted,
+        Assert.assertEquals(requestParamRequestObjectBuilder.isEncrypted(jwt), isEncrypted,
                 "Payload is encrypted:" + isEncrypted);
         Assert.assertEquals(requestObjectValidator.isSigned(requestObject), isSigned,
                 "Request object isSigned: " + isSigned);
+
         if (isSigned) {
             Assert.assertEquals(requestObjectValidator.validateSignature(requestObject, oAuth2Parameters),
                     exceptionNotExpected, errorMsg + "Request Object Signature Validation failed.");

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/openidconnect/RequestParamRequestObjectBuilderTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/openidconnect/RequestParamRequestObjectBuilderTest.java
@@ -102,7 +102,7 @@ public class RequestParamRequestObjectBuilderTest extends PowerMockTestCase {
         mockStatic(OAuth2Util.class);
         when(OAuth2Util.getTenantId("carbon.super")).thenReturn(-1234);
         when((OAuth2Util.getPrivateKey(anyString(), anyInt()))).thenReturn(rsaPrivateKey);
-        when(OAuth2Util.getPublicCertOfOAuthApp(TEST_CLIENT_ID_1, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME))
+        when(OAuth2Util.getX509CertOfOAuthApp(TEST_CLIENT_ID_1, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME))
                 .thenReturn(clientKeyStore.getCertificate("wso2carbon"));
 
         RequestObjectValidator requestObjectValidator = new RequestObjectValidatorImpl();

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/openidconnect/RequestParamRequestObjectBuilderTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/openidconnect/RequestParamRequestObjectBuilderTest.java
@@ -33,6 +33,7 @@ import org.wso2.carbon.identity.oauth2.RequestObjectException;
 import org.wso2.carbon.identity.oauth2.model.OAuth2Parameters;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 import org.wso2.carbon.identity.openidconnect.model.RequestObject;
+import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
 import java.nio.file.Paths;
 import java.security.Key;
@@ -101,6 +102,8 @@ public class RequestParamRequestObjectBuilderTest extends PowerMockTestCase {
         mockStatic(OAuth2Util.class);
         when(OAuth2Util.getTenantId("carbon.super")).thenReturn(-1234);
         when((OAuth2Util.getPrivateKey(anyString(), anyInt()))).thenReturn(rsaPrivateKey);
+        when(OAuth2Util.getPublicCertOfOAuthApp(TEST_CLIENT_ID_1, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME))
+                .thenReturn(clientKeyStore.getCertificate("wso2carbon"));
 
         RequestObjectValidator requestObjectValidator = new RequestObjectValidatorImpl();
         when((oauthServerConfigurationMock.getRequestObjectValidator())).thenReturn(requestObjectValidator);

--- a/pom.xml
+++ b/pom.xml
@@ -698,7 +698,7 @@
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!-- Carbon Identity Framework version -->
-        <carbon.identity.framework.version>5.11.0</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.11.14-SNAPSHOT</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.0.0, 6.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 

--- a/pom.xml
+++ b/pom.xml
@@ -698,7 +698,7 @@
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!-- Carbon Identity Framework version -->
-        <carbon.identity.framework.version>5.11.14-SNAPSHOT</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.11.16</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.0.0, 6.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 


### PR DESCRIPTION
### Proposed changes in this pull request
-  In our previous iterations the public certificate of the Service Provider (OAuth Client) used to validate signature of the Request Object was retrieved from the tenant keystore. (ie. It was imported to the tenant keystore with the alias set to client_id). 

Since we now have the capability to store the Service Provider public certificate in the DB (From improvements done in https://github.com/wso2/carbon-identity-framework/pull/1304) this PR improves the request object signature validation logic to retrieve the public cert from DB rather the key store.

This essentially means we are going to stop supporting public certs of Service Providers imported to keystores and will only considering public certs added to the DB. This will be a **backward incompatible API removal**.

In addition below improvements was also added,

- Add util methods to reuse retrieving public certs of Service Providers using client_id.
- Fix possible NPE due to error codes not set in exceptions.


### Improvements to be done
- Provide an option at Service Provider OAuth Config to enable/disable signature validation for Request Objects.
- Improve the signature validation logic to consider the option explained in the above point.


### When should this PR be merged
- After reviewing

### Follow up actions
- Come up with a migration plan for current service providers having their Public certs in their respective
tenant key stores.
- Update documentation.


### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description.
- [ ] **Is the PR labeled correctly?**

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled.

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests.
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/).

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components.
- [ ] **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

#### Security

- [ ] **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
- [ ] **Are all UI and API inputs run through forms or serializers?**
- [ ] **Are all external inputs validated and sanitized appropriately?**
- [ ] **Does all branching logic have a default case?**
- [ ] **Does this solution handle outliers and edge cases gracefully?**
- [ ] **Are all external communications secured and restricted to SSL?**

#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes should be documented.
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented.
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki.
