### PR TITLE
Move the OIDC discovery endpoint under the root <issuer>/.well-known/openid-configuration

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/oidcdiscovery/OIDCDiscoveryEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/oidcdiscovery/OIDCDiscoveryEndpoint.java
@@ -31,6 +31,7 @@ import org.wso2.carbon.identity.oauth.common.OAuthConstants;
 import org.wso2.carbon.identity.oauth.endpoint.oidcdiscovery.impl.OIDProviderJSONResponseBuilder;
 import org.wso2.carbon.identity.oauth.endpoint.util.EndpointUtil;
 
+import java.net.URISyntaxException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.GET;
@@ -39,8 +40,11 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
 
-@Path("/oidcdiscovery")
+import static org.wso2.carbon.identity.oauth2.util.OAuth2Util.OAuthURL.getOidcDiscoveryEPUrl;
+
+@Path("/{issuer}/.well-known/openid-configuration")
 public class OIDCDiscoveryEndpoint {
 
     private static final Log log = LogFactory.getLog(OIDCDiscoveryEndpoint.class);
@@ -48,21 +52,41 @@ public class OIDCDiscoveryEndpoint {
     @GET
     @Path("/.well-known/openid-configuration")
     @Produces("application/json")
-    public Response getOIDProviderConfiguration(@Context HttpServletRequest request) {
+    public Response getOIDProviderConfiguration(@PathParam("issuer") String tokenEp, @Context HttpServletRequest request
+            , @Context UriInfo uriInfo) {
 
+        String issuer = null;
+        if (StringUtils.isNotEmpty(tokenEp)) {
+            issuer = uriInfo.getBaseUri() + tokenEp;
+        }
         String tenantDomain = null;
         Object tenantObj = IdentityUtil.threadLocalProperties.get().get(OAuthConstants.TENANT_NAME_FROM_CONTEXT);
-        if (tenantObj != null){
+        if (tenantObj != null) {
             tenantDomain = (String) tenantObj;
         }
-        if (StringUtils.isEmpty(tenantDomain)){
+        if (StringUtils.isEmpty(tenantDomain)) {
             tenantDomain = MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
         }
+         /*  [https://openid.net/specs/openid-connect-discovery-1_0.html#IssuerDiscovery]
+             "OpenID Providers supporting Discovery MUST make a JSON document available at the path formed by
+             concatenating the string /.well-known/openid-configuration to the Issuer."*/
+        try {
+            if (getOidcDiscoveryEPUrl(tenantDomain).equals(issuer)) {
 
-        return this.getResponse(request, tenantDomain);
+                return this.getResponse(request, tenantDomain);
+            } else {
+                Response.ResponseBuilder errorResponse = Response.status(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+                return errorResponse.entity("Error while loading the endpoint. The path to the discovery document " +
+                        "should be in the format of {issuer}/.well-known/openid-configuration").build();
+            }
+        } catch (URISyntaxException e) {
+            Response.ResponseBuilder errorResponse = Response.status(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+            return errorResponse.entity("Error while building the endpoint.").build();
+        }
     }
 
     private Response getResponse(HttpServletRequest request, String tenant) {
+
         String response;
         OIDCProcessor processor = EndpointUtil.getOIDCService();
         try {


### PR DESCRIPTION

### Proposed changes in this pull request
According to the spec [1] the discovery endpoint should be located in the path /.well-known/openid-configuration.

OpenID Providers supporting Discovery MUST make a JSON document available at the path formed by concatenating the string /.well-known/openid-configuration to the Issuer.

Currently in IS server, the document is located in "oidcdiscovery/.well-known/openid-configuration".

[1] [https://openid.net/specs/openid-connect-discovery-1_0.html#IssuerDiscovery]

From this PR moved the OIDC discovery endpoint under the root <issuer>/.well-known/openid-configuration

### When should this PR be merged
Immediately


### Follow up actions
None

