### PR TITLE
[Fix]In user consent denial redirect to post_logout_uri 

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
+++ b/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
@@ -57,6 +57,10 @@ public final class OAuthConstants {
     public static final String OAUTH_ERROR_CODE = "oauthErrorCode";
     public static final String OAUTH_ERROR_MESSAGE = "oauthErrorMsg";
 
+    // Authentication Error Response according to specifications
+    public static final String OAUTH_ERROR = "error";
+    public static final String OAUTH_ERROR_DESCRIPTION = "error_description";
+
     // Constants for paging in OAuth UI
     public static final int DEFAULT_ITEMS_PER_PAGE = 10;
     public static final String OAUTH_ADMIN_CLIENT = "OAuthAdminClient";

--- a/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/OIDCSessionConstants.java
+++ b/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/OIDCSessionConstants.java
@@ -31,6 +31,8 @@ public class OIDCSessionConstants {
     public static final String OIDC_POST_LOGOUT_REDIRECT_URI_PARAM = "post_logout_redirect_uri";
     public static final String OIDC_STATE_PARAM = "state";
     public static final String OIDC_SESSION_DATA_KEY_PARAM = "sessionDataKey";
+    public static final String OIDC_LOGOUT_CONSENT_DENIAL_REDIRECT_URL =  "OAuth.OpenIDConnect" +
+            ".RedirectToPostLogoutUriOnConsentDenial";
 
     public static final String OIDC_CACHE_CLIENT_ID_PARAM = "client_id";
 

--- a/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/servlet/OIDCLogoutServlet.java
+++ b/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/servlet/OIDCLogoutServlet.java
@@ -35,9 +35,11 @@ import org.wso2.carbon.identity.application.authentication.framework.model.Authe
 import org.wso2.carbon.identity.application.authentication.framework.model.CommonAuthRequestWrapper;
 import org.wso2.carbon.identity.application.authentication.framework.model.CommonAuthResponseWrapper;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
 import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
 import org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.oauth.common.OAuth2ErrorCodes;
 import org.wso2.carbon.identity.oauth.common.OAuthConstants;
 import org.wso2.carbon.identity.oauth.common.exception.InvalidOAuthClientException;
@@ -75,6 +77,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.RequestParams.TENANT_DOMAIN;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils.getRedirectURL;
+import static org.wso2.carbon.identity.oidc.session.OIDCSessionConstants.OIDC_LOGOUT_CONSENT_DENIAL_REDIRECT_URL;
 
 public class OIDCLogoutServlet extends HttpServlet {
 
@@ -166,6 +169,20 @@ public class OIDCLogoutServlet extends HttpServlet {
                 // User denied logout.
                 redirectURL = OIDCSessionManagementUtil
                         .getErrorPageURL(OAuth2ErrorCodes.ACCESS_DENIED, "End User denied the logout request");
+
+                // Set postLogoutRedirectUri as redirectURL.
+                boolean postLogoutRedirectUriRedirectIsEnabled =
+                        Boolean.parseBoolean(IdentityUtil.getProperty(OIDC_LOGOUT_CONSENT_DENIAL_REDIRECT_URL));
+                if (postLogoutRedirectUriRedirectIsEnabled) {
+                    OIDCSessionDataCacheEntry cacheEntry = getSessionDataFromCache(opBrowserStateCookie.getValue());
+                    if (cacheEntry != null && cacheEntry.getPostLogoutRedirectUri() != null) {
+                        Map<String, String> params = new HashMap<>();
+                        params.put(OAuthConstants.OAUTH_ERROR, OAuth2ErrorCodes.ACCESS_DENIED);
+                        params.put(OAuthConstants.OAUTH_ERROR_DESCRIPTION, "End User denied the logout request");
+                        redirectURL = FrameworkUtils.buildURLWithQueryParams(
+                                cacheEntry.getPostLogoutRedirectUri(), params);
+                    }
+                }
             }
         } else {
             // OIDC Logout response

--- a/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/servlet/OIDCLogoutServlet.java
+++ b/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/servlet/OIDCLogoutServlet.java
@@ -171,7 +171,7 @@ public class OIDCLogoutServlet extends HttpServlet {
                 redirectURL = OIDCSessionManagementUtil
                         .getErrorPageURL(OAuth2ErrorCodes.ACCESS_DENIED, "End User denied the logout request");
                 // If postlogoutUri is available then set it as redirectUrl
-                redirectURL = redirectToPostLogoutRedirectUri(redirectURL, opBrowserStateCookie);
+                redirectURL = generatePostLogoutRedirectUrl(redirectURL, opBrowserStateCookie);
 
             }
         } else {
@@ -215,7 +215,7 @@ public class OIDCLogoutServlet extends HttpServlet {
      * @return
      * @throws UnsupportedEncodingException
      */
-    private String redirectToPostLogoutRedirectUri(String redirectURL, Cookie opBrowserStateCookie)
+    private String generatePostLogoutRedirectUrl(String redirectURL, Cookie opBrowserStateCookie)
             throws UnsupportedEncodingException {
 
         // Set postLogoutRedirectUri as redirectURL.


### PR DESCRIPTION
Fix wso2/product-is#6389
Fix https://github.com/wso2/product-is/issues/6369

In the identity.xml under "OAuth/OpenIDConnect" path, we have to add the following config to make this redirection works

`<RedirectToPostLogoutUriOnConsentDenial>true</RedirectToPostLogoutUriOnConsentDenial>`
