### PR TITLE
Send more specific error message when retrieving the service provider certificate fails

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/RequestObjectValidatorImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/RequestObjectValidatorImpl.java
@@ -211,11 +211,18 @@ public class RequestObjectValidatorImpl implements RequestObjectValidator {
      * @return X509Certificate object containing the public certificate of the Service Provider.
      */
     protected Certificate getX509CertOfOAuthApp(String clientId, String tenantDomain) throws RequestObjectException {
+
         try {
             return OAuth2Util.getX509CertOfOAuthApp(clientId, tenantDomain);
         } catch (IdentityOAuth2Exception e) {
-            throw new RequestObjectException("Error retrieving public certificate of OAuth app with client_id: "
-                    + clientId + " of tenantDomain: " + tenantDomain, e);
+            String errorMsg = "Error retrieving application certificate of OAuth app with client_id: " + clientId +
+                    " , tenantDomain: " + tenantDomain;
+            if (StringUtils.isNotBlank(e.getMessage())) {
+                // We expect OAuth2Util.getX509CertOfOAuthApp() to throw an exception with a more specific reason for
+                // not being able to retrieve the X509 Cert of the service provider.
+                errorMsg = e.getMessage();
+            }
+            throw new RequestObjectException(errorMsg, e);
         }
     }
 


### PR DESCRIPTION
### Proposed changes in this pull request
- In the current implementation the generic error message,
```
String errorMsg = "Error retrieving public certificate of OAuth app with client_id: " + clientId +
                    " , tenantDomain: " + tenantDomain;
```
is returned even though details of the specific cause exists in the exception. This improvement is to send out specific error messages if they are available.

Resolves https://github.com/wso2-extensions/identity-inbound-auth-oauth/issues/800

### When should this PR be merged

### Follow up actions


### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description.
- [ ] **Is the PR labeled correctly?**

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled.

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests.
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/).

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components.
- [ ] **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

#### Security

- [ ] **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
- [ ] **Are all UI and API inputs run through forms or serializers?**
- [ ] **Are all external inputs validated and sanitized appropriately?**
- [ ] **Does all branching logic have a default case?**
- [ ] **Does this solution handle outliers and edge cases gracefully?**
- [ ] **Are all external communications secured and restricted to SSL?**

#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes should be documented.
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented.
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki.
