### PR TITLE
Add 'state' parameter to the IDP's page URL once logged-out

### DIFF
--- a/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/servlet/OIDCLogoutServlet.java
+++ b/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/servlet/OIDCLogoutServlet.java
@@ -194,6 +194,11 @@ public class OIDCLogoutServlet extends HttpServlet {
                 } else {
                     // Add OIDC Cache entry without properties since OIDC Logout should work without id_token_hint
                     OIDCSessionDataCacheEntry cacheEntry = new OIDCSessionDataCacheEntry();
+
+                    // Logout request without id_token_hint will redirected to an IDP's page once logged out, rather a RP's
+                    // callback endpoint. The state parameter is set here in the cache, so that it will be available in the
+                    // redirected IDP's page to support any custom requirement.
+                    setStateParameterInCache(request, cacheEntry);
                     addSessionDataToCache(opBrowserStateCookie.getValue(), cacheEntry);
                 }
 
@@ -407,10 +412,21 @@ public class OIDCLogoutServlet extends HttpServlet {
         } else {
             // Add OIDC Cache entry without properties since OIDC Logout should work without id_token_hint
             OIDCSessionDataCacheEntry cacheEntry = new OIDCSessionDataCacheEntry();
+
+            // Logout request without id_token_hint will redirected to an IDP's page once logged out, rather a RP's
+            // callback endpoint. The state parameter is set here in the cache, so that it will be available in the
+            // redirected IDP's page to support any custom requirement.
+            setStateParameterInCache(request, cacheEntry);
             Cookie opBrowserStateCookie = OIDCSessionManagementUtil.getOPBrowserStateCookie(request);
             addSessionDataToCache(opBrowserStateCookie.getValue(), cacheEntry);
         }
         response.sendRedirect(getRedirectURL(redirectURL, request));
+    }
+
+    private void setStateParameterInCache(HttpServletRequest request, OIDCSessionDataCacheEntry cacheEntry) {
+
+        String state = request.getParameter(OIDCSessionConstants.OIDC_STATE_PARAM);
+        cacheEntry.setState(state);
     }
 
     /**


### PR DESCRIPTION
### Proposed changes in this pull request
- Fixes wso2/product-is#6614.
- The 'state' parameter received in the logout request is dropped, if the id_token_hint parameter is not available. This PR changes this behavior in the above scenario and propagate this value to the IDP's logout page(since id_token_hint parameter is not available) to support a case if IDP's logout page is customized.

#### Documentation

- N/A
