### PR TITLE
Fix failed to rollback the connection while throw sql exception

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dao/AccessTokenDAOImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dao/AccessTokenDAOImpl.java
@@ -306,6 +306,7 @@ public class AccessTokenDAOImpl extends AbstractOAuthDAO implements AccessTokenD
             connection.commit();
             return true;
         } catch (SQLException e) {
+            IdentityDatabaseUtil.rollBack(connection);
             throw new IdentityOAuth2Exception("Error occurred while persisting access token", e);
         } finally {
             IdentityDatabaseUtil.closeConnection(connection);
@@ -1442,6 +1443,7 @@ public class AccessTokenDAOImpl extends AbstractOAuthDAO implements AccessTokenD
             }
             connection.commit();
         } catch (SQLException e) {
+            IdentityDatabaseUtil.rollBack(connection);
             String errorMsg = "Error while regenerating access token";
             throw new IdentityOAuth2Exception(errorMsg, e);
         } finally {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dao/TokenManagementDAOImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dao/TokenManagementDAOImpl.java
@@ -381,6 +381,7 @@ public class TokenManagementDAOImpl extends AbstractOAuthDAO implements TokenMan
             connection.commit();
 
         } catch (SQLException e) {
+            IdentityDatabaseUtil.rollBack(connection);
             String errorMsg = "Error deleting OAuth consent of Application " + applicationName + " and User " + username;
             throw new IdentityOAuth2Exception(errorMsg, e);
         } finally {
@@ -426,6 +427,7 @@ public class TokenManagementDAOImpl extends AbstractOAuthDAO implements TokenMan
             connection.commit();
 
         } catch (SQLException e) {
+            IdentityDatabaseUtil.rollBack(connection);
             String errorMsg = "Error deleting OAuth consent of Application " +
                     applicationName + " and User " + username;
             throw new IdentityOAuth2Exception(errorMsg, e);
@@ -475,6 +477,7 @@ public class TokenManagementDAOImpl extends AbstractOAuthDAO implements TokenMan
             connection.commit();
 
         } catch (SQLException e) {
+            IdentityDatabaseUtil.rollBack(connection);
             String errorMsg = "Error updating trusted always in a consent of Application " +
                     applicationName + " and User " + tenantAwareUserName;
             throw new IdentityOAuth2Exception(errorMsg, e);
@@ -586,6 +589,7 @@ public class TokenManagementDAOImpl extends AbstractOAuthDAO implements TokenMan
             connection.commit();
 
         } catch (SQLException e) {
+            IdentityDatabaseUtil.rollBack(connection);
             throw new IdentityApplicationManagementException("Error while executing the SQL statement.", e);
         } finally {
             IdentityDatabaseUtil.closeStatement(updateStateStatement);

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dao/TokenMgtDAO.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dao/TokenMgtDAO.java
@@ -470,6 +470,7 @@ public class TokenMgtDAO {
             connection.commit();
             return true;
         } catch (SQLException e) {
+            IdentityDatabaseUtil.rollBack(connection);
             throw new IdentityOAuth2Exception("Error occurred while persisting access token", e);
         } finally {
             IdentityDatabaseUtil.closeConnection(connection);
@@ -1853,6 +1854,7 @@ public class TokenMgtDAO {
             // commit both transactions
             connection.commit();
         } catch (SQLException e) {
+            IdentityDatabaseUtil.rollBack(connection);
             String errorMsg = "Error while regenerating access token";
             throw new IdentityOAuth2Exception(errorMsg, e);
         } finally {
@@ -1895,6 +1897,7 @@ public class TokenMgtDAO {
             connection.commit();
 
         } catch (SQLException e) {
+            IdentityDatabaseUtil.rollBack(connection);
             String errorMsg = "Error deleting OAuth consent of Application " + applicationName + " and User " + username;
             throw new IdentityOAuth2Exception(errorMsg, e);
         } finally {
@@ -1939,6 +1942,7 @@ public class TokenMgtDAO {
             connection.commit();
 
         } catch (SQLException e) {
+            IdentityDatabaseUtil.rollBack(connection);
             String errorMsg = "Error deleting OAuth consent of Application " + applicationName + " and User " + username;
             throw new IdentityOAuth2Exception(errorMsg, e);
         } finally {
@@ -1984,6 +1988,7 @@ public class TokenMgtDAO {
             connection.commit();
 
         } catch (SQLException e) {
+            IdentityDatabaseUtil.rollBack(connection);
             String errorMsg = "Error updating trusted always in a consent of Application " + applicationName + " and User " + tenantAwareUserName;
             throw new IdentityOAuth2Exception(errorMsg, e);
         } finally {
@@ -2757,6 +2762,7 @@ public class TokenMgtDAO {
             connection.commit();
 
         } catch (SQLException e) {
+            IdentityDatabaseUtil.rollBack(connection);
             throw new IdentityApplicationManagementException("Error while executing the SQL statement.", e);
         } finally {
             IdentityDatabaseUtil.closeStatement(updateStateStatement);


### PR DESCRIPTION
### Proposed changes in this pull request

When we use the JDBC transaction by applying connection.commit() to commit the SQL statements and make sure SQL statements within a transaction block are all executed successfully. if either one of the SQL statement within the transaction block is failed, abort and rollback everything within the transaction block.
In the identity-inbound-auth-oauth, there are some places use the JDBC transaction but did not properly rollback the connection.
Issue: https://github.com/wso2/product-is/issues/5394