### PR TITLE
Fix #4403:Sending access_token through /oauth2/userinfo API Body in WSO2 5.7.0

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/user/OpenIDConnectUserEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/user/OpenIDConnectUserEndpoint.java
@@ -35,6 +35,7 @@ import org.wso2.carbon.identity.oauth2.dto.OAuth2TokenValidationResponseDTO;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -55,6 +56,7 @@ public class OpenIDConnectUserEndpoint {
 
     @GET
     @Path("/")
+    @Consumes("application/x-www-form-urlencoded")
     @Produces("application/json")
     public Response getUserClaims(@Context HttpServletRequest request) throws OAuthSystemException {
         String userInfoResponse;
@@ -90,6 +92,7 @@ public class OpenIDConnectUserEndpoint {
 
     @POST
     @Path("/")
+    @Consumes("application/x-www-form-urlencoded")
     @Produces("application/json")
     public Response getUserClaimsPost(@Context HttpServletRequest request) throws OAuthSystemException {
         return getUserClaims(request);

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/user/impl/UserInforRequestDefaultValidator.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/user/impl/UserInforRequestDefaultValidator.java
@@ -24,13 +24,11 @@ import org.wso2.carbon.identity.oauth.user.UserInfoRequestValidator;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.HttpHeaders;
-import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.charset.CharacterCodingException;
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetDecoder;
-import java.util.Scanner;
 
 /**
  * Validates the schema and authorization header according to the specification
@@ -38,67 +36,35 @@ import java.util.Scanner;
  * @see http://openid.net/specs/openid-connect-basic-1_0-22.html#anchor6
  */
 public class UserInforRequestDefaultValidator implements UserInfoRequestValidator {
-    private static String CONTENT_TYPE_HEADER_VALUE = "application/x-www-form-urlencoded";
-    private static String US_ASCII = "US-ASCII";
+
+    private static final String US_ASCII = "US-ASCII";
+    private static final String ACCESS_TOKEN_PARAM = "access_token";
+    private static final String BEARER = "Bearer";
 
     @Override
     public String validateRequest(HttpServletRequest request) throws UserInfoEndpointException {
-        String authzHeaders = request.getHeader(HttpHeaders.AUTHORIZATION);
-        if (authzHeaders == null) {
-            String contentTypeHeaders = request.getHeader(HttpHeaders.CONTENT_TYPE);
-            //to validate the Content_Type header
-            if (StringUtils.isEmpty(contentTypeHeaders)) {
-                throw new UserInfoEndpointException(OAuthError.ResourceResponse.INVALID_REQUEST,
-                        "Authorization or Content-Type header is missing");
-            }
-            if ((CONTENT_TYPE_HEADER_VALUE).equals(contentTypeHeaders.trim())) {
-                StringBuilder stringBuilder = new StringBuilder();
 
-                Scanner scanner = null;
-                try {
-                    scanner = new Scanner(request.getInputStream());
-                } catch (IOException e) {
-                    throw new UserInfoEndpointException(OAuthError.ResourceResponse.INVALID_REQUEST,
-                            "can not read the request body");
-                }
-                while (scanner.hasNextLine()) {
-                    stringBuilder.append(scanner.nextLine());
-                }
-                String[] arrAccessToken = new String[2];
-                String requestBody = stringBuilder.toString();
-                String[] arrAccessTokenNew;
-                //to check whether the entity-body consist entirely of ASCII [USASCII] characters
-                if (!isPureAscii(requestBody)) {
-                    throw new UserInfoEndpointException(OAuthError.ResourceResponse.INVALID_REQUEST,
-                            "Body contains non ASCII characters");
-                }
-                if (requestBody.contains("access_token=")) {
-                    arrAccessToken = requestBody.trim().split("access_token=");
-                    if (arrAccessToken[1].contains("&")) {
-                        arrAccessTokenNew = arrAccessToken[1].split("&", 2);
-                        return arrAccessTokenNew[0];
-                    }
-                }
-                return arrAccessToken[1];
-            } else {
-                throw new UserInfoEndpointException(OAuthError.ResourceResponse.INVALID_REQUEST,
-                        "Content-Type header is wrong");
-            }
+        String authzHeaders = request.getHeader(HttpHeaders.AUTHORIZATION);
+        String accessToken = request.getParameter(ACCESS_TOKEN_PARAM);
+        if (StringUtils.isBlank(authzHeaders) && StringUtils.isNotBlank(accessToken)) {
+            return accessToken;
         }
 
-        String[] authzHeaderInfo = ((String) authzHeaders).trim().split(" ");
-        if (!"Bearer".equals(authzHeaderInfo[0])) {
+        if (StringUtils.isBlank(authzHeaders)) {
             throw new UserInfoEndpointException(OAuthError.ResourceResponse.INVALID_REQUEST, "Bearer token missing");
         }
-        if (authzHeaderInfo.length == 1) {
-            throw new UserInfoEndpointException(OAuthError.ResourceResponse.INVALID_REQUEST, "Access token missing");
+
+        String[] authzHeaderInfo = authzHeaders.trim().split(" ");
+        if (authzHeaderInfo.length < 2 || !BEARER.equals(authzHeaderInfo[0])) {
+            throw new UserInfoEndpointException(OAuthError.ResourceResponse.INVALID_REQUEST, "Bearer token missing");
         }
+
         return authzHeaderInfo[1];
     }
 
-
     public static boolean isPureAscii(String requestBody) {
-        byte bytearray[] = requestBody.getBytes();
+
+        byte[] bytearray = requestBody.getBytes();
         CharsetDecoder charsetDecoder = Charset.forName(US_ASCII).newDecoder();
         try {
             CharBuffer charBuffer = charsetDecoder.decode(ByteBuffer.wrap(bytearray));

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/user/impl/UserInfoISAccessTokenValidatorTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/user/impl/UserInfoISAccessTokenValidatorTest.java
@@ -76,26 +76,6 @@ public class UserInfoISAccessTokenValidatorTest extends PowerMockTestCase {
     }
 
     @DataProvider
-    public Object[][] requestBody() {
-        return new Object[][]{
-                {CONTENT_TYPE_HEADER_VALUE, "", null},
-                {CONTENT_TYPE_HEADER_VALUE, null, null},
-                {CONTENT_TYPE_HEADER_VALUE, "access_token=" + TOKEN, TOKEN},
-                {CONTENT_TYPE_HEADER_VALUE, "access_token=" + TOKEN +
-                        "&someOtherParam=value", TOKEN},
-                {CONTENT_TYPE_HEADER_VALUE, "otherParam=value2&access_token=" + TOKEN +
-                        "&someOtherParam=value", TOKEN},
-        };
-    }
-
-    @Test(dataProvider = "requestBody")
-    public void testValidateTokenWithRequestBodySuccess(String contentType, String requestBody, String expected) throws
-            Exception {
-        String token = testValidateTokenWithRequestBody(contentType, requestBody, true);
-        assertEquals(token, expected, "Expected token did not receive");
-    }
-
-    @DataProvider
     public Object[][] requestBodyWithNonASCII() {
         return new Object[][]{
                 {CONTENT_TYPE_HEADER_VALUE, "access_token=" + "¥" + TOKEN, TOKEN},


### PR DESCRIPTION
### Proposed changes in this pull request
- Resolves wso2/product-is#4403
When CorrelationIdValve has enabled it parses the input stream and creates the parameter map. In the current OAuth implementation, it again tries to parse the raw input stream and get parameters hence it fails to get the access token. In this fix, we simply get the access_token parameter by accessing the parameter map(without dealing with the raw input stream.)

- **Test case changes**
Remove testing scenarios related to request body parsing since the request is no longer being parser manually.

### When should this PR be merged
- ASAP


### Follow up actions
- N/A
