### PR TITLE
property added to disable or enable role based scope validation for implicit grant

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
@@ -135,6 +135,7 @@ public class OAuthServerConfiguration {
     private String retainOldAccessTokens;
     private String tokenCleanupFeatureEnable;
     private OauthTokenIssuer oauthIdentityTokenGenerator;
+    private boolean scopeValidationConfigValue = true;
     private boolean cacheEnabled = false;
     private boolean isTokenRenewalPerRequestEnabled = false;
     private boolean isRefreshTokenRenewalEnabled = true;
@@ -289,6 +290,14 @@ public class OAuthServerConfiguration {
         //Get the configured scope validators
         OMElement scopeValidatorsElem = oauthElem.getFirstChildWithName(
                 getQNameWithIdentityNS(ConfigElements.SCOPE_VALIDATORS));
+
+        //Get scopeValidationEnabledConfigValue
+        OMElement scopeValidationElem = oauthElem.getFirstChildWithName(
+                getQNameWithIdentityNS(ConfigElements.SCOPE_VALIDATION_FOR_AUTH_CODE_AND_IMPLICIT));
+
+        if (scopeValidationElem != null) {
+            scopeValidationConfigValue = Boolean.parseBoolean(scopeValidationElem.getText());
+        }
 
         if (scopeValidatorElem != null) {
             parseScopeValidator(scopeValidatorElem);
@@ -2706,6 +2715,10 @@ public class OAuthServerConfiguration {
         }
     }
 
+    public boolean isScopeValidationEnabledForImplicitAndCodeGrant() {
+        return scopeValidationConfigValue;
+    }
+
     /**
      * Localpart names for the OAuth configuration in identity.xml.
      */
@@ -2800,6 +2813,9 @@ public class OAuthServerConfiguration {
         private static final String SCOPE_CLASS_ATTR = "class";
         private static final String SKIP_SCOPE_ATTR = "scopesToSkip";
         private static final String IMPLICIT_ERROR_FRAGMENT = "ImplicitErrorFragment";
+
+        // Enable/Disable scope validation for implicit grant and authorization code grant
+        private static final String SCOPE_VALIDATION_FOR_AUTH_CODE_AND_IMPLICIT = "ScopeValidationEnabledForAuthCodeAndImplicitGrant";
 
         // Default timestamp skew
         private static final String TIMESTAMP_SKEW = "TimestampSkew";

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
@@ -2715,7 +2715,12 @@ public class OAuthServerConfiguration {
         }
     }
 
-    public boolean isScopeValidationEnabledForCodeAndImplicitGran() {
+    /**
+     * This method returns the value of the property ScopeValidationEnabledForAuthzCodeAndImplicitGrant  for the OAuth
+     * configuration
+     * in identity.xml.
+     */
+    public boolean isScopeValidationEnabledForCodeAndImplicitGrant() {
         return scopeValidationConfigValue;
     }
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
@@ -293,7 +293,7 @@ public class OAuthServerConfiguration {
 
         //Get scopeValidationEnabledConfigValue
         OMElement scopeValidationElem = oauthElem.getFirstChildWithName(
-                getQNameWithIdentityNS(ConfigElements.SCOPE_VALIDATION_FOR_AUTH_CODE_AND_IMPLICIT));
+                getQNameWithIdentityNS(ConfigElements.SCOPE_VALIDATION_FOR_AUTHZ_CODE_AND_IMPLICIT));
 
         if (scopeValidationElem != null) {
             scopeValidationConfigValue = Boolean.parseBoolean(scopeValidationElem.getText());
@@ -2715,7 +2715,7 @@ public class OAuthServerConfiguration {
         }
     }
 
-    public boolean isScopeValidationEnabledForImplicitAndCodeGrant() {
+    public boolean isScopeValidationEnabledForCodeAndImplicitGran() {
         return scopeValidationConfigValue;
     }
 
@@ -2815,7 +2815,7 @@ public class OAuthServerConfiguration {
         private static final String IMPLICIT_ERROR_FRAGMENT = "ImplicitErrorFragment";
 
         // Enable/Disable scope validation for implicit grant and authorization code grant
-        private static final String SCOPE_VALIDATION_FOR_AUTH_CODE_AND_IMPLICIT = "ScopeValidationEnabledForAuthCodeAndImplicitGrant";
+        private static final String SCOPE_VALIDATION_FOR_AUTHZ_CODE_AND_IMPLICIT = "ScopeValidationEnabledForAuthzCodeAndImplicitGrant";
 
         // Default timestamp skew
         private static final String TIMESTAMP_SKEW = "TimestampSkew";

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/handlers/AbstractResponseTypeHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/handlers/AbstractResponseTypeHandler.java
@@ -83,7 +83,8 @@ public abstract class AbstractResponseTypeHandler implements ResponseTypeHandler
     @Override
     public boolean validateScope(OAuthAuthzReqMessageContext oauthAuthzMsgCtx) throws IdentityOAuth2Exception {
 
-        if (hasValidateByApplicationScopeValidatorsFailed(oauthAuthzMsgCtx)) {
+        if (OAuthServerConfiguration.getInstance().isScopeValidationEnabledForImplicitAndCodeGrant()
+                && hasValidateByApplicationScopeValidatorsFailed(oauthAuthzMsgCtx)) {
             return false;
         }
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/handlers/AbstractResponseTypeHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/handlers/AbstractResponseTypeHandler.java
@@ -83,7 +83,7 @@ public abstract class AbstractResponseTypeHandler implements ResponseTypeHandler
     @Override
     public boolean validateScope(OAuthAuthzReqMessageContext oauthAuthzMsgCtx) throws IdentityOAuth2Exception {
 
-        if (OAuthServerConfiguration.getInstance().isScopeValidationEnabledForCodeAndImplicitGran()
+        if (OAuthServerConfiguration.getInstance().isScopeValidationEnabledForCodeAndImplicitGrant()
                 && hasValidationByApplicationScopeValidatorsFailed(oauthAuthzMsgCtx)) {
             return false;
         }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/handlers/AbstractResponseTypeHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/handlers/AbstractResponseTypeHandler.java
@@ -83,8 +83,8 @@ public abstract class AbstractResponseTypeHandler implements ResponseTypeHandler
     @Override
     public boolean validateScope(OAuthAuthzReqMessageContext oauthAuthzMsgCtx) throws IdentityOAuth2Exception {
 
-        if (OAuthServerConfiguration.getInstance().isScopeValidationEnabledForImplicitAndCodeGrant()
-                && hasValidateByApplicationScopeValidatorsFailed(oauthAuthzMsgCtx)) {
+        if (OAuthServerConfiguration.getInstance().isScopeValidationEnabledForCodeAndImplicitGran()
+                && hasValidationByApplicationScopeValidatorsFailed(oauthAuthzMsgCtx)) {
             return false;
         }
 
@@ -163,7 +163,7 @@ public abstract class AbstractResponseTypeHandler implements ResponseTypeHandler
     /**
      * Inverting validateByApplicationScopeValidator method for better readability.
      */
-    private boolean hasValidateByApplicationScopeValidatorsFailed(OAuthAuthzReqMessageContext authzReqMessageContext)
+    private boolean hasValidationByApplicationScopeValidatorsFailed(OAuthAuthzReqMessageContext authzReqMessageContext)
             throws IdentityOAuth2Exception {
 
         return !Oauth2ScopeUtils.validateByApplicationScopeValidator(null, authzReqMessageContext);

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AbstractAuthorizationGrantHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AbstractAuthorizationGrantHandler.java
@@ -214,7 +214,7 @@ public abstract class AbstractAuthorizationGrantHandler implements Authorization
     @Override
     public boolean validateScope(OAuthTokenReqMessageContext tokReqMsgCtx) throws IdentityOAuth2Exception {
 
-        if (hasValidateByApplicationScopeValidatorsFailed(tokReqMsgCtx)) {
+        if (hasValidationByApplicationScopeValidatorsFailed(tokReqMsgCtx)) {
             return false;
         }
         OAuthCallback scopeValidationCallback = new OAuthCallback(tokReqMsgCtx.getAuthorizedUser(),
@@ -844,7 +844,7 @@ public abstract class AbstractAuthorizationGrantHandler implements Authorization
     /**
      * Inverting validateByApplicationScopeValidator method for better readability.
      */
-    private boolean hasValidateByApplicationScopeValidatorsFailed(OAuthTokenReqMessageContext tokenReqMsgContext)
+    private boolean hasValidationByApplicationScopeValidatorsFailed(OAuthTokenReqMessageContext tokenReqMsgContext)
             throws IdentityOAuth2Exception {
 
         return !Oauth2ScopeUtils.validateByApplicationScopeValidator(tokenReqMsgContext, null);


### PR DESCRIPTION
### Proposed changes in this pull request

Since the implicit grant did not validate the scopes before, there could be apps implemented to work with this behavior. Just like our playground app fails when this fix[1][2] is applied, those applications would also fail when the fix is applied. Therefore, I think we should add a property and provide the ability for the user to enable/disable this fix[1][2].

#### Configuration Changes

Following configuration should be added to  <IS_HOME>/repository/conf/identity/identity.xml under 
tag  <OAuth> to disable scope validation for Implicit and Authorization Code Grant  types when XACML Scope Validator is enabled. This should go as a documentation update. [3] 

`        <ScopeValidationEnabledForAuthzCodeAndImplicitGrant>false</ScopeValidationEnabledForAuthzCodeAndImplicitGrant>`

Currently this is added as a commented property to identity.xml. [4]

[1].[https://github.com/wso2-support/identity-inbound-auth-oauth/pull/423](https://github.com/wso2-support/identity-inbound-auth-oauth/pull/423)

[2].[wso2-extensions/identity-inbound-auth-oauth/pull/1123](https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/1123)

[3].https://docs.wso2.com/display/IS580/Validating+the+Scope+of+OAuth+Access+Tokens+using+XACML+Policies

[4].[https://github.com/wso2/carbon-identity-framework/pull/2242](https://github.com/wso2/carbon-identity-framework/pull/2242)

#### Related Issue

> wso2/product-is#5335

