### PR TITLE
Fix wso2/product-is#4301: Introduce extension point at token introspection to inject uma permission info

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/introspection/IntrospectionResponseBuilder.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/introspection/IntrospectionResponseBuilder.java
@@ -205,4 +205,16 @@ public class IntrospectionResponseBuilder {
         parameters.put(IntrospectionResponse.Error.ERROR_DESCRIPTION, description);
         return this;
     }
+
+    /**
+     * Set additional response to the introspection response.
+     *
+     * @param additionalData Additional data to be added to the introspection response.
+     * @return IntrospectionResponseBuilder.
+     */
+    public IntrospectionResponseBuilder setAdditionalData(Map<String, Object> additionalData) {
+
+        additionalData.entrySet().forEach(dataEntry -> parameters.put(dataEntry.getKey(), dataEntry.getValue()));
+        return this;
+    }
 }

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/introspection/IntrospectionResponseBuilderTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/introspection/IntrospectionResponseBuilderTest.java
@@ -17,13 +17,20 @@
  */
 package org.wso2.carbon.identity.oauth.endpoint.introspection;
 
+import org.json.JSONArray;
 import org.json.JSONObject;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 /**
  * This class does unit test coverage for RecoveryConfigImpl class
@@ -143,4 +150,45 @@ public class IntrospectionResponseBuilderTest {
                 "ERROR_DESCRIPTION already exists in the response builder");
     }
 
+    @Test (dependsOnMethods = "testResposeBuilderWithVal")
+    public void testResponseBuilderWithAdditionalProperties() throws Exception {
+
+        Map<String, Object> additionalData = new HashMap<>();
+        List<Map<String, Object>> permissions = new ArrayList<>();
+
+        Map<String, Object> resource1 = new HashMap<>();
+        String resourceIdKey = "resource_id";
+        String resourceScopesKey = "resource_scopes";
+        String permissionKey = "permission";
+
+        resource1.put(resourceIdKey, "resource-id-1");
+        List<String> scopesList1 = new ArrayList<>();
+        scopesList1.add("view");
+        scopesList1.add("edit");
+        resource1.put(resourceScopesKey, scopesList1);
+
+        Map<String, Object> resource2 = new HashMap<>();
+        resource2.put(resourceIdKey, "resource-id-2");
+        List<String> scopesList2 = new ArrayList<>();
+        scopesList2.add("view");
+        scopesList2.add("edit");
+        resource2.put(resourceScopesKey, scopesList2);
+
+        permissions.add(resource1);
+        permissions.add(resource2);
+
+        additionalData.put(permissionKey, permissions);
+        introspectionResponseBuilder1.setAdditionalData(additionalData);
+
+        JSONObject permissionEntry = new JSONObject(introspectionResponseBuilder1.build());
+        assertTrue(permissionEntry.has(permissionKey), permissionKey + " key not found in introspection response.");
+
+        JSONArray resourcesArray = permissionEntry.getJSONArray(permissionKey);
+        assertEquals(resourcesArray.length(), 2, "Resources array should contain 2 elements.");
+
+        JSONObject resourceEntry = resourcesArray.getJSONObject(1);
+        assertTrue(resourceEntry.has(resourceIdKey), resourceIdKey + " key not found in introspection response.");
+        assertTrue(resourceEntry.has(resourceScopesKey), resourceScopesKey + " key not found in introspection " +
+                                                         "response.");
+    }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
@@ -240,6 +240,9 @@ public class OAuthServerConfiguration {
     // Property added to determine the expiration of logout token in oidc back-channel logout.
     private String openIDConnectBCLogoutTokenExpiryInSeconds = "120";
 
+    // Property to determine whether data providers should be executed during token introspection.
+    private boolean enableIntrospectionDataProviders = false;
+
     private OAuthServerConfiguration() {
         buildOAuthServerConfiguration();
     }
@@ -375,6 +378,23 @@ public class OAuthServerConfiguration {
 
         // Read the value of  old  Access Tokens cleanup enable  config. If true cleanup feature will be enable.
         tokenCleanupFeatureConfig(oauthElem);
+
+        // Read token introspection related configurations.
+        parseTokenIntrospectionConfig(oauthElem);
+    }
+
+    private void parseTokenIntrospectionConfig(OMElement oauthElem) {
+
+        OMElement introspectionElem = oauthElem.getFirstChildWithName(getQNameWithIdentityNS(
+                ConfigElements.INTROSPECTION_CONFIG));
+        if (introspectionElem != null) {
+            // Reads 'EnableDataProviders' config.
+            OMElement enableDataProvidersElem = introspectionElem.getFirstChildWithName(
+                    getQNameWithIdentityNS(ConfigElements.ENABLE_DATA_PROVIDERS_CONFIG));
+            if (enableDataProvidersElem != null) {
+                enableIntrospectionDataProviders = Boolean.parseBoolean(enableDataProvidersElem.getText().trim());
+            }
+        }
     }
 
     private void parseShowDisplayNameInConsentPage(OMElement oauthElem) {
@@ -1154,6 +1174,15 @@ public class OAuthServerConfiguration {
         return isRevokeResponseHeadersEnabled;
     }
 
+    /**
+     * Returns whether introspection data providers should be enabled.
+     *
+     * @return true if introspection data providers should be enabled.
+     */
+    public boolean isEnableIntrospectionDataProviders() {
+
+        return enableIntrospectionDataProviders;
+    }
     /**
      * Return the value of whether the refresh token is allowed for this grant type. Null will be returned if there is
      * no tag or empty tag.
@@ -2744,6 +2773,9 @@ public class OAuthServerConfiguration {
         private static final String HASH_ALGORITHM = "HashAlgorithm";
         private static final String ENABLE_CLIENT_SECRET_HASH = "EnableClientSecretHash";
 
+        // Token introspection Configs
+        private static final String INTROSPECTION_CONFIG = "Introspection";
+        private static final String ENABLE_DATA_PROVIDERS_CONFIG = "EnableDataProviders";
     }
 
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/IntrospectionDataProvider.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/IntrospectionDataProvider.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.carbon.identity.oauth2;
+
+import org.wso2.carbon.identity.oauth2.dto.OAuth2IntrospectionResponseDTO;
+import org.wso2.carbon.identity.oauth2.dto.OAuth2TokenValidationRequestDTO;
+
+import java.util.Map;
+
+/**
+ * This extension is to provide additional information for introspection response.
+ */
+public interface IntrospectionDataProvider {
+
+    /**
+     * Provide additional data for OAuth token introspection.
+     *
+     * @param oAuth2TokenValidationRequestDTO Token validation request DTO.
+     * @param oAuth2IntrospectionResponseDTO Token introspection response DTO.
+     * @return Map of additional data to be added to the introspection response.
+     * @throws IdentityOAuth2Exception If an error occurs while setting additional introspection data.
+     */
+    Map<String, Object> getIntrospectionData(OAuth2TokenValidationRequestDTO oAuth2TokenValidationRequestDTO,
+                                             OAuth2IntrospectionResponseDTO oAuth2IntrospectionResponseDTO) throws
+            IdentityOAuth2Exception;
+}


### PR DESCRIPTION
Introduces `IntrospectionDataProvider` interface for injecting additional data to introspection response.

To enable data providers for token introspection, make the following configuration in identity.xml. The default value is false.

```xml
<OAuth>
    <Introspection>
        <EnableDataProviders>true</EnableDataProviders>
    </Introspection>
</OAuth>
```