### PR TITLE
Remove "ext_param_owner" parameter from DCR

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.dcr.endpoint/src/main/resources/api.identity.oauth.dcr.endpoint.yaml
+++ b/components/org.wso2.carbon.identity.oauth.dcr.endpoint/src/main/resources/api.identity.oauth.dcr.endpoint.yaml
@@ -203,7 +203,6 @@ paths:
         "Content-Type: application/json" -d '{
           "redirect_uris":["https://client.example.org/callback"],
           "client_name": "application_1",
-          "ext_param_owner": "application_owner",
           "grant_types": ["password"] }'
         "https://localhost:9443/api/identity/oauth2/dcr/v1.1/register"
       x-wso2-response: |


### PR DESCRIPTION
This parameter is only supported for the endpoint https://localhost:9443/identity/connect/register/ and it causes an issue when customers try to use the updateApplication operation