### PR TITLE
Fix audience was not retrieved as expected from the identity.xml

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -167,7 +167,7 @@ public class OAuth2Util {
     public static final String ENABLE_OPENID_CONNECT_AUDIENCES = "EnableAudiences";
     public static final String OPENID_CONNECT_AUDIENCE = "audience";
     /*
-     * Maintain a separate parameter "OPENID_CONNECT_IDENTITY_CONFIG_AUDIENCE" to get the audience from the identity.xml
+     * Maintain a separate parameter "OPENID_CONNECT_AUDIENCE_IDENTITY_CONFIG" to get the audience from the identity.xml
      * when user didn't add any audience in the UI while creating service provider.
      */
     public static final String OPENID_CONNECT_AUDIENCE_IDENTITY_CONFIG = "Audience";

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -167,10 +167,10 @@ public class OAuth2Util {
     public static final String ENABLE_OPENID_CONNECT_AUDIENCES = "EnableAudiences";
     public static final String OPENID_CONNECT_AUDIENCE = "audience";
     /*
-     * Maintain a separate parameter "OPENID_CONNECT_IDENTITY_CONFIG_AUDIENCE" for get the audience form the identity.xml
-     * when user didn't add any audience in the dashboard while creating service provider.
+     * Maintain a separate parameter "OPENID_CONNECT_IDENTITY_CONFIG_AUDIENCE" to get the audience from the identity.xml
+     * when user didn't add any audience in the UI while creating service provider.
      */
-    public static final String OPENID_CONNECT_IDENTITY_CONFIG_AUDIENCE = "Audience";
+    public static final String OPENID_CONNECT_AUDIENCE_IDENTITY_CONFIG = "Audience";
     private static final String OPENID_CONNECT_AUDIENCES = "Audiences";
     private static final String DOT_SEPARATER = ".";
     private static final String IDP_ENTITY_ID = "IdPEntityId";
@@ -1592,7 +1592,7 @@ public class OAuth2Util {
         }
 
         Iterator iterator = audienceConfig.getChildrenWithName(new QName(IdentityCoreConstants.
-                IDENTITY_DEFAULT_NAMESPACE, OPENID_CONNECT_IDENTITY_CONFIG_AUDIENCE));
+                IDENTITY_DEFAULT_NAMESPACE, OPENID_CONNECT_AUDIENCE_IDENTITY_CONFIG));
         while (iterator.hasNext()) {
             OMElement supportedAudience = (OMElement) iterator.next();
             String supportedAudienceName;

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -165,7 +165,7 @@ public class OAuth2Util {
     public static final String CONFIG_ELEM_OAUTH = "OAuth";
     public static final String OPENID_CONNECT = "OpenIDConnect";
     public static final String ENABLE_OPENID_CONNECT_AUDIENCES = "EnableAudiences";
-    public static final String OPENID_CONNECT_AUDIENCE = "audience";
+    public static final String OPENID_CONNECT_AUDIENCE = "Audience";
     private static final String OPENID_CONNECT_AUDIENCES = "Audiences";
     private static final String DOT_SEPARATER = ".";
     private static final String IDP_ENTITY_ID = "IdPEntityId";

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -165,7 +165,12 @@ public class OAuth2Util {
     public static final String CONFIG_ELEM_OAUTH = "OAuth";
     public static final String OPENID_CONNECT = "OpenIDConnect";
     public static final String ENABLE_OPENID_CONNECT_AUDIENCES = "EnableAudiences";
-    public static final String OPENID_CONNECT_AUDIENCE = "Audience";
+    public static final String OPENID_CONNECT_AUDIENCE = "audience";
+    /*
+     * Maintain a separate parameter "OPENID_CONNECT_IDENTITY_CONFIG_AUDIENCE" for get the audience form the identity.xml
+     * when user didn't add any audience in the dashboard while creating service provider.
+     */
+    public static final String OPENID_CONNECT_IDENTITY_CONFIG_AUDIENCE = "Audience";
     private static final String OPENID_CONNECT_AUDIENCES = "Audiences";
     private static final String DOT_SEPARATER = ".";
     private static final String IDP_ENTITY_ID = "IdPEntityId";
@@ -1587,7 +1592,7 @@ public class OAuth2Util {
         }
 
         Iterator iterator = audienceConfig.getChildrenWithName(new QName(IdentityCoreConstants.
-                IDENTITY_DEFAULT_NAMESPACE, OPENID_CONNECT_AUDIENCE));
+                IDENTITY_DEFAULT_NAMESPACE, OPENID_CONNECT_IDENTITY_CONFIG_AUDIENCE));
         while (iterator.hasNext()) {
             OMElement supportedAudience = (OMElement) iterator.next();
             String supportedAudienceName;


### PR DESCRIPTION
Issue: wso2/product-is#6086

A new feature was introduced to set the audiences per service provider from the management console itself. So we can add the audience from the service provider configurations of the management console. With this feature, we can set audiences per each service providers(Not on a global level as in previous releases). If we have not set any audiences from the service provider configurations we are retrieving from the identity.xml file as in previous identity server releases.

However, if we have not set the audience from the UI management console and when we try to retrieve the audience from the identity.xml file it is not working as expected. in the source code, we are using an incorrect local name for the element. Please refer to the code segment where we are retrieving the audience from here[1]. As you can see from here [2]the OPENID_CONNECT_AUDIENCE variable is initialized as "audience". So now when retrieving the audiences from the identity.xml file what happened was it tried to retrieve an element with the local name "audience" inside the "" tag. (The element name is "Audience" - notice that the first letter is in the capital letter). Since there is no such element a null was returned and the audiences defined inside the identity.xml file is not used.

So in order to overcome this issue what we can do is set the audiences(set the audience tag to lower letters) as below in the identity.xml file.

https://localhost/oauth2/token (Please notice in above the first letter is in lower case of the "audience" element)
[1] - https://github.com/wso2-extensions/identity-inbound-auth-oauth/blob/7d211551a5a9c96e09f4a8a473235ed54f69c9d6/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java#L1589

[2] - https://github.com/wso2-extensions/identity-inbound-auth-oauth/blob/7d211551a5a9c96e09f4a8a473235ed54f69c9d6/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java#L168