### PR TITLE
Fix minor spelling issue

### DIFF
--- a/features/org.wso2.carbon.identity.oauth.server.feature/resources/oauth-scope-bindings.xml
+++ b/features/org.wso2.carbon.identity.oauth.server.feature/resources/oauth-scope-bindings.xml
@@ -596,7 +596,7 @@
       <Permission>/permission/admin/manage/identity/usermgt/view</Permission>
    </Permissions>
 </Scope>
-<Scope name="internal_user_mgt_craete" displayName="Create Users">
+<Scope name="internal_user_mgt_create" displayName="Create Users">
     <Permissions>
       <Permission>/permission/admin/manage/identity/usermgt/create</Permission>
    </Permissions>


### PR DESCRIPTION
### Purpose

> Fixed minor spelling error in a scope name

