### PR TITLE
Handle prompt=consent and "Approve Always" options in OIDC flow with consent management

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/pom.xml
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/pom.xml
@@ -97,6 +97,11 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.application.authentication.endpoint.util</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.wso2.orbit.com.nimbusds</groupId>
             <artifactId>nimbus-jose-jwt</artifactId>
             <scope>provided</scope>

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
@@ -491,7 +491,7 @@ public class EndpointUtil {
      */
     public static ApplicationManagementService getApplicationManagementService() {
         return (ApplicationManagementService) PrivilegedCarbonContext.getThreadLocalCarbonContext().getOSGiService
-                (ApplicationManagementService.class);
+                (ApplicationManagementService.class, null);
     }
     public static String getRealmInfo() {
         return "Basic realm=" + getHostName();

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/util/TestOAuthEndpointBase.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/util/TestOAuthEndpointBase.java
@@ -22,6 +22,7 @@ import org.wso2.carbon.identity.core.util.IdentityDatabaseUtil;
 import org.wso2.carbon.identity.testutil.powermock.PowerMockIdentityBaseTest;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
+import java.sql.SQLException;
 
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.when;
@@ -75,5 +76,9 @@ public class TestOAuthEndpointBase extends PowerMockIdentityBaseTest {
 
     public void cleanData() throws Exception {
         dataSource.close();
+    }
+
+    public Connection getConnection() throws SQLException {
+        return dataSource.getConnection();
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -2203,6 +2203,29 @@ public class OAuth2Util {
     }
 
     /**
+     * Returns the service provider associated with the OAuth clientId.
+     *
+     * @param clientId OAuth2/OIDC Client Identifier
+     * @return
+     * @throws IdentityOAuth2Exception
+     */
+    public static ServiceProvider getServiceProvider(String clientId) throws IdentityOAuth2Exception {
+        ApplicationManagementService applicationMgtService = OAuth2ServiceComponentHolder.getApplicationMgtService();
+        String tenantDomain = null;
+        try {
+            tenantDomain = getTenantDomainOfOauthApp(clientId);
+            // Get the Service Provider.
+            return applicationMgtService.getServiceProviderByClientId(
+                    clientId, IdentityApplicationConstants.OAuth2.NAME, tenantDomain);
+        } catch (IdentityApplicationManagementException e) {
+            throw new IdentityOAuth2Exception("Error while obtaining the service provider for client_id: " +
+                    clientId + " of tenantDomain: " + tenantDomain, e);
+        } catch (InvalidOAuthClientException e) {
+            throw new IdentityOAuth2Exception("Could not find an existing app for clientId: " + clientId, e);
+        }
+    }
+
+    /**
      *  Returns the public certificate of the service provider associated with the OAuth consumer app as
      *  an X509 @{@link Certificate} object.
      *

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/OpenIDConnectClaimFilterImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/OpenIDConnectClaimFilterImpl.java
@@ -25,6 +25,7 @@ import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.application.authentication.framework.exception.FrameworkException;
 import org.wso2.carbon.identity.application.authentication.framework.handler.request.impl.consent.ClaimMetaData;
+import org.wso2.carbon.identity.application.authentication.framework.handler.request.impl.consent.exception.SSOConsentServiceException;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
 import org.wso2.carbon.identity.application.common.model.ServiceProvider;
 import org.wso2.carbon.identity.claim.metadata.mgt.exception.ClaimMetadataException;
@@ -158,10 +159,10 @@ public class OpenIDConnectClaimFilterImpl implements OpenIDConnectClaimFilter {
                     .filter(userConsentClaimUrisInOIDCDialect::contains)
                     .collect(Collectors.toMap(key -> key, userClaims::get));
 
-        } catch (IdentityOAuth2Exception | FrameworkException e) {
+        } catch (IdentityOAuth2Exception | SSOConsentServiceException e) {
             String msg = "Error while filtering claims based on user consent for user: " +
                     authenticatedUser.toFullQualifiedUsername() + " for client_id: " + clientId;
-            log.error(e);
+            log.error(msg, e);
         }
 
         return userClaims;
@@ -169,7 +170,7 @@ public class OpenIDConnectClaimFilterImpl implements OpenIDConnectClaimFilter {
 
     private List<String> getUserConsentedLocalClaimURIs(AuthenticatedUser authenticatedUser, String clientId,
                                                         String spTenantDomain)
-            throws IdentityOAuth2Exception, FrameworkException {
+            throws IdentityOAuth2Exception, SSOConsentServiceException {
 
         ServiceProvider serviceProvider = OAuth2Util.getServiceProvider(clientId, spTenantDomain);
         List<ClaimMetaData> claimsWithConsents = OpenIDConnectServiceComponentHolder.getInstance()

--- a/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/OIDCSessionState.java
+++ b/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/OIDCSessionState.java
@@ -109,7 +109,8 @@ public class OIDCSessionState implements Serializable {
     }
 
     /**
-     * Sets add session state flag
+     * Sets add session state flag. When this flag is set session_state parameter is returned in the OIDC
+     * authentication response.
      *
      * @param addSessionState
      */

--- a/pom.xml
+++ b/pom.xml
@@ -217,6 +217,11 @@
                 <version>${carbon.identity.framework.version}</version>
                 <type>war</type>
             </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.framework</groupId>
+                <artifactId>org.wso2.carbon.identity.application.authentication.endpoint.util</artifactId>
+                <version>${carbon.identity.framework.version}</version>
+            </dependency>
 
 
             <!-- Orbit dependencies -->
@@ -703,7 +708,7 @@
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!-- Carbon Identity Framework version -->
-        <carbon.identity.framework.version>5.11.78</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.11.95</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.0.0, 6.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 


### PR DESCRIPTION
### Proposed changes in this pull request

Resolves https://github.com/wso2/product-is/issues/2704 and https://github.com/wso2/product-is/issues/2767

In our previous iterations,
- If a user selects "Approve Always" any claim added as mandatory by SP thereafter will not be prompted for consent. ie. "Approve Always" overrides and consent pending.
- prompt=consent does not revoke "Approve Always" if selected by user previously.

Below improvements have been added,
- If a service provider adds mandatory claims after a user has given "Approve Always" consent. In the next authentication request, the user will be prompted to give consent to share the claims.
- When the prompt=consent value set in the OIDC Authentication Request, all existing OIDC consents will be revoked and the user will be prompted to consent for both OIDC Scopes as well as for user attributes.

### When should this PR be merged
ASAP

### Follow up actions
- Update product-is pom
