### PR TITLE
Fix OAuthServerConfiguration default token issuer resolving logic

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
@@ -2032,15 +2032,6 @@ public class OAuthServerConfiguration {
             }
         }
 
-        //Adding default token types if not added in the configuration
-        if (!supportedTokenIssuers.containsKey(DEFAULT_TOKEN_TYPE)) {
-            supportedTokenIssuers.put(DEFAULT_TOKEN_TYPE,
-                    new TokenIssuerDO(DEFAULT_TOKEN_TYPE, DEFAULT_OAUTH_TOKEN_ISSUER_CLASS, true));
-        }
-        if (!supportedTokenIssuers.containsKey(JWT_TOKEN_TYPE)) {
-            supportedTokenIssuers.put(JWT_TOKEN_TYPE, new TokenIssuerDO(JWT_TOKEN_TYPE, JWT_TOKEN_ISSUER_CLASS, true));
-        }
-
         boolean isRegistered = false;
         //Adding global token issuer configured in the identity xml as a supported token issuer
         for (Map.Entry<String, TokenIssuerDO> entry : supportedTokenIssuers.entrySet()) {
@@ -2055,11 +2046,23 @@ public class OAuthServerConfiguration {
         if (!isRegistered && oauthIdentityTokenGeneratorClassName != null) {
             boolean isPersistTokenAlias = true;
             if (persistAccessTokenAlias != null) {
-                isPersistTokenAlias = Boolean.valueOf(persistAccessTokenAlias);
+                isPersistTokenAlias = Boolean.parseBoolean(persistAccessTokenAlias);
             }
-            supportedTokenIssuers.put(oauthIdentityTokenGeneratorClassName,
+
+            // If a server level <IdentityOAuthTokenGenerator> is defined, that will be our first choice for the
+            // "Default" token type issuer implementation.
+            supportedTokenIssuers.put(DEFAULT_TOKEN_TYPE,
                     new TokenIssuerDO(oauthIdentityTokenGeneratorClassName, oauthIdentityTokenGeneratorClassName,
                             isPersistTokenAlias));
+        }
+
+        // Adding default token types if not added in the configuration.
+        if (!supportedTokenIssuers.containsKey(DEFAULT_TOKEN_TYPE)) {
+            supportedTokenIssuers.put(DEFAULT_TOKEN_TYPE,
+                    new TokenIssuerDO(DEFAULT_TOKEN_TYPE, DEFAULT_OAUTH_TOKEN_ISSUER_CLASS, true));
+        }
+        if (!supportedTokenIssuers.containsKey(JWT_TOKEN_TYPE)) {
+            supportedTokenIssuers.put(JWT_TOKEN_TYPE, new TokenIssuerDO(JWT_TOKEN_TYPE, JWT_TOKEN_ISSUER_CLASS, true));
         }
     }
 


### PR DESCRIPTION
In older versions, we had a <IdentityOAuthTokenGenerator> tag in the identity.xml which was used to customize the token issuer implementation.

If a <IdentityOAuthTokenGenerator> is defined in the identity.xml that implementation needs to act as our server default token issuer.

Our current logic ignores the <IdentityOAuthTokenGenerator> tag and sets "org.wso2.carbon.identity.oauth2.token.OauthTokenIssuerImpl" as the default token issuer.

This change will first check <IdentityOAuthTokenGenerator> value and if it is present, the "Default" token type will use that implementation.