### PR TITLE
Clear cached token when renewAccessTokenPerRequest is enabled in the token issuer

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AbstractAuthorizationGrantHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AbstractAuthorizationGrantHandler.java
@@ -131,39 +131,36 @@ public abstract class AbstractAuthorizationGrantHandler implements Authorization
                 existingTokenBean = getExistingToken(tokReqMsgCtx,
                         getOAuthCacheKey(scope, consumerKey, authorizedUser, authenticatedIDP));
             }
-            // Return a new access token in each request when JWTTokenIssuer is used.
-            if (accessTokenNotRenewedPerRequest(oauthTokenIssuer, tokReqMsgCtx)) {
-
-                // Revoke token if RenewTokenPerRequest configuration is enabled.
-                if (existingTokenBean != null &&
-                        OAuthServerConfiguration.getInstance().isTokenRenewalPerRequestEnabled()) {
-                    if (log.isDebugEnabled()) {
-                        log.debug("RenewTokenPerRequest configuration active. " +
-                                "Proceeding to revoke any existing active tokens for client Id: "
-                                + consumerKey + ", user: " + authorizedUser + " and scope: " + scope + ".");
-                    }
-                    revokeExistingToken(tokReqMsgCtx.getOauth2AccessTokenReqDTO().getoAuthClientAuthnContext(),
-                            existingTokenBean.getAccessToken());
-                    // When revoking the token state will be set as REVOKED.
-                    // existingTokenBean.setTokenState(TOKEN_STATE_REVOKED) can be used instead of 'null' but
-                    // then the token state will again be updated to EXPIRED when a new token is generated.
-                    existingTokenBean = null;
-                }
-                if (existingTokenBean != null) {
-                    long expireTime = getAccessTokenExpiryTimeMillis(existingTokenBean);
-                    if (isExistingTokenValid(existingTokenBean, expireTime)) {
-                        tokReqMsgCtx.addProperty(EXISTING_TOKEN_ISSUED, true);
-                        setDetailsToMessageContext(tokReqMsgCtx, existingTokenBean);
-                        return createResponseWithTokenBean(existingTokenBean, expireTime, scope);
-                    }
-                }
-                // Issuing new access token.
+            // Revoke token if RenewTokenPerRequest is enabled in
+            // tokenIssuer, OAuthTokenReqMessageContext or configuration.
+            if (existingTokenBean != null && accessTokenRenewedPerRequest(oauthTokenIssuer, tokReqMsgCtx)) {
                 if (log.isDebugEnabled()) {
-                    log.debug("No active access token found for client Id: " + consumerKey +
-                            ", user: " + authorizedUser + " and scope: " + scope +
-                            ". Therefore issuing new token");
+                    log.debug("RenewTokenPerRequest is enabled. " +
+                            "Proceeding to revoke any existing active tokens for client Id: " +
+                            consumerKey + ", user: " + authorizedUser + " and scope: " + scope + ".");
+                }
+                revokeExistingToken(tokReqMsgCtx.getOauth2AccessTokenReqDTO().getoAuthClientAuthnContext(),
+                        existingTokenBean.getAccessToken());
+                // When revoking the token state will be set as REVOKED.
+                // existingTokenBean.setTokenState(TOKEN_STATE_REVOKED) can be used instead of 'null' but
+                // then the token state will again be updated to EXPIRED when a new token is generated.
+                existingTokenBean = null;
+            }
+            if (existingTokenBean != null) {
+                long expireTime = getAccessTokenExpiryTimeMillis(existingTokenBean);
+                if (isExistingTokenValid(existingTokenBean, expireTime)) {
+                    tokReqMsgCtx.addProperty(EXISTING_TOKEN_ISSUED, true);
+                    setDetailsToMessageContext(tokReqMsgCtx, existingTokenBean);
+                    return createResponseWithTokenBean(existingTokenBean, expireTime, scope);
                 }
             }
+            // Issuing new access token.
+            if (log.isDebugEnabled()) {
+                log.debug("No active access token found for client Id: " + consumerKey +
+                        ", user: " + authorizedUser + " and scope: " + scope +
+                        ". Therefore issuing new token");
+            }
+
             return generateNewAccessTokenResponse(tokReqMsgCtx, scope, consumerKey, existingTokenBean,
                     oauthTokenIssuer);
         }
@@ -804,19 +801,18 @@ public abstract class AbstractAuthorizationGrantHandler implements Authorization
         return !(refreshTokenExpireTime > 0 && refreshTokenExpireTime > validityPeriod);
     }
 
-    private boolean accessTokenNotRenewedPerRequest(OauthTokenIssuer oauthTokenIssuer, OAuthTokenReqMessageContext tokReqMsgCtx) {
+    private boolean accessTokenRenewedPerRequest(OauthTokenIssuer oauthTokenIssuer,
+                                                 OAuthTokenReqMessageContext tokReqMsgCtx) {
         boolean isRenew1 = oauthTokenIssuer.renewAccessTokenPerRequest();
         boolean isRenew2 = oauthIssuerImpl.renewAccessTokenPerRequest(tokReqMsgCtx);
+        boolean isRenew3 = OAuthServerConfiguration.getInstance().isTokenRenewalPerRequestEnabled();
         if (log.isDebugEnabled()) {
-            log.debug("Enable Access Token renew per request: " + isRenew1);
+            log.debug("Enable Access Token renew per request considering the issuer: " + isRenew1);
             log.debug("Enable Access Token renew per request considering OAuthTokenReqMessageContext: " + isRenew2);
+            log.debug("Enable Access Token renew per request considering the configuration: " + isRenew3);
         }
-        if (isRenew1 || isRenew2) {
-            return false;
-        }
-        return true;
+        return isRenew1 || isRenew2 || isRenew3;
     }
-
 
     private void revokeExistingToken(OAuthClientAuthnContext oAuthClientAuthnContext, String accessToken) throws
             IdentityOAuth2Exception {


### PR DESCRIPTION
Resolves https://github.com/wso2/product-is/issues/4876

This will revoke the existing active token (clear up the caches as well) when we have set renewAccessTokenPerRequest to true in the access token issuer. Previously it was not really revoking access token but just updated the status in the DB to revoked. Hence it was not clearing the cache and the old access tokens were valid even after issuing a new access token.

Previously it did revoke the access token only when we have enabled RenewTokenPerRequest from identity.xml [1]. This fix does not break the behavior described in the doc [1].

[1] https://docs.wso2.com/display/IS580/Issuing+New+Tokens+Per+Request