### PR TITLE
Validate expiry time (exp) of Request Object if it present

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/RequestObjectValidatorImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/RequestObjectValidatorImpl.java
@@ -94,14 +94,15 @@ public class RequestObjectValidatorImpl implements RequestObjectValidator {
     public boolean validateRequestObject(RequestObject requestObject, OAuth2Parameters oAuth2Parameters)
             throws RequestObjectException {
 
-        boolean isValid = validateClientIdAndResponseType(requestObject, oAuth2Parameters);
+        boolean isValid = validateClientIdAndResponseType(requestObject, oAuth2Parameters) && checkExpirationTime
+                (requestObject);
         if (isParamPresent(requestObject, Constants.REQUEST_URI)) {
             isValid = false;
         } else if (isParamPresent(requestObject, Constants.REQUEST)) {
             isValid = false;
         } else if (requestObject.isSigned()) {
             isValid = isValidIssuer(requestObject, oAuth2Parameters) && isValidAudience(requestObject,
-                    oAuth2Parameters) && checkExpirationTime(requestObject);
+                    oAuth2Parameters);
         }
         return isValid;
     }
@@ -121,6 +122,7 @@ public class RequestObjectValidatorImpl implements RequestObjectValidator {
             long timeStampSkewMillis = OAuthServerConfiguration.getInstance().getTimeStampSkewInSeconds() * 1000;
             long expirationTimeInMillis = expirationTime.getTime();
             long currentTimeInMillis = System.currentTimeMillis();
+                    expirationTimeInMillis);
             if ((currentTimeInMillis + timeStampSkewMillis) > expirationTimeInMillis) {
                 String msg = "Request Object is expired." +
                         ", Expiration Time(ms) : " + expirationTimeInMillis +

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/RequestObjectValidatorImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/RequestObjectValidatorImpl.java
@@ -122,7 +122,6 @@ public class RequestObjectValidatorImpl implements RequestObjectValidator {
             long timeStampSkewMillis = OAuthServerConfiguration.getInstance().getTimeStampSkewInSeconds() * 1000;
             long expirationTimeInMillis = expirationTime.getTime();
             long currentTimeInMillis = System.currentTimeMillis();
-                    expirationTimeInMillis);
             if ((currentTimeInMillis + timeStampSkewMillis) > expirationTimeInMillis) {
                 String msg = "Request Object is expired." +
                         ", Expiration Time(ms) : " + expirationTimeInMillis +

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/openidconnect/RequestObjectValidatorImplTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/openidconnect/RequestObjectValidatorImplTest.java
@@ -57,6 +57,7 @@ import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.when;
 import static org.wso2.carbon.identity.openidconnect.util.TestUtils.buildJWE;
 import static org.wso2.carbon.identity.openidconnect.util.TestUtils.buildJWT;
+import static org.wso2.carbon.identity.openidconnect.util.TestUtils.buildJWTWithExpiry;
 import static org.wso2.carbon.identity.openidconnect.util.TestUtils.getKeyStoreFromFile;
 import static org.wso2.carbon.utils.multitenancy.MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
 import static org.wso2.carbon.utils.multitenancy.MultitenantConstants.SUPER_TENANT_ID;
@@ -100,13 +101,16 @@ public class RequestObjectValidatorImplTest extends PowerMockTestCase {
                 claims1);
         String jsonWebToken2 = buildJWT(TEST_CLIENT_ID_1, TEST_CLIENT_ID_1, "1001", audience, "none", privateKey, 0,
                 claims1);
+        String jsonWebToken3 = buildJWTWithExpiry(TEST_CLIENT_ID_1, TEST_CLIENT_ID_1, "1003", audience, "none",
+                privateKey, 0, claims1, (- 3600 * 1000));
         String jsonWebEncryption1 = buildJWE(TEST_CLIENT_ID_1, TEST_CLIENT_ID_1, "2000", audience,
                 JWSAlgorithm.NONE.getName(), privateKey, publicKey, 0, claims1);
         String jsonWebEncryption2 = buildJWE(TEST_CLIENT_ID_1, TEST_CLIENT_ID_1, "2001", audience,
                 JWSAlgorithm.RS256.getName(), privateKey, publicKey, 0, claims1);
         return new Object[][]{
                 {jsonWebToken1, true, false, true, "Valid Request Object, signed not encrypted."},
-                {jsonWebToken2, false, false, true, "Valid Request Object, signed not encrypted."},
+                {jsonWebToken2, false, false, true, "Valid Request Object, not xsigned not encrypted."},
+                {jsonWebToken3, false, false, false, "InValid Request Object, expired, not signed not encrypted."},
                 {jsonWebEncryption1, false, true, true, "Valid Request Object, signed and encrypted."},
                 {jsonWebEncryption2, true, true, true, "Valid Request Object, signed and encrypted."}
         };

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/openidconnect/util/TestUtils.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/openidconnect/util/TestUtils.java
@@ -77,8 +77,30 @@ public class TestUtils {
     public static String buildJWT(String issuer, String subject, String jti, String audience, String algorythm,
                                   Key privateKey, long notBeforeMillis, Map<String,Object> claims)
             throws RequestObjectException {
+        long lifetimeInMillis = 3600 * 1000;
+        return buildJWTWithExpiry(issuer, subject, jti, audience, algorythm, privateKey,notBeforeMillis, claims,
+                lifetimeInMillis);
+    }
 
-        JWTClaimsSet jwtClaimsSet = getJwtClaimsSet(issuer, subject, jti, audience, notBeforeMillis, claims);
+    /**
+     * Return a JWT string with provided info, and default time
+     *
+     * @param issuer
+     * @param subject
+     * @param jti
+     * @param audience
+     * @param algorythm
+     * @param privateKey
+     * @param notBeforeMillis
+     * @return
+     * @throws org.wso2.carbon.identity.oauth2.RequestObjectException
+     */
+    public static String buildJWTWithExpiry(String issuer, String subject, String jti, String audience, String
+            algorythm, Key privateKey, long notBeforeMillis, Map<String,Object> claims, long lifetimeInMillis)
+            throws RequestObjectException {
+
+        JWTClaimsSet jwtClaimsSet = getJwtClaimsSet(issuer, subject, jti, audience, notBeforeMillis, claims,
+                lifetimeInMillis);
         if (JWSAlgorithm.NONE.getName().equals(algorythm)) {
             return new PlainJWT(jwtClaimsSet).serialize();
         }
@@ -86,17 +108,17 @@ public class TestUtils {
         return signJWTWithRSA(jwtClaimsSet, privateKey);
     }
 
-    private static JWTClaimsSet getJwtClaimsSet(String issuer, String subject, String jti, String audience, long notBeforeMillis, Map<String, Object> claims) {
-        long lifetimeInMillis = 3600 * 1000;
-        long curTimeInMillis = Calendar.getInstance().getTimeInMillis();
+    private static JWTClaimsSet getJwtClaimsSet(String issuer, String subject, String jti, String audience, long
+            notBeforeMillis, Map<String, Object> claims, long lifetimeInMillis) {
 
+        long curTimeInMillis = Calendar.getInstance().getTimeInMillis();
         // Set claims to jwt token.
         JWTClaimsSet.Builder jwtClaimsSetBuilder = new JWTClaimsSet.Builder();
         jwtClaimsSetBuilder.issuer(issuer);
         jwtClaimsSetBuilder.subject(subject);
         jwtClaimsSetBuilder.audience(Arrays.asList(audience));
         jwtClaimsSetBuilder.jwtID(jti);
-        jwtClaimsSetBuilder.expirationTime(new Date(curTimeInMillis + lifetimeInMillis));
+        jwtClaimsSetBuilder.expirationTime(new Date((curTimeInMillis + lifetimeInMillis)));
         jwtClaimsSetBuilder.issueTime(new Date(curTimeInMillis));
 
         if (notBeforeMillis > 0) {
@@ -216,7 +238,9 @@ public class TestUtils {
     public static String buildJWE(String issuer, String subject, String jti, String audience, String algorythm,
                                   Key privateKey,Key publicKey, long notBeforeMillis, Map<String,
             Object> claims) throws RequestObjectException {
-        JWTClaimsSet jwtClaimsSet = getJwtClaimsSet(issuer, subject, jti, audience, notBeforeMillis, claims);
+        long lifetimeInMillis = 3600 * 1000;
+        JWTClaimsSet jwtClaimsSet = getJwtClaimsSet(issuer, subject, jti, audience, notBeforeMillis, claims,
+                lifetimeInMillis);
 
         if (JWSAlgorithm.NONE.getName().equals(algorythm)) {
             return getEncryptedJWT((RSAPublicKey) publicKey, jwtClaimsSet);


### PR DESCRIPTION
### Proposed changes in this pull request

Fix for https://github.com/wso2/product-is/issues/5039
Currently, Request Object expiry time is not accounted for validating the Request Object in OIDC flow.
This PR will enable validating **exp** of Request Object if a value is present, Otherwise skipped.

### When should this PR be merged

Now
