### PR TITLE
Fix NullPointerException in OIDCLogoutEventHandler

### DIFF
--- a/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/handler/OIDCLogoutEventHandler.java
+++ b/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/handler/OIDCLogoutEventHandler.java
@@ -46,7 +46,7 @@ public class OIDCLogoutEventHandler extends AbstractEventHandler {
 
         if (StringUtils.equals(event.getEventName(), EventName.SESSION_TERMINATE.name())) {
             HttpServletRequest request = getHttpRequestFromEvent(event);
-            Cookie opbsCookie = OIDCSessionManagementUtil.getOPBrowserStateCookie(request);
+            Cookie opbsCookie = request != null ? OIDCSessionManagementUtil.getOPBrowserStateCookie(request) : null;
 
             if (hasOPBSCookieValue(opbsCookie)) {
                 if (log.isDebugEnabled()) {

--- a/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/handler/OIDCLogoutEventHandler.java
+++ b/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/handler/OIDCLogoutEventHandler.java
@@ -46,7 +46,11 @@ public class OIDCLogoutEventHandler extends AbstractEventHandler {
 
         if (StringUtils.equals(event.getEventName(), EventName.SESSION_TERMINATE.name())) {
             HttpServletRequest request = getHttpRequestFromEvent(event);
-            Cookie opbsCookie = request != null ? OIDCSessionManagementUtil.getOPBrowserStateCookie(request) : null;
+            Cookie opbsCookie = null;
+
+            if (request != null) {
+                opbsCookie = OIDCSessionManagementUtil.getOPBrowserStateCookie(request);
+            }
 
             if (hasOPBSCookieValue(opbsCookie)) {
                 if (log.isDebugEnabled()) {


### PR DESCRIPTION
Encountered this issue while testing out the KillAllUserSessions function in https://github.com/wso2-extensions/identity-conditional-auth-functions/pull/49

This exception is thrown because the request object is directly used without doing a null check.