### PR TITLE
Remove unnecessary dependencies

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.scope.endpoint/src/main/webapp/WEB-INF/web.xml
+++ b/components/org.wso2.carbon.identity.oauth.scope.endpoint/src/main/webapp/WEB-INF/web.xml
@@ -14,11 +14,6 @@
     </context-param>
 
     <filter>
-        <filter-name>CaptchaFilter</filter-name>
-        <filter-class>org.wso2.carbon.identity.captcha.filter.CaptchaFilter</filter-class>
-    </filter>
-
-    <filter>
         <filter-name>HttpHeaderSecurityFilter</filter-name>
         <filter-class>org.apache.catalina.filters.HttpHeaderSecurityFilter</filter-class>
         <init-param>
@@ -76,13 +71,6 @@
         <servlet-name>CXFServlet</servlet-name>
         <url-pattern>/*</url-pattern>
     </servlet-mapping>
-
-    <filter-mapping>
-        <filter-name>CaptchaFilter</filter-name>
-        <url-pattern>/*</url-pattern>
-        <dispatcher>REQUEST</dispatcher>
-    </filter-mapping>
-
     <session-config>
         <session-timeout>60</session-timeout>
     </session-config>

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuth2ServiceComponent.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuth2ServiceComponent.java
@@ -68,7 +68,7 @@ public class OAuth2ServiceComponent {
     @Reference(
             name = "framework.authentication.context.method.name.translator",
             service = AuthenticationMethodNameTranslator.class,
-            cardinality = ReferenceCardinality.MANDATORY,
+            cardinality = ReferenceCardinality.OPTIONAL,
             policy = ReferencePolicy.DYNAMIC,
             unbind = "unsetAuthenticationMethodNameTranslator"
     )


### PR DESCRIPTION
### Proposed changes in this pull request
* Removing unused CaptchaFilter in org.wso2.carbon.identity.oauth.scope.endpoint. 
This filter does not perform any functionality to the scope endpoint and also makes oauth features to take an additional dependence on identity-governance.

* Make AuthenticationMethodNameTranslator an optional dependency for oauth
In the OAuth2ServiceComponent class, we are consuming AuthenticationMethodNameTranslator as a mandatory dependency. This shouldn't be the case if someone is using pure OAuth.