### PR TITLE
Revert wso2/product-is#4804: Adhering to SPlevelConfig in introspection response by default

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/TokenValidationHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/TokenValidationHandler.java
@@ -475,13 +475,8 @@ public class TokenValidationHandler {
 
         String consumerKey = accessTokenDO.getConsumerKey();
         try {
-            boolean buildSubjectIdentifierFromSPConfig = true;
-            String subjectIdentifierFromSPConfig = IdentityUtil.getProperty(BUILD_FQU_FROM_SP_CONFIG);
-            if (StringUtils.isNotEmpty(subjectIdentifierFromSPConfig)) {
-                buildSubjectIdentifierFromSPConfig =
-                        Boolean.parseBoolean(subjectIdentifierFromSPConfig);
-            }
-
+            boolean buildSubjectIdentifierFromSPConfig = Boolean.parseBoolean(IdentityUtil.getProperty
+                    (BUILD_FQU_FROM_SP_CONFIG));
             if (buildSubjectIdentifierFromSPConfig) {
                 ServiceProvider serviceProvider = getServiceProvider(consumerKey);
                 boolean useTenantDomainInLocalSubjectIdentifier = serviceProvider


### PR DESCRIPTION
Reverts wso2-extensions/identity-inbound-auth-oauth#1046

Reverting due to concerns raised in [1].

[1] https://github.com/wso2/product-is/issues/4804#issuecomment-491532186