### PR TITLE
Fix DCR delete flow when there is no association SP for the OAuth application

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/DCRMConstants.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/DCRMConstants.java
@@ -62,4 +62,6 @@ public class DCRMConstants {
         public static String INVALID_SOFTWARE_STATEMENT = "invalid_software_statement";
         public static String UNAPPROVED_SOFTWARE_STATEMENT = "unapproved_software_statement";
     }
+
+    public static final String OAUTH2 = "oauth2";
 }

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/service/DCRMService.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/service/DCRMService.java
@@ -27,6 +27,7 @@ import org.wso2.carbon.identity.application.common.model.InboundAuthenticationCo
 import org.wso2.carbon.identity.application.common.model.InboundAuthenticationRequestConfig;
 import org.wso2.carbon.identity.application.common.model.ServiceProvider;
 import org.wso2.carbon.identity.application.common.model.User;
+import org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants;
 import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.oauth.IdentityOAuthAdminException;
 import org.wso2.carbon.identity.oauth.OAuthAdminService;
@@ -130,20 +131,15 @@ public class DCRMService {
         String applicationOwner = PrivilegedCarbonContext.getThreadLocalCarbonContext().getUsername();
         String tenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
         String spName;
-        String defaultSP;
-
-        ApplicationManagementService applicationManagementService = DCRDataHolder.getInstance()
-                .getApplicationManagementService();
         try {
-            spName = applicationManagementService.getServiceProviderNameByClientId(appDTO.getOauthConsumerKey(),
-                    DCRMConstants.OAUTH2, tenantDomain);
-            defaultSP = applicationManagementService.getDefaultServiceProvider().getApplicationName();
+            spName = DCRDataHolder.getInstance().getApplicationManagementService()
+                    .getServiceProviderNameByClientId(appDTO.getOauthConsumerKey(), DCRMConstants.OAUTH2, tenantDomain);
         } catch (IdentityApplicationManagementException e) {
             throw new DCRMException("Error while retrieving the service provider.", e);
         }
 
         // If a SP name returned for the client ID then the application has an associated service provider.
-        if (!StringUtils.equals(spName, defaultSP)) {
+        if (!StringUtils.equals(spName, IdentityApplicationConstants.DEFAULT_SP_CONFIG)) {
             if (log.isDebugEnabled()) {
                 log.debug("The application with consumer key: " + appDTO.getOauthConsumerKey() +
                         " has an association with the service provider: " + spName);

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/service/DCRMServiceTest.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/service/DCRMServiceTest.java
@@ -500,6 +500,10 @@ public class DCRMServiceTest extends PowerMockTestCase {
         when(mockApplicationManagementService.getServiceProvider(dummyClientName, dummyTenantDomain)).thenReturn
                 (null, serviceProvider);
 
+        ServiceProvider defaultServiceProvider = new ServiceProvider();
+        defaultServiceProvider.setApplicationName("default");
+        when(mockApplicationManagementService.getDefaultServiceProvider()).thenReturn(defaultServiceProvider);
+
         applicationRegistrationRequest.setRedirectUris(redirectUri);
 
         OAuthConsumerAppDTO oAuthConsumerApp = new OAuthConsumerAppDTO();

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/service/DCRMServiceTest.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/service/DCRMServiceTest.java
@@ -500,10 +500,6 @@ public class DCRMServiceTest extends PowerMockTestCase {
         when(mockApplicationManagementService.getServiceProvider(dummyClientName, dummyTenantDomain)).thenReturn
                 (null, serviceProvider);
 
-        ServiceProvider defaultServiceProvider = new ServiceProvider();
-        defaultServiceProvider.setApplicationName("default");
-        when(mockApplicationManagementService.getDefaultServiceProvider()).thenReturn(defaultServiceProvider);
-
         applicationRegistrationRequest.setRedirectUris(redirectUri);
 
         OAuthConsumerAppDTO oAuthConsumerApp = new OAuthConsumerAppDTO();


### PR DESCRIPTION
This PR contains behaviour change during DCR delete as below,

* If an associated SP found for the consumer key, then remove both SP and OAuth app
* If an associated SP not found for the consumer key,
  -- Remove the OAuth application and
  -- Remove the SP if there is an SP exists with the same name as OAuth app and that SP doesn't have an association with any other applications.

Resolves [wso2/product-is#4365](https://github.com/wso2/product-is/issues/4365)