### PR TITLE
Add support for JWKS based JWT validation

### DIFF
--- a/components/org.wso2.carbon.identity.discovery/pom.xml
+++ b/components/org.wso2.carbon.identity.discovery/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.inbound.auth.oauth2</groupId>
         <artifactId>identity-inbound-auth-oauth</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>5.6.71-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/components/org.wso2.carbon.identity.oauth.client.authn.filter/pom.xml
+++ b/components/org.wso2.carbon.identity.oauth.client.authn.filter/pom.xml
@@ -22,7 +22,7 @@
         <groupId>org.wso2.carbon.identity.inbound.auth.oauth2</groupId>
         <artifactId>identity-inbound-auth-oauth</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>5.6.71-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/components/org.wso2.carbon.identity.oauth.common/pom.xml
+++ b/components/org.wso2.carbon.identity.oauth.common/pom.xml
@@ -23,7 +23,7 @@
         <groupId>org.wso2.carbon.identity.inbound.auth.oauth2</groupId>
         <artifactId>identity-inbound-auth-oauth</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>5.6.71-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/components/org.wso2.carbon.identity.oauth.dcr.endpoint/pom.xml
+++ b/components/org.wso2.carbon.identity.oauth.dcr.endpoint/pom.xml
@@ -6,7 +6,7 @@
         <groupId>org.wso2.carbon.identity.inbound.auth.oauth2</groupId>
         <artifactId>identity-inbound-auth-oauth</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>5.6.71-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/components/org.wso2.carbon.identity.oauth.dcr/pom.xml
+++ b/components/org.wso2.carbon.identity.oauth.dcr/pom.xml
@@ -22,7 +22,7 @@
         <groupId>org.wso2.carbon.identity.inbound.auth.oauth2</groupId>
         <artifactId>identity-inbound-auth-oauth</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>5.6.71-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/components/org.wso2.carbon.identity.oauth.endpoint/pom.xml
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/pom.xml
@@ -22,7 +22,7 @@
         <groupId>org.wso2.carbon.identity.inbound.auth.oauth2</groupId>
         <artifactId>identity-inbound-auth-oauth</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>5.6.71-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/user/impl/UserInfoJWTResponse.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/user/impl/UserInfoJWTResponse.java
@@ -56,9 +56,11 @@ public class UserInfoJWTResponse extends AbstractUserInfoResponseBuilder {
                                    String spTenantDomain,
                                    Map<String, Object> filteredUserClaims) throws UserInfoEndpointException {
 
-        JWTClaimsSet jwtClaimsSet = new JWTClaimsSet();
-        jwtClaimsSet.setAllClaims(filteredUserClaims);
-        return buildJWTResponse(tokenResponse, spTenantDomain, jwtClaimsSet);
+        JWTClaimsSet.Builder jwtClaimsSetBuilder = new JWTClaimsSet.Builder();
+        for (Map.Entry<String, Object> entry : filteredUserClaims.entrySet()) {
+            jwtClaimsSetBuilder.claim(entry.getKey(), entry.getValue());
+        }
+        return buildJWTResponse(tokenResponse, spTenantDomain, jwtClaimsSetBuilder.build());
     }
 
     private String buildJWTResponse(OAuth2TokenValidationResponseDTO tokenResponse,

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpointTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpointTest.java
@@ -17,7 +17,7 @@
  */
 package org.wso2.carbon.identity.oauth.endpoint.authz;
 
-import com.nimbusds.jwt.ReadOnlyJWTClaimsSet;
+import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
 import org.apache.axis2.transport.http.HTTPConstants;
 import org.apache.commons.collections.CollectionUtils;
@@ -186,9 +186,6 @@ public class OAuth2AuthzEndpointTest extends TestOAuthEndpointBase {
 
     @Mock
     SignedJWT signedJWT;
-
-    @Mock
-    ReadOnlyJWTClaimsSet readOnlyJWTClaimsSet;
 
     @Mock
     OIDCSessionManager oidcSessionManager;
@@ -1058,8 +1055,10 @@ public class OAuth2AuthzEndpointTest extends TestOAuthEndpointBase {
         } else {
             when(SignedJWT.parse(anyString())).thenReturn(signedJWT);
         }
-        when(signedJWT.getJWTClaimsSet()).thenReturn(readOnlyJWTClaimsSet);
-        when(readOnlyJWTClaimsSet.getSubject()).thenReturn(idTokenHintSubject);
+        JWTClaimsSet.Builder jwtClaimsSetBuilder = new JWTClaimsSet.Builder();
+        jwtClaimsSetBuilder.subject(idTokenHintSubject);
+        JWTClaimsSet jwtClaimsSet = jwtClaimsSetBuilder.build();
+        when(signedJWT.getJWTClaimsSet()).thenReturn(jwtClaimsSet);
         when(oAuth2Service.getOauthApplicationState(CLIENT_ID_VALUE)).thenReturn("ACTIVE");
 
         mockApplicationManagementService();

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/user/impl/UserInfoJWTResponseTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/user/impl/UserInfoJWTResponseTest.java
@@ -19,8 +19,8 @@
 package org.wso2.carbon.identity.oauth.endpoint.user.impl;
 
 import com.nimbusds.jwt.JWT;
+import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.JWTParser;
-import com.nimbusds.jwt.ReadOnlyJWTClaimsSet;
 import org.mockito.Mockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.testng.annotations.BeforeClass;
@@ -129,7 +129,7 @@ public class UserInfoJWTResponseTest extends UserInfoResponseBaseTest {
         assertNotNull(jwt);
         assertNotNull(jwt.getJWTClaimsSet());
 
-        Map<String, Object> claimsInResponse = jwt.getJWTClaimsSet().getAllClaims();
+        Map<String, Object> claimsInResponse = jwt.getJWTClaimsSet().getClaims();
         assertSubjectClaimPresent(claimsInResponse);
         assertNotNull(claimsInResponse.get(claimUri));
         assertEquals(claimsInResponse.get(claimUri), Boolean.parseBoolean(claimValue));
@@ -144,7 +144,7 @@ public class UserInfoJWTResponseTest extends UserInfoResponseBaseTest {
         assertNotNull(jwt);
         assertNotNull(jwt.getJWTClaimsSet());
 
-        Map<String, Object> claimsInResponse = jwt.getJWTClaimsSet().getAllClaims();
+        Map<String, Object> claimsInResponse = jwt.getJWTClaimsSet().getClaims();
         assertSubjectClaimPresent(claimsInResponse);
         assertNotNull(claimsInResponse.get(claimUri));
         assertTrue(claimsInResponse.get(claimUri) instanceof Integer || claimsInResponse.get(claimUri) instanceof Long);
@@ -168,12 +168,12 @@ public class UserInfoJWTResponseTest extends UserInfoResponseBaseTest {
                             getTokenResponseDTO(AUTHORIZED_USER_FULL_QUALIFIED, requestedScopes));
 
             JWT jwt = JWTParser.parse(responseString);
-            ReadOnlyJWTClaimsSet jwtClaimsSet = jwt.getJWTClaimsSet();
+            JWTClaimsSet jwtClaimsSet = jwt.getJWTClaimsSet();
             assertNotNull(jwtClaimsSet);
             assertNotNull(jwtClaimsSet.getSubject());
 
             for (Map.Entry<String, Object> expectedClaimEntry : expectedClaims.entrySet()) {
-                assertTrue(jwtClaimsSet.getAllClaims().containsKey(expectedClaimEntry.getKey()));
+                assertTrue(jwtClaimsSet.getClaims().containsKey(expectedClaimEntry.getKey()));
                 assertNotNull(jwtClaimsSet.getClaim(expectedClaimEntry.getKey()));
                 assertEquals(
                         expectedClaimEntry.getValue(),

--- a/components/org.wso2.carbon.identity.oauth.scope.endpoint/pom.xml
+++ b/components/org.wso2.carbon.identity.oauth.scope.endpoint/pom.xml
@@ -22,7 +22,7 @@
         <groupId>org.wso2.carbon.identity.inbound.auth.oauth2</groupId>
         <artifactId>identity-inbound-auth-oauth</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>5.6.71-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/components/org.wso2.carbon.identity.oauth.stub/pom.xml
+++ b/components/org.wso2.carbon.identity.oauth.stub/pom.xml
@@ -22,7 +22,7 @@
         <groupId>org.wso2.carbon.identity.inbound.auth.oauth2</groupId>
         <artifactId>identity-inbound-auth-oauth</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>5.6.71-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/components/org.wso2.carbon.identity.oauth.ui/pom.xml
+++ b/components/org.wso2.carbon.identity.oauth.ui/pom.xml
@@ -22,7 +22,7 @@
         <groupId>org.wso2.carbon.identity.inbound.auth.oauth2</groupId>
         <artifactId>identity-inbound-auth-oauth</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>5.6.71-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/components/org.wso2.carbon.identity.oauth/pom.xml
+++ b/components/org.wso2.carbon.identity.oauth/pom.xml
@@ -23,7 +23,7 @@
         <groupId>org.wso2.carbon.identity.inbound.auth.oauth2</groupId>
         <artifactId>identity-inbound-auth-oauth</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>5.6.71-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authcontext/JWTTokenGenerator.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authcontext/JWTTokenGenerator.java
@@ -214,14 +214,14 @@ public class JWTTokenGenerator implements AuthorizationContextTokenGenerator {
         long expireIn = currentTime + 1000 * 60 * getTTL();
 
         // Prepare JWT with claims set
-        JWTClaimsSet claimsSet = new JWTClaimsSet();
-        claimsSet.setIssuer(API_GATEWAY_ID);
-        claimsSet.setSubject(authzUser);
-        claimsSet.setIssueTime(new Date(issuedTime));
-        claimsSet.setExpirationTime(new Date(expireIn));
-        claimsSet.setClaim(API_GATEWAY_ID+"/subscriber",subscriber);
-        claimsSet.setClaim(API_GATEWAY_ID+"/applicationname",applicationName);
-        claimsSet.setClaim(API_GATEWAY_ID+"/enduser",authzUser);
+        JWTClaimsSet.Builder claimsSetBuilder = new JWTClaimsSet.Builder();
+        claimsSetBuilder.issuer(API_GATEWAY_ID);
+        claimsSetBuilder.subject(authzUser);
+        claimsSetBuilder.issueTime(new Date(issuedTime));
+        claimsSetBuilder.expirationTime(new Date(expireIn));
+        claimsSetBuilder.claim(API_GATEWAY_ID+"/subscriber",subscriber);
+        claimsSetBuilder.claim(API_GATEWAY_ID+"/applicationname",applicationName);
+        claimsSetBuilder.claim(API_GATEWAY_ID+"/enduser",authzUser);
 
         if(claimsRetriever != null){
 
@@ -279,14 +279,15 @@ public class JWTTokenGenerator implements AuthorizationContextTokenGenerator {
                                 claimList.add(attValue);
                             }
                         }
-                        claimsSet.setClaim(claimURI, claimList.toArray(new String[claimList.size()]));
+                        claimsSetBuilder.claim(claimURI, claimList.toArray(new String[claimList.size()]));
                     } else {
-                        claimsSet.setClaim(claimURI, claimVal);
+                        claimsSetBuilder.claim(claimURI, claimVal);
                     }
                 }
             }
         }
 
+        JWTClaimsSet claimsSet = claimsSetBuilder.build();
         JWT jwt = null;
         if(!JWSAlgorithm.NONE.equals(signatureAlgorithm)){
             jwt = OAuth2Util.signJWT(claimsSet, signatureAlgorithm, tenantDomain);

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -1791,11 +1791,11 @@ public class OAuth2Util {
             Certificate publicCert = getX509CertOfOAuthApp(clientId, spTenantDomain);
             Key publicKey = publicCert.getPublicKey();
 
-            JWEHeader header = new JWEHeader(encryptionAlgorithm, encryptionMethod);
+            JWEHeader.Builder headerBuilder = new JWEHeader.Builder(encryptionAlgorithm, encryptionMethod);
             String thumbPrint = getThumbPrint(publicCert);
-            header.setKeyID(thumbPrint);
-            header.setX509CertThumbprint(new Base64URL(thumbPrint));
-
+            headerBuilder.keyID(thumbPrint);
+            headerBuilder.x509CertThumbprint(new Base64URL(thumbPrint));
+            JWEHeader header = headerBuilder.build();
             EncryptedJWT encryptedJWT = new EncryptedJWT(header, jwtClaimsSet);
 
             if (log.isDebugEnabled()) {
@@ -1868,10 +1868,10 @@ public class OAuth2Util {
             int tenantId = IdentityTenantUtil.getTenantId(tenantDomain);
             Key privateKey = getPrivateKey(tenantDomain, tenantId);
             JWSSigner signer = new RSASSASigner((RSAPrivateKey) privateKey);
-            JWSHeader header = new JWSHeader((JWSAlgorithm) signatureAlgorithm);
-            header.setKeyID(getThumbPrint(tenantDomain, tenantId));
-            header.setX509CertThumbprint(new Base64URL(getThumbPrint(tenantDomain, tenantId)));
-            SignedJWT signedJWT = new SignedJWT(header, jwtClaimsSet);
+            JWSHeader.Builder headerBuilder = new JWSHeader.Builder((JWSAlgorithm) signatureAlgorithm);
+            headerBuilder.keyID(getThumbPrint(tenantDomain, tenantId));
+            headerBuilder.x509CertThumbprint(new Base64URL(getThumbPrint(tenantDomain, tenantId)));
+            SignedJWT signedJWT = new SignedJWT(headerBuilder.build(), jwtClaimsSet);
             signedJWT.sign(signer);
             return signedJWT;
         } catch (JOSEException e) {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/OAuth2JWTTokenValidator.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/OAuth2JWTTokenValidator.java
@@ -19,10 +19,10 @@
 package org.wso2.carbon.identity.oauth2.validators;
 
 import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSHeader;
 import com.nimbusds.jose.JWSVerifier;
-import com.nimbusds.jose.ReadOnlyJWSHeader;
 import com.nimbusds.jose.crypto.RSASSAVerifier;
-import com.nimbusds.jwt.ReadOnlyJWTClaimsSet;
+import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
@@ -59,7 +59,7 @@ public class OAuth2JWTTokenValidator extends DefaultOAuth2TokenValidator {
             throws IdentityOAuth2Exception {
         try {
             SignedJWT signedJWT = getSignedJWT(validationReqDTO);
-            ReadOnlyJWTClaimsSet claimsSet = signedJWT.getJWTClaimsSet();
+            JWTClaimsSet claimsSet = signedJWT.getJWTClaimsSet();
             if (claimsSet == null) {
                 throw new IdentityOAuth2Exception("Claim values are empty in the given Token.");
             }
@@ -88,7 +88,7 @@ public class OAuth2JWTTokenValidator extends DefaultOAuth2TokenValidator {
      * @return the resolved X509 Certificate, to be used to validate the JWT signature.
      * @throws IdentityOAuth2Exception something goes wrong.
      */
-    protected X509Certificate resolveSignerCertificate(ReadOnlyJWSHeader header,
+    protected X509Certificate resolveSignerCertificate(JWSHeader header,
                                                        IdentityProvider idp) throws IdentityOAuth2Exception {
         X509Certificate x509Certificate;
         String tenantDomain = getTenantDomain();
@@ -106,7 +106,7 @@ public class OAuth2JWTTokenValidator extends DefaultOAuth2TokenValidator {
         return SignedJWT.parse(validationReqDTO.getRequestDTO().getAccessToken().getIdentifier());
     }
 
-    private String resolveSubject(ReadOnlyJWTClaimsSet claimsSet) {
+    private String resolveSubject(JWTClaimsSet claimsSet) {
         return claimsSet.getSubject();
     }
 
@@ -140,7 +140,7 @@ public class OAuth2JWTTokenValidator extends DefaultOAuth2TokenValidator {
             throws JOSEException, IdentityOAuth2Exception {
 
         JWSVerifier verifier = null;
-        ReadOnlyJWSHeader header = signedJWT.getHeader();
+        JWSHeader header = signedJWT.getHeader();
         X509Certificate x509Certificate = resolveSignerCertificate(header, idp);
         if (x509Certificate == null) {
             throw new IdentityOAuth2Exception("Unable to locate certificate for Identity Provider: " + idp
@@ -222,7 +222,7 @@ public class OAuth2JWTTokenValidator extends DefaultOAuth2TokenValidator {
         return true;
     }
 
-    private boolean validateRequiredFields(ReadOnlyJWTClaimsSet claimsSet) throws IdentityOAuth2Exception {
+    private boolean validateRequiredFields(JWTClaimsSet claimsSet) throws IdentityOAuth2Exception {
 
         String subject = resolveSubject(claimsSet);
         List<String> audience = claimsSet.getAudience();

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/jwt/JWKSBasedJWTValidator.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/jwt/JWKSBasedJWTValidator.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth2.validators.jwt;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.jwk.source.JWKSource;
+import com.nimbusds.jose.proc.BadJOSEException;
+import com.nimbusds.jose.proc.JWSKeySelector;
+import com.nimbusds.jose.proc.JWSVerificationKeySelector;
+import com.nimbusds.jose.proc.SecurityContext;
+import com.nimbusds.jose.proc.SimpleSecurityContext;
+import com.nimbusds.jwt.EncryptedJWT;
+import com.nimbusds.jwt.JWT;
+import com.nimbusds.jwt.JWTParser;
+import com.nimbusds.jwt.PlainJWT;
+import com.nimbusds.jwt.SignedJWT;
+import com.nimbusds.jwt.proc.ConfigurableJWTProcessor;
+import com.nimbusds.jwt.proc.DefaultJWTProcessor;
+import org.apache.commons.collections.MapUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
+
+import java.net.MalformedURLException;
+import java.text.ParseException;
+import java.util.Map;
+
+/**
+ * Validate JWT using Identity Provider's jwks_uri.
+ */
+public class JWKSBasedJWTValidator implements JWTValidator {
+
+    private static final Log log = LogFactory.getLog(JWKSBasedJWTValidator.class);
+    private ConfigurableJWTProcessor<SecurityContext> jwtProcessor;
+
+    public JWKSBasedJWTValidator() {
+        /* Set up a JWT processor to parse the tokens and then check their signature and validity time window
+        (bounded by the "iat", "nbf" and "exp" claims). */
+        this.jwtProcessor = new DefaultJWTProcessor<>();
+    }
+
+    @Override
+    public boolean validateSignature(String jwtString, String jwksUri, String algorithm, Map<String, Object> opts)
+            throws IdentityOAuth2Exception {
+
+        try {
+            JWT jwt = JWTParser.parse(jwtString);
+            return this.validateSignature(jwt, jwksUri, algorithm, opts);
+
+        } catch (ParseException e) {
+            throw new IdentityOAuth2Exception("Error occurred while parsing JWT string.", e);
+        }
+    }
+
+    @Override
+    public boolean validateSignature(JWT jwt, String jwksUri, String algorithm, Map<String, Object> opts) throws
+            IdentityOAuth2Exception {
+
+        if (log.isDebugEnabled()) {
+            log.debug("validating JWT signature using jwks_uri: " + jwksUri + " , for signing algorithm: " +
+                    algorithm);
+        }
+        try {
+            // set the Key Selector for the jwks_uri.
+            setJWKeySelector(jwksUri, algorithm);
+
+            // Process the token, set optional context parameters.
+            SecurityContext securityContext = null;
+            if (MapUtils.isNotEmpty(opts)) {
+                securityContext = new SimpleSecurityContext();
+                ((SimpleSecurityContext)securityContext).putAll(opts);
+            }
+
+          if (jwt instanceof PlainJWT) {
+                jwtProcessor.process((PlainJWT)jwt, securityContext);
+            } else if (jwt instanceof SignedJWT) {
+                jwtProcessor.process((SignedJWT)jwt, securityContext);
+            } else if (jwt instanceof EncryptedJWT) {
+                jwtProcessor.process((EncryptedJWT)jwt, securityContext);
+            } else {
+                jwtProcessor.process(jwt, securityContext);
+            }
+            return true;
+
+        } catch (MalformedURLException e) {
+            throw new IdentityOAuth2Exception("Provided jwks_uri is malformed.", e);
+        } catch (JOSEException e) {
+            throw new IdentityOAuth2Exception("Signature validation failed for the provided JWT.", e);
+        } catch (BadJOSEException e) {
+            throw new IdentityOAuth2Exception("Signature validation failed for the provided JWT", e);
+        }
+    }
+
+
+    private void setJWKeySelector(String jwksUri, String algorithm) throws MalformedURLException {
+
+        /* The public RSA keys to validate the signatures will be sourced from the OAuth 2.0 server's JWK set,
+        published at a well-known URL. The RemoteJWKSet object caches the retrieved keys to speed up subsequent
+        look-ups and can also gracefully handle key-rollover. */
+        JWKSource<SecurityContext> keySource = JWKSourceDataProvider.getInstance().getJWKSource(jwksUri);
+
+        // The expected JWS algorithm of the access tokens (agreed out-of-band).
+        JWSAlgorithm expectedJWSAlg = JWSAlgorithm.parse(algorithm);
+
+        /* Configure the JWT processor with a key selector to feed matching public RSA keys sourced from the JWK set
+        URL. */
+        JWSKeySelector<SecurityContext> keySelector = new JWSVerificationKeySelector<>(expectedJWSAlg, keySource);
+        jwtProcessor.setJWSKeySelector(keySelector);
+    }
+}

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/jwt/JWKSourceDataProvider.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/jwt/JWKSourceDataProvider.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth2.validators.jwt;
+
+import com.nimbusds.jose.jwk.source.RemoteJWKSet;
+import com.nimbusds.jose.proc.SecurityContext;
+import com.nimbusds.jose.util.DefaultResourceRetriever;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Provides JWK sources for JWT validation.
+ */
+public class JWKSourceDataProvider {
+
+    private static final int DEFAULT_HTTP_CONNECTION_TIMEOUT = 1000;
+    private static final int DEFAULT_HTTP_READ_TIMEOUT = 1000;
+    private static final String HTTP_CONNECTION_TIMEOUT_XPATH = "JWTValidatorConfigs.JWKSEndpoint" +
+            ".HTTPConnectionTimeout";
+    private static final String HTTP_READ_TIMEOUT_XPATH = "JWTValidatorConfigs.JWKSEndpoint" +
+            ".HTTPReadTimeout";
+    private static final String HTTP_SIZE_LIMIT_XPATH = "JWTValidatorConfigs.JWKSEndpoint" +
+            ".HTTPSizeLimit";
+    private static final Log log = LogFactory.getLog(JWKSourceDataProvider.class);
+
+    private static JWKSourceDataProvider jwkSourceDataProvider = new JWKSourceDataProvider();
+    private Map<String, RemoteJWKSet<SecurityContext>> jwkSourceMap = new ConcurrentHashMap<>();
+
+    private JWKSourceDataProvider() {
+
+    }
+
+    /**
+     * Returns an instance of JWK-Source data holder.
+     *
+     * @return JWKSSourceDataHolder.
+     */
+    public static JWKSourceDataProvider getInstance() {
+
+        return jwkSourceDataProvider;
+    }
+
+    /**
+     * Get cached JWKSet for the jwks_uri.
+     *
+     * @param jwksUri Identity provider's JWKS endpoint.
+     * @return RemoteJWKSet.
+     * @throws MalformedURLException for invalid URL.
+     */
+    public RemoteJWKSet<SecurityContext> getJWKSource(String jwksUri) throws MalformedURLException {
+
+        RemoteJWKSet<SecurityContext> jwkSet = jwkSourceMap.get(jwksUri);
+
+        if (jwkSet == null) {
+            jwkSet = retrieveJWKSFromJWKSEndpoint(jwksUri);
+            jwkSourceMap.put(jwksUri, jwkSet);
+        }
+        return jwkSet;
+    }
+
+    public Map<String, RemoteJWKSet<SecurityContext>> getJwkSourceMap() {
+
+        return jwkSourceMap;
+    }
+
+    /**
+     * Retrieve the new-keyset from the JWKS endpoint in case of signature validation failure.
+     *
+     * @param jwksUri Identity providers jwks_uri.
+     * @throws IdentityOAuth2Exception for invalid/malformed URL.
+     */
+    public void refreshJWKSResource(String jwksUri) throws IdentityOAuth2Exception {
+
+        try {
+            jwkSourceMap.remove(jwksUri);
+            RemoteJWKSet<SecurityContext> jwkSet = retrieveJWKSFromJWKSEndpoint(jwksUri);
+            jwkSourceMap.put(jwksUri, jwkSet);
+        } catch (MalformedURLException e) {
+            throw new IdentityOAuth2Exception("Provided URI is malformed. jwks_uri: " + jwksUri, e);
+        }
+    }
+
+    /**
+     * Retrieve JWKS from jwks_uri.
+     *
+     * @param jwksUri Identity provider's jwks_uri.
+     * @return RemoteJWKSet
+     * @throws MalformedURLException for invalid URL.
+     */
+    private RemoteJWKSet<SecurityContext> retrieveJWKSFromJWKSEndpoint(String jwksUri) throws MalformedURLException {
+
+        // Retrieve HTTP endpoint configurations.
+        int connectionTimeout = readHTTPConnectionConfigValue(HTTP_CONNECTION_TIMEOUT_XPATH);
+        int readTimeout = readHTTPConnectionConfigValue(HTTP_READ_TIMEOUT_XPATH);
+        int sizeLimit = readHTTPConnectionConfigValue(HTTP_SIZE_LIMIT_XPATH);
+
+        if (connectionTimeout <= 0) {
+            connectionTimeout = DEFAULT_HTTP_CONNECTION_TIMEOUT;
+        }
+        if (readTimeout <= 0) {
+            readTimeout = DEFAULT_HTTP_READ_TIMEOUT;
+        }
+        if (sizeLimit <= 0) {
+            sizeLimit = RemoteJWKSet.DEFAULT_HTTP_SIZE_LIMIT;
+        }
+        DefaultResourceRetriever resourceRetriever = new DefaultResourceRetriever(
+                connectionTimeout,
+                readTimeout,
+                sizeLimit);
+
+        return new RemoteJWKSet<>(new URL(jwksUri), resourceRetriever);
+    }
+
+    /**
+     * Read HTTP connection configurations from identity.xml file.
+     *
+     * @param xPath xpath of the config property.
+     * @return Config property value.
+     */
+    private int readHTTPConnectionConfigValue(String xPath) {
+
+        int configValue = 0;
+        String config = IdentityUtil.getProperty(xPath);
+        if (StringUtils.isNotBlank(config)) {
+            try {
+                configValue = Integer.parseInt(config);
+            } catch (NumberFormatException e) {
+                log.error("Provided HTTP connection config value in " + xPath + " should be an integer type. Value : "
+                        + config);
+            }
+        }
+        return configValue;
+    }
+}

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/jwt/JWTValidator.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/jwt/JWTValidator.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth2.validators.jwt;
+
+import com.nimbusds.jwt.JWT;
+import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
+
+import java.util.Map;
+
+/**
+ * Validates JWT.
+ */
+public interface JWTValidator {
+
+    /**
+     * Validates a JWT string using jwks_uri.
+     *
+     * @param jwt       JWT string.
+     * @param jwksUri   Identity provider's jwks_uri.
+     * @param algorithm JWT signature algorithm.
+     * @param opts      Optional values.
+     * @return whether the provided token is valid.
+     * @throws IdentityOAuth2Exception
+     */
+    public boolean validateSignature(String jwt, String jwksUri, String algorithm, Map<String, Object> opts) throws
+            IdentityOAuth2Exception;
+
+    /**
+     * Validates a JWT token using jwks_uri.
+     *
+     * @param jwt       JWT.
+     * @param jwksUri   Identity provider's jwks_uri.
+     * @param algorithm JWT signature algorithm.
+     * @param opts      Optional values.
+     * @return whether the provided token is valid.
+     * @throws IdentityOAuth2Exception
+     */
+    public boolean validateSignature(JWT jwt, String jwksUri, String algorithm, Map<String, Object> opts) throws
+            IdentityOAuth2Exception;
+}

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/CustomClaimsCallbackHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/CustomClaimsCallbackHandler.java
@@ -26,8 +26,8 @@ import org.wso2.carbon.identity.oauth2.token.OAuthTokenReqMessageContext;
  */
 public interface CustomClaimsCallbackHandler {
 
-    public void handleCustomClaims(JWTClaimsSet builder, OAuthTokenReqMessageContext request);
+    public JWTClaimsSet handleCustomClaims(JWTClaimsSet.Builder builder, OAuthTokenReqMessageContext request);
 
-    public void handleCustomClaims(JWTClaimsSet builder, OAuthAuthzReqMessageContext request);
+    public JWTClaimsSet handleCustomClaims(JWTClaimsSet.Builder builder, OAuthAuthzReqMessageContext request);
 
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/RequestObjectValidatorImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/RequestObjectValidatorImpl.java
@@ -18,8 +18,8 @@
 package org.wso2.carbon.identity.openidconnect;
 
 import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSHeader;
 import com.nimbusds.jose.JWSVerifier;
-import com.nimbusds.jose.ReadOnlyJWSHeader;
 import com.nimbusds.jose.crypto.RSASSAVerifier;
 import com.nimbusds.jwt.SignedJWT;
 import org.apache.commons.lang.StringUtils;
@@ -251,7 +251,7 @@ public class RequestObjectValidatorImpl implements RequestObjectValidator {
     protected boolean isSignatureVerified(SignedJWT signedJWT, Certificate x509Certificate) {
 
         JWSVerifier verifier;
-        ReadOnlyJWSHeader header = signedJWT.getHeader();
+        JWSHeader header = signedJWT.getHeader();
         if (x509Certificate == null) {
             return logAndReturnFalse("Unable to locate certificate for JWT " + header.toString());
         }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/model/RequestObject.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/model/RequestObject.java
@@ -16,8 +16,8 @@
 package org.wso2.carbon.identity.openidconnect.model;
 
 
+import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.PlainJWT;
-import com.nimbusds.jwt.ReadOnlyJWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
 import net.minidev.json.JSONArray;
 import net.minidev.json.JSONObject;
@@ -46,7 +46,7 @@ public class RequestObject implements Serializable {
 
     private SignedJWT signedJWT;
     private PlainJWT plainJWT;
-    private ReadOnlyJWTClaimsSet claimsSet;
+    private JWTClaimsSet claimsSet;
 
     /**
      * To store the claims requestor and the the requested claim list. claim requestor can be either userinfo or
@@ -124,11 +124,11 @@ public class RequestObject implements Serializable {
         }
     }
 
-    public void setClaimSet(ReadOnlyJWTClaimsSet claimSet) {
+    public void setClaimSet(JWTClaimsSet claimSet) {
         this.claimsSet = claimSet;
     }
 
-    public ReadOnlyJWTClaimsSet getClaimsSet() {
+    public JWTClaimsSet getClaimsSet() {
         return claimsSet;
     }
 

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/validators/jwt/JWKSBasedJWTValidatorTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/validators/jwt/JWKSBasedJWTValidatorTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth2.validators.jwt;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.jwk.source.RemoteJWKSet;
+import com.nimbusds.jose.proc.BadJOSEException;
+import com.nimbusds.jose.proc.SecurityContext;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.proc.DefaultJWTProcessor;
+import org.mockito.Mock;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.common.testng.WithCarbonHome;
+import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
+import org.wso2.carbon.identity.testutil.powermock.PowerMockIdentityBaseTest;
+
+import java.net.MalformedURLException;
+import java.text.ParseException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.MockitoAnnotations.initMocks;
+import static org.powermock.api.mockito.PowerMockito.doReturn;
+import static org.powermock.api.mockito.PowerMockito.doThrow;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.when;
+import static org.powermock.api.mockito.PowerMockito.whenNew;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+@WithCarbonHome
+@PrepareForTest({JWKSourceDataProvider.class, JWKSBasedJWTValidator.class})
+public class JWKSBasedJWTValidatorTest extends PowerMockIdentityBaseTest {
+
+    private JWKSBasedJWTValidator validator;
+
+    private String jwtString =
+            "eyJ4NXQiOiJObUptT0dVeE16WmxZak0yWkRSaE5UWmxZVEExWXpkaFpUUmlPV0UwTldJMk0ySm1PVGMxWkEiLCJhb" +
+                    "GciOiJSUzI1NiJ9.eyJhdF9oYXNoIjoiR2ptOGFsN21FSkRVYjZuN3V1Mi1qUSIsInN1YiI6ImFkbWluQGNhcmJvbi5zdXBlciIs" +
+                    "ImF1ZCI6WyJhVmdieWhBMVY3TWV0ZW1PNEtrUjlFYnBzOW9hIiwiaHR0cHM6XC9cL2xvY2FsaG9zdDo5NDQzXC9vYXV0aDJcL3Rv" +
+                    "a2VuIl0sImF6cCI6ImFWZ2J5aEExVjdNZXRlbU80S2tSOUVicHM5b2EiLCJhdXRoX3RpbWUiOjE1MjUyMzYzMzcsImlzcyI6Imh0" +
+                    "dHBzOlwvXC8xMC4xMDAuOC4yOjk0NDNcL29hdXRoMlwvdG9rZW4iLCJleHAiOjE1MjUyMzk5MzcsImlhdCI6MTUyNTIzNjMzN30." +
+                    "DOPv7UHymV3zJJpxxWqbGcrvjY-OOzmdJVUxwHorDlOGABP_X_Krd584rLIbcYFmd8q5wSUuX21wXCLCOXFli1CUC-ZfP0S0fJqU" +
+                    "Zv_ynNo6NTFY9d3-sv0b7QYT-8mnxSmjqqsmDrOcxlD7gcYkkr1pLLQe9ZK2B_lR5KZlMW0";
+
+    @Mock
+    private DefaultJWTProcessor<SecurityContext> jwtProcessor;
+    @Mock
+    private JWKSourceDataProvider dataProvider;
+    @Mock
+    private RemoteJWKSet<SecurityContext> jwkSet;
+
+    @BeforeMethod
+    public void setUp() {
+
+        initMocks(this);
+    }
+
+    @Test(dataProvider = "validateDataForException")
+    public void testValidateSignature(Object test, String jwt, String jwksUri, String algorithm, Map<String, Object>
+            opts) throws
+            Exception {
+
+        mockStatic(JWKSourceDataProvider.class);
+        when(JWKSourceDataProvider.getInstance()).thenReturn(dataProvider);
+        whenNew(DefaultJWTProcessor.class).withNoArguments().thenReturn(jwtProcessor);
+        validator = new JWKSBasedJWTValidator();
+
+        TestScenario testScenario = (TestScenario) test;
+
+        if (testScenario == TestScenario.INVALID_JWKS) {
+            doThrow(testScenario.throwError()).when(dataProvider).getJWKSource(jwksUri);
+        } else {
+            when(JWKSourceDataProvider.getInstance().getJWKSource(anyString())).thenReturn(jwkSet);
+        }
+
+        if (testScenario == TestScenario.VALID_JWT) {
+            JWTClaimsSet jwtClaimsSet = new JWTClaimsSet.Builder().build();
+            doReturn(jwtClaimsSet).when(jwtProcessor).process(jwtString, null);
+        } else if (testScenario != TestScenario.INVALID_JWKS) {
+            doThrow(testScenario.throwError()).when(jwtProcessor).process(anyString(), any(SecurityContext
+                    .class));
+        }
+
+        try {
+            boolean isValid = validator.validateSignature(jwt, jwksUri, algorithm, opts);
+            assertTrue(isValid, "JWT validation failed with unexpected error.");
+        } catch (IdentityOAuth2Exception e) {
+
+            if (testScenario == TestScenario.INVALID_JWT) {
+                assertEquals("Error occurred while parsing JWT string.", e.getMessage(),
+                        "Signature validation not handled properly.");
+            }
+            if (testScenario == TestScenario.INVALID_JWKS) {
+                assertEquals("Provided jwks_uri is malformed.", e.getMessage(), "Failed to validate jwks_uri.");
+            }
+            if (testScenario == TestScenario.INVALID_SIGNATURE) {
+                assertEquals("Signature validation failed for the provided JWT.", e.getMessage(), "invalid algorithm");
+            }
+        }
+    }
+
+    @DataProvider(name = "validateDataForException")
+    public Object[][] provideValidateDataForException() {
+
+        HashMap opts = new HashMap();
+        opts.put("nonce", "nonceValue");
+        return new Object[][]{
+                {TestScenario.VALID_JWT, jwtString, "https://localhost:9444/oauth2/jwks", "RS256",
+                        Collections.emptyMap()},
+                {TestScenario.INVALID_JWT, "invalidJWT", "https://localhost:9444/oauth2/jwks", "RS256",
+                        Collections.emptyMap()},
+                {TestScenario.INVALID_JWKS, jwtString, "invalidUri", "invalid", Collections.emptyMap()},
+                {TestScenario.INVALID_SIGNATURE, jwtString, "https://localhost:9444/oauth2/jwks", "RS256", opts},
+        };
+    }
+
+    public enum TestScenario {
+        VALID_JWT,
+        INVALID_JWT,
+        INVALID_JWKS,
+        INVALID_SIGNATURE,
+        UNSUPPORTED_ALGO;
+
+        Exception throwError() {
+
+            switch (this) {
+                case VALID_JWT:
+                case INVALID_JWT:
+                    return new ParseException("Error occurred while parsing JWT string.", 0);
+                case INVALID_JWKS:
+                    return new MalformedURLException();
+                case INVALID_SIGNATURE:
+                    return new JOSEException("Signature validated failed.");
+                case UNSUPPORTED_ALGO:
+                    return new BadJOSEException("Unsupported algorithm");
+                default:
+                    return null;
+            }
+        }
+    }
+
+}

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/openidconnect/DefaultOIDCClaimsCallbackHandlerTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/openidconnect/DefaultOIDCClaimsCallbackHandlerTest.java
@@ -245,16 +245,17 @@ public class DefaultOIDCClaimsCallbackHandlerTest {
      */
     @Test
     public void testHandleCustomClaimsWithOAuthTokenReqMsgCtxtNoValidSp() throws Exception {
-        JWTClaimsSet jwtClaimsSet = new JWTClaimsSet();
+        JWTClaimsSet.Builder jwtClaimsSetBuilder = new JWTClaimsSet.Builder();
         OAuthTokenReqMessageContext requestMsgCtx = getTokenReqMessageContextForLocalUser();
 
         ServiceProvider serviceProvider = new ServiceProvider();
         serviceProvider.setApplicationName(SERVICE_PROVIDER_NAME);
         mockApplicationManagementService();
 
-        defaultOIDCClaimsCallbackHandler.handleCustomClaims(jwtClaimsSet, requestMsgCtx);
+        JWTClaimsSet jwtClaimsSet = defaultOIDCClaimsCallbackHandler.handleCustomClaims(jwtClaimsSetBuilder,
+                requestMsgCtx);
         assertNotNull(jwtClaimsSet);
-        assertTrue(jwtClaimsSet.getCustomClaims().isEmpty());
+        assertTrue(jwtClaimsSet.getClaims().isEmpty());
     }
 
     /**
@@ -262,15 +263,16 @@ public class DefaultOIDCClaimsCallbackHandlerTest {
      */
     @Test
     public void testHandleCustomClaimsWithOAuthTokenReqMsgCtxtNoSpRequestedClaims() throws Exception {
-        JWTClaimsSet jwtClaimsSet = new JWTClaimsSet();
+        JWTClaimsSet.Builder jwtClaimsSetBuilder = new JWTClaimsSet.Builder();
         OAuthTokenReqMessageContext requestMsgCtx = getTokenReqMessageContextForLocalUser();
 
         ServiceProvider serviceProvider = getSpWithDefaultRequestedClaimsMappings();
         mockApplicationManagementService(serviceProvider);
 
-        defaultOIDCClaimsCallbackHandler.handleCustomClaims(jwtClaimsSet, requestMsgCtx);
+        JWTClaimsSet jwtClaimsSet = defaultOIDCClaimsCallbackHandler.handleCustomClaims(jwtClaimsSetBuilder,
+                requestMsgCtx);
         assertNotNull(jwtClaimsSet);
-        assertTrue(jwtClaimsSet.getCustomClaims().isEmpty());
+        assertTrue(jwtClaimsSet.getClaims().isEmpty());
     }
 
     private ServiceProvider getSpWithDefaultRequestedClaimsMappings() {
@@ -293,21 +295,22 @@ public class DefaultOIDCClaimsCallbackHandlerTest {
 
     @Test
     public void testHandleCustomClaimsWithOAuthTokenReqMsgCtxtNoRealmFound() throws Exception {
-        JWTClaimsSet jwtClaimsSet = new JWTClaimsSet();
+        JWTClaimsSet.Builder jwtClaimsSetBuilder = new JWTClaimsSet.Builder();
         OAuthTokenReqMessageContext requestMsgCtx = getTokenReqMessageContextForLocalUser();
 
         ServiceProvider serviceProvider = new ServiceProvider();
         serviceProvider.setApplicationName(SERVICE_PROVIDER_NAME);
         mockApplicationManagementService(serviceProvider);
 
-        defaultOIDCClaimsCallbackHandler.handleCustomClaims(jwtClaimsSet, requestMsgCtx);
+        JWTClaimsSet jwtClaimsSet = defaultOIDCClaimsCallbackHandler.handleCustomClaims(jwtClaimsSetBuilder,
+                requestMsgCtx);
         assertNotNull(jwtClaimsSet);
-        assertTrue(jwtClaimsSet.getCustomClaims().isEmpty());
+        assertTrue(jwtClaimsSet.getClaims().isEmpty());
     }
 
     @Test
     public void testHandleCustomClaimsWithOAuthTokenReqMsgCtxtNoUserClaims() throws Exception {
-        JWTClaimsSet jwtClaimsSet = new JWTClaimsSet();
+        JWTClaimsSet.Builder jwtClaimsSetBuilder = new JWTClaimsSet.Builder();
         OAuthTokenReqMessageContext requestMsgCtx = getTokenReqMessageContextForLocalUser();
 
         ServiceProvider serviceProvider = getSpWithDefaultRequestedClaimsMappings();
@@ -318,14 +321,15 @@ public class DefaultOIDCClaimsCallbackHandlerTest {
 
         mockUserRealm(requestMsgCtx.getAuthorizedUser().toString(), userRealm);
 
-        defaultOIDCClaimsCallbackHandler.handleCustomClaims(jwtClaimsSet, requestMsgCtx);
+        JWTClaimsSet jwtClaimsSet = defaultOIDCClaimsCallbackHandler.handleCustomClaims(jwtClaimsSetBuilder,
+                requestMsgCtx);
         assertNotNull(jwtClaimsSet);
-        assertTrue(jwtClaimsSet.getCustomClaims().isEmpty());
+        assertTrue(jwtClaimsSet.getClaims().isEmpty());
     }
 
     @Test
     public void testHandleCustomClaimsWithOAuthTokenReqMsgCtxtUserNotFoundInUserStore() throws Exception {
-        JWTClaimsSet jwtClaimsSet = new JWTClaimsSet();
+        JWTClaimsSet.Builder jwtClaimsSetBuilder = new JWTClaimsSet.Builder();
         OAuthTokenReqMessageContext requestMsgCtx = getTokenReqMessageContextForLocalUser();
 
         ServiceProvider serviceProvider = getSpWithDefaultRequestedClaimsMappings();
@@ -334,14 +338,14 @@ public class DefaultOIDCClaimsCallbackHandlerTest {
         UserRealm userRealm = getExceptionThrowingUserRealm(new UserStoreException(USER_NOT_FOUND));
         mockUserRealm(requestMsgCtx.getAuthorizedUser().toString(), userRealm);
 
-        defaultOIDCClaimsCallbackHandler.handleCustomClaims(jwtClaimsSet, requestMsgCtx);
+        JWTClaimsSet jwtClaimsSet = defaultOIDCClaimsCallbackHandler.handleCustomClaims(jwtClaimsSetBuilder, requestMsgCtx);
         assertNotNull(jwtClaimsSet);
-        assertTrue(jwtClaimsSet.getCustomClaims().isEmpty());
+        assertTrue(jwtClaimsSet.getClaims().isEmpty());
     }
 
     @Test
     public void testHandleCustomClaimsWithOAuthTokenReqMsgCtxtUserStoreException() throws Exception {
-        JWTClaimsSet jwtClaimsSet = new JWTClaimsSet();
+        JWTClaimsSet.Builder jwtClaimsSetBuilder = new JWTClaimsSet.Builder();
         OAuthTokenReqMessageContext requestMsgCtx = getTokenReqMessageContextForLocalUser();
 
         ServiceProvider serviceProvider = getSpWithDefaultRequestedClaimsMappings();
@@ -350,14 +354,15 @@ public class DefaultOIDCClaimsCallbackHandlerTest {
         UserRealm userRealm = getExceptionThrowingUserRealm(new UserStoreException(""));
         mockUserRealm(requestMsgCtx.getAuthorizedUser().toString(), userRealm);
 
-        defaultOIDCClaimsCallbackHandler.handleCustomClaims(jwtClaimsSet, requestMsgCtx);
+        JWTClaimsSet jwtClaimsSet = defaultOIDCClaimsCallbackHandler.handleCustomClaims(jwtClaimsSetBuilder,
+                requestMsgCtx);
         assertNotNull(jwtClaimsSet);
-        assertTrue(jwtClaimsSet.getCustomClaims().isEmpty());
+        assertTrue(jwtClaimsSet.getClaims().isEmpty());
     }
 
     @Test
     public void testHandleCustomClaimsWithOAuthTokenReqMsgCtxtEmptyUserClaims() throws Exception {
-        JWTClaimsSet jwtClaimsSet = new JWTClaimsSet();
+        JWTClaimsSet.Builder jwtClaimsSetBuilder = new JWTClaimsSet.Builder();
         OAuthTokenReqMessageContext requestMsgCtx = getTokenReqMessageContextForLocalUser();
 
         ServiceProvider serviceProvider = getSpWithDefaultRequestedClaimsMappings();
@@ -366,16 +371,17 @@ public class DefaultOIDCClaimsCallbackHandlerTest {
         UserRealm userRealm = getUserRealmWithUserClaims(Collections.emptyMap());
         mockUserRealm(requestMsgCtx.getAuthorizedUser().toString(), userRealm);
 
-        defaultOIDCClaimsCallbackHandler.handleCustomClaims(jwtClaimsSet, requestMsgCtx);
+        JWTClaimsSet jwtClaimsSet = defaultOIDCClaimsCallbackHandler.handleCustomClaims(jwtClaimsSetBuilder,
+                requestMsgCtx);
         assertNotNull(jwtClaimsSet);
-        assertTrue(jwtClaimsSet.getCustomClaims().isEmpty());
+        assertTrue(jwtClaimsSet.getClaims().isEmpty());
     }
 
     @Test
     public void testHandleCustomClaimsWithOAuthTokenReqMsgCtxtRegistryError() throws Exception {
         try {
             PrivilegedCarbonContext.startTenantFlow();
-            JWTClaimsSet jwtClaimsSet = new JWTClaimsSet();
+            JWTClaimsSet.Builder jwtClaimsSetBuilder = new JWTClaimsSet.Builder();
             OAuthTokenReqMessageContext requestMsgCtx = getTokenReqMessageContextForLocalUser();
 
             ServiceProvider serviceProvider = getSpWithDefaultRequestedClaimsMappings();
@@ -386,9 +392,10 @@ public class DefaultOIDCClaimsCallbackHandlerTest {
 
             mockClaimHandler();
 
-            defaultOIDCClaimsCallbackHandler.handleCustomClaims(jwtClaimsSet, requestMsgCtx);
+            JWTClaimsSet jwtClaimsSet = defaultOIDCClaimsCallbackHandler.handleCustomClaims(jwtClaimsSetBuilder,
+                    requestMsgCtx);
             assertNotNull(jwtClaimsSet);
-            assertTrue(jwtClaimsSet.getCustomClaims().isEmpty());
+            assertTrue(jwtClaimsSet.getClaims().isEmpty());
         } finally {
             PrivilegedCarbonContext.endTenantFlow();
         }
@@ -398,7 +405,7 @@ public class DefaultOIDCClaimsCallbackHandlerTest {
     public void testHandleCustomClaimsWithOAuthTokenReqMsgCtxtNoOIDCScopes() throws Exception {
         try {
             PrivilegedCarbonContext.startTenantFlow();
-            JWTClaimsSet jwtClaimsSet = new JWTClaimsSet();
+            JWTClaimsSet.Builder jwtClaimsSetBuilder = new JWTClaimsSet.Builder();
             OAuthTokenReqMessageContext requestMsgCtx = getTokenReqMessageContextForLocalUser();
 
             ServiceProvider serviceProvider = getSpWithDefaultRequestedClaimsMappings();
@@ -410,9 +417,10 @@ public class DefaultOIDCClaimsCallbackHandlerTest {
             mockClaimHandler();
             mockOIDCScopeResource();
 
-            defaultOIDCClaimsCallbackHandler.handleCustomClaims(jwtClaimsSet, requestMsgCtx);
+            JWTClaimsSet jwtClaimsSet = defaultOIDCClaimsCallbackHandler.handleCustomClaims(jwtClaimsSetBuilder,
+                    requestMsgCtx);
             assertNotNull(jwtClaimsSet);
-            assertTrue(jwtClaimsSet.getCustomClaims().isEmpty());
+            assertTrue(jwtClaimsSet.getClaims().isEmpty());
         } finally {
             PrivilegedCarbonContext.endTenantFlow();
         }
@@ -422,7 +430,7 @@ public class DefaultOIDCClaimsCallbackHandlerTest {
     public void testHandleCustomClaimsWithOAuthTokenReqMsgCtxtWithOIDCScopes() throws Exception {
         try {
             PrivilegedCarbonContext.startTenantFlow();
-            JWTClaimsSet jwtClaimsSet = new JWTClaimsSet();
+            JWTClaimsSet.Builder jwtClaimsSetBuilder = new JWTClaimsSet.Builder();
             OAuthTokenReqMessageContext requestMsgCtx = getTokenReqMessageContextForLocalUser();
 
             ServiceProvider serviceProvider = getSpWithDefaultRequestedClaimsMappings();
@@ -438,15 +446,16 @@ public class DefaultOIDCClaimsCallbackHandlerTest {
             oidcProperties.setProperty(OIDC_SCOPE, StringUtils.join(oidcScopeClaims, ","));
             mockOIDCScopeResource(oidcProperties);
 
-            defaultOIDCClaimsCallbackHandler.handleCustomClaims(jwtClaimsSet, requestMsgCtx);
+            JWTClaimsSet jwtClaimsSet = defaultOIDCClaimsCallbackHandler.handleCustomClaims(jwtClaimsSetBuilder,
+                    requestMsgCtx);
             assertNotNull(jwtClaimsSet);
-            assertNull(jwtClaimsSet.getCustomClaim(EMAIL));
+            assertNull(jwtClaimsSet.getClaim(EMAIL));
 
-            assertNotNull(jwtClaimsSet.getCustomClaim(USERNAME));
-            assertEquals(jwtClaimsSet.getCustomClaim(USERNAME), USER_NAME);
+            assertNotNull(jwtClaimsSet.getClaim(USERNAME));
+            assertEquals(jwtClaimsSet.getClaim(USERNAME), USER_NAME);
 
-            assertNotNull(jwtClaimsSet.getCustomClaim(ROLE));
-            JSONArray jsonArray = (JSONArray) jwtClaimsSet.getCustomClaim(ROLE);
+            assertNotNull(jwtClaimsSet.getClaim(ROLE));
+            JSONArray jsonArray = (JSONArray) jwtClaimsSet.getClaim(ROLE);
             String[] expectedRoles = new String[]{ROLE1, ROLE2, ROLE3};
             for (String role : expectedRoles) {
                 assertTrue(jsonArray.contains(role));
@@ -460,7 +469,7 @@ public class DefaultOIDCClaimsCallbackHandlerTest {
     public void testHandleCustomClaimsWithOAuthTokenReqMsgCtxtWithSpRoleMappings() throws Exception {
         try {
             PrivilegedCarbonContext.startTenantFlow();
-            JWTClaimsSet jwtClaimsSet = new JWTClaimsSet();
+            JWTClaimsSet.Builder jwtClaimsSetBuilder = new JWTClaimsSet.Builder();
             OAuthTokenReqMessageContext requestMsgCtx = getTokenReqMessageContextForLocalUser();
 
             ServiceProvider serviceProvider = getSpWithDefaultRequestedClaimsMappings();
@@ -482,15 +491,16 @@ public class DefaultOIDCClaimsCallbackHandlerTest {
             oidcProperties.setProperty(OIDC_SCOPE, StringUtils.join(oidcScopeClaims, ","));
             mockOIDCScopeResource(oidcProperties);
 
-            defaultOIDCClaimsCallbackHandler.handleCustomClaims(jwtClaimsSet, requestMsgCtx);
+            JWTClaimsSet jwtClaimsSet = defaultOIDCClaimsCallbackHandler.handleCustomClaims(jwtClaimsSetBuilder,
+                    requestMsgCtx);
 
             assertNotNull(jwtClaimsSet);
-            assertNull(jwtClaimsSet.getCustomClaim(EMAIL));
-            assertNotNull(jwtClaimsSet.getCustomClaim(USERNAME));
-            assertEquals(jwtClaimsSet.getCustomClaim(USERNAME), USER_NAME);
+            assertNull(jwtClaimsSet.getClaim(EMAIL));
+            assertNotNull(jwtClaimsSet.getClaim(USERNAME));
+            assertEquals(jwtClaimsSet.getClaim(USERNAME), USER_NAME);
 
-            assertNotNull(jwtClaimsSet.getCustomClaim(ROLE));
-            JSONArray jsonArray = (JSONArray) jwtClaimsSet.getCustomClaim(ROLE);
+            assertNotNull(jwtClaimsSet.getClaim(ROLE));
+            JSONArray jsonArray = (JSONArray) jwtClaimsSet.getClaim(ROLE);
             String[] expectedRoles = new String[]{ROLE1, SP_ROLE_2, ROLE3};
             for (String role : expectedRoles) {
                 assertTrue(jsonArray.contains(role));
@@ -514,7 +524,7 @@ public class DefaultOIDCClaimsCallbackHandlerTest {
             throws Exception {
         try {
             PrivilegedCarbonContext.startTenantFlow();
-            JWTClaimsSet jwtClaimsSet = new JWTClaimsSet();
+            JWTClaimsSet.Builder jwtClaimsSetBuilder = new JWTClaimsSet.Builder();
             OAuthTokenReqMessageContext requestMsgCtx = getTokenReqMessageContextForLocalUser();
             requestMsgCtx.setScope(new String[]{OIDC_SCOPE});
 
@@ -546,18 +556,19 @@ public class DefaultOIDCClaimsCallbackHandlerTest {
             oidcProperties.setProperty(OIDC_SCOPE, StringUtils.join(oidcScopeClaims, ","));
             mockOIDCScopeResource(oidcProperties);
 
-            defaultOIDCClaimsCallbackHandler.handleCustomClaims(jwtClaimsSet, requestMsgCtx);
+            JWTClaimsSet jwtClaimsSet = defaultOIDCClaimsCallbackHandler.handleCustomClaims(jwtClaimsSetBuilder,
+                    requestMsgCtx);
 
             assertNotNull(jwtClaimsSet);
-            assertNotNull(jwtClaimsSet.getCustomClaim(UPDATED_AT));
-            assertTrue(jwtClaimsSet.getCustomClaim(UPDATED_AT) instanceof Integer ||
-                    jwtClaimsSet.getCustomClaim(UPDATED_AT) instanceof Long);
+            assertNotNull(jwtClaimsSet.getClaim(UPDATED_AT));
+            assertTrue(jwtClaimsSet.getClaim(UPDATED_AT) instanceof Integer ||
+                    jwtClaimsSet.getClaim(UPDATED_AT) instanceof Long);
 
-            assertNotNull(jwtClaimsSet.getCustomClaim(PHONE_NUMBER_VERIFIED));
-            assertTrue(jwtClaimsSet.getCustomClaim(PHONE_NUMBER_VERIFIED) instanceof Boolean);
+            assertNotNull(jwtClaimsSet.getClaim(PHONE_NUMBER_VERIFIED));
+            assertTrue(jwtClaimsSet.getClaim(PHONE_NUMBER_VERIFIED) instanceof Boolean);
 
-            assertNotNull(jwtClaimsSet.getCustomClaim(EMAIL_VERIFIED));
-            assertTrue(jwtClaimsSet.getCustomClaim(EMAIL_VERIFIED) instanceof Boolean);
+            assertNotNull(jwtClaimsSet.getClaim(EMAIL_VERIFIED));
+            assertTrue(jwtClaimsSet.getClaim(EMAIL_VERIFIED) instanceof Boolean);
         } finally {
             PrivilegedCarbonContext.endTenantFlow();
         }
@@ -584,7 +595,7 @@ public class DefaultOIDCClaimsCallbackHandlerTest {
     public void testHandleCustomClaimsWithOAuthTokenReqMsgCtxtAddressClaim(Properties oidcProperties) throws Exception {
         try {
             PrivilegedCarbonContext.startTenantFlow();
-            JWTClaimsSet jwtClaimsSet = new JWTClaimsSet();
+            JWTClaimsSet.Builder jwtClaimsSetBuilder = new JWTClaimsSet.Builder();
             OAuthTokenReqMessageContext requestMsgCtx = getTokenReqMessageContextForLocalUser();
 
             ClaimMapping claimMappings[] = new ClaimMapping[]{
@@ -607,10 +618,11 @@ public class DefaultOIDCClaimsCallbackHandlerTest {
             mockOIDCScopeResource(oidcProperties);
             mockClaimHandler();
 
-            defaultOIDCClaimsCallbackHandler.handleCustomClaims(jwtClaimsSet, requestMsgCtx);
+            JWTClaimsSet jwtClaimsSet = defaultOIDCClaimsCallbackHandler.handleCustomClaims(jwtClaimsSetBuilder,
+                    requestMsgCtx);
 
             assertNotNull(jwtClaimsSet);
-            assertNotNull(jwtClaimsSet.getCustomClaim(ADDRESS));
+            assertNotNull(jwtClaimsSet.getClaim(ADDRESS));
 
         } finally {
             PrivilegedCarbonContext.endTenantFlow();
@@ -693,7 +705,7 @@ public class DefaultOIDCClaimsCallbackHandlerTest {
         try {
             PrivilegedCarbonContext.startTenantFlow();
 
-            JWTClaimsSet jwtClaimsSet = new JWTClaimsSet();
+            JWTClaimsSet.Builder jwtClaimsSetBuilder = new JWTClaimsSet.Builder();
             OAuthAuthzReqMessageContext oAuthAuthzReqMessageContext = mock(OAuthAuthzReqMessageContext.class);
             when(oAuthAuthzReqMessageContext.getApprovedScope()).thenReturn(APPROVED_SCOPES);
             when(oAuthAuthzReqMessageContext.getProperty(OAuthConstants.ACCESS_TOKEN))
@@ -710,8 +722,9 @@ public class DefaultOIDCClaimsCallbackHandlerTest {
 
             mockOIDCScopeResource();
 
-            defaultOIDCClaimsCallbackHandler.handleCustomClaims(jwtClaimsSet, oAuthAuthzReqMessageContext);
-            assertEquals(jwtClaimsSet.getAllClaims().size(), 8, "Claims are not successfully set.");
+            JWTClaimsSet jwtClaimsSet = defaultOIDCClaimsCallbackHandler.handleCustomClaims(jwtClaimsSetBuilder,
+                    oAuthAuthzReqMessageContext);
+            assertEquals(jwtClaimsSet.getClaims().size(), 0, "Claims are not successfully set.");
         } finally {
             PrivilegedCarbonContext.endTenantFlow();
         }
@@ -751,7 +764,7 @@ public class DefaultOIDCClaimsCallbackHandlerTest {
 
     @Test
     public void testCustomClaimForOAuthTokenReqMessageContextWithNullAssertion() throws Exception {
-        JWTClaimsSet jwtClaimsSet = new JWTClaimsSet();
+        JWTClaimsSet.Builder jwtClaimsSetBuilder = new JWTClaimsSet.Builder();
         OAuthTokenReqMessageContext requestMsgCtx = mock(OAuthTokenReqMessageContext.class);
 
         when(requestMsgCtx.getScope()).thenReturn(APPROVED_SCOPES);
@@ -772,8 +785,9 @@ public class DefaultOIDCClaimsCallbackHandlerTest {
         mockApplicationManagementService();
         getMockOIDCScopeResource();
 
-        defaultOIDCClaimsCallbackHandler.handleCustomClaims(jwtClaimsSet, requestMsgCtx);
-        assertEquals(jwtClaimsSet.getAllClaims().size(), 8, "Claims are not successfully set.");
+        JWTClaimsSet jwtClaimsSet = defaultOIDCClaimsCallbackHandler.handleCustomClaims(jwtClaimsSetBuilder,
+                requestMsgCtx);
+        assertEquals(jwtClaimsSet.getClaims().size(), 0, "Claims are not successfully set.");
     }
 
     private void mockApplicationManagementService() throws Exception {
@@ -791,7 +805,7 @@ public class DefaultOIDCClaimsCallbackHandlerTest {
 
     @Test
     public void testHandleClaimsForOAuthAuthzReqMessageContextNullAccessToken() throws Exception {
-        JWTClaimsSet jwtClaimsSet = new JWTClaimsSet();
+        JWTClaimsSet.Builder jwtClaimsSetBuilder = new JWTClaimsSet.Builder();
 
         AuthenticatedUser authenticatedUser = getDefaultAuthenticatedUserFederatedUser();
         OAuth2AuthorizeReqDTO authorizeReqDTO = new OAuth2AuthorizeReqDTO();
@@ -815,8 +829,9 @@ public class DefaultOIDCClaimsCallbackHandlerTest {
 
         mockApplicationManagementService(serviceProvider);
 
-        defaultOIDCClaimsCallbackHandler.handleCustomClaims(jwtClaimsSet, authzReqMessageContext);
-        assertEquals(jwtClaimsSet.getAllClaims().size(), 8, "Claims are not successfully set.");
+        JWTClaimsSet jwtClaimsSet = defaultOIDCClaimsCallbackHandler.handleCustomClaims(jwtClaimsSetBuilder,
+                authzReqMessageContext);
+        assertEquals(jwtClaimsSet.getClaims().size(), 0, "Claims are not successfully set.");
     }
 
     private AuthenticatedUser getDefaultAuthenticatedLocalUser() {

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/openidconnect/util/TestUtils.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/openidconnect/util/TestUtils.java
@@ -91,23 +91,23 @@ public class TestUtils {
         long curTimeInMillis = Calendar.getInstance().getTimeInMillis();
 
         // Set claims to jwt token.
-        JWTClaimsSet jwtClaimsSet = new JWTClaimsSet();
-        jwtClaimsSet.setIssuer(issuer);
-        jwtClaimsSet.setSubject(subject);
-        jwtClaimsSet.setAudience(Arrays.asList(audience));
-        jwtClaimsSet.setJWTID(jti);
-        jwtClaimsSet.setExpirationTime(new Date(curTimeInMillis + lifetimeInMillis));
-        jwtClaimsSet.setIssueTime(new Date(curTimeInMillis));
+        JWTClaimsSet.Builder jwtClaimsSetBuilder = new JWTClaimsSet.Builder();
+        jwtClaimsSetBuilder.issuer(issuer);
+        jwtClaimsSetBuilder.subject(subject);
+        jwtClaimsSetBuilder.audience(Arrays.asList(audience));
+        jwtClaimsSetBuilder.jwtID(jti);
+        jwtClaimsSetBuilder.expirationTime(new Date(curTimeInMillis + lifetimeInMillis));
+        jwtClaimsSetBuilder.issueTime(new Date(curTimeInMillis));
 
         if (notBeforeMillis > 0) {
-            jwtClaimsSet.setNotBeforeTime(new Date(curTimeInMillis + notBeforeMillis));
+            jwtClaimsSetBuilder.notBeforeTime(new Date(curTimeInMillis + notBeforeMillis));
         }
         if (claims != null && !claims.isEmpty()) {
             for (Map.Entry entry : claims.entrySet()) {
-                jwtClaimsSet.setClaim(entry.getKey().toString(), entry.getValue());
+                jwtClaimsSetBuilder.claim(entry.getKey().toString(), entry.getValue());
             }
         }
-        return jwtClaimsSet;
+        return jwtClaimsSetBuilder.build();
     }
 
     public static String buildJWT(String issuer, String subject, String jti, String audience, String algorythm,
@@ -122,17 +122,18 @@ public class TestUtils {
             lifetimeInMillis = 3600 * 1000;
         }
         // Set claims to jwt token.
-        JWTClaimsSet jwtClaimsSet = new JWTClaimsSet();
-        jwtClaimsSet.setIssuer(issuer);
-        jwtClaimsSet.setSubject(subject);
-        jwtClaimsSet.setAudience(Arrays.asList(audience));
-        jwtClaimsSet.setJWTID(jti);
-        jwtClaimsSet.setExpirationTime(new Date(issuedTime + lifetimeInMillis));
-        jwtClaimsSet.setIssueTime(new Date(issuedTime));
+        JWTClaimsSet.Builder jwtClaimsSetBuilder = new JWTClaimsSet.Builder();
+        jwtClaimsSetBuilder.issuer(issuer);
+        jwtClaimsSetBuilder.subject(subject);
+        jwtClaimsSetBuilder.audience(Arrays.asList(audience));
+        jwtClaimsSetBuilder.jwtID(jti);
+        jwtClaimsSetBuilder.expirationTime(new Date(issuedTime + lifetimeInMillis));
+        jwtClaimsSetBuilder.issueTime(new Date(issuedTime));
 
         if (notBeforeMillis > 0) {
-            jwtClaimsSet.setNotBeforeTime(new Date(issuedTime + notBeforeMillis));
+            jwtClaimsSetBuilder.notBeforeTime(new Date(issuedTime + notBeforeMillis));
         }
+        JWTClaimsSet jwtClaimsSet = jwtClaimsSetBuilder.build();
         if (JWSAlgorithm.NONE.getName().equals(algorythm)) {
             return new PlainJWT(jwtClaimsSet).serialize();
         }

--- a/components/org.wso2.carbon.identity.oauth/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.identity.oauth/src/test/resources/testng.xml
@@ -107,6 +107,7 @@
             <class name="org.wso2.carbon.identity.oauth2.util.OAuth2UtilTest"/>
             <class name="org.wso2.carbon.identity.openidconnect.DefaultIDTokenBuilderTest"/>
             <class name="org.wso2.carbon.identity.openidconnect.DefaultOIDCClaimsCallbackHandlerTest"/>
+            <class name="org.wso2.carbon.identity.oauth2.validators.jwt.JWKSBasedJWTValidatorTest"/>
         </classes>
     </test>
 

--- a/components/org.wso2.carbon.identity.oidc.dcr/pom.xml
+++ b/components/org.wso2.carbon.identity.oidc.dcr/pom.xml
@@ -22,7 +22,7 @@
         <groupId>org.wso2.carbon.identity.inbound.auth.oauth2</groupId>
         <artifactId>identity-inbound-auth-oauth</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>5.6.71-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/components/org.wso2.carbon.identity.oidc.session/pom.xml
+++ b/components/org.wso2.carbon.identity.oidc.session/pom.xml
@@ -22,7 +22,7 @@
         <groupId>org.wso2.carbon.identity.inbound.auth.oauth2</groupId>
         <artifactId>identity-inbound-auth-oauth</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>5.6.71-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/backChannelLogout/DefaultLogoutTokenBuilder.java
+++ b/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/backChannelLogout/DefaultLogoutTokenBuilder.java
@@ -132,17 +132,17 @@ public class DefaultLogoutTokenBuilder implements LogoutTokenBuilder {
         JSONObject event = new JSONObject().put("http://schemas.openidnet/event/backchannel-logout",
                 new JSONObject());
 
-        JWTClaimsSet jwtClaimsSet = new JWTClaimsSet();
-        jwtClaimsSet.setSubject(sub);
-        jwtClaimsSet.setIssuer(iss);
-        jwtClaimsSet.setAudience(audience);
-        jwtClaimsSet.setClaim("jti", jti);
-        jwtClaimsSet.setClaim("event", event);
-        jwtClaimsSet.setExpirationTime(new Date(currentTimeInMillis + logoutTokenValidityInMillis));
-        jwtClaimsSet.setClaim("iat", iat);
-        jwtClaimsSet.setClaim("sid", sid);
+        JWTClaimsSet.Builder jwtClaimsSetBuilder = new JWTClaimsSet.Builder();
+        jwtClaimsSetBuilder.subject(sub);
+        jwtClaimsSetBuilder.issuer(iss);
+        jwtClaimsSetBuilder.audience(audience);
+        jwtClaimsSetBuilder.claim("jti", jti);
+        jwtClaimsSetBuilder.claim("event", event);
+        jwtClaimsSetBuilder.expirationTime(new Date(currentTimeInMillis + logoutTokenValidityInMillis));
+        jwtClaimsSetBuilder.claim("iat", iat);
+        jwtClaimsSetBuilder.claim("sid", sid);
 
-        return jwtClaimsSet;
+        return jwtClaimsSetBuilder.build();
     }
 
     /**

--- a/components/org.wso2.carbon.identity.webfinger/pom.xml
+++ b/components/org.wso2.carbon.identity.webfinger/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.wso2.carbon.identity.inbound.auth.oauth2</groupId>
         <artifactId>identity-inbound-auth-oauth</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>5.6.71-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.oauth.common.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.oauth.common.feature/pom.xml
@@ -22,7 +22,7 @@
         <groupId>org.wso2.carbon.identity.inbound.auth.oauth2</groupId>
         <artifactId>identity-inbound-auth-oauth</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>5.6.71-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.oauth.dcr.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.oauth.dcr.server.feature/pom.xml
@@ -22,7 +22,7 @@
         <groupId>org.wso2.carbon.identity.inbound.auth.oauth2</groupId>
         <artifactId>identity-inbound-auth-oauth</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>5.6.71-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.oauth.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.oauth.feature/pom.xml
@@ -22,7 +22,7 @@
         <groupId>org.wso2.carbon.identity.inbound.auth.oauth2</groupId>
         <artifactId>identity-inbound-auth-oauth</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>5.6.71-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.oauth.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.oauth.server.feature/pom.xml
@@ -22,7 +22,7 @@
         <groupId>org.wso2.carbon.identity.inbound.auth.oauth2</groupId>
         <artifactId>identity-inbound-auth-oauth</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>5.6.71-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.oauth.ui.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.oauth.ui.feature/pom.xml
@@ -22,7 +22,7 @@
         <groupId>org.wso2.carbon.identity.inbound.auth.oauth2</groupId>
         <artifactId>identity-inbound-auth-oauth</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>5.6.71-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.wso2.carbon.identity.inbound.auth.oauth2</groupId>
     <artifactId>identity-inbound-auth-oauth</artifactId>
-    <version>5.6.71-SNAPSHOT</version>
+    <version>6.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>WSO2 Carbon OAuth module</name>
     <url>http://wso2.org</url>
@@ -697,7 +697,7 @@
     <properties>
         <!-- Identity Inbound Auth OAuth Version-->
         <identity.inbound.auth.oauth.exp.pkg.version>${project.version}</identity.inbound.auth.oauth.exp.pkg.version>
-        <identity.inbound.auth.oauth.imp.pkg.version.range>[5.0.0, 6.0.0)</identity.inbound.auth.oauth.imp.pkg.version.range>
+        <identity.inbound.auth.oauth.imp.pkg.version.range>[6.0.0, 7.0.0)</identity.inbound.auth.oauth.imp.pkg.version.range>
 
         <!-- OSGi/Equinox dependency version -->
         <equinox.javax.servlet.version>3.0.0.v201112011016</equinox.javax.servlet.version>

--- a/pom.xml
+++ b/pom.xml
@@ -756,8 +756,8 @@
         <waffle-jna.wso2.version>1.6.wso2v5</waffle-jna.wso2.version>
         <waffle-jna.imp.pkg.version.range>[1.6.wso2v1, 2.0)</waffle-jna.imp.pkg.version.range>
 
-        <nimbusds.version>2.26.1.wso2v3</nimbusds.version>
-        <nimbusds.osgi.version.range>[2.26.1,3.0.0)</nimbusds.osgi.version.range>
+        <nimbusds.version>5.8.0.wso2v1</nimbusds.version>
+        <nimbusds.osgi.version.range>[5.8.0,6.0.0)</nimbusds.osgi.version.range>
 
         <thetransactioncompany.cors-filter.wso2.version>1.7.0.wso2v1</thetransactioncompany.cors-filter.wso2.version>
         <thetransactioncompany.utils.wso2.version>1.9.0.wso2v1</thetransactioncompany.utils.wso2.version>

--- a/test-utils/org.wso2.carbon.identity.oauth.common.testng/pom.xml
+++ b/test-utils/org.wso2.carbon.identity.oauth.common.testng/pom.xml
@@ -23,7 +23,7 @@
         <groupId>org.wso2.carbon.identity.inbound.auth.oauth2</groupId>
         <artifactId>identity-inbound-auth-oauth</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>5.6.71-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
Part of fix for wso2/product-is#3140

**Needs to be merged after merging** https://github.com/wso2/orbit/pull/315

JWKS validation for JWT is supported in nimbus 5.8 onwards. Therefore this PR upgrades the nimbus version in oauth components. As it involves API changes this PR contains the changes in code to reflect the API changes in Nimbus. 
There are some API level changes coming with nimbus version upgrade. Some are listed below.  

- JWTClaimSet state is changed to immutable/read-only. As a result ReadOnlyJWTClaimSet class is removed in nimbus 5.8
- JWSHeader state is changed to immutable/read-only. As a result ReadOnlyJWSHeader class is removed in 5.8.
-  JWTClaimSet constructor access modifier have been changed to private. Therefore JWTClaimSet object instantiation should be done via JWTClaimSet.Builder class similar to following.
```

JWTClaimSet.Builder jwtClaimSetBuilder = new JWTClaimSet.Builder();
JWTClaimSet jwtClaimSet = JWTClaimSetBuilder.build();
```

Because of the immutability in JWTClaimSet class, it was required to change following APIs in identity-inbound-auth-oauth components.

**Old API**
`public void handleCustomClaims(JWTClaimsSet builder, OAuthTokenReqMessageContext request)`

**New API**
`public JWTClaimsSet handleCustomClaims(JWTClaimsSet.Builder builder, OAuthTokenReqMessageContext request)`

Release of a major version required with the above API changes (6.0.0).

