### PR TITLE
Introduce an extension to intercept OIDC logout flow

### DIFF
--- a/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/OIDCSessionManagementException.java
+++ b/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/OIDCSessionManagementException.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oidc.session;
+
+import org.wso2.carbon.identity.base.IdentityException;
+
+public class OIDCSessionManagementException extends IdentityException {
+
+    public OIDCSessionManagementException(String message) {
+
+        super(message);
+    }
+
+    public OIDCSessionManagementException(String message, Throwable cause) {
+
+        super(message, cause);
+    }
+
+}

--- a/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/handler/OIDCLogoutHandler.java
+++ b/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/handler/OIDCLogoutHandler.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.identity.oidc.session.handler;
+
+import org.wso2.carbon.identity.oidc.session.OIDCSessionManagementException;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * Provides an extension point to plug in any custom logic that needs to be executed during an OpenIDConnect
+ * logout flow.
+ */
+public interface OIDCLogoutHandler {
+
+    void handlePreLogout(HttpServletRequest logoutRequest,
+                         HttpServletResponse logoutResponse) throws OIDCSessionManagementException;
+
+    void handlePostLogout(HttpServletRequest logoutRequest,
+                          HttpServletResponse logoutResponse) throws OIDCSessionManagementException;
+
+}

--- a/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/internal/OIDCSessionManagementComponent.java
+++ b/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/internal/OIDCSessionManagementComponent.java
@@ -29,6 +29,7 @@ import org.osgi.service.component.annotations.ReferencePolicy;
 import org.osgi.service.http.HttpService;
 import org.wso2.carbon.identity.oidc.session.backChannelLogout.ClaimProviderImpl;
 import org.wso2.carbon.identity.oidc.session.OIDCSessionConstants;
+import org.wso2.carbon.identity.oidc.session.handler.OIDCLogoutHandler;
 import org.wso2.carbon.identity.oidc.session.servlet.OIDCLogoutServlet;
 import org.wso2.carbon.identity.oidc.session.servlet.OIDCSessionIFrameServlet;
 import org.wso2.carbon.identity.openidconnect.ClaimProvider;
@@ -138,5 +139,26 @@ public class OIDCSessionManagementComponent {
             log.debug("Unsetting the Realm Service.");
         }
         OIDCSessionManagementComponentServiceHolder.setRealmService(null);
+    }
+
+    @Reference(
+            name = "oidc.logout.handlers",
+            service = OIDCLogoutHandler.class,
+            cardinality = ReferenceCardinality.MULTIPLE,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unregisterOIDCLogoutHandler"
+    )
+    protected void registerOIDCLogoutHandler(OIDCLogoutHandler oidcLogoutHandler) {
+        if (log.isDebugEnabled()) {
+            log.debug("Registering OIDC Logout Handler: " + oidcLogoutHandler.getClass().getName());
+        }
+        OIDCSessionManagementComponentServiceHolder.addPostLogoutHandler(oidcLogoutHandler);
+    }
+
+    protected void unregisterOIDCLogoutHandler(OIDCLogoutHandler oidcLogoutHandler) {
+        if (log.isDebugEnabled()) {
+            log.debug("Un-registering OIDC Logout Handler: " + oidcLogoutHandler.getClass().getName());
+        }
+        OIDCSessionManagementComponentServiceHolder.removePostLogoutHandler(oidcLogoutHandler);
     }
 }

--- a/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/internal/OIDCSessionManagementComponentServiceHolder.java
+++ b/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/internal/OIDCSessionManagementComponentServiceHolder.java
@@ -19,11 +19,17 @@
 package org.wso2.carbon.identity.oidc.session.internal;
 
 import org.osgi.service.http.HttpService;
+import org.wso2.carbon.identity.oidc.session.handler.OIDCLogoutHandler;
 import org.wso2.carbon.user.core.service.RealmService;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 public class OIDCSessionManagementComponentServiceHolder {
     private static HttpService httpService;
     private static RealmService realmService;
+    private static List<OIDCLogoutHandler> OIDCPostLogoutHandlers = new ArrayList<>();
 
     private OIDCSessionManagementComponentServiceHolder() {
 
@@ -42,5 +48,17 @@ public class OIDCSessionManagementComponentServiceHolder {
 
     public static RealmService getRealmService() {
         return realmService;
+    }
+
+    public static List<OIDCLogoutHandler> getOIDCLogoutHandlers() {
+        return Collections.unmodifiableList(OIDCPostLogoutHandlers);
+    }
+
+    public static void addPostLogoutHandler(OIDCLogoutHandler OIDCPostLogoutHandler) {
+        OIDCPostLogoutHandlers.add(OIDCPostLogoutHandler);;
+    }
+
+    public static void removePostLogoutHandler(OIDCLogoutHandler OIDCPostLogoutHandler) {
+        OIDCPostLogoutHandlers.remove(OIDCPostLogoutHandler);
     }
 }

--- a/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/servlet/OIDCLogoutServlet.java
+++ b/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/servlet/OIDCLogoutServlet.java
@@ -45,9 +45,12 @@ import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 import org.wso2.carbon.identity.oidc.session.backChannelLogout.LogoutRequestSender;
 import org.wso2.carbon.identity.oidc.session.OIDCSessionConstants;
+import org.wso2.carbon.identity.oidc.session.OIDCSessionManagementException;
 import org.wso2.carbon.identity.oidc.session.cache.OIDCSessionDataCache;
 import org.wso2.carbon.identity.oidc.session.cache.OIDCSessionDataCacheEntry;
 import org.wso2.carbon.identity.oidc.session.cache.OIDCSessionDataCacheKey;
+import org.wso2.carbon.identity.oidc.session.handler.OIDCLogoutHandler;
+import org.wso2.carbon.identity.oidc.session.internal.OIDCSessionManagementComponentServiceHolder;
 import org.wso2.carbon.identity.oidc.session.util.OIDCSessionManagementUtil;
 import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
@@ -61,6 +64,7 @@ import java.security.interfaces.RSAPublicKey;
 import java.text.ParseException;
 import java.util.Enumeration;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -402,6 +406,17 @@ public class OIDCLogoutServlet extends HttpServlet {
     private void sendToFrameworkForLogout(HttpServletRequest request, HttpServletResponse response)
             throws ServletException, IOException {
 
+        try {
+            triggerLogoutHandlersForPreLogout(request, response);
+        } catch (OIDCSessionManagementException e) {
+            log.error("Error executing logout handlers on pre logout.");
+            if (log.isDebugEnabled()) {
+                log.debug("Error executing logout handlers on pre logout.", e);
+            }
+            response.sendRedirect(
+                    OIDCSessionManagementUtil.getErrorPageURL(OAuth2ErrorCodes.SERVER_ERROR, "User logout failed."));
+        }
+
         // Generate a SessionDataKey. Authentication framework expects this parameter
         String sessionDataKey = UUID.randomUUID().toString();
 
@@ -446,6 +461,18 @@ public class OIDCLogoutServlet extends HttpServlet {
             if (redirectURL == null) {
                 redirectURL = OIDCSessionManagementUtil.getOIDCLogoutURL();
             }
+
+            try {
+                triggerLogoutHandlersForPostLogout(request, response);
+            } catch (OIDCSessionManagementException e) {
+                log.error("Error executing logout handlers on post logout.");
+                if (log.isDebugEnabled()) {
+                    log.debug("Error executing logout handlers on post logout.", e);
+                }
+                response.sendRedirect(
+                        OIDCSessionManagementUtil.getErrorPageURL(OAuth2ErrorCodes.SERVER_ERROR, "User logout failed."));
+            }
+
             redirectURL = appendStateQueryParam(redirectURL, cacheEntry.getState());
             removeSessionDataFromCache(sessionDataKey);
             Cookie opBrowserStateCookie = OIDCSessionManagementUtil.removeOPBrowserStateCookie(request, response);
@@ -454,6 +481,28 @@ public class OIDCLogoutServlet extends HttpServlet {
         } else {
             response.sendRedirect(
                     OIDCSessionManagementUtil.getErrorPageURL(OAuth2ErrorCodes.SERVER_ERROR, "User logout failed"));
+        }
+    }
+
+    private void triggerLogoutHandlersForPostLogout(HttpServletRequest request,
+                                                    HttpServletResponse response) throws OIDCSessionManagementException {
+
+        List<OIDCLogoutHandler> oidcLogoutHandlers =
+                OIDCSessionManagementComponentServiceHolder.getOIDCLogoutHandlers();
+
+        for (OIDCLogoutHandler oidcLogoutHandler : oidcLogoutHandlers) {
+            oidcLogoutHandler.handlePostLogout(request, response);
+        }
+    }
+
+    private void triggerLogoutHandlersForPreLogout(HttpServletRequest request,
+                                                    HttpServletResponse response) throws OIDCSessionManagementException {
+
+        List<OIDCLogoutHandler> oidcLogoutHandlers =
+                OIDCSessionManagementComponentServiceHolder.getOIDCLogoutHandlers();
+
+        for (OIDCLogoutHandler oidcLogoutHandler : oidcLogoutHandlers) {
+            oidcLogoutHandler.handlePreLogout(request, response);
         }
     }
 


### PR DESCRIPTION
### Proposed changes in this pull request
- This improvement introduces an extension point to inject custom logic/customizations into OIDC logout flow.

As an example, suppose someone wants to revoke the access token that was issued during the OIDC login they can do so using this extension by using the context information that comes in id_token passed in the OIDC logout request as id_token_hint etc.

Resolves https://github.com/wso2/product-is/issues/3227

### When should this PR be merged
ASAP


