### PR TITLE
Validate Basic keyword in basic auth header in token endpoint

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
+++ b/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
@@ -27,6 +27,7 @@ public final class OAuthConstants {
 
     //OAuth2 request headers.
     public static final String HTTP_REQ_HEADER_AUTHZ = "Authorization";
+    public static final String HTTP_REQ_HEADER_AUTH_METHOD_BASIC = "Basic";
 
     // OAuth2 response headers
     public static final String HTTP_RESP_HEADER_CACHE_CONTROL = "Cache-Control";

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtilTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtilTest.java
@@ -160,9 +160,11 @@ public class EndpointUtilTest extends PowerMockIdentityBaseTest {
     public Object[][] provideAuthzHeader() {
 
         String authzValue = "Basic " + Base64Utils.encode((username + ":" + password).getBytes());
+        String incorrectAuthzValue = "SomeValue " + Base64Utils.encode((username + ":" + password).getBytes());
 
         return new Object[][] {
                 { authzValue, username, null},
+                { incorrectAuthzValue, username, "Error decoding authorization header"},
                 { username, null, "Error decoding authorization header"},
                 { "Basic " + Base64Utils.encode(username.getBytes()), null, "Error decoding authorization header"},
                 { null, null, "Authorization header value is null"},


### PR DESCRIPTION
### Proposed changes in this pull request

- Validate format of basic auth header "Authorization:Basic <base64encoded-credentials>"