### PR TITLE
Remove user consent based claim filtering for back channel grant types

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
@@ -2301,7 +2301,6 @@ public class OAuthServerConfiguration {
         private static final String USER_CONSENT_ENABLED_GRANT_TYPE = "UserConsentEnabledGrantType";
         private static final String USER_CONSENT_ENABLED_GRANT_TYPE_NAME = "GrantTypeName";
 
-
         private static final String ID_TOKEN_ALLOWED = "IdTokenAllowed";
         private static final String GET_CONSENT_FOR_USER_CLAIMS = "GetConsentForUserClaims";
         private static final String GRANT_TYPE_HANDLER_IMPL_CLASS = "GrantTypeHandlerImplClass";


### PR DESCRIPTION
### Proposed changes in this pull request
- $subject

Changes
- Introduced a util method in OIDCClaimUtil to handle filtering claims based on consent. This will avoid code duplication for id_token and user info response building logic.
- In the above-introduced util method added a check to avoid filtering claims based on user consent for back channel grant types. Therefore for back channel grant types such as password, jwt-bearer, saml bearer filtering user claims based on consent will be skipped.
- We have introduced a config in https://github.com/wso2/carbon-identity-framework/pull/1437 to get the list of grant types that require claim filtering based on user consent. Basically, these are the grant type that has an option to prompt the user for consent via a consent page at the moment.

