### PR TITLE
Fix getSupportTokenTypes() method

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImpl.java
@@ -50,7 +50,6 @@ import org.wso2.carbon.identity.oauth2.OAuth2Service;
 import org.wso2.carbon.identity.oauth2.authz.handlers.ResponseTypeHandler;
 import org.wso2.carbon.identity.oauth2.dao.OAuthTokenPersistenceFactory;
 import org.wso2.carbon.identity.oauth2.model.AccessTokenDO;
-import org.wso2.carbon.identity.oauth2.model.TokenIssuerDO;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 import org.wso2.carbon.identity.oauth2.validators.OAuth2ScopeValidator;
 import org.wso2.carbon.user.api.UserStoreException;
@@ -83,7 +82,6 @@ public class OAuthAdminServiceImpl {
     static final String RESPONSE_TYPE_ID_TOKEN = "id_token";
     static List<String> allowedGrants = null;
     static String[] allowedScopeValidators = null;
-    private static List<String> supportedTokenTypes = new ArrayList<>();
 
     protected static final Log log = LogFactory.getLog(OAuthAdminServiceImpl.class);
 
@@ -1070,13 +1068,7 @@ public class OAuthAdminServiceImpl {
      */
     public List<String> getSupportedTokenTypes() {
 
-        Map<String, TokenIssuerDO> supportedTokenTypesMap = OAuthServerConfiguration.getInstance()
-                .getSupportedTokenIssuers();
-        for (Object tokenTypeObj : supportedTokenTypesMap.keySet()) {
-            supportedTokenTypes.add(tokenTypeObj.toString());
-        }
-
-        return supportedTokenTypes;
+        return OAuthServerConfiguration.getInstance().getSupportedTokenTypes();
     }
 
     /**

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
@@ -66,6 +66,7 @@ import org.wso2.carbon.utils.CarbonUtils;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Hashtable;
@@ -159,6 +160,7 @@ public class OAuthServerConfiguration {
     private Map<String, String> supportedResponseTypeValidatorNames = new HashMap<>();
     private Map<String, Class<? extends OAuthValidator<HttpServletRequest>>> supportedResponseTypeValidators;
     private Map<String, TokenIssuerDO> supportedTokenIssuers = new HashMap<>();
+    private List<String> supportedTokenTypes = new ArrayList<>();
     private Map<String, OauthTokenIssuer> oauthTokenIssuerMap = new HashMap<>();
     private String[] supportedClaims = null;
     private Map<String, Properties> supportedClientAuthHandlerData = new HashMap<>();
@@ -2064,6 +2066,14 @@ public class OAuthServerConfiguration {
         if (!supportedTokenIssuers.containsKey(JWT_TOKEN_TYPE)) {
             supportedTokenIssuers.put(JWT_TOKEN_TYPE, new TokenIssuerDO(JWT_TOKEN_TYPE, JWT_TOKEN_ISSUER_CLASS, true));
         }
+
+        // Create the token types list.
+        supportedTokenTypes.addAll(supportedTokenIssuers.keySet());
+    }
+
+    public List<String> getSupportedTokenTypes() {
+
+        return Collections.unmodifiableList(supportedTokenTypes);
     }
 
     /**

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImplTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImplTest.java
@@ -530,4 +530,21 @@ public class OAuthAdminServiceImplTest extends PowerMockIdentityBaseTest {
     public void testRemoveOAuthApplicationData() throws Exception {
 
     }
+
+    @Test
+    public void testGetSupportedTokens() throws Exception {
+
+        OAuthAdminServiceImpl oAuthAdminService = new OAuthAdminServiceImpl();
+
+        List<String> supportedTokenTypes = oAuthAdminService.getSupportedTokenTypes();
+        Assert.assertEquals(supportedTokenTypes.size(), 2);
+        Assert.assertTrue(supportedTokenTypes.contains("Default"));
+        Assert.assertTrue(supportedTokenTypes.contains("JWT"));
+
+        // Calling again to test that the same list is returned again.
+        List<String> supportedTokenTypesCall2 = oAuthAdminService.getSupportedTokenTypes();
+        Assert.assertEquals(supportedTokenTypesCall2.size(), 2);
+        Assert.assertTrue(supportedTokenTypesCall2.contains("Default"));
+        Assert.assertTrue(supportedTokenTypesCall2.contains("JWT"));
+    }
 }


### PR DESCRIPTION
The current getSupportTokenTypes() method has a flaw,

Every time we call the getSupportTokenTypes() method, the supported token types read from identity.xml are added to the same list and returned. So after serval calls, the list contains duplicated items and continues to grow.

call1 -> "Default", "JWT"
call2 -> "Default", "JWT", "Default", "JWT"