### PR TITLE
Fix OAuth inbound update with import logic

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImpl.java
@@ -386,9 +386,10 @@ public class OAuthAdminServiceImpl {
                 throw handleClientError(INVALID_OAUTH_CLIENT, msg);
             }
             if (!StringUtils.equals(consumerAppDTO.getOauthConsumerSecret(), oauthappdo.getOauthConsumerSecret())) {
+                errorMessage = "Invalid ConsumerSecret is provided for updating the OAuth application with " +
+                        "consumerKey: " + oauthConsumerKey;
                 if (log.isDebugEnabled()) {
-                    log.debug("Invalid ConsumerSecret is provided for updating the OAuth" +
-                              " application with ConsumerKey: " + oauthConsumerKey);
+                    log.debug(errorMessage);
                 }
                 throw handleClientError(INVALID_REQUEST, errorMessage);
             }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/internal/OAuthComponentServiceHolder.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/internal/OAuthComponentServiceHolder.java
@@ -20,6 +20,7 @@ package org.wso2.carbon.identity.oauth.internal;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.oauth.OAuthAdminServiceImpl;
 import org.wso2.carbon.identity.oauth.common.token.bindings.TokenBinderInfo;
 import org.wso2.carbon.identity.oauth.dto.TokenBindingMetaDataDTO;
 import org.wso2.carbon.identity.oauth.event.OAuthEventInterceptor;
@@ -41,6 +42,7 @@ public class OAuthComponentServiceHolder {
     private static final Log log = LogFactory.getLog(OAuthComponentServiceHolder.class);
     private OAuth2ScopeService oauth2ScopeService;
     private List<TokenBindingMetaDataDTO> tokenBindingMetaDataDTOs = new ArrayList<>();
+    private OAuthAdminServiceImpl oAuthAdminService;
 
     private OAuthComponentServiceHolder() {
 
@@ -97,7 +99,6 @@ public class OAuthComponentServiceHolder {
         this.oauth2ScopeService = oauth2ScopeService;
     }
 
-
     public List<TokenBindingMetaDataDTO> getTokenBindingMetaDataDTOs() {
 
         return tokenBindingMetaDataDTOs;
@@ -114,5 +115,15 @@ public class OAuthComponentServiceHolder {
 
         tokenBindingMetaDataDTOs.removeIf(tokenBindingMetaDataDTO -> tokenBinderInfo.getBindingType()
                 .equals(tokenBindingMetaDataDTO.getTokenBindingType()));
+    }
+
+    public OAuthAdminServiceImpl getoAuthAdminService() {
+
+        return oAuthAdminService;
+    }
+
+    public void setOAuthAdminService(OAuthAdminServiceImpl oAuthAdminService) {
+
+        this.oAuthAdminService = oAuthAdminService;
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/internal/OAuthServiceComponent.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/internal/OAuthServiceComponent.java
@@ -36,7 +36,6 @@ import org.wso2.carbon.identity.oauth.event.OAuthEventInterceptor;
 import org.wso2.carbon.identity.oauth.listener.IdentityOathEventListener;
 import org.wso2.carbon.identity.oauth2.OAuth2ScopeService;
 import org.wso2.carbon.identity.oauth2.OAuth2Service;
-import org.wso2.carbon.identity.oauth2.internal.OAuth2ServiceComponent;
 import org.wso2.carbon.identity.oauth2.internal.OAuth2ServiceComponentHolder;
 import org.wso2.carbon.registry.core.service.RegistryService;
 import org.wso2.carbon.user.core.listener.UserOperationEventListener;
@@ -49,7 +48,6 @@ import org.wso2.carbon.user.core.service.RealmService;
 public class OAuthServiceComponent {
 
     private static final Log log = LogFactory.getLog(OAuthServiceComponent.class);
-    private static IdentityOathEventListener listener = null;
     private ServiceRegistration serviceRegistration = null;
 
     protected void activate(ComponentContext context) {
@@ -61,7 +59,7 @@ public class OAuthServiceComponent {
                 log.debug("OAuth Caching is enabled. Initializing the cache.");
             }
 
-            listener = new IdentityOathEventListener();
+            IdentityOathEventListener listener = new IdentityOathEventListener();
             serviceRegistration = context.getBundleContext().registerService(UserOperationEventListener.class.getName(),
                     listener, null);
             log.debug("Identity Oath Event Listener is enabled");
@@ -75,6 +73,8 @@ public class OAuthServiceComponent {
 
             OAuthAdminServiceImpl oauthAdminService = new OAuthAdminServiceImpl();
             context.getBundleContext().registerService(OAuthAdminServiceImpl.class.getName(), oauthAdminService, null);
+
+            OAuthComponentServiceHolder.getInstance().setOAuthAdminService(oauthAdminService);
             OAuth2ServiceComponentHolder.getInstance().setOAuthAdminService(oauthAdminService);
 
             if (log.isDebugEnabled()) {


### PR DESCRIPTION
When updating an existing app via a file import,
we should use the existing client secret instead of generating a client secret.