### PR TITLE
Fix client secret is set to empty after click cancel in OAuth configs

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.ui/src/main/resources/web/oauth/edit.jsp
+++ b/components/org.wso2.carbon.identity.oauth.ui/src/main/resources/web/oauth/edit.jsp
@@ -81,6 +81,7 @@
                 (ConfigurationContext) config.getServletContext()
                         .getAttribute(CarbonConstants.CONFIGURATION_CONTEXT);
         client = new OAuthAdminClient(cookie, backendServerURL, configContext);
+        isHashDisabled = client.isHashDisabled();
 
         supportedIdTokenEncryptionAlgorithms = client.getSupportedIDTokenAlgorithms().getSupportedIdTokenEncryptionAlgorithms();
         supportedIdTokenEncryptionMethods = client.getSupportedIDTokenAlgorithms().getSupportedIdTokenEncryptionMethods();
@@ -94,7 +95,6 @@
         OAuthConsumerAppDTO consumerApp = null;
         if (OAuthConstants.ACTION_REGENERATE.equalsIgnoreCase(action)) {
             String oauthAppState = client.getOauthApplicationState(consumerkey);
-            isHashDisabled = client.isHashDisabled();
             if (isHashDisabled) {
                 client.regenerateSecretKey(consumerkey);
             } else {


### PR DESCRIPTION
### Proposed changes in this pull request

- Properly update isHashdisabled status to include the cancel button onclick event as well.

#### Documentation

N/A
