### PR TITLE
Clear token data upon tenant deactivation

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuthTenantMgtListenerImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuthTenantMgtListenerImpl.java
@@ -37,6 +37,18 @@ public class OAuthTenantMgtListenerImpl extends AbstractIdentityTenantMgtListene
 
     @Override
     public void onPreDelete(int tenantId) throws StratosException {
+
+        clearTokenData(tenantId);
+    }
+
+    @Override
+    public void onTenantDeactivation(int tenantId) throws StratosException {
+
+        clearTokenData(tenantId);
+    }
+
+    private void clearTokenData(int tenantId) throws StratosException {
+
         try {
             Set<AccessTokenDO> accessTokenDOs = OAuthTokenPersistenceFactory.getInstance()
                     .getAccessTokenDAO().getAccessTokensByTenant(tenantId);


### PR DESCRIPTION
### Proposed changes in this pull request

> Token data is cleared during `onPreDelete` event. This PR brings the same behavior to the `onTenantDeactivation` event.

### When should this PR be merged

> ASAP

#### Documentation

> N/A
