### PR TITLE
Fix OIDC hybrid flow not working without Implicit grant configured in SP

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -1325,13 +1325,16 @@ public class OAuth2Util {
         return OAuth2ServiceComponentHolder.isPkceEnabled();
     }
 
+    /**
+     * To check whether the given response type is for Implicit flow.
+     *
+     * @param responseType response type
+     * @return true if the response type is for Implicit flow
+     */
     public static boolean isImplicitResponseType(String responseType) {
 
-        if (StringUtils.isNotBlank(responseType) && (responseType.contains(ResponseType.TOKEN.toString()) ||
-                responseType.contains(OAuthConstants.ID_TOKEN))) {
-            return true;
-        }
-        return false;
+        return (StringUtils.isNotBlank(responseType) && (OAuthConstants.ID_TOKEN).equals(responseType) ||
+                (OAuthConstants.TOKEN).equals(responseType) || (OAuthConstants.IDTOKEN_TOKEN).equals(responseType));
     }
 
     /**


### PR DESCRIPTION

### Proposed changes in this pull request
OIDC hybrid flow depends on implicit grant type when working with authorization code grant type. This fix improve the code to validate whether the implicit grant is enabled, only if the response types are id_token token, id_token, token


### When should this PR be merged
Immediately


### Follow up actions
None

