### PR TITLE
Fix - role based scope validation added to implicit grant

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/handlers/AbstractResponseTypeHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/handlers/AbstractResponseTypeHandler.java
@@ -35,10 +35,10 @@ import org.wso2.carbon.identity.oauth2.dto.OAuth2AuthorizeReqDTO;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2AuthorizeRespDTO;
 import org.wso2.carbon.identity.oauth2.token.OauthTokenIssuer;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
+import org.wso2.carbon.identity.oauth2.util.Oauth2ScopeUtils;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 /**
  * AbstractResponseTypeHandler contains all the common methods of all three basic handlers.
@@ -82,6 +82,11 @@ public abstract class AbstractResponseTypeHandler implements ResponseTypeHandler
 
     @Override
     public boolean validateScope(OAuthAuthzReqMessageContext oauthAuthzMsgCtx) throws IdentityOAuth2Exception {
+
+        if (hasValidateByApplicationScopeValidatorsFailed(oauthAuthzMsgCtx)) {
+            return false;
+        }
+
         OAuth2AuthorizeReqDTO authorizationReqDTO = oauthAuthzMsgCtx.getAuthorizationReqDTO();
         OAuthCallback scopeValidationCallback = new OAuthCallback(authorizationReqDTO.getUser(),
                 authorizationReqDTO.getConsumerKey(), OAuthCallback.OAuthCallbackType.SCOPE_VALIDATION_AUTHZ);
@@ -154,4 +159,12 @@ public abstract class AbstractResponseTypeHandler implements ResponseTypeHandler
         return respDTO;
     }
 
+    /**
+     * Inverting validateByApplicationScopeValidator method for better readability.
+     */
+    private boolean hasValidateByApplicationScopeValidatorsFailed(OAuthAuthzReqMessageContext authzReqMessageContext)
+            throws IdentityOAuth2Exception {
+
+        return !Oauth2ScopeUtils.validateByApplicationScopeValidator(null, authzReqMessageContext);
+    }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/handlers/AccessTokenResponseTypeHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/handlers/AccessTokenResponseTypeHandler.java
@@ -67,11 +67,12 @@ public class AccessTokenResponseTypeHandler extends AbstractResponseTypeHandler 
     /**
      * This method is used to set relevant values in to respDTO object when an access token is issued.
      * When an access token is issued we have to set access token, validity period and token type.
-     * @param respDTO
+     * @param oauthAuthzMsgCtx
      * @param accessTokenDO
      * @return OAuth2AuthorizeRespDTO object with access token details.
      */
-    private OAuth2AuthorizeRespDTO buildResponseDTO(OAuthAuthzReqMessageContext oauthAuthzMsgCtx, AccessTokenDO accessTokenDO) throws IdentityOAuth2Exception {
+    private OAuth2AuthorizeRespDTO buildResponseDTO(OAuthAuthzReqMessageContext oauthAuthzMsgCtx,
+                                                    AccessTokenDO accessTokenDO) throws IdentityOAuth2Exception {
         // Initializing the response.
         OAuth2AuthorizeRespDTO respDTO = initResponse(oauthAuthzMsgCtx);
         // Add access token details to the response.

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -1753,9 +1753,8 @@ public class OAuth2Util {
     public static String getTenantDomainOfOauthApp(OAuthAppDO oAuthAppDO) {
 
         String tenantDomain = MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
-        if (oAuthAppDO != null) {
-            AuthenticatedUser appDeveloper = oAuthAppDO.getUser();
-            tenantDomain = appDeveloper.getTenantDomain();
+        if (oAuthAppDO != null && oAuthAppDO.getUser() != null) {
+            tenantDomain = oAuthAppDO.getUser().getTenantDomain();
         }
         return tenantDomain;
     }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/Oauth2ScopeUtils.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/Oauth2ScopeUtils.java
@@ -16,18 +16,33 @@
 
 package org.wso2.carbon.identity.oauth2.util;
 
+import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
-import org.wso2.carbon.base.MultitenantConstants;
-import org.wso2.carbon.context.CarbonContext;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.base.IdentityException;
-import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
-import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.oauth.common.exception.InvalidOAuthClientException;
+import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
+import org.wso2.carbon.identity.oauth.dao.OAuthAppDO;
+import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2ScopeClientException;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2ScopeServerException;
 import org.wso2.carbon.identity.oauth2.Oauth2ScopeConstants;
+import org.wso2.carbon.identity.oauth2.authz.OAuthAuthzReqMessageContext;
+import org.wso2.carbon.identity.oauth2.token.OAuthTokenReqMessageContext;
+import org.wso2.carbon.identity.oauth2.validators.OAuth2ScopeValidator;
+import org.wso2.carbon.user.api.UserStoreException;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
 
 public class Oauth2ScopeUtils {
+
+    private static final Log log = LogFactory.getLog(Oauth2ScopeUtils.class);
+    public static final String OAUTH_APP_DO_PROPERTY_NAME = "OAuthAppDO";
 
     public static IdentityOAuth2ScopeServerException generateServerException(Oauth2ScopeConstants.ErrorMessages
                                                                                 error, String data)
@@ -98,5 +113,162 @@ public class Oauth2ScopeUtils {
 
     public static int getTenantID() {
         return PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantId();
+    }
+
+    /**
+     * Validate the scopes in the request using application scope validators.
+     *
+     * @param tokenReqMsgContext     If a token request, can pass an OAuthTokenReqMessageContext object.
+     * @param authzReqMessageContext If an authorization request, can pass an OAuthAuthzReqMessageContext object.
+     * @return TRUE if the validation successful, FALSE otherwise.
+     * @throws IdentityOAuth2Exception
+     */
+    public static boolean validateByApplicationScopeValidator(OAuthTokenReqMessageContext tokenReqMsgContext,
+                                                               OAuthAuthzReqMessageContext authzReqMessageContext)
+            throws IdentityOAuth2Exception {
+
+        String[] scopeValidators;
+        OAuthAppDO oAuthAppDO;
+
+        if (isATokenRequest(tokenReqMsgContext)) {
+            oAuthAppDO = getOAuthAppDO(tokenReqMsgContext);
+        } else {
+            oAuthAppDO = getOAuthAppDO(authzReqMessageContext);
+        }
+
+        scopeValidators = oAuthAppDO.getScopeValidators();
+
+        if (ArrayUtils.isEmpty(scopeValidators)) {
+            if (log.isDebugEnabled()) {
+                log.debug(String.format("There is no scope validator registered for %s@%s",
+                        oAuthAppDO.getApplicationName(), OAuth2Util.getTenantDomainOfOauthApp(oAuthAppDO)));
+            }
+            return true;
+        }
+
+        List<String> appScopeValidators = new ArrayList<>(Arrays.asList(scopeValidators));
+        // Return false only if iterateOAuth2ScopeValidators returned false. One more validation to do if it was true.
+        if (isATokenRequest(tokenReqMsgContext)) {
+            if (hasScopeValidationFailed(tokenReqMsgContext, appScopeValidators, null)) {
+                return false;
+            }
+        } else {
+            if (hasScopeValidationFailed(null, appScopeValidators, authzReqMessageContext)) {
+                return false;
+            }
+        }
+
+        if (!appScopeValidators.isEmpty()) {
+            throw new IdentityOAuth2Exception(String.format("The scope validators %s registered for application " +
+                    "%s@%s are not found in the server configuration ", StringUtils.join(appScopeValidators,
+                    ", "), oAuthAppDO.getApplicationName(), OAuth2Util.getTenantDomainOfOauthApp(oAuthAppDO)));
+        }
+        return true;
+    }
+
+    private static boolean isATokenRequest(OAuthTokenReqMessageContext tokenReqMsgContext) {
+
+        return tokenReqMsgContext != null;
+    }
+
+    private static OAuthAppDO getOAuthAppDO(OAuthTokenReqMessageContext tokenReqMsgContext) throws IdentityOAuth2Exception {
+
+        OAuthAppDO oAuthAppDO =
+                (OAuthAppDO) tokenReqMsgContext.getProperty(OAUTH_APP_DO_PROPERTY_NAME);
+
+        if (oAuthAppDO == null) {
+            try {
+                if (tokenReqMsgContext.getOauth2AccessTokenReqDTO() != null) {
+                    throw new IdentityOAuth2Exception("OAuth2 Access Token Request Object was null when obtaining" +
+                            " OAuth Application.");
+                } else {
+                    oAuthAppDO = OAuth2Util.getAppInformationByClientId(
+                            tokenReqMsgContext.getOauth2AccessTokenReqDTO().getClientId());
+                }
+            } catch (InvalidOAuthClientException e) {
+                throw new IdentityOAuth2Exception("Error while retrieving OAuth application for client id: " +
+                        tokenReqMsgContext.getOauth2AccessTokenReqDTO().getClientId(), e);
+            }
+        }
+        return oAuthAppDO;
+    }
+
+    private static OAuthAppDO getOAuthAppDO(OAuthAuthzReqMessageContext authzReqMessageContext)
+            throws IdentityOAuth2Exception {
+
+        OAuthAppDO oAuthAppDO =
+                (OAuthAppDO) authzReqMessageContext.getProperty(OAUTH_APP_DO_PROPERTY_NAME);
+
+        if (oAuthAppDO == null) {
+            try {
+                if (authzReqMessageContext.getAuthorizationReqDTO() != null) {
+                    throw new IdentityOAuth2Exception("Authorization Request Object was null when obtaining" +
+                            " OAuth Application.");
+                } else {
+                    oAuthAppDO = OAuth2Util.getAppInformationByClientId(
+                            authzReqMessageContext.getAuthorizationReqDTO().getConsumerKey());
+                }
+            } catch (InvalidOAuthClientException e) {
+                throw new IdentityOAuth2Exception("Error while retrieving OAuth application for client id: " +
+                        authzReqMessageContext.getAuthorizationReqDTO().getConsumerKey(), e);
+            }
+        }
+        return oAuthAppDO;
+    }
+
+    /**
+     * Inverting iterateOAuth2ScopeValidators method for better readability.
+     */
+    private static boolean hasScopeValidationFailed(OAuthTokenReqMessageContext tokenReqMsgContext,
+                                                    List<String> appScopeValidators,
+                                                    OAuthAuthzReqMessageContext authzReqMessageContext)
+            throws IdentityOAuth2Exception {
+
+        return !iterateOAuth2ScopeValidators(authzReqMessageContext, tokenReqMsgContext, appScopeValidators);
+    }
+
+    /**
+     * Iterate through the set of OAuth2ScopeValidators and validate the scopes in the request, considering only the
+     * validators added in the OAuth App.
+     *
+     * @param authzReqMessageContext OAuthAuthzReqMessageContext object. tokenReqMsgContext should be null.
+     * @param tokenReqMsgContext     OAuthTokenReqMessageContext object. authzReqMessageContext should be null.
+     * @param appScopeValidators     Validators to be considered.
+     * @return True if scopes are valid according to all the validators sent, false otherwise.
+     * @throws IdentityOAuth2Exception
+     */
+    private static boolean iterateOAuth2ScopeValidators(OAuthAuthzReqMessageContext authzReqMessageContext,
+                                                        OAuthTokenReqMessageContext tokenReqMsgContext,
+                                                        List<String> appScopeValidators)
+            throws IdentityOAuth2Exception {
+
+        Set<OAuth2ScopeValidator> oAuth2ScopeValidators = OAuthServerConfiguration.getInstance()
+                .getOAuth2ScopeValidators();
+        // Iterate through all available scope validators.
+        for (OAuth2ScopeValidator validator : oAuth2ScopeValidators) {
+            // Validate the scopes from the validator only if it's configured in the OAuth app.
+            if (validator != null && appScopeValidators.contains(validator.getValidatorName())) {
+                if (log.isDebugEnabled()) {
+                    log.debug(String.format("Validating scope of token request using %s",
+                            validator.getValidatorName()));
+                }
+                boolean isValid;
+                try {
+                    if (authzReqMessageContext != null) {
+                        isValid = validator.validateScope(authzReqMessageContext);
+                    } else {
+                        isValid = validator.validateScope(tokenReqMsgContext);
+                    }
+                } catch (UserStoreException e) {
+                    throw new IdentityOAuth2Exception("Error while validating scopes from application scope " +
+                            "validator", e);
+                }
+                appScopeValidators.remove(validator.getValidatorName());
+                if (!isValid) {
+                    return false;
+                }
+            }
+        }
+        return true;
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/JDBCScopeValidator.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/JDBCScopeValidator.java
@@ -36,6 +36,7 @@ import org.wso2.carbon.identity.oauth.cache.OAuthCacheKey;
 import org.wso2.carbon.identity.oauth.internal.OAuthComponentServiceHolder;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2ScopeServerException;
+import org.wso2.carbon.identity.oauth2.authz.OAuthAuthzReqMessageContext;
 import org.wso2.carbon.identity.oauth2.bean.Scope;
 import org.wso2.carbon.identity.oauth2.dao.OAuthTokenPersistenceFactory;
 import org.wso2.carbon.identity.oauth2.model.AccessTokenDO;
@@ -50,7 +51,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
-
 
 /**
  * The JDBC Scope Validation implementation. This validates the Resource's scope (stored in IDN_OAUTH2_RESOURCE_SCOPE)
@@ -170,7 +170,29 @@ public class JDBCScopeValidator extends OAuth2ScopeValidator {
     public boolean validateScope(OAuthTokenReqMessageContext tokReqMsgCtx) throws
             UserStoreException, IdentityOAuth2Exception {
 
-        String[] requestedScopes = tokReqMsgCtx.getScope();
+        return validateScope(tokReqMsgCtx.getScope(), tokReqMsgCtx.getAuthorizedUser());
+    }
+
+    @Override
+    public boolean validateScope(OAuthAuthzReqMessageContext authzReqMessageContext) throws
+            UserStoreException, IdentityOAuth2Exception {
+
+        return validateScope(authzReqMessageContext.getAuthorizationReqDTO().getScopes(),
+                authzReqMessageContext.getAuthorizationReqDTO().getUser());
+    }
+
+    /**
+     * Validate given set of scopes against an authenticated user.
+     *
+     * @param requestedScopes Scopes to be validated.
+     * @param user Authenticated user.
+     * @return True is all scopes are valid. False otherwise.
+     * @throws UserStoreException If were unable to get tenant or user roles.
+     * @throws IdentityOAuth2Exception by an Underline method.
+     */
+    private boolean validateScope(String[] requestedScopes, AuthenticatedUser user)
+            throws UserStoreException, IdentityOAuth2Exception {
+
         // Remove openid scope from the list if available
         requestedScopes = (String[]) ArrayUtils.removeElement(requestedScopes, OPENID);
 
@@ -179,7 +201,6 @@ public class JDBCScopeValidator extends OAuth2ScopeValidator {
             return true;
         }
 
-        AuthenticatedUser user = tokReqMsgCtx.getAuthorizedUser();
         int tenantId = getTenantId(user);
         String[] userRoles = getUserRoles(user);
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/OAuth2ScopeValidator.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/OAuth2ScopeValidator.java
@@ -19,6 +19,7 @@
 package org.wso2.carbon.identity.oauth2.validators;
 
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
+import org.wso2.carbon.identity.oauth2.authz.OAuthAuthzReqMessageContext;
 import org.wso2.carbon.identity.oauth2.model.AccessTokenDO;
 import org.wso2.carbon.identity.oauth2.token.OAuthTokenReqMessageContext;
 import org.wso2.carbon.user.api.UserStoreException;
@@ -55,6 +56,20 @@ public abstract class OAuth2ScopeValidator {
      */
     public boolean validateScope(OAuthTokenReqMessageContext tokReqMsgCtx) throws
             IdentityOAuth2Exception, UserStoreException {
+        return true;
+    }
+
+    /**
+     * Method to validate scopes in the authorization request against the roles of the user.
+     *
+     * @param authzReqMessageContext Authorization request
+     * @return - true if the user has enough permission to generate tokens with requested scopes or
+     * no scopes are requested, otherwise false
+     * @throws IdentityOAuth2Exception
+     */
+    public boolean validateScope(OAuthAuthzReqMessageContext authzReqMessageContext) throws
+            UserStoreException, IdentityOAuth2Exception {
+
         return true;
     }
 


### PR DESCRIPTION
Resolves wso2/product-is#5335

Apart from fixing the implicit flow, this change will enforce scope validation in authorization code grant type authorization request as well. The previous implementation only validated scopes in token request and a valid code was returned even for an invalid scope. This is a spec violation.