### PR TITLE
Retrieve token using access token hash during validation

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/user/impl/UserInfoJWTResponse.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/user/impl/UserInfoJWTResponse.java
@@ -105,25 +105,23 @@ public class UserInfoJWTResponse extends AbstractUserInfoResponseBuilder {
         if (isJWTSignedWithSPKey) {
             signingTenantDomain = spTenantDomain;
         } else {
-            AccessTokenDO accessTokenDO = getAccessTokenDO(tokenResponse.getAuthorizationContextToken().getTokenString());
-            signingTenantDomain = accessTokenDO.getAuthzUser().getTenantDomain();
+            signingTenantDomain = getAuthzUserTenantDomain(tokenResponse);
         }
         return signingTenantDomain;
+    }
+
+    private String getAuthzUserTenantDomain(OAuth2TokenValidationResponseDTO tokenResponse)
+            throws UserInfoEndpointException {
+        AccessTokenDO accessTokenDO = getAccessTokenDO(tokenResponse.getAuthorizationContextToken().getTokenString());
+        return accessTokenDO.getAuthzUser().getTenantDomain();
     }
 
     private AccessTokenDO getAccessTokenDO(String accessToken) throws UserInfoEndpointException {
         AccessTokenDO accessTokenDO;
         try {
-            OauthTokenIssuer tokenIssuer = OAuth2Util.getTokenIssuer(accessToken);
-            String tokenIdentifier = null;
-            try {
-                tokenIdentifier = tokenIssuer.getAccessTokenHash(accessToken);
-            } catch (OAuthSystemException e) {
-                log.error("Error while getting token identifier", e);
-            }
-            accessTokenDO = OAuth2Util.getAccessTokenDOfromTokenIdentifier(tokenIdentifier);
+            accessTokenDO = OAuth2Util.getAccessTokenDOfromTokenIdentifier(accessToken);
         } catch (IdentityOAuth2Exception e) {
-            throw new UserInfoEndpointException("Error occurred while signing JWT", e);
+            throw new UserInfoEndpointException("Error while retrieving access token information.", e);
         }
 
         if (accessTokenDO == null) {

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/ClaimUtil.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/ClaimUtil.java
@@ -23,7 +23,6 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.oltu.oauth2.common.error.OAuthError;
-import org.apache.oltu.oauth2.common.exception.OAuthSystemException;
 import org.wso2.carbon.identity.application.authentication.framework.exception.FrameworkException;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
@@ -49,7 +48,6 @@ import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2TokenValidationResponseDTO;
 import org.wso2.carbon.identity.oauth2.internal.OAuth2ServiceComponentHolder;
 import org.wso2.carbon.identity.oauth2.model.AccessTokenDO;
-import org.wso2.carbon.identity.oauth2.token.OauthTokenIssuer;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 import org.wso2.carbon.identity.openidconnect.OIDCClaimUtil;
 import org.wso2.carbon.user.api.RealmConfiguration;
@@ -344,25 +342,8 @@ public class ClaimUtil {
         return cacheEntry.getUserAttributes();
     }
 
-    private static String getAccessToken(OAuth2TokenValidationResponseDTO tokenResponse) {
-        return tokenResponse.getAuthorizationContextToken().getTokenString();
-    }
-
     private static String getAccessTokenIdentifier(OAuth2TokenValidationResponseDTO tokenResponse) {
-
-        String accessToken = tokenResponse.getAuthorizationContextToken().getTokenString();
-        String tokenIdentifier = null;
-        try {
-            OauthTokenIssuer tokenIssuer = OAuth2Util.getTokenIssuer(accessToken);
-            if (tokenIssuer != null) {
-                tokenIdentifier = tokenIssuer.getAccessTokenHash(accessToken);
-            }
-        } catch (OAuthSystemException e) {
-            log.error("Error while getting token identifier", e);
-        } catch (IdentityOAuth2Exception e) {
-            log.error("Error while retrieving token issuer", e);
-        }
-        return tokenIdentifier;
+        return tokenResponse.getAuthorizationContextToken().getTokenString();
     }
 
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/TokenValidationHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/TokenValidationHandler.java
@@ -632,77 +632,11 @@ public class TokenValidationHandler {
      */
     private AccessTokenDO findAccessToken(String tokenIdentifier) throws IdentityOAuth2Exception {
 
-        String consumerKey = null;
-        OauthTokenIssuer oauthTokenIssuer = null;
-        if (isJWT(tokenIdentifier) || isIDTokenEncrypted(tokenIdentifier)) {
-            oauthTokenIssuer = new JWTTokenIssuer();
-        } else {
-            try {
-                consumerKey = OAuth2Util.getClientIdForAccessToken(tokenIdentifier);
-            } catch (IllegalArgumentException e) {
-                if (log.isDebugEnabled()) {
-                    log.debug("Consumer key is not found for token identifier: " + tokenIdentifier, e);
-                }
-            }
-        }
-
-        try {
-            if (consumerKey != null) {
-                oauthTokenIssuer = OAuth2Util.getOAuthTokenIssuerForOAuthApp(consumerKey);
-            }
-
-            if (oauthTokenIssuer == null) {
-                //server level token issuer
-                oauthTokenIssuer = OAuthServerConfiguration.getInstance().getIdentityOauthTokenIssuer();
-                log.info("No token issuer is found for access token identifier. Hence default token issuer is used.");
-            }
-
-            if (oauthTokenIssuer.usePersistedAccessTokenAlias()) {
-                return OAuth2Util.getAccessTokenDOfromTokenIdentifier(oauthTokenIssuer
-                        .getAccessTokenHash(tokenIdentifier));
-            } else {
-                return OAuth2Util.getAccessTokenDOfromTokenIdentifier(tokenIdentifier);
-            }
-        } catch (OAuthSystemException e) {
-            if (log.isDebugEnabled()) {
-                if (IdentityUtil.isTokenLoggable(IdentityConstants.IdentityTokens.ACCESS_TOKEN)) {
-                    log.debug("Error while getting access token hash from token: " + tokenIdentifier, e);
-                } else {
-                    log.debug("Error while getting access token hash.", e);
-                }
-            }
-            throw new IdentityOAuth2Exception("Error while getting access token hash.", e);
-        } catch (InvalidOAuthClientException e) {
-            throw new IdentityOAuth2Exception(
-                    "Error while retrieving oauth issuer for the app with clientId: " + consumerKey, e);
-        }
+        return OAuth2Util.getAccessTokenDOfromTokenIdentifier(tokenIdentifier);
     }
 
     private AccessTokenDO findRefreshToken(String refreshToken) throws IdentityOAuth2Exception {
 
         return OAuthTokenPersistenceFactory.getInstance().getTokenManagementDAO().getRefreshToken(refreshToken);
     }
-
-    /**
-     * Return true if the token identifier is JWT.
-     *
-     * @param tokenIdentifier String JWT token identifier.
-     * @return  true for a JWT token.
-     */
-    private boolean isJWT(String tokenIdentifier) {
-        // JWT token contains 3 base64 encoded components separated by periods.
-        return StringUtils.countMatches(tokenIdentifier, ".") == 2;
-    }
-
-    /**
-     * Return true if the JWT id token is encrypted.
-     *
-     * @param idToken String JWT ID token.
-     * @return  Boolean state of encryption.
-     */
-    private boolean isIDTokenEncrypted(String idToken) {
-        // Encrypted ID token contains 5 base64 encoded components separated by periods.
-        return StringUtils.countMatches(idToken, ".") == 4;
-    }
-
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/AbstractUserInfoResponseBuilder.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/AbstractUserInfoResponseBuilder.java
@@ -31,7 +31,6 @@ import org.wso2.carbon.identity.oauth.cache.AuthorizationGrantCache;
 import org.wso2.carbon.identity.oauth.cache.AuthorizationGrantCacheEntry;
 import org.wso2.carbon.identity.oauth.cache.AuthorizationGrantCacheKey;
 import org.wso2.carbon.identity.oauth.common.exception.InvalidOAuthClientException;
-import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
 import org.wso2.carbon.identity.oauth.dao.OAuthAppDO;
 import org.wso2.carbon.identity.oauth.user.UserInfoEndpointException;
 import org.wso2.carbon.identity.oauth.user.UserInfoResponseBuilder;
@@ -40,7 +39,6 @@ import org.wso2.carbon.identity.oauth2.RequestObjectException;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2TokenValidationResponseDTO;
 import org.wso2.carbon.identity.oauth2.internal.OAuth2ServiceComponentHolder;
 import org.wso2.carbon.identity.oauth2.model.AccessTokenDO;
-import org.wso2.carbon.identity.oauth2.token.OauthTokenIssuer;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 import org.wso2.carbon.identity.openidconnect.internal.OpenIDConnectServiceComponentHolder;
 import org.wso2.carbon.identity.openidconnect.model.RequestedClaim;
@@ -63,7 +61,7 @@ public abstract class AbstractUserInfoResponseBuilder implements UserInfoRespons
     public String getResponseString(OAuth2TokenValidationResponseDTO tokenResponse)
             throws UserInfoEndpointException, OAuthSystemException {
 
-        String clientId = getClientId(getAccessTokenIdentifier(tokenResponse));
+        String clientId = getClientId(getAccessToken(tokenResponse));
         String spTenantDomain = getServiceProviderTenantDomain(tokenResponse);
         // Retrieve user claims.
         Map<String, Object> userClaims = retrieveUserClaims(tokenResponse);
@@ -82,9 +80,9 @@ public abstract class AbstractUserInfoResponseBuilder implements UserInfoRespons
                                                  Map<String, Object> userClaims)
             throws OAuthSystemException, UserInfoEndpointException {
 
-        if(MapUtils.isEmpty(userClaims)) {
+        if (MapUtils.isEmpty(userClaims)) {
             if (log.isDebugEnabled()) {
-                AuthenticatedUser authenticatedUser = getAuthenticatedUser(getAccessTokenIdentifier(tokenResponse));
+                AuthenticatedUser authenticatedUser = getAuthenticatedUser(getAccessToken(tokenResponse));
                 log.debug("No user claims available to be filtered for user: " +
                         authenticatedUser.toFullQualifiedUsername() + " for client_id: " + clientId +
                         " of tenantDomain: " + spTenantDomain);
@@ -94,19 +92,20 @@ public abstract class AbstractUserInfoResponseBuilder implements UserInfoRespons
 
         // Filter user claims based on the requested scopes
         Map<String, Object> userClaimsFilteredByScope =
-                getUserClaimsFilteredByScope(tokenResponse,userClaims, tokenResponse.getScope(), clientId, spTenantDomain);
+                getUserClaimsFilteredByScope(tokenResponse, userClaims, tokenResponse.getScope(), clientId, spTenantDomain);
 
         // Handle essential claims
         Map<String, Object> essentialClaims = getEssentialClaims(tokenResponse, userClaims);
         userClaimsFilteredByScope.putAll(essentialClaims);
 
         //Handle essential claims of the request object
+
         Map<String, Object> filteredClaimsFromRequestObject =
                 filterClaimsFromRequestObject(userClaims, getAccessToken(tokenResponse));
         userClaimsFilteredByScope.putAll(filteredClaimsFromRequestObject);
 
         // Filter the user claims based on user consent
-        AuthenticatedUser authenticatedUser = getAuthenticatedUser(getAccessTokenIdentifier(tokenResponse));
+        AuthenticatedUser authenticatedUser = getAuthenticatedUser(getAccessToken(tokenResponse));
         return getUserClaimsFilteredByConsent(tokenResponse, userClaimsFilteredByScope, authenticatedUser, clientId,
                 spTenantDomain);
     }
@@ -114,12 +113,10 @@ public abstract class AbstractUserInfoResponseBuilder implements UserInfoRespons
     private String getGrantType(OAuth2TokenValidationResponseDTO tokenResponse) throws UserInfoEndpointException {
 
         try {
-            return OAuth2Util.getAccessTokenDOfromTokenIdentifier(getAccessTokenIdentifier(tokenResponse)).getGrantType();
+            return OAuth2Util.getAccessTokenDOfromTokenIdentifier(getAccessToken(tokenResponse)).getGrantType();
         } catch (IdentityOAuth2Exception e) {
             throw new UserInfoEndpointException(
-                    "Error while retrieving access token information to derive the grant type." , e);
-        } catch (OAuthSystemException e) {
-            throw new UserInfoEndpointException("Error while retrieving access token identifier" , e);
+                    "Error while retrieving access token information to derive the grant type.", e);
         }
     }
 
@@ -156,13 +153,14 @@ public abstract class AbstractUserInfoResponseBuilder implements UserInfoRespons
                                      OAuth2TokenValidationResponseDTO tokenResponse)
             throws UserInfoEndpointException, OAuthSystemException {
         // Get sub claim from AuthorizationGrantCache.
+
         String subjectClaim = OIDCClaimUtil.getSubjectClaimCachedAgainstAccessToken(getAccessToken(tokenResponse));
         if (StringUtils.isNotBlank(subjectClaim)) {
             // We expect the subject claim cached to have the correct format.
             return subjectClaim;
         }
 
-        AuthenticatedUser authenticatedUser = getAuthenticatedUser(getAccessTokenIdentifier(tokenResponse));
+        AuthenticatedUser authenticatedUser = getAuthenticatedUser(getAccessToken(tokenResponse));
         // Subject claim returned among claims user claims.
         subjectClaim = (String) userClaims.get(OAuth2Util.SUB);
         if (StringUtils.isBlank(subjectClaim)) {
@@ -223,7 +221,6 @@ public abstract class AbstractUserInfoResponseBuilder implements UserInfoRespons
     }
 
 
-
     protected Map<String, Object> getEssentialClaims(OAuth2TokenValidationResponseDTO tokenResponse,
                                                      Map<String, Object> claims) throws UserInfoEndpointException {
 
@@ -278,12 +275,10 @@ public abstract class AbstractUserInfoResponseBuilder implements UserInfoRespons
         String clientId = null;
         OAuthAppDO oAuthAppDO;
         try {
-            clientId = getClientId(getAccessTokenIdentifier(tokenResponse));
+            clientId = getClientId(getAccessToken(tokenResponse));
             oAuthAppDO = OAuth2Util.getAppInformationByClientId(clientId);
         } catch (IdentityOAuth2Exception | InvalidOAuthClientException e) {
             throw new UserInfoEndpointException("Error while retrieving OAuth app information for clientId: " + clientId);
-        } catch (OAuthSystemException e) {
-            throw new UserInfoEndpointException("Error while retrieving token issuer ");
         }
         return OAuth2Util.getTenantDomainOfOauthApp(oAuthAppDO);
     }
@@ -353,33 +348,12 @@ public abstract class AbstractUserInfoResponseBuilder implements UserInfoRespons
         return new ArrayList<>();
     }
 
-    private boolean isLocalUser(AuthenticatedUser authenticatedUser) {
-
-        return !authenticatedUser.isFederatedUser();
-    }
-
     private String getAccessToken(OAuth2TokenValidationResponseDTO tokenResponse) {
-
         return tokenResponse.getAuthorizationContextToken().getTokenString();
     }
 
-    private String getAccessTokenIdentifier(OAuth2TokenValidationResponseDTO tokenResponse)
-            throws OAuthSystemException {
+    private boolean isLocalUser(AuthenticatedUser authenticatedUser) {
 
-        String accessToken = tokenResponse.getAuthorizationContextToken().getTokenString();
-        String tokenIdentifier = null;
-        try {
-            OauthTokenIssuer tokenIssuer = OAuth2Util.getTokenIssuer(accessToken);
-            if (tokenIssuer != null) {
-                tokenIdentifier = tokenIssuer.getAccessTokenHash(accessToken);
-            }
-        } catch (OAuthSystemException e) {
-            log.error("Error while getting token identifier");
-            throw new OAuthSystemException(e);
-        } catch (IdentityOAuth2Exception e) {
-            log.error("Error while retrieving token issuer");
-            throw new OAuthSystemException(e);
-        }
-        return tokenIdentifier;
+        return !authenticatedUser.isFederatedUser();
     }
 }


### PR DESCRIPTION
Fixes https://github.com/wso2/product-is/issues/4190

When we persist an access token regardless of the value we store in the ACCESS_TOKEN column, we store the original access token's hash in the ACCESS_TOKEN_HASH column. For example, in JWT access tokens we store the 'jti' claim in the ACCESS_TOKEN column instead of the original JWT returned to the client. Even, in that case, we store the JWT's hash in the ACCESS_TOKEN_HASH. 

Since the DAO methods retrieve the access token metadata using the ACCESS_TOKEN_HASH and not the ACCESS_TOKEN column from the IDN_OAUTH2_ACCESS_TOKEN table we do not need to do anything special for retrieving JWT access tokens or any custom token type that persists an alias instead of the original value returned to the client. 

For any type of access token if the client presents the identifier sent to them we can do the lookup based on its hash value (which is our current DAO impl). 

In this fix, we remove specially treating JWT. This fixes validation logic breaking for custom access tokens that might contain '.' in them 
