### PR TITLE
Fix revocation issue during hashed token

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/tokenprocessor/HashingPersistenceProcessor.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/tokenprocessor/HashingPersistenceProcessor.java
@@ -85,7 +85,7 @@ public class HashingPersistenceProcessor implements TokenPersistenceProcessor {
     public String getPreprocessedAccessTokenIdentifier(String processedAccessTokenIdentifier)
             throws IdentityOAuth2Exception {
 
-        throw new UnsupportedOperationException("Invalid operation on hashed access token");
+        return processedAccessTokenIdentifier;
     }
 
     @Override
@@ -97,7 +97,7 @@ public class HashingPersistenceProcessor implements TokenPersistenceProcessor {
     @Override
     public String getPreprocessedRefreshToken(String processedRefreshToken) throws IdentityOAuth2Exception {
 
-        throw new UnsupportedOperationException("Invalid operation on hashed refresh token");
+        return processedRefreshToken;
     }
 
     /**

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/OAuth2Service.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/OAuth2Service.java
@@ -379,8 +379,12 @@ public class OAuth2Service extends AbstractAdmin {
                             OAuth2Util.buildScopeString(refreshTokenDO.getScope()));
                     OAuthUtil.clearOAuthCache(revokeRequestDTO.getConsumerKey(), refreshTokenDO.getAuthorizedUser());
                     OAuthUtil.clearOAuthCache(refreshTokenDO.getAccessToken());
+                    // As the server implementation knows about the PersistenceProcessor Processed Access Token,
+                    // we are converting in the service layer.
                     OAuthTokenPersistenceFactory.getInstance().getAccessTokenDAO()
-                            .revokeAccessTokens(new String[]{refreshTokenDO.getAccessToken()});
+                            .revokeAccessTokens(
+                                    new String[]{OAuth2Util.getPersistenceProcessor()
+                                            .getProcessedAccessTokenIdentifier(refreshTokenDO.getAccessToken())});
                     addRevokeResponseHeaders(revokeResponseDTO,
                             refreshTokenDO.getAccessToken(),
                             revokeRequestDTO.getToken(),
@@ -395,8 +399,11 @@ public class OAuth2Service extends AbstractAdmin {
                         String scope = OAuth2Util.buildScopeString(accessTokenDO.getScope());
                         String authorizedUser = accessTokenDO.getAuthzUser().toString();
                         synchronized ((revokeRequestDTO.getConsumerKey() + ":" + authorizedUser + ":" + scope).intern()) {
+                            // As the server implementation knows about the PersistenceProcessor Processed Access Token,
+                            // we are converting in the service layer.
                             OAuthTokenPersistenceFactory.getInstance().getAccessTokenDAO()
-                                    .revokeAccessTokens(new String[]{accessTokenDO.getAccessToken()});
+                                    .revokeAccessTokens(new String[]{OAuth2Util.getPersistenceProcessor()
+                                            .getProcessedAccessTokenIdentifier(accessTokenDO.getAccessToken())});
                         }
                         addRevokeResponseHeaders(revokeResponseDTO,
                                 revokeRequestDTO.getToken(),

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -458,7 +458,7 @@ public class OAuth2Util {
         return true;
     }
 
-    private static TokenPersistenceProcessor getPersistenceProcessor() {
+    public static TokenPersistenceProcessor getPersistenceProcessor() {
 
         TokenPersistenceProcessor persistenceProcessor;
         try {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -1368,8 +1368,12 @@ public class OAuth2Util {
         boolean cacheHit = false;
         AccessTokenDO accessTokenDO = null;
 
+        // As the server implementation knows about the PersistenceProcessor Processed Access Token,
+        // we are converting before adding to the cache.
+        String processedToken = getPersistenceProcessor().getProcessedAccessTokenIdentifier(accessTokenIdentifier);
+
         // check the cache, if caching is enabled.
-        OAuthCacheKey cacheKey = new OAuthCacheKey(accessTokenIdentifier);
+        OAuthCacheKey cacheKey = new OAuthCacheKey(processedToken);
         CacheEntry result = OAuthCache.getInstance().getValueFromCache(cacheKey);
         // cache hit, do the type check.
         if (result != null && result instanceof AccessTokenDO) {
@@ -1390,7 +1394,7 @@ public class OAuth2Util {
 
         // add the token back to the cache in the case of a cache miss
         if (!cacheHit) {
-            cacheKey = new OAuthCacheKey(accessTokenIdentifier);
+            cacheKey = new OAuthCacheKey(processedToken);
             OAuthCache.getInstance().addToCache(cacheKey, accessTokenDO);
             if (log.isDebugEnabled()) {
                 log.debug("Access Token Info object was added back to the cache.");

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/validators/TokenValidationHandlerTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/validators/TokenValidationHandlerTest.java
@@ -40,6 +40,7 @@ import org.wso2.carbon.identity.oauth.cache.AppInfoCache;
 import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
 import org.wso2.carbon.identity.oauth.dao.OAuthAppDO;
 import org.wso2.carbon.identity.oauth.internal.OAuthComponentServiceHolder;
+import org.wso2.carbon.identity.oauth.tokenprocessor.PlainTextPersistenceProcessor;
 import org.wso2.carbon.identity.oauth2.dao.TokenMgtDAO;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2ClientApplicationDTO;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2TokenValidationRequestDTO;
@@ -49,6 +50,7 @@ import org.wso2.carbon.identity.oauth2.model.AccessTokenDO;
 import org.wso2.carbon.identity.oauth2.token.JWTTokenIssuer;
 import org.wso2.carbon.identity.oauth2.token.OauthTokenIssuer;
 import org.wso2.carbon.identity.oauth2.token.OauthTokenIssuerImpl;
+import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 import org.wso2.carbon.identity.openidconnect.util.TestUtils;
 import org.wso2.carbon.user.api.RealmConfiguration;
 import org.wso2.carbon.user.core.service.RealmService;
@@ -150,6 +152,7 @@ public class TokenValidationHandlerTest extends PowerMockTestCase {
         oAuth2AccessToken.setTokenType("bearer");
         oAuth2TokenValidationRequestDTO.setAccessToken(oAuth2AccessToken);
 
+        when(OAuth2Util.getPersistenceProcessor()).thenReturn(new PlainTextPersistenceProcessor());
         OAuth2ClientApplicationDTO response = tokenValidationHandler
                 .findOAuthConsumerIfTokenIsValid(oAuth2TokenValidationRequestDTO);
         assertNotNull(response);
@@ -199,6 +202,7 @@ public class TokenValidationHandlerTest extends PowerMockTestCase {
         tokenMgtDAO.persistAccessToken(ACCESS_TOKEN, "testConsumerKey", accessTokenDO, accessTokenDO,
                 "TESTDOMAIN");
         oAuth2TokenValidationRequestDTO.setAccessToken(accessToken);
+        when(OAuth2Util.getPersistenceProcessor()).thenReturn(new PlainTextPersistenceProcessor());
 
         assertNotNull(tokenValidationHandler.buildIntrospectionResponse(oAuth2TokenValidationRequestDTO));
     }


### PR DESCRIPTION
### Proposed changes in this pull request

Fix : https://github.com/wso2/product-is/issues/4654

There were the following issues

1. When adding to the cache, the hashed token has to be added.
2. When revoking the access token from a listener (delete user/app/tenant), the token retrieved from DB is a hashed one. But the token revocation from the user is a plain text one.
3. When the token hash is enabled, there can be more than one access token for the user, scope, application combination. This needs to be checked during the revocation.
