### PR TITLE
Code improvements to OAuthAdminService

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthAdminService.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthAdminService.java
@@ -127,35 +127,10 @@ public class OAuthAdminService extends AbstractAdmin {
         OAuthAppDO[] apps = dao.getOAuthConsumerAppsOfUser(userName, tenantId);
         if (apps != null && apps.length > 0) {
             dtos = new OAuthConsumerAppDTO[apps.length];
-            OAuthConsumerAppDTO dto;
             OAuthAppDO app;
             for (int i = 0; i < apps.length; i++) {
                 app = apps[i];
-                dto = new OAuthConsumerAppDTO();
-                dto.setApplicationName(app.getApplicationName());
-                dto.setCallbackUrl(app.getCallbackUrl());
-                dto.setOauthConsumerKey(app.getOauthConsumerKey());
-                dto.setOauthConsumerSecret(app.getOauthConsumerSecret());
-                dto.setOAuthVersion(app.getOauthVersion());
-                dto.setGrantTypes(app.getGrantTypes());
-                dto.setScopeValidators(app.getScopeValidators());
-                dto.setUsername(UserCoreUtil.addDomainToName(app.getUser().getUserName(), app.getUser().getUserStoreDomain()));
-                dto.setPkceMandatory(app.isPkceMandatory());
-                dto.setPkceSupportPlain(app.isPkceSupportPlain());
-                dto.setUserAccessTokenExpiryTime(app.getUserAccessTokenExpiryTime());
-                dto.setApplicationAccessTokenExpiryTime(app.getApplicationAccessTokenExpiryTime());
-                dto.setRefreshTokenExpiryTime(app.getRefreshTokenExpiryTime());
-                dto.setIdTokenExpiryTime(app.getIdTokenExpiryTime());
-                dto.setAudiences(app.getAudiences());
-                dto.setRequestObjectSignatureValidationEnabled(app.isRequestObjectSignatureValidationEnabled());
-                dto.setIdTokenEncryptionEnabled(app.isIdTokenEncryptionEnabled());
-                dto.setIdTokenEncryptionAlgorithm(app.getIdTokenEncryptionAlgorithm());
-                dto.setIdTokenEncryptionMethod(app.getIdTokenEncryptionMethod());
-                dto.setBackChannelLogoutUrl(app.getBackChannelLogoutUrl());
-                dto.setFrontchannelLogoutUrl(app.getFrontchannelLogoutUrl());
-                dto.setTokenType(app.getTokenType());
-                dto.setBypassClientCredentials(app.isBypassClientCredentials());
-                dtos[i] = dto;
+                dtos[i] = buildConsumerAppDTO(app);
             }
         }
         return dtos;
@@ -170,38 +145,17 @@ public class OAuthAdminService extends AbstractAdmin {
      */
     public OAuthConsumerAppDTO getOAuthApplicationData(String consumerKey) throws IdentityOAuthAdminException {
 
-        OAuthConsumerAppDTO dto = new OAuthConsumerAppDTO();
+        OAuthConsumerAppDTO dto;
         OAuthAppDAO dao = new OAuthAppDAO();
         try {
             OAuthAppDO app = dao.getAppInformation(consumerKey);
             if (app != null) {
-                dto.setApplicationName(app.getApplicationName());
-                dto.setCallbackUrl(app.getCallbackUrl());
-                dto.setOauthConsumerKey(app.getOauthConsumerKey());
-                dto.setOauthConsumerSecret(app.getOauthConsumerSecret());
-                dto.setOAuthVersion(app.getOauthVersion());
-                dto.setGrantTypes(app.getGrantTypes());
-                dto.setScopeValidators(app.getScopeValidators());
-                dto.setUsername(app.getUser().toString());
-                dto.setPkceMandatory(app.isPkceMandatory());
-                dto.setPkceSupportPlain(app.isPkceSupportPlain());
-                dto.setUserAccessTokenExpiryTime(app.getUserAccessTokenExpiryTime());
-                dto.setApplicationAccessTokenExpiryTime(app.getApplicationAccessTokenExpiryTime());
-                dto.setRefreshTokenExpiryTime(app.getRefreshTokenExpiryTime());
-                dto.setIdTokenExpiryTime(app.getIdTokenExpiryTime());
-                dto.setAudiences(app.getAudiences());
-                dto.setRequestObjectSignatureValidationEnabled(app.isRequestObjectSignatureValidationEnabled());
-                dto.setIdTokenEncryptionEnabled(app.isIdTokenEncryptionEnabled());
-                dto.setIdTokenEncryptionAlgorithm(app.getIdTokenEncryptionAlgorithm());
-                dto.setIdTokenEncryptionMethod(app.getIdTokenEncryptionMethod());
-                dto.setBackChannelLogoutUrl(app.getBackChannelLogoutUrl());
-                dto.setFrontchannelLogoutUrl(app.getFrontchannelLogoutUrl());
-                dto.setTokenType(app.getTokenType());
-                dto.setBypassClientCredentials(app.isBypassClientCredentials());
-
+                dto = buildConsumerAppDTO(app);
                 if (log.isDebugEnabled()) {
                     log.debug("Found App :" + dto.getApplicationName() + " for consumerKey: " + consumerKey);
                 }
+            } else {
+                dto = new OAuthConsumerAppDTO();
             }
             return dto;
         } catch (InvalidOAuthClientException | IdentityOAuth2Exception e) {
@@ -219,34 +173,14 @@ public class OAuthAdminService extends AbstractAdmin {
      */
     public OAuthConsumerAppDTO getOAuthApplicationDataByAppName(String appName) throws IdentityOAuthAdminException {
 
-        OAuthConsumerAppDTO dto = new OAuthConsumerAppDTO();
+        OAuthConsumerAppDTO dto;
         OAuthAppDAO dao = new OAuthAppDAO();
         try {
             OAuthAppDO app = dao.getAppInformationByAppName(appName);
             if (app != null) {
-                dto.setApplicationName(app.getApplicationName());
-                dto.setCallbackUrl(app.getCallbackUrl());
-                dto.setOauthConsumerKey(app.getOauthConsumerKey());
-                dto.setOauthConsumerSecret(app.getOauthConsumerSecret());
-                dto.setOAuthVersion(app.getOauthVersion());
-                dto.setGrantTypes(app.getGrantTypes());
-                dto.setScopeValidators(app.getScopeValidators());
-                dto.setUsername(app.getUser().toString());
-                dto.setPkceMandatory(app.isPkceMandatory());
-                dto.setPkceSupportPlain(app.isPkceSupportPlain());
-                dto.setUserAccessTokenExpiryTime(app.getUserAccessTokenExpiryTime());
-                dto.setApplicationAccessTokenExpiryTime(app.getApplicationAccessTokenExpiryTime());
-                dto.setRefreshTokenExpiryTime(app.getRefreshTokenExpiryTime());
-                dto.setIdTokenExpiryTime(app.getIdTokenExpiryTime());
-                dto.setAudiences(app.getAudiences());
-                dto.setRequestObjectSignatureValidationEnabled(app.isRequestObjectSignatureValidationEnabled());
-                dto.setIdTokenEncryptionEnabled(app.isIdTokenEncryptionEnabled());
-                dto.setIdTokenEncryptionAlgorithm(app.getIdTokenEncryptionAlgorithm());
-                dto.setIdTokenEncryptionMethod(app.getIdTokenEncryptionMethod());
-                dto.setBackChannelLogoutUrl(app.getBackChannelLogoutUrl());
-                dto.setFrontchannelLogoutUrl(app.getFrontchannelLogoutUrl());
-                dto.setTokenType(app.getTokenType());
-                dto.setBypassClientCredentials(app.isBypassClientCredentials());
+                dto = buildConsumerAppDTO(app);
+            } else {
+                dto = new OAuthConsumerAppDTO();
             }
             return dto;
         } catch (InvalidOAuthClientException | IdentityOAuth2Exception e) {
@@ -386,40 +320,43 @@ public class OAuthAdminService extends AbstractAdmin {
             }
             throw new IdentityOAuthAdminException("No authenticated user found. Failed to register OAuth App");
         }
-        return getConsumerApplicationDetails(app);
+        return buildConsumerAppDTO(app);
     }
 
     /**
      * Get created oauth application details.
      *
-     * @param application <code>OAuthAppDO</code> with created application information.
+     * @param appDO <code>OAuthAppDO</code> with created application information.
      * @return OAuthConsumerAppDTO Created OAuth application details.
      */
-    private OAuthConsumerAppDTO getConsumerApplicationDetails(OAuthAppDO application) {
+    private OAuthConsumerAppDTO buildConsumerAppDTO(OAuthAppDO appDO) {
 
-        OAuthConsumerAppDTO oAuthConsumerAppDTO = new OAuthConsumerAppDTO();
-        oAuthConsumerAppDTO.setApplicationName(application.getApplicationName());
-        oAuthConsumerAppDTO.setCallbackUrl(application.getCallbackUrl());
-        oAuthConsumerAppDTO.setOauthConsumerKey(application.getOauthConsumerKey());
-        oAuthConsumerAppDTO.setOauthConsumerSecret(application.getOauthConsumerSecret());
-        oAuthConsumerAppDTO.setGrantTypes(application.getGrantTypes());
-        oAuthConsumerAppDTO.setOAuthVersion(application.getOauthVersion());
-        oAuthConsumerAppDTO.setScopeValidators(application.getScopeValidators());
-        oAuthConsumerAppDTO.setAudiences(application.getAudiences());
-        oAuthConsumerAppDTO.setUserAccessTokenExpiryTime(application.getUserAccessTokenExpiryTime());
-        oAuthConsumerAppDTO.setApplicationAccessTokenExpiryTime(application.getApplicationAccessTokenExpiryTime());
-        oAuthConsumerAppDTO.setRefreshTokenExpiryTime(application.getRefreshTokenExpiryTime());
-        oAuthConsumerAppDTO.setRequestObjectSignatureValidationEnabled(
-                application.isRequestObjectSignatureValidationEnabled());
-        oAuthConsumerAppDTO.setIdTokenEncryptionEnabled(application.isIdTokenEncryptionEnabled());
-        oAuthConsumerAppDTO.setIdTokenEncryptionAlgorithm(application.getIdTokenEncryptionAlgorithm());
-        oAuthConsumerAppDTO.setIdTokenEncryptionMethod(application.getIdTokenEncryptionMethod());
-        oAuthConsumerAppDTO.setBackChannelLogoutUrl(application.getBackChannelLogoutUrl());
-        oAuthConsumerAppDTO.setFrontchannelLogoutUrl(application.getFrontchannelLogoutUrl());
-        oAuthConsumerAppDTO.setPkceMandatory(application.isPkceMandatory());
-        oAuthConsumerAppDTO.setPkceSupportPlain(application.isPkceSupportPlain());
-
-        return oAuthConsumerAppDTO;
+        OAuthConsumerAppDTO dto = new OAuthConsumerAppDTO();
+        dto.setApplicationName(appDO.getApplicationName());
+        dto.setCallbackUrl(appDO.getCallbackUrl());
+        dto.setOauthConsumerKey(appDO.getOauthConsumerKey());
+        dto.setOauthConsumerSecret(appDO.getOauthConsumerSecret());
+        dto.setOAuthVersion(appDO.getOauthVersion());
+        dto.setGrantTypes(appDO.getGrantTypes());
+        dto.setScopeValidators(appDO.getScopeValidators());
+        dto.setUsername(appDO.getUser().toFullQualifiedUsername());
+        dto.setState(appDO.getState());
+        dto.setPkceMandatory(appDO.isPkceMandatory());
+        dto.setPkceSupportPlain(appDO.isPkceSupportPlain());
+        dto.setUserAccessTokenExpiryTime(appDO.getUserAccessTokenExpiryTime());
+        dto.setApplicationAccessTokenExpiryTime(appDO.getApplicationAccessTokenExpiryTime());
+        dto.setRefreshTokenExpiryTime(appDO.getRefreshTokenExpiryTime());
+        dto.setIdTokenExpiryTime(appDO.getIdTokenExpiryTime());
+        dto.setAudiences(appDO.getAudiences());
+        dto.setRequestObjectSignatureValidationEnabled(appDO.isRequestObjectSignatureValidationEnabled());
+        dto.setIdTokenEncryptionEnabled(appDO.isIdTokenEncryptionEnabled());
+        dto.setIdTokenEncryptionAlgorithm(appDO.getIdTokenEncryptionAlgorithm());
+        dto.setIdTokenEncryptionMethod(appDO.getIdTokenEncryptionMethod());
+        dto.setBackChannelLogoutUrl(appDO.getBackChannelLogoutUrl());
+        dto.setFrontchannelLogoutUrl(appDO.getFrontchannelLogoutUrl());
+        dto.setTokenType(appDO.getTokenType());
+        dto.setBypassClientCredentials(appDO.isBypassClientCredentials());
+        return dto;
     }
 
     /**
@@ -441,12 +378,10 @@ public class OAuthAdminService extends AbstractAdmin {
             }
             throw new IdentityOAuthAdminException(errorMessage);
         }
-        String userName = CarbonContext.getThreadLocalCarbonContext().getUsername();
-        String tenantAwareUsername = MultitenantUtils.getTenantAwareUsername(userName);
-        String tenantDomain = CarbonContext.getThreadLocalCarbonContext().getTenantDomain();
 
+        String tenantDomain = CarbonContext.getThreadLocalCarbonContext().getTenantDomain();
         OAuthAppDAO dao = new OAuthAppDAO();
-        OAuthAppDO oauthappdo = null;
+        OAuthAppDO oauthappdo;
         try {
             oauthappdo = dao.getAppInformation(consumerAppDTO.getOauthConsumerKey());
             if (oauthappdo == null) {
@@ -1260,9 +1195,16 @@ public class OAuthAdminService extends AbstractAdmin {
     private void setApplicationOwner(String tenantDomain, OAuthConsumerAppDTO oAuthConsumerAppDTO, OAuthAppDO oauthappdo) {
 
         if (oAuthConsumerAppDTO != null && oAuthConsumerAppDTO.getUsername() != null) {
+            // Get full qualified username
+            String fullQualifiedUsername = oAuthConsumerAppDTO.getUsername();
+
+            String tenantAwareUserName = MultitenantUtils.getTenantAwareUsername(fullQualifiedUsername);
+            String domainFreeTenantAwareUserName = UserCoreUtil.removeDomainFromName(tenantAwareUserName);
+            String userStoreDomain = UserCoreUtil.extractDomainFromName(tenantAwareUserName);
+
             AuthenticatedUser authenticatedUser = new AuthenticatedUser();
-            authenticatedUser.setUserName(UserCoreUtil.removeDomainFromName(oAuthConsumerAppDTO.getUsername()));
-            authenticatedUser.setUserStoreDomain(IdentityUtil.extractDomainFromName(oAuthConsumerAppDTO.getUsername()));
+            authenticatedUser.setUserName(domainFreeTenantAwareUserName);
+            authenticatedUser.setUserStoreDomain(userStoreDomain);
             authenticatedUser.setTenantDomain(tenantDomain);
             oauthappdo.setAppOwner(authenticatedUser);
         }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthAdminService.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthAdminService.java
@@ -1171,9 +1171,8 @@ public class OAuthAdminService extends AbstractAdmin {
         AuthenticatedUser appOwner = buildAuthenticatedUser(tenantAwareLoggedInUser, tenantDomain);
 
         String applicationOwnerInRequest = application.getUsername();
-        String tenantAwareAppOwnerInRequest = MultitenantUtils.getTenantAwareUsername(applicationOwnerInRequest);
-
-        if (StringUtils.isNotBlank(tenantAwareAppOwnerInRequest)) {
+        if (StringUtils.isNotBlank(applicationOwnerInRequest)) {
+            String tenantAwareAppOwnerInRequest = MultitenantUtils.getTenantAwareUsername(applicationOwnerInRequest);
             try {
                 if (CarbonContext.getThreadLocalCarbonContext().getUserRealm().
                         getUserStoreManager().isExistingUser(tenantAwareAppOwnerInRequest)) {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dao/OAuthAppDO.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dao/OAuthAppDO.java
@@ -39,8 +39,6 @@ public class OAuthAppDO implements Serializable {
     private String oauthConsumerSecret;
     private String applicationName;
     private String callbackUrl;
-    @XmlTransient
-    private AuthenticatedUser user;
     private String oauthVersion;
     private String grantTypes;
     @XmlElementWrapper(name="scopeValidators")
@@ -64,6 +62,7 @@ public class OAuthAppDO implements Serializable {
     private String idTokenEncryptionMethod;
     private String backChannelLogoutUrl;
     private String frontchannelLogoutUrl;
+    @XmlTransient
     private AuthenticatedUser appOwner;
     private String tokenType;
 
@@ -76,12 +75,20 @@ public class OAuthAppDO implements Serializable {
         this.appOwner = appOwner;
     }
 
+    /**
+     * @deprecated use {@link #getAppOwner()} instead.
+     */
+    @Deprecated
     public AuthenticatedUser getUser() {
-        return user;
+        return this.getAppOwner();
     }
 
+    /**
+     * @deprecated use {@link #setAppOwner(AuthenticatedUser)} instead.
+     */
+    @Deprecated
     public void setUser(AuthenticatedUser user) {
-        this.user = user;
+        this.setAppOwner(user);
     }
 
     public String getOauthConsumerKey() {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuth2ServiceComponent.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuth2ServiceComponent.java
@@ -75,13 +75,13 @@ public class OAuth2ServiceComponent {
             policy = ReferencePolicy.DYNAMIC,
             unbind = "unsetAuthenticationMethodNameTranslator"
     )
-    protected static void setAuthenticationMethodNameTranslator(
+    protected void setAuthenticationMethodNameTranslator(
             AuthenticationMethodNameTranslator authenticationMethodNameTranslator) {
 
         OAuth2ServiceComponentHolder.setAuthenticationMethodNameTranslator(authenticationMethodNameTranslator);
     }
 
-    protected static void unsetAuthenticationMethodNameTranslator(
+    protected void unsetAuthenticationMethodNameTranslator(
             AuthenticationMethodNameTranslator authenticationMethodNameTranslator) {
 
         if (OAuth2ServiceComponentHolder.getAuthenticationMethodNameTranslator() ==

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceTest.java
@@ -35,6 +35,9 @@ import org.wso2.carbon.utils.ConfigurationContextService;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Properties;
 
 import static org.mockito.Matchers.anyString;
@@ -63,7 +66,7 @@ public class OAuthAdminServiceTest extends PowerMockIdentityBaseTest {
     @Mock
     private UserStoreManager userStoreManager;
     @Mock
-    private OAuthAppDAO oAtuhAppDAO;
+    private OAuthAppDAO oAuthAppDAO;
     @Mock
     private ConfigurationContext configurationContext;
     @Mock
@@ -78,6 +81,8 @@ public class OAuthAdminServiceTest extends PowerMockIdentityBaseTest {
         System.setProperty("carbon.home",
                 System.getProperty("user.dir") + File.separator + "src" + File.separator + "test"
                         + File.separator + "resources");
+
+        initConfigsAndRealm();
         IdentityTenantUtil.setRealmService(realmService);
         when(realmService.getTenantManager()).thenReturn(tenantManager);
         when(realmService.getBootstrapRealmConfiguration()).thenReturn(realmConfiguration);
@@ -111,8 +116,8 @@ public class OAuthAdminServiceTest extends PowerMockIdentityBaseTest {
         when(realmService.getBootstrapRealmConfiguration()).thenReturn(realmConfiguration);
 
 
-        whenNew(OAuthAppDAO.class).withNoArguments().thenReturn(oAtuhAppDAO);
-        when(oAtuhAppDAO.addOAuthConsumer("admin", -1234, "PRIMARY")).thenReturn(new String[]{"consumer:key",
+        whenNew(OAuthAppDAO.class).withNoArguments().thenReturn(oAuthAppDAO);
+        when(oAuthAppDAO.addOAuthConsumer("admin", -1234, "PRIMARY")).thenReturn(new String[]{"consumer:key",
                 "consumer:secret"});
         OAuthAdminService oAuthAdminService = new OAuthAdminService();
         String[] keySecret = oAuthAdminService.registerOAuthConsumer();
@@ -135,13 +140,13 @@ public class OAuthAdminServiceTest extends PowerMockIdentityBaseTest {
         PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantId(-1234);
         PrivilegedCarbonContext.getThreadLocalCarbonContext().setUsername(userName);
 
-        whenNew(OAuthAppDAO.class).withNoArguments().thenReturn(oAtuhAppDAO);
+        whenNew(OAuthAppDAO.class).withNoArguments().thenReturn(oAuthAppDAO);
         OAuthAppDO oAuthAppDO = new OAuthAppDO();
         AuthenticatedUser authenticatedUser = new AuthenticatedUser();
         oAuthAppDO.setApplicationName("testapp1");
         oAuthAppDO.setUser(authenticatedUser);
         authenticatedUser.setUserName(userName);
-        when(oAtuhAppDAO.getOAuthConsumerAppsOfUser(userName, -1234)).thenReturn(new OAuthAppDO[]{oAuthAppDO});
+        when(oAuthAppDAO.getOAuthConsumerAppsOfUser(userName, -1234)).thenReturn(new OAuthAppDO[]{oAuthAppDO});
         OAuthAdminService oAuthAdminService = new OAuthAdminService();
         try {
             OAuthConsumerAppDTO[] allOAuthApplicationData =
@@ -170,8 +175,6 @@ public class OAuthAdminServiceTest extends PowerMockIdentityBaseTest {
     public void testRegisterOAuthApplicationData(String oauthVersion, String userName, String consumerKey, String
             consumerSecret) throws Exception {
 
-        initConfigsAndRealm();
-
         PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain("carbon.super");
         PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantId(-1234);
         PrivilegedCarbonContext.getThreadLocalCarbonContext().setUsername(userName);
@@ -188,8 +191,8 @@ public class OAuthAdminServiceTest extends PowerMockIdentityBaseTest {
         oAuthConsumerAppDTO.setOauthConsumerSecret(consumerSecret);
         oAuthConsumerAppDTO.setOAuthVersion(oauthVersion);
 
-        whenNew(OAuthAppDAO.class).withNoArguments().thenReturn(oAtuhAppDAO);
-        doNothing().when(oAtuhAppDAO).addOAuthApplication(Matchers.any(OAuthAppDO.class));
+        whenNew(OAuthAppDAO.class).withNoArguments().thenReturn(oAuthAppDAO);
+        doNothing().when(oAuthAppDAO).addOAuthApplication(Matchers.any(OAuthAppDO.class));
 
         try {
             oAuthAdminService.registerOAuthApplicationData(oAuthConsumerAppDTO);
@@ -207,24 +210,20 @@ public class OAuthAdminServiceTest extends PowerMockIdentityBaseTest {
     public void testGetAllOAuthApplicationData() throws Exception {
 
         String username = "Moana";
-        String tenantAwareUserName = username;
         int tenantId = MultitenantConstants.SUPER_TENANT_ID;
 
         PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain("carbon.super");
         PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantId(tenantId);
         PrivilegedCarbonContext.getThreadLocalCarbonContext().setUsername(username);
 
-        //mockStatic(MultitenantUtils.class);
-        //when(MultitenantUtils.getTenantAwareUsername(Matchers.anyString())).thenReturn(tenantAwareUserName);
-        OAuthAppDO app = getDummyOAuthApp(username);
-        when(oAtuhAppDAO.getOAuthConsumerAppsOfUser(tenantAwareUserName, tenantId)).thenReturn(new OAuthAppDO[]{app});
-        whenNew(OAuthAppDAO.class).withAnyArguments().thenReturn(oAtuhAppDAO);
+        OAuthAppDO app = buildDummyOAuthAppDO(username);
+        when(oAuthAppDAO.getOAuthConsumerAppsOfUser(username, tenantId)).thenReturn(new OAuthAppDO[]{app});
+        whenNew(OAuthAppDAO.class).withAnyArguments().thenReturn(oAuthAppDAO);
 
         OAuthAdminService oAuthAdminService = new OAuthAdminService();
         OAuthConsumerAppDTO[] oAuthConsumerApps = oAuthAdminService.getAllOAuthApplicationData();
         Assert.assertTrue((oAuthConsumerApps.length == 1), "OAuth consumer application count should be one.");
-        Assert.assertEquals(oAuthConsumerApps[0].getApplicationName(), app.getApplicationName(), "Application Name should be" +
-                " as same as the given application name in the app data object.");
+        assertAllAttributesOfConsumerAppDTO(oAuthConsumerApps[0], app);
     }
 
     @Test(expectedExceptions = IdentityOAuthAdminException.class)
@@ -234,7 +233,7 @@ public class OAuthAdminServiceTest extends PowerMockIdentityBaseTest {
         PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantId(-1234);
         PrivilegedCarbonContext.getThreadLocalCarbonContext().setUsername(null);
 
-        whenNew(OAuthAppDAO.class).withAnyArguments().thenReturn(oAtuhAppDAO);
+        whenNew(OAuthAppDAO.class).withAnyArguments().thenReturn(oAuthAppDAO);
 
         OAuthAdminService oAuthAdminService = new OAuthAdminService();
         oAuthAdminService.getAllOAuthApplicationData();
@@ -245,14 +244,51 @@ public class OAuthAdminServiceTest extends PowerMockIdentityBaseTest {
 
         String consumerKey = "some-consumer-key";
 
-        OAuthAppDO app = getDummyOAuthApp("some-user-name");
-        when(oAtuhAppDAO.getAppInformation(consumerKey)).thenReturn(app);
-        whenNew(OAuthAppDAO.class).withAnyArguments().thenReturn(oAtuhAppDAO);
+        OAuthAppDO app = buildDummyOAuthAppDO("some-user-name");
+        when(oAuthAppDAO.getAppInformation(consumerKey)).thenReturn(app);
+        whenNew(OAuthAppDAO.class).withAnyArguments().thenReturn(oAuthAppDAO);
 
         OAuthAdminService oAuthAdminService = new OAuthAdminService();
         OAuthConsumerAppDTO oAuthConsumerApp = oAuthAdminService.getOAuthApplicationData(consumerKey);
-        Assert.assertEquals(oAuthConsumerApp.getApplicationName(), app.getApplicationName(), "Application name should be " +
-                "same as the application name in app data object.");
+        assertAllAttributesOfConsumerAppDTO(oAuthConsumerApp, app);
+    }
+
+    private void assertAllAttributesOfConsumerAppDTO(OAuthConsumerAppDTO consumerAppDTO, OAuthAppDO appDO) {
+
+        Assert.assertEquals(consumerAppDTO.getApplicationName(), appDO.getApplicationName());
+        Assert.assertEquals(consumerAppDTO.getOauthConsumerKey(), appDO.getOauthConsumerKey());
+        Assert.assertEquals(consumerAppDTO.getOauthConsumerSecret(), appDO.getOauthConsumerSecret());
+        Assert.assertEquals(consumerAppDTO.getCallbackUrl(), appDO.getCallbackUrl());
+        Assert.assertEquals(consumerAppDTO.getOAuthVersion(), appDO.getOauthVersion());
+        Assert.assertEquals(consumerAppDTO.getUsername(), appDO.getUser().toString());
+        Assert.assertEquals(consumerAppDTO.getGrantTypes(), appDO.getGrantTypes());
+        Assert.assertEquals(consumerAppDTO.getScopeValidators(), appDO.getScopeValidators());
+        Assert.assertEquals(consumerAppDTO.getPkceSupportPlain(), appDO.isPkceSupportPlain());
+        Assert.assertEquals(consumerAppDTO.getPkceMandatory(), appDO.isPkceMandatory());
+        Assert.assertEquals(consumerAppDTO.getState(), appDO.getState());
+        Assert.assertEquals(consumerAppDTO.getUserAccessTokenExpiryTime(), appDO.getUserAccessTokenExpiryTime());
+        Assert.assertEquals(consumerAppDTO.getApplicationAccessTokenExpiryTime(),
+                appDO.getApplicationAccessTokenExpiryTime());
+        Assert.assertEquals(consumerAppDTO.getRefreshTokenExpiryTime(), appDO.getRefreshTokenExpiryTime());
+
+        assertArrayEquals(consumerAppDTO.getAudiences(), appDO.getAudiences());
+
+        Assert.assertEquals(consumerAppDTO.isRequestObjectSignatureValidationEnabled(),
+                appDO.isRequestObjectSignatureValidationEnabled());
+        Assert.assertEquals(consumerAppDTO.isIdTokenEncryptionEnabled(), appDO.isIdTokenEncryptionEnabled());
+        Assert.assertEquals(consumerAppDTO.getIdTokenEncryptionAlgorithm(), appDO.getIdTokenEncryptionAlgorithm());
+        Assert.assertEquals(consumerAppDTO.getIdTokenEncryptionMethod(), appDO.getIdTokenEncryptionMethod());
+        Assert.assertEquals(consumerAppDTO.getBackChannelLogoutUrl(), appDO.getBackChannelLogoutUrl());
+        Assert.assertEquals(consumerAppDTO.getIdTokenExpiryTime(), appDO.getIdTokenExpiryTime());
+        Assert.assertEquals(consumerAppDTO.getFrontchannelLogoutUrl(), appDO.getFrontchannelLogoutUrl());
+        Assert.assertEquals(consumerAppDTO.isBypassClientCredentials(), appDO.isBypassClientCredentials());
+    }
+
+    private void assertArrayEquals(String[] audiences, String[] audiencesToCompare) {
+        List<String> list1 = new ArrayList<>(Arrays.asList(audiences));
+        List<String> list2 = new ArrayList<>(Arrays.asList(audiencesToCompare));
+        list1.removeAll(list2);
+        Assert.assertTrue(list1.isEmpty());
     }
 
     @DataProvider(name = "getAppInformationExceptions")
@@ -267,12 +303,12 @@ public class OAuthAdminServiceTest extends PowerMockIdentityBaseTest {
 
         switch (exception) {
             case "InvalidOAuthClientException":
-                when(oAtuhAppDAO.getAppInformation(consumerKey)).thenThrow(InvalidOAuthClientException.class);
+                when(oAuthAppDAO.getAppInformation(consumerKey)).thenThrow(InvalidOAuthClientException.class);
                 break;
             case "IdentityOAuth2Exception":
-                when(oAtuhAppDAO.getAppInformation(consumerKey)).thenThrow(IdentityOAuth2Exception.class);
+                when(oAuthAppDAO.getAppInformation(consumerKey)).thenThrow(IdentityOAuth2Exception.class);
         }
-        whenNew(OAuthAppDAO.class).withAnyArguments().thenReturn(oAtuhAppDAO);
+        whenNew(OAuthAppDAO.class).withAnyArguments().thenReturn(oAuthAppDAO);
 
         OAuthAdminService oAuthAdminService = new OAuthAdminService();
         oAuthAdminService.getOAuthApplicationData(consumerKey);
@@ -284,9 +320,9 @@ public class OAuthAdminServiceTest extends PowerMockIdentityBaseTest {
         String appName = "some-app-name";
 
         // Create oauth application data.
-        OAuthAppDO app = getDummyOAuthApp("some-user-name");
-        when(oAtuhAppDAO.getAppInformationByAppName(appName)).thenReturn(app);
-        whenNew(OAuthAppDAO.class).withAnyArguments().thenReturn(oAtuhAppDAO);
+        OAuthAppDO app = buildDummyOAuthAppDO("some-user-name");
+        when(oAuthAppDAO.getAppInformationByAppName(appName)).thenReturn(app);
+        whenNew(OAuthAppDAO.class).withAnyArguments().thenReturn(oAuthAppDAO);
 
         OAuthAdminService oAuthAdminService = new OAuthAdminService();
         OAuthConsumerAppDTO oAuthConsumerApp = oAuthAdminService.getOAuthApplicationDataByAppName(appName);
@@ -301,18 +337,18 @@ public class OAuthAdminServiceTest extends PowerMockIdentityBaseTest {
 
         switch (exception) {
             case "InvalidOAuthClientException":
-                when(oAtuhAppDAO.getAppInformationByAppName(appName)).thenThrow(InvalidOAuthClientException.class);
+                when(oAuthAppDAO.getAppInformationByAppName(appName)).thenThrow(InvalidOAuthClientException.class);
                 break;
             case "IdentityOAuth2Exception":
-                when(oAtuhAppDAO.getAppInformationByAppName(appName)).thenThrow(IdentityOAuth2Exception.class);
+                when(oAuthAppDAO.getAppInformationByAppName(appName)).thenThrow(IdentityOAuth2Exception.class);
         }
-        whenNew(OAuthAppDAO.class).withAnyArguments().thenReturn(oAtuhAppDAO);
+        whenNew(OAuthAppDAO.class).withAnyArguments().thenReturn(oAuthAppDAO);
 
         OAuthAdminService oAuthAdminService = new OAuthAdminService();
         oAuthAdminService.getOAuthApplicationDataByAppName(appName);
     }
 
-    private OAuthAppDO getDummyOAuthApp(String username) {
+    private OAuthAppDO buildDummyOAuthAppDO(String ownerUserName) {
 
         // / Create oauth application data.
         OAuthAppDO app = new OAuthAppDO();
@@ -326,27 +362,47 @@ public class OAuthAdminServiceTest extends PowerMockIdentityBaseTest {
         // Create authenticated user.
         AuthenticatedUser user = new AuthenticatedUser();
         user.setUserStoreDomain(UserCoreConstants.PRIMARY_DEFAULT_DOMAIN_NAME);
-        user.setUserName(username);
+        user.setUserName(ownerUserName);
+        user.setTenantDomain("wso2.com");
         // Set authenticated user to the app data object.
         app.setUser(user);
-        app.setPkceMandatory(false);
-        app.setPkceSupportPlain(false);
-        app.setUserAccessTokenExpiryTime(1500000);
-        app.setApplicationAccessTokenExpiryTime(2000000);
-        app.setRefreshTokenExpiryTime(3000000);
+        app.setPkceMandatory(true);
+        app.setPkceSupportPlain(true);
+        app.setUserAccessTokenExpiryTime(1500);
+        app.setApplicationAccessTokenExpiryTime(2000);
+        app.setRefreshTokenExpiryTime(3000);
+
+        app.setState("ACTIVE");
+        app.setAudiences(new String[] { "audience1", "audience2"});
+        app.setRequestObjectSignatureValidationEnabled(true);
+        app.setIdTokenEncryptionEnabled(true);
+        app.setIdTokenEncryptionAlgorithm("RSA-11");
+        app.setIdTokenEncryptionMethod("Method1");
+        app.setBackChannelLogoutUrl("https://localhost/app/logout");
+        app.setIdTokenExpiryTime(8000);
+        app.setFrontchannelLogoutUrl("https://localhost/app/frontchannellogout");
+        app.setBypassClientCredentials(true);
+
         return app;
     }
 
     @Test
     public void testUpdateConsumerApplication() throws Exception {
+
+        PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain("carbon.super");
+        PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantId(-1234);
+        PrivilegedCarbonContext.getThreadLocalCarbonContext().setUsername("admin");
+
         String consumerKey = "some-consumer-key";
 
-        OAuthAppDO app = getDummyOAuthApp("some-user-name");
+        OAuthAppDO app = buildDummyOAuthAppDO("some-user-name");
+        AuthenticatedUser originalOwner = app.getAppOwner();
+
         OAuthAppDAO oAuthAppDAOMock = PowerMockito.spy(new OAuthAppDAO());
         OAuthAppDO oAuthAppDO = new OAuthAppDO();
         PowerMockito.doReturn(true).when(oAuthAppDAOMock, "validateUserForOwnerUpdate", oAuthAppDO);
-        when(oAtuhAppDAO.getAppInformation(consumerKey)).thenReturn(app);
-        whenNew(OAuthAppDAO.class).withAnyArguments().thenReturn(oAtuhAppDAO);
+        when(oAuthAppDAO.getAppInformation(consumerKey)).thenReturn(app);
+        whenNew(OAuthAppDAO.class).withAnyArguments().thenReturn(oAuthAppDAO);
 
         OAuthAdminService oAuthAdminService = new OAuthAdminService();
         OAuthConsumerAppDTO consumerAppDTO = new OAuthConsumerAppDTO();
@@ -355,15 +411,22 @@ public class OAuthAdminServiceTest extends PowerMockIdentityBaseTest {
         consumerAppDTO.setOauthConsumerKey("some-consumer-key");
         consumerAppDTO.setOauthConsumerSecret("some-consumer-secret");
         consumerAppDTO.setOAuthVersion("new-oauth-version");
-        consumerAppDTO.setUsername("new-user-name");
+
+        AuthenticatedUser newOwner = new AuthenticatedUser();
+        newOwner.setUserName("new-user-name");
+        newOwner.setUserStoreDomain("H2");
+        newOwner.setTenantDomain(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+
+        consumerAppDTO.setUsername(newOwner.toFullQualifiedUsername());
         oAuthAdminService.updateConsumerApplication(consumerAppDTO);
         OAuthConsumerAppDTO updatedOAuthConsumerApp = oAuthAdminService.getOAuthApplicationData(consumerKey);
         Assert.assertEquals(updatedOAuthConsumerApp.getApplicationName(), consumerAppDTO.getApplicationName(),
                 "Updated Application name should be same as the application name in consumerAppDTO data object.");
         Assert.assertEquals(updatedOAuthConsumerApp.getCallbackUrl(), consumerAppDTO.getCallbackUrl(),
                 "Updated Application callbackUrl should be same as the callbackUrl in consumerAppDTO data object.");
-        // Application update should not set the username.  It should be the username of the original owner
-        Assert.assertEquals(updatedOAuthConsumerApp.getUsername(), "some-user-name");
+        // Application update should change the app owner.
+        Assert.assertNotEquals(updatedOAuthConsumerApp.getUsername(), originalOwner.toFullQualifiedUsername());
+        Assert.assertEquals(updatedOAuthConsumerApp.getUsername(), newOwner.toFullQualifiedUsername());
     }
 
     @Test
@@ -378,7 +441,6 @@ public class OAuthAdminServiceTest extends PowerMockIdentityBaseTest {
 
     @Test
     public void testUpdateOauthSecretKey() throws Exception {
-        initConfigsAndRealm();
 
         mockStatic(OAuthUtil.class);
         when(OAuthUtil.getRandomNumber()).thenReturn(UPDATED_CONSUMER_SECRET);
@@ -393,7 +455,6 @@ public class OAuthAdminServiceTest extends PowerMockIdentityBaseTest {
 
     @Test(expectedExceptions = IdentityOAuthAdminException.class)
     public void testUpdateOauthSecretKeyWithException() throws Exception {
-        initConfigsAndRealm();
 
         mockStatic(OAuthUtil.class);
         when(OAuthUtil.getRandomNumber()).thenReturn(UPDATED_CONSUMER_SECRET);


### PR DESCRIPTION
* Make unnecessary static method in the OAuth2ServiceComponent to be instance methods (This is required to able to run unit tests using IDE.)

* Code improvements to OAuthAdminService

1. Remove duplicate code
2. Improve app owner change logic (ie. check whether app owner exists during app update)

* Improve unit tests

These improvements are related to the fix given for  wso2/product-is#4280