### PR TITLE
Fix #4711:Incorrect behavior when empty client id is sent in authorize request

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/state/OAuthRequestStateValidator.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/state/OAuthRequestStateValidator.java
@@ -114,15 +114,6 @@ public class OAuthRequestStateValidator {
                 oAuthMessage.setSessionDataKeyFromConsent(null);
             }
         }
-
-        validateOauthApplication(oAuthMessage);
-    }
-
-    private void validateOauthApplication(OAuthMessage oAuthMessage) throws InvalidRequestParentException {
-
-        if (StringUtils.isNotBlank(oAuthMessage.getClientId())) {
-            EndpointUtil.validateOauthApplication(oAuthMessage.getClientId());
-        }
     }
 
     private void validateInputParameters(OAuthMessage oAuthMessage) throws InvalidRequestException {


### PR DESCRIPTION
### Proposed changes in this pull request

- Resolves wso2/product-is#4711

In the current implementation, app-validity and app-state are checked at the time of building the OAuthMessage object and return a JSON string if clientId is an invalid one. Since the error message is seen by the end-user instead of returning a plain JSON string we will redirect the users to an error page.
This is not against the OAuth 2.0 spec as stated in **section 4.2.2.1**

> If the request fails due to a missing, invalid, or mismatching
>    redirection URI, or if the client identifier is missing or invalid,
>    the authorization server SHOULD inform the resource owner of the
>    error and MUST NOT automatically redirect the user-agent to the
>    invalid redirection URI.
> 
>    If the resource owner denies the access request or if the request
>    fails for reasons other than a missing or invalid redirection URI,
>    the authorization server informs the client by adding the following
>    parameters to the fragment component of the redirection URI using the
>    "application/x-www-form-urlencoded" format, per Appendix B: 
> 
**Test Case changes**
- Add test case to handle empty client_id
- Change invalid client Id test case so that client_id and app is validated at the time of app validation
- In case of invalid/empty client_id, user will be redirected to an error page instead of sending a **401** response