### PR TITLE
Integrating User Consent Management into OpenID connect Authorization Code and Implicit flow

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/exception/ConsentHandlingFailedException.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/exception/ConsentHandlingFailedException.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.identity.oauth.endpoint.exception;
+
+public class ConsentHandlingFailedException extends InvalidRequestParentException {
+
+    public ConsentHandlingFailedException(String message) {
+        super(message);
+    }
+
+    public ConsentHandlingFailedException(String message, Throwable throwable) {
+        super(message, throwable);
+    }
+}

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/exception/InvalidRequestParentException.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/exception/InvalidRequestParentException.java
@@ -31,6 +31,10 @@ public class InvalidRequestParentException extends Exception {
         super(cause);
     }
 
+    public InvalidRequestParentException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
     public InvalidRequestParentException(String message, String errorCode) {
         super(message);
         this.errorCode = errorCode;

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/expmapper/InvalidRequestExceptionMapper.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/expmapper/InvalidRequestExceptionMapper.java
@@ -122,6 +122,9 @@ public class InvalidRequestExceptionMapper implements ExceptionMapper<InvalidReq
                 return handleInternalServerError();
             }
         } else {
+            if (log.isDebugEnabled()) {
+                log.debug("OAuth System error while processing request: ", exception);
+            }
             return handleInternalServerError();
         }
     }

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
@@ -29,6 +29,7 @@ import org.apache.oltu.oauth2.common.exception.OAuthSystemException;
 import org.wso2.carbon.base.ServerConfiguration;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.application.authentication.framework.cache.AuthenticationRequestCacheEntry;
+import org.wso2.carbon.identity.application.authentication.framework.handler.request.impl.consent.SSOConsentService;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticationRequest;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
@@ -78,6 +79,16 @@ public class EndpointUtil {
 
     private EndpointUtil() {
 
+    }
+
+    /**
+     * Returns the registered {@code {@link SSOConsentService}} instance
+     *
+     * @return
+     */
+    public static SSOConsentService getSSOConsentService() {
+        return (SSOConsentService) PrivilegedCarbonContext.getThreadLocalCarbonContext()
+                .getOSGiService(SSOConsentService.class, null);
     }
 
     /**

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/user/impl/UserInfoJSONResponseBuilderTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/user/impl/UserInfoJSONResponseBuilderTest.java
@@ -72,7 +72,7 @@ public class UserInfoJSONResponseBuilderTest extends UserInfoResponseBaseTest {
     }
 
     private void setUpRequestObjectService() throws RequestObjectException {
-        List<RequestedClaim> requestedClaims =  Collections.EMPTY_LIST;
+        List<RequestedClaim> requestedClaims =  Collections.emptyList();
         when(requestObjectService.getRequestedClaimsForIDToken(anyString())).
                 thenReturn(requestedClaims);
         when(requestObjectService.getRequestedClaimsForUserInfo(anyString())).

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/user/impl/UserInfoResponseBaseTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/user/impl/UserInfoResponseBaseTest.java
@@ -1,6 +1,7 @@
 package org.wso2.carbon.identity.oauth.endpoint.user.impl;
 
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.testng.PowerMockObjectFactory;
@@ -45,6 +46,7 @@ import java.util.Map;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyMap;
 import static org.mockito.Matchers.anyString;
 import static org.powermock.api.mockito.PowerMockito.mock;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
@@ -123,9 +125,13 @@ public class UserInfoResponseBaseTest extends PowerMockTestCase {
 
     @BeforeClass
     public void setUp() {
-        OpenIDConnectServiceComponentHolder.getInstance()
-                .getOpenIDConnectClaimFilters()
-                .add(new OpenIDConnectClaimFilterImpl());
+        // Skipping filtering with user consent.
+        // TODO: Remove mocking claims filtering based on consent when fixing https://github.com/wso2/product-is/issues/2676
+        OpenIDConnectClaimFilterImpl openIDConnectClaimFilter = Mockito.spy(new OpenIDConnectClaimFilterImpl());
+        when(openIDConnectClaimFilter
+                .getClaimsFilteredByUserConsent(anyMap(), any(AuthenticatedUser.class), anyString(), anyString()))
+                .thenAnswer(invocation -> invocation.getArguments()[0]);
+        OpenIDConnectServiceComponentHolder.getInstance().getOpenIDConnectClaimFilters().add(openIDConnectClaimFilter);
         resource = new ResourceImpl();
     }
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuth2ServiceComponent.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuth2ServiceComponent.java
@@ -45,7 +45,6 @@ import org.wso2.carbon.identity.oauth2.client.authentication.OAuthClientAuthnSer
 import org.wso2.carbon.identity.oauth2.dao.SQLQueries;
 import org.wso2.carbon.identity.oauth2.listener.TenantCreationEventListener;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
-import org.wso2.carbon.identity.openidconnect.ClaimProvider;
 import org.wso2.carbon.identity.openidconnect.OpenIDConnectClaimFilter;
 import org.wso2.carbon.identity.openidconnect.OpenIDConnectClaimFilterImpl;
 import org.wso2.carbon.identity.user.store.configuration.listener.UserStoreConfigListener;

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuth2ServiceComponentHolder.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuth2ServiceComponentHolder.java
@@ -19,6 +19,7 @@
 package org.wso2.carbon.identity.oauth2.internal;
 
 import org.wso2.carbon.identity.application.authentication.framework.AuthenticationMethodNameTranslator;
+import org.wso2.carbon.identity.application.authentication.framework.handler.request.impl.consent.SSOConsentService;
 import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.core.handler.HandlerComparator;
 import org.wso2.carbon.identity.entitlement.EntitlementService;
@@ -154,5 +155,4 @@ public class OAuth2ServiceComponentHolder {
     public static EntitlementService getEntitlementService() {
         return entitlementService;
     }
-
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/AbstractUserInfoResponseBuilder.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/AbstractUserInfoResponseBuilder.java
@@ -16,6 +16,7 @@
 
 package org.wso2.carbon.identity.openidconnect;
 
+import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -64,23 +65,47 @@ public abstract class AbstractUserInfoResponseBuilder implements UserInfoRespons
         String spTenantDomain = getServiceProviderTenantDomain(tokenResponse);
         // Retrieve user claims.
         Map<String, Object> userClaims = retrieveUserClaims(tokenResponse);
-
-        // Filter user claims based on the requested scopes
-        Map<String, Object> filteredUserClaims =
-                getUserClaimsFilteredByScope(userClaims, tokenResponse.getScope(), clientId, spTenantDomain);
+        Map<String, Object> filteredUserClaims = filterOIDCClaims(tokenResponse, clientId, spTenantDomain, userClaims);
 
         // Handle subject claim.
         String subjectClaim = getSubjectClaim(userClaims, clientId, spTenantDomain, tokenResponse);
         filteredUserClaims.put(OAuth2Util.SUB, subjectClaim);
 
+        return buildResponse(tokenResponse, spTenantDomain, filteredUserClaims);
+    }
+
+    private Map<String, Object> filterOIDCClaims(OAuth2TokenValidationResponseDTO tokenResponse,
+                                                 String clientId,
+                                                 String spTenantDomain,
+                                                 Map<String, Object> userClaims)
+            throws OAuthSystemException, UserInfoEndpointException {
+
+        if(MapUtils.isEmpty(userClaims)) {
+            if (log.isDebugEnabled()) {
+                AuthenticatedUser authenticatedUser = getAuthenticatedUser(getAccessToken(tokenResponse));
+                log.debug("No user claims available to be filtered for user: " +
+                        authenticatedUser.toFullQualifiedUsername() + " for client_id: " + clientId +
+                        " of tenantDomain: " + spTenantDomain);
+            }
+            return new HashMap<>();
+        }
+
+        // Filter user claims based on the requested scopes
+        Map<String, Object> userClaimsFilteredByScope =
+                getUserClaimsFilteredByScope(userClaims, tokenResponse.getScope(), clientId, spTenantDomain);
+
         // Handle essential claims
         Map<String, Object> essentialClaims = getEssentialClaims(tokenResponse, userClaims);
-        filteredUserClaims.putAll(essentialClaims);
+        userClaimsFilteredByScope.putAll(essentialClaims);
 
         //Handle essential claims of the request object
-        filteredUserClaims.putAll(filterClaimsFromRequestObject(userClaims, getAccessToken(tokenResponse)));
+        Map<String, Object> filteredClaimsFromRequestObject =
+                filterClaimsFromRequestObject(userClaims, getAccessToken(tokenResponse));
+        userClaimsFilteredByScope.putAll(filteredClaimsFromRequestObject);
 
-        return buildResponse(tokenResponse, spTenantDomain, filteredUserClaims);
+        // Filter the user claims based on user consent
+        AuthenticatedUser authenticatedUser = getAuthenticatedUser(getAccessToken(tokenResponse));
+        return getUserClaimsFilteredByConsent(userClaimsFilteredByScope, authenticatedUser, clientId, spTenantDomain);
     }
 
     private Map<String, Object> filterClaimsFromRequestObject(Map<String, Object> userAttributes,
@@ -161,6 +186,26 @@ public abstract class AbstractUserInfoResponseBuilder implements UserInfoRespons
                 .getHighestPriorityOpenIDConnectClaimFilter()
                 .getClaimsFilteredByOIDCScopes(userClaims, requestedScopes, clientId, tenantDomain);
     }
+
+    /**
+     * Filter user claims requested by the Service Provider based on the requested scopes.
+     *
+     * @param userClaims
+     * @param user
+     * @param clientId
+     * @param tenantDomain
+     * @return
+     */
+    protected Map<String, Object> getUserClaimsFilteredByConsent(Map<String, Object> userClaims,
+                                                                 AuthenticatedUser user,
+                                                                 String clientId,
+                                                                 String tenantDomain) {
+        return OpenIDConnectServiceComponentHolder.getInstance()
+                .getHighestPriorityOpenIDConnectClaimFilter()
+                .getClaimsFilteredByUserConsent(userClaims, user , clientId, tenantDomain);
+    }
+
+
 
     protected Map<String, Object> getEssentialClaims(OAuth2TokenValidationResponseDTO tokenResponse,
                                                      Map<String, Object> claims) throws UserInfoEndpointException {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/OpenIDConnectClaimFilter.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/OpenIDConnectClaimFilter.java
@@ -16,7 +16,7 @@
 
 package org.wso2.carbon.identity.openidconnect;
 
-
+import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
 import org.wso2.carbon.identity.openidconnect.model.RequestedClaim;
 
 import java.util.List;
@@ -47,6 +47,23 @@ public interface OpenIDConnectClaimFilter {
                                                       String spTenantDomain);
 
     /**
+     *
+     *
+     *
+     * @param userClaims
+     * @param authenticatedUser
+     * @param clientId
+     * @param spTenantDomain
+     * @return
+     */
+    default Map<String, Object> getClaimsFilteredByUserConsent(Map<String, Object> userClaims,
+                                                               AuthenticatedUser authenticatedUser,
+                                                               String clientId,
+                                                               String spTenantDomain) {
+        return userClaims;
+    }
+
+    /**
      * Priority of the Claim Filter. Claims filters will be sorted based on their priority value and by default only
      * the claim filter with the highest priority will be executed.
      *
@@ -60,5 +77,6 @@ public interface OpenIDConnectClaimFilter {
      * @param requestParamClaims
      * @return
      */
-    Map<String, Object> getClaimsFilteredByEssentialClaims(Map<String, Object> userClaims, List<RequestedClaim> requestParamClaims);
+    Map<String, Object> getClaimsFilteredByEssentialClaims(Map<String, Object> userClaims,
+                                                           List<RequestedClaim> requestParamClaims);
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/OpenIDConnectClaimFilterImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/OpenIDConnectClaimFilterImpl.java
@@ -23,8 +23,18 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.identity.application.authentication.framework.exception.FrameworkException;
+import org.wso2.carbon.identity.application.authentication.framework.handler.request.impl.consent.ClaimMetaData;
+import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
+import org.wso2.carbon.identity.application.common.model.ServiceProvider;
+import org.wso2.carbon.identity.claim.metadata.mgt.exception.ClaimMetadataException;
+import org.wso2.carbon.identity.claim.metadata.mgt.model.Claim;
+import org.wso2.carbon.identity.claim.metadata.mgt.model.ExternalClaim;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.internal.OAuth2ServiceComponentHolder;
+import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
+import org.wso2.carbon.identity.openidconnect.internal.OpenIDConnectServiceComponentHolder;
 import org.wso2.carbon.identity.openidconnect.model.RequestedClaim;
 import org.wso2.carbon.registry.api.RegistryException;
 import org.wso2.carbon.registry.api.Resource;
@@ -32,12 +42,13 @@ import org.wso2.carbon.registry.core.service.RegistryService;
 
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.stream.Collectors;
 
 import static org.apache.commons.collections.MapUtils.isEmpty;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCClaims.ADDRESS;
@@ -71,11 +82,10 @@ public class OpenIDConnectClaimFilterImpl implements OpenIDConnectClaimFilter {
                                                              String[] requestedScopes,
                                                              String clientId,
                                                              String spTenantDomain) {
+
         if (isEmpty(userClaims)) {
             // No user claims to filter.
-            if (log.isDebugEnabled()) {
-                log.debug("No user claims to filter. Returning an empty map of filtered claims.");
-            }
+            logDebugForEmptyUserClaims();
             return new HashMap<>();
         }
 
@@ -126,25 +136,68 @@ public class OpenIDConnectClaimFilterImpl implements OpenIDConnectClaimFilter {
     }
 
     @Override
+    public Map<String, Object> getClaimsFilteredByUserConsent(Map<String, Object> userClaims,
+                                                              AuthenticatedUser authenticatedUser,
+                                                              String clientId,
+                                                              String spTenantDomain) {
+
+        if (isEmpty(userClaims)) {
+            // No user claims to filter.
+            logDebugForEmptyUserClaims();
+            return new HashMap<>();
+        }
+
+        // Filter the claims based on the user consent.
+        try {
+            List<String> userConsentedClaimUris =
+                    getUserConsentedLocalClaimURIs(authenticatedUser, clientId, spTenantDomain);
+
+            List<String> userConsentClaimUrisInOIDCDialect = getOIDCClaimURIs(userConsentedClaimUris, spTenantDomain);
+
+            return userClaims.keySet().stream()
+                    .filter(userConsentClaimUrisInOIDCDialect::contains)
+                    .collect(Collectors.toMap(key -> key, userClaims::get));
+
+        } catch (IdentityOAuth2Exception | FrameworkException e) {
+            String msg = "Error while filtering claims based on user consent for user: " +
+                    authenticatedUser.toFullQualifiedUsername() + " for client_id: " + clientId;
+            log.error(e);
+        }
+
+        return userClaims;
+    }
+
+    private List<String> getUserConsentedLocalClaimURIs(AuthenticatedUser authenticatedUser, String clientId,
+                                                        String spTenantDomain)
+            throws IdentityOAuth2Exception, FrameworkException {
+
+        ServiceProvider serviceProvider = OAuth2Util.getServiceProvider(clientId, spTenantDomain);
+        List<ClaimMetaData> claimsWithConsents = OpenIDConnectServiceComponentHolder.getInstance()
+                .getSsoConsentService().getClaimsWithConsents(serviceProvider, authenticatedUser);
+        return getClaimUrisWithConsent(claimsWithConsents);
+    }
+
+    @Override
     public int getPriority() {
+
         return DEFAULT_PRIORITY;
     }
 
     @Override
-    public Map<String, Object> getClaimsFilteredByEssentialClaims(Map<String, Object> userClaims, List<RequestedClaim> requestParamClaims) {
+    public Map<String, Object> getClaimsFilteredByEssentialClaims(Map<String, Object> userClaims,
+                                                                  List<RequestedClaim> requestParamClaims) {
 
-        Map<String, Object> essentialClaims = new HashMap<>();
         if (isEmpty(userClaims)) {
             // No user claims to filter.
-            if (log.isDebugEnabled()) {
-                log.debug("No user claims to filter. Returning an empty map of filtered claims.");
-            }
+            logDebugForEmptyUserClaims();
             return new HashMap<>();
         }
+
+        Map<String, Object> essentialClaims = new HashMap<>();
         if (CollectionUtils.isNotEmpty(requestParamClaims)) {
             for (RequestedClaim essentialClaim : requestParamClaims) {
                 String claimName = essentialClaim.getName();
-                if (essentialClaim.isEssential() && userClaims.get(claimName) != null){
+                if (essentialClaim.isEssential() && userClaims.get(claimName) != null) {
                     essentialClaims.put(claimName, userClaims.get(claimName));
                 }
             }
@@ -153,6 +206,7 @@ public class OpenIDConnectClaimFilterImpl implements OpenIDConnectClaimFilter {
     }
 
     private Properties getOIDCScopeProperties(String spTenantDomain) {
+
         Resource oidcScopesResource = null;
         try {
             int tenantId = IdentityTenantUtil.getTenantId(spTenantDomain);
@@ -189,6 +243,7 @@ public class OpenIDConnectClaimFilterImpl implements OpenIDConnectClaimFilter {
                                                          Properties oidcScopeProperties,
                                                          List<String> addressScopeClaimUris,
                                                          String oidcScope) {
+
         Map<String, Object> filteredClaims = new HashMap<>();
         List<String> claimUrisInRequestedScope = getClaimUrisInSupportedOidcScope(oidcScopeProperties, oidcScope);
         for (String scopeClaim : claimUrisInRequestedScope) {
@@ -217,6 +272,7 @@ public class OpenIDConnectClaimFilterImpl implements OpenIDConnectClaimFilter {
      * @return Scope prefix removed claim URI
      */
     private String getOIDCClaimUri(String scopeClaim) {
+
         return StringUtils.contains(scopeClaim, SCOPE_CLAIM_PREFIX) ?
                 StringUtils.substringAfterLast(scopeClaim, SCOPE_CLAIM_PREFIX) :
                 StringUtils.substringBefore(scopeClaim, SCOPE_CLAIM_PREFIX);
@@ -224,6 +280,7 @@ public class OpenIDConnectClaimFilterImpl implements OpenIDConnectClaimFilter {
 
     private void handleAddressClaim(Map<String, Object> returnedClaims,
                                     Map<String, Object> claimsforAddressScope) {
+
         if (MapUtils.isNotEmpty(claimsforAddressScope)) {
             final JSONObject jsonObject = new JSONObject();
             for (Map.Entry<String, Object> addressScopeClaimEntry : claimsforAddressScope.entrySet()) {
@@ -234,14 +291,17 @@ public class OpenIDConnectClaimFilterImpl implements OpenIDConnectClaimFilter {
     }
 
     private List<String> getAddressScopeClaimUris(Properties oidcProperties) {
+
         return getClaimUrisInSupportedOidcScope(oidcProperties, ADDRESS_SCOPE);
     }
 
     private boolean isAddressClaim(String scopeClaim, List<String> addressScopeClaims) {
+
         return StringUtils.startsWith(scopeClaim, ADDRESS_PREFIX) || addressScopeClaims.contains(scopeClaim);
     }
 
     private List<String> getClaimUrisInSupportedOidcScope(Properties properties, String requestedScope) {
+
         String[] requestedScopeClaimsArray;
         List<String> requestedScopeClaimsList = new ArrayList<>();
         if (StringUtils.isNotBlank(properties.getProperty(requestedScope))) {
@@ -272,6 +332,7 @@ public class OpenIDConnectClaimFilterImpl implements OpenIDConnectClaimFilter {
     }
 
     private void handlePhoneNumberVerifiedClaim(Map<String, Object> returnClaims) {
+
         if (returnClaims.containsKey(PHONE_NUMBER_VERIFIED))
             if (returnClaims.get(PHONE_NUMBER_VERIFIED) != null) {
                 if (returnClaims.get(PHONE_NUMBER_VERIFIED) instanceof String) {
@@ -282,6 +343,7 @@ public class OpenIDConnectClaimFilterImpl implements OpenIDConnectClaimFilter {
     }
 
     private void handleEmailVerifiedClaim(Map<String, Object> returnClaims) {
+
         if (returnClaims.containsKey(EMAIL_VERIFIED) && returnClaims.get(EMAIL_VERIFIED) != null) {
             if (returnClaims.get(EMAIL_VERIFIED) instanceof String) {
                 returnClaims.put(EMAIL_VERIFIED, (Boolean.valueOf((String) (returnClaims.get(EMAIL_VERIFIED)))));
@@ -290,6 +352,7 @@ public class OpenIDConnectClaimFilterImpl implements OpenIDConnectClaimFilter {
     }
 
     private void startTenantFlow(String tenantDomain, int tenantId) {
+
         PrivilegedCarbonContext.startTenantFlow();
         PrivilegedCarbonContext carbonContext = PrivilegedCarbonContext.getThreadLocalCarbonContext();
         carbonContext.setTenantId(tenantId);
@@ -297,15 +360,18 @@ public class OpenIDConnectClaimFilterImpl implements OpenIDConnectClaimFilter {
     }
 
     private boolean isNotEmpty(Map<String, Object> claimsToBeReturned) {
+
         return claimsToBeReturned != null && !claimsToBeReturned.isEmpty();
     }
 
     private boolean isNotEmpty(Properties properties) {
+
         return properties != null && !properties.isEmpty();
     }
 
     /**
      * Return a Date object if the given string is a valid date string.
+     *
      * @param dateString date string in yyyy-MM-dd'T'HH:mm:ss format.
      * @return Date object if success null otherwise.
      */
@@ -316,10 +382,47 @@ public class OpenIDConnectClaimFilterImpl implements OpenIDConnectClaimFilter {
             date = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss").parse(dateString);
         } catch (Exception ex) {
             if (log.isDebugEnabled()) {
-                log.debug("The given date string: " + dateString  + " is not in correct date time format.");
+                log.debug("The given date string: " + dateString + " is not in correct date time format.");
             }
             return null;
         }
         return date;
+    }
+
+    private List<String> getOIDCClaimURIs(List<String> userConsentedClaimUris,
+                                          String tenantDomain) {
+
+        final String OIDC_DIALECT = "http://wso2.org/oidc/claim";
+        try {
+            List<ExternalClaim> externalClaims = OpenIDConnectServiceComponentHolder.getInstance()
+                    .getClaimMetadataManagementService()
+                    .getExternalClaims(OIDC_DIALECT, tenantDomain);
+
+            return externalClaims.stream()
+                    .filter(externalClaim -> userConsentedClaimUris.contains(externalClaim.getMappedLocalClaim()))
+                    .map(Claim::getClaimURI)
+                    .collect(Collectors.toList());
+        } catch (ClaimMetadataException e) {
+            String msg = "Error while trying to convert user consented claims to OIDC dialect in tenantDomain: "
+                    + tenantDomain;
+            log.error(msg);
+            if (log.isDebugEnabled()) {
+                log.debug(msg, e);
+            }
+        }
+
+        return Collections.emptyList();
+    }
+
+    private List<String> getClaimUrisWithConsent(List<ClaimMetaData> claimsWithConsents) {
+
+        return claimsWithConsents.stream().map(ClaimMetaData::getClaimUri).collect(Collectors.toList());
+    }
+
+    private void logDebugForEmptyUserClaims() {
+
+        if (log.isDebugEnabled()) {
+            log.debug("No user claims to filter. Returning an empty map of filtered claims.");
+        }
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/internal/OpenIDConnectServiceComponent.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/internal/OpenIDConnectServiceComponent.java
@@ -24,9 +24,12 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
+import org.wso2.carbon.identity.application.authentication.framework.handler.request.impl.consent.SSOConsentService;
+import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
 import org.wso2.carbon.identity.core.util.IdentityCoreInitializedEvent;
 import org.wso2.carbon.identity.event.handler.AbstractEventHandler;
 import org.wso2.carbon.identity.event.services.IdentityEventService;
+import org.wso2.carbon.identity.oauth2.internal.OAuth2ServiceComponentHolder;
 import org.wso2.carbon.identity.openidconnect.ClaimProvider;
 import org.wso2.carbon.identity.openidconnect.OpenIDConnectClaimFilter;
 import org.wso2.carbon.identity.openidconnect.OpenIDConnectSystemClaimImpl;
@@ -211,4 +214,45 @@ public class OpenIDConnectServiceComponent {
         }
         OpenIDConnectServiceComponentHolder.setRequestObjectHandler(null);
     }
+
+    @Reference(
+            name = "claim.manager.listener.service",
+            service = ClaimMetadataManagementService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetClaimManagementService"
+    )
+    protected void setClaimManagementService(ClaimMetadataManagementService claimMetadataManagementService) {
+        OpenIDConnectServiceComponentHolder.getInstance()
+                .setClaimMetadataManagementService(claimMetadataManagementService);
+    }
+
+    protected void unsetClaimManagementService(ClaimMetadataManagementService claimMetadataManagementService) {
+        OpenIDConnectServiceComponentHolder.getInstance()
+                .setClaimMetadataManagementService(null);
+    }
+
+    @Reference(
+            name = "sso.consent.service",
+            service = SSOConsentService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetConsentManagementService"
+    )
+    protected void setConsentManagementService(SSOConsentService ssoConsentService) {
+
+        if (log.isDebugEnabled()) {
+            log.debug("Setting the SSOConsentService.");
+        }
+        OpenIDConnectServiceComponentHolder.getInstance().setSsoConsentService(ssoConsentService);
+    }
+
+    protected void unsetConsentManagementService(SSOConsentService ssoConsentService) {
+
+        if (log.isDebugEnabled()) {
+            log.debug("Un setting the SSOConsentService");
+        }
+        OpenIDConnectServiceComponentHolder.getInstance().setSsoConsentService(null);
+    }
+
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/internal/OpenIDConnectServiceComponentHolder.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/internal/OpenIDConnectServiceComponentHolder.java
@@ -16,6 +16,8 @@
 
 package org.wso2.carbon.identity.openidconnect.internal;
 
+import org.wso2.carbon.identity.application.authentication.framework.handler.request.impl.consent.SSOConsentService;
+import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
 import org.wso2.carbon.identity.event.services.IdentityEventService;
 import org.wso2.carbon.identity.openidconnect.ClaimProvider;
 import org.wso2.carbon.identity.openidconnect.OpenIDConnectClaimFilter;
@@ -33,6 +35,8 @@ public class OpenIDConnectServiceComponentHolder {
     private static RequestObjectService requestObjectService;
     private static IdentityEventService identityEventService;
     private static RequestObjectHandler requestObjectHandler;
+    private ClaimMetadataManagementService claimMetadataManagementService;
+    private SSOConsentService ssoConsentService;
 
     public static RequestObjectHandler getRequestObjectHandler() {
 
@@ -90,5 +94,23 @@ public class OpenIDConnectServiceComponentHolder {
      */
     public List<ClaimProvider> getClaimProviders() {
         return claimProviders;
+    }
+
+    public void setClaimMetadataManagementService(ClaimMetadataManagementService claimMetadataManagementService) {
+        this.claimMetadataManagementService = claimMetadataManagementService;
+    }
+
+    public ClaimMetadataManagementService getClaimMetadataManagementService() {
+        return claimMetadataManagementService;
+    }
+
+    public void setSsoConsentService(SSOConsentService ssoConsentService) {
+
+        this.ssoConsentService = ssoConsentService;
+    }
+
+    public SSOConsentService getSsoConsentService() {
+
+        return ssoConsentService;
     }
 }

--- a/features/org.wso2.carbon.identity.oauth.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.oauth.server.feature/pom.xml
@@ -200,6 +200,8 @@
                                 <importFeatureDef>org.wso2.carbon.security.mgt.server:compatible:${carbon.identity.framework.version}</importFeatureDef>
                                 <importFeatureDef>org.wso2.carbon.identity.application.mgt.server:compatible:${carbon.identity.framework.version}</importFeatureDef>
                                 <importFeatureDef>org.wso2.carbon.identity.application.authentication.framework.server:compatible:${carbon.identity.framework.version}</importFeatureDef>
+                                <importFeatureDef>org.wso2.carbon.claim.mgt.server:compatible:${carbon.identity.framework.version}</importFeatureDef>
+                                <importFeatureDef>org.wso2.carbon.identity.event.server:compatible:${carbon.identity.framework.version}</importFeatureDef>
                             </importFeatures>
                         </configuration>
                     </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -703,7 +703,7 @@
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!-- Carbon Identity Framework version -->
-        <carbon.identity.framework.version>5.11.28</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.11.78</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.0.0, 6.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 


### PR DESCRIPTION
### Proposed changes in this pull request
Integrating User Consent Management into OpenID connect Authorization Code and Implicit flow.

With the changes introduced in this PR
- A user will be prompted to provide consent to share any claims deemed mandatory by the Service Provider. Once approved user consent will be stored and can be revoked/updated using the IS User Portal.

- Claims sent in the id_token and user info response will be filtered based on the consents provided by the user.

