### PR TITLE
Fix app ownership update logic

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthAdminService.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthAdminService.java
@@ -239,7 +239,8 @@ public class OAuthAdminService extends AbstractAdmin {
                     }
                 }
 
-                AuthenticatedUser appOwner = getAppOwner(application, tenantAwareLoggedInUser, tenantDomain);
+                AuthenticatedUser defaultAppOwner = buildAuthenticatedUser(tenantAwareLoggedInUser, tenantDomain);
+                AuthenticatedUser appOwner = getAppOwner(application, defaultAppOwner);
                 app.setAppOwner(appOwner);
 
                 if (application.getOAuthVersion() != null) {
@@ -356,7 +357,8 @@ public class OAuthAdminService extends AbstractAdmin {
 
         String consumerKey = consumerAppDTO.getOauthConsumerKey();
 
-        AuthenticatedUser appOwner = getAppOwner(consumerAppDTO, tenantAwareLoggedInUserName, tenantDomain);
+        AuthenticatedUser defaultAppOwner = oauthappdo.getAppOwner();
+        AuthenticatedUser appOwner = getAppOwner(consumerAppDTO, defaultAppOwner);
         oauthappdo.setAppOwner(appOwner);
 
         oauthappdo.setOauthConsumerKey(consumerKey);
@@ -1155,12 +1157,10 @@ public class OAuthAdminService extends AbstractAdmin {
 
 
     private AuthenticatedUser getAppOwner(OAuthConsumerAppDTO application,
-                                          String tenantAwareLoggedInUser,
-                                          String tenantDomain) throws IdentityOAuthAdminException {
+                                          AuthenticatedUser defaultAppOwner) throws IdentityOAuthAdminException {
 
         // We first set the logged in user as the owner.
-        AuthenticatedUser appOwner = buildAuthenticatedUser(tenantAwareLoggedInUser, tenantDomain);
-
+        AuthenticatedUser appOwner = defaultAppOwner;
         String applicationOwnerInRequest = application.getUsername();
         if (StringUtils.isNotBlank(applicationOwnerInRequest)) {
             String tenantAwareAppOwnerInRequest = MultitenantUtils.getTenantAwareUsername(applicationOwnerInRequest);
@@ -1169,11 +1169,12 @@ public class OAuthAdminService extends AbstractAdmin {
                         getUserStoreManager().isExistingUser(tenantAwareAppOwnerInRequest)) {
                     // Since the app owner sent in OAuthConsumerAppDTO is a valid one we set the appOwner to be
                     // the one sent in the OAuthConsumerAppDTO.
+                    String tenantDomain = CarbonContext.getThreadLocalCarbonContext().getTenantDomain();
                     appOwner = buildAuthenticatedUser(tenantAwareAppOwnerInRequest, tenantDomain);
                 } else {
                     log.warn("OAuth application owner user name " + applicationOwnerInRequest +
-                            " does not exist in the user store. Using logged-in user name " +
-                            tenantAwareLoggedInUser + " as app owner name");
+                            " does not exist in the user store. Using user: " +
+                            defaultAppOwner.toFullQualifiedUsername() + " as app owner.");
                 }
             } catch (UserStoreException e) {
                 throw handleError("Error while retrieving the user store manager for user: " +

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceTest.java
@@ -397,9 +397,9 @@ public class OAuthAdminServiceTest extends PowerMockIdentityBaseTest {
 
         return new Object[][]{
                 // Logged In user , App Owner in Request , App Owner in request exists, Excepted App Owner after update
-                {"admin@carbon.super", "H2/new-app-owner@carbon.super", false, "admin@carbon.super"},
+                {"admin@carbon.super", "H2/new-app-owner@carbon.super", false, "original-app-owner@wso2.com"},
                 {"admin@carbon.super", "H2/new-app-owner@carbon.super", true, "H2/new-app-owner@carbon.super"},
-                {"admin@wso2.com", "H2/new-app-owner@wso2.com", false, "admin@wso2.com"},
+                {"admin@wso2.com", "H2/new-app-owner@wso2.com", false, "original-app-owner@wso2.com"},
                 {"admin@wso2.com", "H2/new-app-owner@wso2.com", true, "H2/new-app-owner@wso2.com"}
         };
     }
@@ -441,7 +441,7 @@ public class OAuthAdminServiceTest extends PowerMockIdentityBaseTest {
         when(userStoreManager.isExistingUser(tenantAwareUsernameOfAppOwner)).thenReturn(appOwnerInRequestExists);
 
         String consumerKey = "some-consumer-key";
-        OAuthAppDO app = buildDummyOAuthAppDO("some-user-name");
+        OAuthAppDO app = buildDummyOAuthAppDO("original-app-owner");
         AuthenticatedUser originalOwner = app.getAppOwner();
 
         OAuthAppDAO oAuthAppDAOMock = PowerMockito.spy(new OAuthAppDAO());
@@ -467,8 +467,10 @@ public class OAuthAdminServiceTest extends PowerMockIdentityBaseTest {
         Assert.assertEquals(updatedOAuthConsumerApp.getCallbackUrl(), consumerAppDTO.getCallbackUrl(),
                 "Updated Application callbackUrl should be same as the callbackUrl in consumerAppDTO data object.");
 
-        // Application update should change the app owner.
-        Assert.assertNotEquals(updatedOAuthConsumerApp.getUsername(), originalOwner.toFullQualifiedUsername());
+        if (appOwnerInRequestExists) {
+            // Application update should change the app owner if the app owner sent in the request is a valid user.
+            Assert.assertNotEquals(updatedOAuthConsumerApp.getUsername(), originalOwner.toFullQualifiedUsername());
+        }
         Assert.assertEquals(updatedOAuthConsumerApp.getUsername(), expectedAppOwnerAfterUpdate);
     }
 


### PR DESCRIPTION
According to the current logic, if the app owner we are trying to update is an invalid one, then the ownership goes to the user who calls the OAuthAdminService#updateConsumerApplication().
Instead, this fixes the logic to keep the current app owner to be the app owner if the user we are trying to update as the new app owner is an invalid user.

Fixes https://github.com/wso2/product-is/issues/5323