### PR TITLE
Tenant qualify OIDC discovery endpoint response

### DIFF
--- a/components/org.wso2.carbon.identity.discovery/src/main/java/org/wso2/carbon/identity/discovery/builders/ProviderConfigBuilder.java
+++ b/components/org.wso2.carbon.identity.discovery/src/main/java/org/wso2/carbon/identity/discovery/builders/ProviderConfigBuilder.java
@@ -75,8 +75,8 @@ public class ProviderConfigBuilder {
         providerConfig.setCodeChallengeMethodsSupported(OAuth2Util.getSupportedCodeChallengeMethods()
                 .toArray(new String[0]));
         try {
-            providerConfig.setRegistrationEndpoint(OAuth2Util.OAuthURL.getOAuth2DCREPUrl(request.getTenantDomain()));
-            providerConfig.setJwksUri(OAuth2Util.OAuthURL.getOAuth2JWKSPageUrl(request.getTenantDomain()));
+            providerConfig.setRegistrationEndpoint(OAuth2Util.OAuthURL.getOAuth2DCREPUrl());
+            providerConfig.setJwksUri(OAuth2Util.OAuthURL.getOAuth2JWKSPageUrl());
         } catch (URISyntaxException e) {
             throw new ServerConfigurationException("Error while building tenant specific url", e);
         }
@@ -110,10 +110,10 @@ public class ProviderConfigBuilder {
 
         providerConfig.setSubjectTypesSupported(new String[]{"pairwise"});
 
-        providerConfig.setCheckSessionIframe(IdentityUtil.getProperty(
-                IdentityConstants.OAuth.OIDC_CHECK_SESSION_EP_URL));
-        providerConfig.setEndSessionEndpoint(IdentityUtil.getProperty(
-                IdentityConstants.OAuth.OIDC_LOGOUT_EP_URL));
+        providerConfig.setCheckSessionIframe(IdentityUtil.resolveURL(IdentityUtil.getProperty(
+                IdentityConstants.OAuth.OIDC_CHECK_SESSION_EP_URL), true, false));
+        providerConfig.setEndSessionEndpoint(IdentityUtil.resolveURL(IdentityUtil.getProperty(
+                IdentityConstants.OAuth.OIDC_LOGOUT_EP_URL), true, false));
 
         try {
             providerConfig.setUserinfoSigningAlgValuesSupported(new String[] {

--- a/components/org.wso2.carbon.identity.discovery/src/test/java/org/wso2/carbon/identity/discovery/builders/ProviderConfigBuilderTest.java
+++ b/components/org.wso2.carbon.identity.discovery/src/test/java/org/wso2/carbon/identity/discovery/builders/ProviderConfigBuilderTest.java
@@ -29,6 +29,7 @@ import org.wso2.carbon.base.ServerConfigurationException;
 import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
 import org.wso2.carbon.identity.claim.metadata.mgt.exception.ClaimMetadataException;
 import org.wso2.carbon.identity.claim.metadata.mgt.model.ExternalClaim;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.discovery.OIDProviderRequest;
 import org.wso2.carbon.identity.discovery.internal.OIDCDiscoveryDataHolder;
 import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
@@ -39,6 +40,7 @@ import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.MockitoAnnotations.initMocks;
 import static org.powermock.api.mockito.PowerMockito.mock;
@@ -48,7 +50,7 @@ import static org.powermock.api.mockito.PowerMockito.when;
 import static org.testng.Assert.assertNotNull;
 
 @PrepareForTest({OAuth2Util.class, OAuthServerConfiguration.class, OIDCDiscoveryDataHolder.class,
-        ClaimMetadataManagementService.class})
+        ClaimMetadataManagementService.class, IdentityUtil.class})
 /**
  * Unit test covering ProviderConfigBuilder class.
  */
@@ -90,6 +92,7 @@ public class ProviderConfigBuilderTest {
 
         mockStatic(OAuth2Util.class);
         mockStatic(OAuth2Util.OAuthURL.class);
+        mockStatic(IdentityUtil.class);
 
         List<ExternalClaim> claims = new ArrayList<>();
         ExternalClaim externalClaim = new ExternalClaim("aaa", "bbb", "ccc");
@@ -101,6 +104,7 @@ public class ProviderConfigBuilderTest {
 
         when(OAuth2Util.mapSignatureAlgorithmForJWSAlgorithm(idTokenSignatureAlgorithm)).thenReturn(JWSAlgorithm.RS256);
         when(OAuth2Util.mapSignatureAlgorithmForJWSAlgorithm(anyString())).thenReturn(JWSAlgorithm.RS256);
+        when(IdentityUtil.resolveURL(anyString(), anyBoolean(), anyBoolean())).thenReturn("/testUrl");
         assertNotNull(providerConfigBuilder.buildOIDProviderConfig(mockOidProviderRequest));
     }
 
@@ -113,7 +117,7 @@ public class ProviderConfigBuilderTest {
 
         mockStatic(OAuth2Util.class);
         mockStatic(OAuth2Util.OAuthURL.class);
-        when(OAuth2Util.OAuthURL.getOAuth2JWKSPageUrl(anyString())).thenThrow(new URISyntaxException("input",
+        when(OAuth2Util.OAuthURL.getOAuth2JWKSPageUrl()).thenThrow(new URISyntaxException("input",
                 "URISyntaxException"));
         when(OAuth2Util.getIdTokenIssuer(anyString())).thenReturn("issuer");
         providerConfigBuilder.buildOIDProviderConfig(mockOidProviderRequest);

--- a/components/org.wso2.carbon.identity.discovery/src/test/java/org/wso2/carbon/identity/discovery/builders/ProviderConfigBuilderTest.java
+++ b/components/org.wso2.carbon.identity.discovery/src/test/java/org/wso2/carbon/identity/discovery/builders/ProviderConfigBuilderTest.java
@@ -109,21 +109,6 @@ public class ProviderConfigBuilderTest {
     }
 
     @Test(expectedExceptions = ServerConfigurationException.class)
-    public void testBuildOIDProviderConfig1Legacy() throws Exception {
-
-        OAuthServerConfiguration mockOAuthServerConfiguration = mock(OAuthServerConfiguration.class);
-        mockStatic(OAuthServerConfiguration.class);
-        when(OAuthServerConfiguration.getInstance()).thenReturn(mockOAuthServerConfiguration);
-
-        mockStatic(OAuth2Util.class);
-        mockStatic(OAuth2Util.OAuthURL.class);
-        when(OAuth2Util.OAuthURL.getOAuth2JWKSPageUrl(anyString())).thenThrow(new URISyntaxException("input",
-                "URISyntaxException"));
-        when(OAuth2Util.getIdTokenIssuer(anyString())).thenReturn("issuer");
-        providerConfigBuilder.buildOIDProviderConfig(mockOidProviderRequest);
-    }
-
-    @Test(expectedExceptions = ServerConfigurationException.class)
     public void testBuildOIDProviderConfig1() throws Exception {
 
         OAuthServerConfiguration mockOAuthServerConfiguration = mock(OAuthServerConfiguration.class);

--- a/components/org.wso2.carbon.identity.discovery/src/test/java/org/wso2/carbon/identity/discovery/builders/ProviderConfigBuilderTest.java
+++ b/components/org.wso2.carbon.identity.discovery/src/test/java/org/wso2/carbon/identity/discovery/builders/ProviderConfigBuilderTest.java
@@ -109,6 +109,21 @@ public class ProviderConfigBuilderTest {
     }
 
     @Test(expectedExceptions = ServerConfigurationException.class)
+    public void testBuildOIDProviderConfig1Legacy() throws Exception {
+
+        OAuthServerConfiguration mockOAuthServerConfiguration = mock(OAuthServerConfiguration.class);
+        mockStatic(OAuthServerConfiguration.class);
+        when(OAuthServerConfiguration.getInstance()).thenReturn(mockOAuthServerConfiguration);
+
+        mockStatic(OAuth2Util.class);
+        mockStatic(OAuth2Util.OAuthURL.class);
+        when(OAuth2Util.OAuthURL.getOAuth2JWKSPageUrl(anyString())).thenThrow(new URISyntaxException("input",
+                "URISyntaxException"));
+        when(OAuth2Util.getIdTokenIssuer(anyString())).thenReturn("issuer");
+        providerConfigBuilder.buildOIDProviderConfig(mockOidProviderRequest);
+    }
+
+    @Test(expectedExceptions = ServerConfigurationException.class)
     public void testBuildOIDProviderConfig1() throws Exception {
 
         OAuthServerConfiguration mockOAuthServerConfiguration = mock(OAuthServerConfiguration.class);

--- a/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
+++ b/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
@@ -244,6 +244,9 @@ public final class OAuthConstants {
         public static final String ACCESS_TOKEN_URL = "/access-token";
         public static final String REQUEST_TOKEN_URL = "/request-token";
         public static final String AUTHORIZE_TOKEN_URL = "/authorize-token";
+        public static final String OAUTH_TOKEN_EP_URL = "oauth/access-token";
+        public static final String OAUTH_AUTHZ_EP_URL = "oauth/authorize-url";
+        public static final String OAUTH_REQUEST_TOKEN_EP_URL = "oauth/request-token";
 
         private OAuth10AEndpoints() {
 
@@ -257,6 +260,18 @@ public final class OAuthConstants {
 
         public static final String OAUTH20_ACCESS_TOKEN_URL = "/token";
         public static final String OAUTH20_AUTHORIZE_TOKEN_URL = "/authorize";
+        public static final String OAUTH2_AUTHZ_EP_URL = "oauth2/authorize";
+        public static final String OAUTH2_TOKEN_EP_URL = "oauth2/token";
+        public static final String OAUTH2_DCR_EP_URL = "/api/identity/oauth2/dcr/v1.0/register";
+        public static final String OAUTH2_JWKS_EP_URL = "/oauth2/jwks";
+        public static final String  OAUTH2_DISCOVERY_EP_URL = "/oauth2/oidcdiscovery";
+        public static final String OAUTH2_USER_INFO_EP_URL = "oauth2/userinfo";
+        public static final String OAUTH2_REVOKE_EP_URL = "oauth2/revoke";
+        public static final String OIDC_WEB_FINGER_EP_URL = ".well-know/webfinger";
+        public static final String OAUTH2_INTROSPECT_EP_URL = "oauth2/introspect";
+        public static final String OIDC_CONSENT_EP_URL = "/authenticationendpoint/oauth2_consent.do";
+        public static final String OAUTH2_CONSENT_EP_URL = "/authenticationendpoint/oauth2_authz.do";
+        public static final String OAUTH2_ERROR_EP_URL = "/authenticationendpoint/oauth2_error.do";
 
         private OAuth20Endpoints() {
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -3119,8 +3119,13 @@ public class OAuth2Util {
         FederatedAuthenticatorConfig oidcAuthenticatorConfig =
                 IdentityApplicationManagementUtil.getFederatedAuthenticator(fedAuthnConfigs,
                         IdentityApplicationConstants.Authenticator.OIDC.NAME);
-        return IdentityApplicationManagementUtil.getProperty(oidcAuthenticatorConfig.getProperties(),
+        String idpEntityId = IdentityApplicationManagementUtil.getProperty(oidcAuthenticatorConfig.getProperties(),
                 IDP_ENTITY_ID).getValue();
+        if (idpEntityId.equals(IdentityUtil.getProperty("OAuth.OpenIDConnect.IDTokenIssuerID"))) {
+            return IdentityUtil.resolveURL(idpEntityId, tenantDomain, true, false, false, false);
+        } else {
+            return idpEntityId;
+        }
     }
 
     private static IdentityProvider getResidentIdp(String tenantDomain) throws IdentityOAuth2Exception {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -172,6 +172,21 @@ import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OAuth10AEndpoints.OAUTH_AUTHZ_EP_URL;
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OAuth10AEndpoints.OAUTH_REQUEST_TOKEN_EP_URL;
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OAuth10AEndpoints.OAUTH_TOKEN_EP_URL;
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OAuth20Endpoints.OAUTH2_AUTHZ_EP_URL;
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OAuth20Endpoints.OAUTH2_CONSENT_EP_URL;
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OAuth20Endpoints.OAUTH2_DCR_EP_URL;
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OAuth20Endpoints.OAUTH2_DISCOVERY_EP_URL;
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OAuth20Endpoints.OAUTH2_ERROR_EP_URL;
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OAuth20Endpoints.OAUTH2_INTROSPECT_EP_URL;
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OAuth20Endpoints.OAUTH2_JWKS_EP_URL;
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OAuth20Endpoints.OAUTH2_REVOKE_EP_URL;
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OAuth20Endpoints.OAUTH2_TOKEN_EP_URL;
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OAuth20Endpoints.OAUTH2_USER_INFO_EP_URL;
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OAuth20Endpoints.OIDC_CONSENT_EP_URL;
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OAuth20Endpoints.OIDC_WEB_FINGER_EP_URL;
 import static org.wso2.carbon.identity.oauth2.Oauth2ScopeConstants.PERMISSIONS_BINDING_TYPE;
 
 /**
@@ -1130,7 +1145,7 @@ public class OAuth2Util {
 
             String oauth1RequestTokenUrl = OAuthServerConfiguration.getInstance().getOAuth1RequestTokenUrl();
             if (StringUtils.isBlank(oauth1RequestTokenUrl)) {
-                oauth1RequestTokenUrl = IdentityUtil.getServerURL("oauth/request-token", true, true);
+                oauth1RequestTokenUrl = IdentityUtil.getServerURL(OAUTH_REQUEST_TOKEN_EP_URL, true, true);
             }
             return oauth1RequestTokenUrl;
         }
@@ -1139,7 +1154,7 @@ public class OAuth2Util {
 
             String oauth1AuthorizeUrl = OAuthServerConfiguration.getInstance().getOAuth1AuthorizeUrl();
             if (StringUtils.isBlank(oauth1AuthorizeUrl)) {
-                oauth1AuthorizeUrl = IdentityUtil.getServerURL("oauth/authorize-url", true, true);
+                oauth1AuthorizeUrl = IdentityUtil.getServerURL(OAUTH_AUTHZ_EP_URL, true, true);
             }
             return oauth1AuthorizeUrl;
         }
@@ -1148,7 +1163,7 @@ public class OAuth2Util {
 
             String oauth1AccessTokenUrl = OAuthServerConfiguration.getInstance().getOAuth1AccessTokenUrl();
             if (StringUtils.isBlank(oauth1AccessTokenUrl)) {
-                oauth1AccessTokenUrl = IdentityUtil.getServerURL("oauth/access-token", true, true);
+                oauth1AccessTokenUrl = IdentityUtil.getServerURL(OAUTH_TOKEN_EP_URL, true, true);
             }
             return oauth1AccessTokenUrl;
         }
@@ -1157,7 +1172,7 @@ public class OAuth2Util {
 
             String oauth2AuthzEPUrl = OAuthServerConfiguration.getInstance().getOAuth2AuthzEPUrl();
             if (StringUtils.isBlank(oauth2AuthzEPUrl)) {
-                oauth2AuthzEPUrl = IdentityUtil.getServerURL("oauth2/authorize", true, false);
+                oauth2AuthzEPUrl = IdentityUtil.getServerURL(OAUTH2_AUTHZ_EP_URL, true, false);
             }
             return IdentityUtil.resolveURL(oauth2AuthzEPUrl, true, false);
         }
@@ -1166,7 +1181,7 @@ public class OAuth2Util {
 
             String oauth2TokenEPUrl = OAuthServerConfiguration.getInstance().getOAuth2TokenEPUrl();
             if (StringUtils.isBlank(oauth2TokenEPUrl)) {
-                oauth2TokenEPUrl = IdentityUtil.getServerURL("oauth2/token", true, false);
+                oauth2TokenEPUrl = IdentityUtil.getServerURL(OAUTH2_TOKEN_EP_URL, true, false);
             }
             return IdentityUtil.resolveURL(oauth2TokenEPUrl, true, false);
         }
@@ -1175,7 +1190,7 @@ public class OAuth2Util {
 
             String oauth2TokenEPUrl = OAuthServerConfiguration.getInstance().getOAuth2DCREPUrl();
             if (StringUtils.isBlank(oauth2TokenEPUrl)) {
-                oauth2TokenEPUrl = IdentityUtil.getServerURL("/api/identity/oauth2/dcr/v1.0/register", true, false);
+                oauth2TokenEPUrl = IdentityUtil.getServerURL(OAUTH2_DCR_EP_URL, true, false);
             }
             if (StringUtils.isNotBlank(tenantDomain) && !MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equals
                     (tenantDomain)) {
@@ -1188,7 +1203,7 @@ public class OAuth2Util {
 
             String oauth2TokenEPUrl = OAuthServerConfiguration.getInstance().getOAuth2DCREPUrl();
             if (StringUtils.isBlank(oauth2TokenEPUrl)) {
-                oauth2TokenEPUrl = IdentityUtil.getServerURL("/api/identity/oauth2/dcr/v1.0/register", true, false);
+                oauth2TokenEPUrl = IdentityUtil.getServerURL(OAUTH2_DCR_EP_URL, true, false);
             }
             return IdentityUtil.resolveURL(oauth2TokenEPUrl, true, true);
         }
@@ -1197,7 +1212,7 @@ public class OAuth2Util {
 
             String auth2JWKSPageUrl = OAuthServerConfiguration.getInstance().getOAuth2JWKSPageUrl();
             if (StringUtils.isBlank(auth2JWKSPageUrl)) {
-                auth2JWKSPageUrl = IdentityUtil.getServerURL("/oauth2/jwks", true, false);
+                auth2JWKSPageUrl = IdentityUtil.getServerURL(OAUTH2_JWKS_EP_URL, true, false);
             }
             if (StringUtils.isNotBlank(tenantDomain) && !MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equals
                     (tenantDomain)) {
@@ -1210,7 +1225,7 @@ public class OAuth2Util {
 
             String auth2JWKSPageUrl = OAuthServerConfiguration.getInstance().getOAuth2JWKSPageUrl();
             if (StringUtils.isBlank(auth2JWKSPageUrl)) {
-                auth2JWKSPageUrl = IdentityUtil.getServerURL("/oauth2/jwks", true, false);
+                auth2JWKSPageUrl = IdentityUtil.getServerURL(OAUTH2_JWKS_EP_URL, true, false);
             }
             return IdentityUtil.resolveURL(auth2JWKSPageUrl, true, true);
         }
@@ -1219,7 +1234,7 @@ public class OAuth2Util {
 
             String oauth2TokenEPUrl = OAuthServerConfiguration.getInstance().getOidcWebFingerEPUrl();
             if (StringUtils.isBlank(oauth2TokenEPUrl)) {
-                oauth2TokenEPUrl = IdentityUtil.getServerURL(".well-know/webfinger", true, false);
+                oauth2TokenEPUrl = IdentityUtil.getServerURL(OIDC_WEB_FINGER_EP_URL, true, false);
             }
             return IdentityUtil.resolveURL(oauth2TokenEPUrl, true, true);
         }
@@ -1228,7 +1243,7 @@ public class OAuth2Util {
 
             String oidcDiscoveryEPUrl = OAuthServerConfiguration.getInstance().getOidcDiscoveryUrl();
             if (StringUtils.isBlank(oidcDiscoveryEPUrl)) {
-                oidcDiscoveryEPUrl = IdentityUtil.getServerURL("/oauth2/oidcdiscovery", true, false);
+                oidcDiscoveryEPUrl = IdentityUtil.getServerURL(OAUTH2_DISCOVERY_EP_URL, true, false);
             }
             if (StringUtils.isNotBlank(tenantDomain) && !MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equals
                     (tenantDomain)) {
@@ -1242,7 +1257,7 @@ public class OAuth2Util {
 
             String oauth2UserInfoEPUrl = OAuthServerConfiguration.getInstance().getOauth2UserInfoEPUrl();
             if (StringUtils.isBlank(oauth2UserInfoEPUrl)) {
-                oauth2UserInfoEPUrl = IdentityUtil.getServerURL("oauth2/userinfo", true, false);
+                oauth2UserInfoEPUrl = IdentityUtil.getServerURL(OAUTH2_USER_INFO_EP_URL, true, false);
             }
             return IdentityUtil.resolveURL(oauth2UserInfoEPUrl, true, false);
         }
@@ -1256,7 +1271,7 @@ public class OAuth2Util {
 
             String oauth2RevokeEPUrl = OAuthServerConfiguration.getInstance().getOauth2RevocationEPUrl();
             if (StringUtils.isBlank(oauth2RevokeEPUrl)) {
-                oauth2RevokeEPUrl = IdentityUtil.getServerURL("oauth2/revoke", true, false);
+                oauth2RevokeEPUrl = IdentityUtil.getServerURL(OAUTH2_REVOKE_EP_URL, true, false);
             }
             return IdentityUtil.resolveURL(oauth2RevokeEPUrl, true, false);
         }
@@ -1270,7 +1285,7 @@ public class OAuth2Util {
 
             String oauth2IntrospectEPUrl = OAuthServerConfiguration.getInstance().getOauth2IntrospectionEPUrl();
             if (StringUtils.isBlank(oauth2IntrospectEPUrl)) {
-                oauth2IntrospectEPUrl = IdentityUtil.getServerURL("oauth2/introspect", true, false);
+                oauth2IntrospectEPUrl = IdentityUtil.getServerURL(OAUTH2_INTROSPECT_EP_URL, true, false);
             }
             return IdentityUtil.resolveURL(oauth2IntrospectEPUrl, true, false);
         }
@@ -1279,7 +1294,7 @@ public class OAuth2Util {
 
             String oidcConsentPageUrl = OAuthServerConfiguration.getInstance().getOIDCConsentPageUrl();
             if (StringUtils.isBlank(oidcConsentPageUrl)) {
-                oidcConsentPageUrl = IdentityUtil.getServerURL("/authenticationendpoint/oauth2_consent.do", false,
+                oidcConsentPageUrl = IdentityUtil.getServerURL(OIDC_CONSENT_EP_URL, false,
                         false);
             }
             return oidcConsentPageUrl;
@@ -1289,7 +1304,7 @@ public class OAuth2Util {
 
             String oAuth2ConsentPageUrl = OAuthServerConfiguration.getInstance().getOauth2ConsentPageUrl();
             if (StringUtils.isBlank(oAuth2ConsentPageUrl)) {
-                oAuth2ConsentPageUrl = IdentityUtil.getServerURL("/authenticationendpoint/oauth2_authz.do", false,
+                oAuth2ConsentPageUrl = IdentityUtil.getServerURL(OAUTH2_CONSENT_EP_URL, false,
                         false);
             }
             return oAuth2ConsentPageUrl;
@@ -1299,7 +1314,7 @@ public class OAuth2Util {
 
             String oAuth2ErrorPageUrl = OAuthServerConfiguration.getInstance().getOauth2ErrorPageUrl();
             if (StringUtils.isBlank(oAuth2ErrorPageUrl)) {
-                oAuth2ErrorPageUrl = IdentityUtil.getServerURL("/authenticationendpoint/oauth2_error.do", false, false);
+                oAuth2ErrorPageUrl = IdentityUtil.getServerURL(OAUTH2_ERROR_EP_URL, false, false);
             }
             return oAuth2ErrorPageUrl;
         }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -1171,13 +1171,39 @@ public class OAuth2Util {
             return IdentityUtil.resolveURL(oauth2TokenEPUrl, true, false);
         }
 
+        public static String getOAuth2DCREPUrl(String tenantDomain) throws URISyntaxException {
+
+            String oauth2TokenEPUrl = OAuthServerConfiguration.getInstance().getOAuth2DCREPUrl();
+            if (StringUtils.isBlank(oauth2TokenEPUrl)) {
+                oauth2TokenEPUrl = IdentityUtil.getServerURL("/api/identity/oauth2/dcr/v1.0/register", true, false);
+            }
+            if (StringUtils.isNotBlank(tenantDomain) && !MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equals
+                    (tenantDomain)) {
+                oauth2TokenEPUrl = getTenantUrl(oauth2TokenEPUrl, tenantDomain);
+            }
+            return oauth2TokenEPUrl;
+        }
+
         public static String getOAuth2DCREPUrl() throws URISyntaxException {
 
             String oauth2TokenEPUrl = OAuthServerConfiguration.getInstance().getOAuth2DCREPUrl();
             if (StringUtils.isBlank(oauth2TokenEPUrl)) {
                 oauth2TokenEPUrl = IdentityUtil.getServerURL("/api/identity/oauth2/dcr/v1.0/register", true, false);
             }
-            return IdentityUtil.resolveURL(oauth2TokenEPUrl, true, false, false, true);
+            return IdentityUtil.resolveURL(oauth2TokenEPUrl, true, true);
+        }
+
+        public static String getOAuth2JWKSPageUrl(String tenantDomain) throws URISyntaxException {
+
+            String auth2JWKSPageUrl = OAuthServerConfiguration.getInstance().getOAuth2JWKSPageUrl();
+            if (StringUtils.isBlank(auth2JWKSPageUrl)) {
+                auth2JWKSPageUrl = IdentityUtil.getServerURL("/oauth2/jwks", true, false);
+            }
+            if (StringUtils.isNotBlank(tenantDomain) && !MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equals
+                    (tenantDomain)) {
+                auth2JWKSPageUrl = getTenantUrl(auth2JWKSPageUrl, tenantDomain);
+            }
+            return auth2JWKSPageUrl;
         }
 
         public static String getOAuth2JWKSPageUrl() throws URISyntaxException {
@@ -1186,7 +1212,7 @@ public class OAuth2Util {
             if (StringUtils.isBlank(auth2JWKSPageUrl)) {
                 auth2JWKSPageUrl = IdentityUtil.getServerURL("/oauth2/jwks", true, false);
             }
-            return IdentityUtil.resolveURL(auth2JWKSPageUrl, true, false, false, true);
+            return IdentityUtil.resolveURL(auth2JWKSPageUrl, true, true);
         }
 
         public static String getOidcWebFingerEPUrl() {
@@ -3078,8 +3104,8 @@ public class OAuth2Util {
         FederatedAuthenticatorConfig oidcAuthenticatorConfig =
                 IdentityApplicationManagementUtil.getFederatedAuthenticator(fedAuthnConfigs,
                         IdentityApplicationConstants.Authenticator.OIDC.NAME);
-        return IdentityUtil.resolveURL(IdentityApplicationManagementUtil
-                .getProperty(oidcAuthenticatorConfig.getProperties(), IDP_ENTITY_ID).getValue(), true, false);
+        return IdentityApplicationManagementUtil.getProperty(oidcAuthenticatorConfig.getProperties(),
+                IDP_ENTITY_ID).getValue();
     }
 
     private static IdentityProvider getResidentIdp(String tenantDomain) throws IdentityOAuth2Exception {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -1159,7 +1159,7 @@ public class OAuth2Util {
             if (StringUtils.isBlank(oauth2AuthzEPUrl)) {
                 oauth2AuthzEPUrl = IdentityUtil.getServerURL("oauth2/authorize", true, false);
             }
-            return oauth2AuthzEPUrl;
+            return IdentityUtil.resolveURL(oauth2AuthzEPUrl, true, false);
         }
 
         public static String getOAuth2TokenEPUrl() {
@@ -1168,33 +1168,25 @@ public class OAuth2Util {
             if (StringUtils.isBlank(oauth2TokenEPUrl)) {
                 oauth2TokenEPUrl = IdentityUtil.getServerURL("oauth2/token", true, false);
             }
-            return oauth2TokenEPUrl;
+            return IdentityUtil.resolveURL(oauth2TokenEPUrl, true, false);
         }
 
-        public static String getOAuth2DCREPUrl(String tenantDomain) throws URISyntaxException {
+        public static String getOAuth2DCREPUrl() throws URISyntaxException {
 
             String oauth2TokenEPUrl = OAuthServerConfiguration.getInstance().getOAuth2DCREPUrl();
             if (StringUtils.isBlank(oauth2TokenEPUrl)) {
                 oauth2TokenEPUrl = IdentityUtil.getServerURL("/api/identity/oauth2/dcr/v1.0/register", true, false);
             }
-            if (StringUtils.isNotBlank(tenantDomain) && !MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equals
-                    (tenantDomain)) {
-                oauth2TokenEPUrl = getTenantUrl(oauth2TokenEPUrl, tenantDomain);
-            }
-            return oauth2TokenEPUrl;
+            return IdentityUtil.resolveURL(oauth2TokenEPUrl, true, false, false, true);
         }
 
-        public static String getOAuth2JWKSPageUrl(String tenantDomain) throws URISyntaxException {
+        public static String getOAuth2JWKSPageUrl() throws URISyntaxException {
 
             String auth2JWKSPageUrl = OAuthServerConfiguration.getInstance().getOAuth2JWKSPageUrl();
             if (StringUtils.isBlank(auth2JWKSPageUrl)) {
                 auth2JWKSPageUrl = IdentityUtil.getServerURL("/oauth2/jwks", true, false);
             }
-            if (StringUtils.isNotBlank(tenantDomain) && !MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equals
-                    (tenantDomain)) {
-                auth2JWKSPageUrl = getTenantUrl(auth2JWKSPageUrl, tenantDomain);
-            }
-            return auth2JWKSPageUrl;
+            return IdentityUtil.resolveURL(auth2JWKSPageUrl, true, false, false, true);
         }
 
         public static String getOidcWebFingerEPUrl() {
@@ -1203,7 +1195,7 @@ public class OAuth2Util {
             if (StringUtils.isBlank(oauth2TokenEPUrl)) {
                 oauth2TokenEPUrl = IdentityUtil.getServerURL(".well-know/webfinger", true, false);
             }
-            return oauth2TokenEPUrl;
+            return IdentityUtil.resolveURL(oauth2TokenEPUrl, true, true);
         }
 
         public static String getOidcDiscoveryEPUrl(String tenantDomain) throws URISyntaxException {
@@ -1226,7 +1218,7 @@ public class OAuth2Util {
             if (StringUtils.isBlank(oauth2UserInfoEPUrl)) {
                 oauth2UserInfoEPUrl = IdentityUtil.getServerURL("oauth2/userinfo", true, false);
             }
-            return oauth2UserInfoEPUrl;
+            return IdentityUtil.resolveURL(oauth2UserInfoEPUrl, true, false);
         }
 
         /**
@@ -1240,7 +1232,7 @@ public class OAuth2Util {
             if (StringUtils.isBlank(oauth2RevokeEPUrl)) {
                 oauth2RevokeEPUrl = IdentityUtil.getServerURL("oauth2/revoke", true, false);
             }
-            return oauth2RevokeEPUrl;
+            return IdentityUtil.resolveURL(oauth2RevokeEPUrl, true, false);
         }
 
         /**
@@ -1254,7 +1246,7 @@ public class OAuth2Util {
             if (StringUtils.isBlank(oauth2IntrospectEPUrl)) {
                 oauth2IntrospectEPUrl = IdentityUtil.getServerURL("oauth2/introspect", true, false);
             }
-            return oauth2IntrospectEPUrl;
+            return IdentityUtil.resolveURL(oauth2IntrospectEPUrl, true, false);
         }
 
         public static String getOIDCConsentPageUrl() {
@@ -3086,8 +3078,8 @@ public class OAuth2Util {
         FederatedAuthenticatorConfig oidcAuthenticatorConfig =
                 IdentityApplicationManagementUtil.getFederatedAuthenticator(fedAuthnConfigs,
                         IdentityApplicationConstants.Authenticator.OIDC.NAME);
-        return IdentityApplicationManagementUtil.getProperty(oidcAuthenticatorConfig.getProperties(),
-                IDP_ENTITY_ID).getValue();
+        return IdentityUtil.resolveURL(IdentityApplicationManagementUtil
+                .getProperty(oidcAuthenticatorConfig.getProperties(), IDP_ENTITY_ID).getValue(), true, false);
     }
 
     private static IdentityProvider getResidentIdp(String tenantDomain) throws IdentityOAuth2Exception {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -1186,6 +1186,13 @@ public class OAuth2Util {
             return IdentityUtil.resolveURL(oauth2TokenEPUrl, true, false);
         }
 
+        /**
+         * This method is used to get the resolved URL for the OAuth2 Registration Endpoint.
+         *
+         * @param tenantDomain Tenant Domain.
+         * @return String of the resolved URL for the Registration endpoint.
+         * @throws URISyntaxException URI Syntax Exception.
+         */
         public static String getOAuth2DCREPUrl(String tenantDomain) throws URISyntaxException {
 
             String oauth2TokenEPUrl = OAuthServerConfiguration.getInstance().getOAuth2DCREPUrl();
@@ -1199,6 +1206,12 @@ public class OAuth2Util {
             return oauth2TokenEPUrl;
         }
 
+        /**
+         * This method is used to get the resolved URL for the OAuth2 Registration Endpoint.
+         *
+         * @return String of the resolved URL for the Registration endpoint.
+         * @throws URISyntaxException URI Syntax Exception.
+         */
         public static String getOAuth2DCREPUrl() throws URISyntaxException {
 
             String oauth2TokenEPUrl = OAuthServerConfiguration.getInstance().getOAuth2DCREPUrl();
@@ -1208,6 +1221,13 @@ public class OAuth2Util {
             return IdentityUtil.resolveURL(oauth2TokenEPUrl, true, true, false, true);
         }
 
+        /**
+         * This method is used to get the resolved URL for the JWKS Page.
+         *
+         * @param tenantDomain Tenant Domain.
+         * @return String of the resolved URL for the JWKS page.
+         * @throws URISyntaxException URI Syntax Exception.
+         */
         public static String getOAuth2JWKSPageUrl(String tenantDomain) throws URISyntaxException {
 
             String auth2JWKSPageUrl = OAuthServerConfiguration.getInstance().getOAuth2JWKSPageUrl();
@@ -1221,6 +1241,12 @@ public class OAuth2Util {
             return auth2JWKSPageUrl;
         }
 
+        /**
+         * This method is used to get the resolved URL for the JWKS Page.
+         *
+         * @return String of the resolved URL for the JWKS page.
+         * @throws URISyntaxException URI Syntax Exception.
+         */
         public static String getOAuth2JWKSPageUrl() throws URISyntaxException {
 
             String auth2JWKSPageUrl = OAuthServerConfiguration.getInstance().getOAuth2JWKSPageUrl();

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -1205,7 +1205,7 @@ public class OAuth2Util {
             if (StringUtils.isBlank(oauth2TokenEPUrl)) {
                 oauth2TokenEPUrl = IdentityUtil.getServerURL(OAUTH2_DCR_EP_URL, true, false);
             }
-            return IdentityUtil.resolveURL(oauth2TokenEPUrl, true, true);
+            return IdentityUtil.resolveURL(oauth2TokenEPUrl, true, true, false, true);
         }
 
         public static String getOAuth2JWKSPageUrl(String tenantDomain) throws URISyntaxException {
@@ -1227,7 +1227,7 @@ public class OAuth2Util {
             if (StringUtils.isBlank(auth2JWKSPageUrl)) {
                 auth2JWKSPageUrl = IdentityUtil.getServerURL(OAUTH2_JWKS_EP_URL, true, false);
             }
-            return IdentityUtil.resolveURL(auth2JWKSPageUrl, true, true);
+            return IdentityUtil.resolveURL(auth2JWKSPageUrl, true, true, false, true);
         }
 
         public static String getOidcWebFingerEPUrl() {
@@ -3121,7 +3121,8 @@ public class OAuth2Util {
                         IdentityApplicationConstants.Authenticator.OIDC.NAME);
         String idpEntityId = IdentityApplicationManagementUtil.getProperty(oidcAuthenticatorConfig.getProperties(),
                 IDP_ENTITY_ID).getValue();
-        if (idpEntityId.equals(IdentityUtil.getProperty("OAuth.OpenIDConnect.IDTokenIssuerID"))) {
+        if (StringUtils.isNotBlank(idpEntityId) && idpEntityId.equals(IdentityUtil.getProperty("OAuth.OpenIDConnect" +
+                ".IDTokenIssuerID"))) {
             return IdentityUtil.resolveURL(idpEntityId, tenantDomain, true, false, false, false);
         } else {
             return idpEntityId;

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/saml/SAML1BearerGrantHandlerTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/saml/SAML1BearerGrantHandlerTest.java
@@ -204,6 +204,9 @@ public class SAML1BearerGrantHandlerTest extends PowerMockIdentityBaseTest {
         when(keyStoreManager.getDefaultPrimaryCertificate()).thenReturn(cert);
         Map<String, Object> configuration = new HashMap<>();
         configuration.put("SSOService.EntityId", "LOCAL");
+        configuration.put("SSOService.SAMLECPEndpoint", "https://localhost:9443/samlecp");
+        configuration.put("SSOService.ArtifactResolutionEndpoint", "https://localhost:9443/samlartresolve");
+        configuration.put("OAuth.OpenIDConnect.IDTokenIssuerID", "https://localhost:9443/oauth2/token");
         WhiteboxImpl.setInternalState(IdentityUtil.class, "configuration", configuration);
         saml1BearerGrantHandler.profileValidator = new SAMLSignatureProfileValidator();
         assertEquals(saml1BearerGrantHandler.validateGrant(oAuthTokenReqMessageContext), expectedResult);

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/util/OAuth2UtilTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/util/OAuth2UtilTest.java
@@ -977,9 +977,11 @@ public class OAuth2UtilTest extends PowerMockIdentityBaseTest {
         };
     }
 
-    @DataProvider(name = "OAuthURLData3")
-    public Object[][] oauthURLData3() {
+    @DataProvider(name = "OAuthTenantSupportURLData1")
+    public Object[][] oAuthTenantSupportURLData1() {
+
         return new Object[][]{
+                // enableTenantURLSupport
                 // configUrl
                 // serverUrl
                 // tenantDomain
@@ -989,11 +991,15 @@ public class OAuth2UtilTest extends PowerMockIdentityBaseTest {
                 {true, "", "https://localhost:9443/testUrl", "",
                         "https://localhost:9443/t/carbon.super/testUrl"},
                 {true, "", "https://localhost:9443/testUrl", "testDomain",
-                        "https://localhost:9443/t/testDomain/testUrl"}
+                        "https://localhost:9443/t/testDomain/testUrl"},
+                {false, "", "https://localhost:9443/testUrl", "testDomain",
+                        "https://localhost:9443/t/testDomain/testUrl"},
+                {false, "", "https://localhost:9443/testUrl", "",
+                        "https://localhost:9443/testUrl"},
         };
     }
 
-    @Test(dataProvider = "OAuthURLData3")
+    @Test(dataProvider = "OAuthTenantSupportURLData1")
     public void testGetOAuth2JWKSPageUrl(Boolean enableTenantURLSupport, String configUrl, String serverUrl,
                                          String tenantDomain, String oauthUrl) throws Exception {
 
@@ -1005,7 +1011,7 @@ public class OAuth2UtilTest extends PowerMockIdentityBaseTest {
         assertEquals(OAuth2Util.OAuthURL.getOAuth2JWKSPageUrl(), oauthUrl);
     }
 
-    @Test(dataProvider = "OAuthURLData3")
+    @Test(dataProvider = "OAuthTenantSupportURLData1")
     public void testGetOAuth2DCREPUrl(Boolean enableTenantURLSupport, String configUrl, String serverUrl,
                                       String tenantDomain, String oauthUrl) throws Exception {
 
@@ -1036,8 +1042,43 @@ public class OAuth2UtilTest extends PowerMockIdentityBaseTest {
     }
 
     @Test(dataProvider = "OAuthURLData")
-    public void testGetOidcWebFingerEPUrl(String configUrl, String serverUrl, String oauthUrl) throws Exception {
+    public void testGetOidcWebFingerEPUrlLegacy(String configUrl, String serverUrl, String oauthUrl) throws Exception {
+
         when(oauthServerConfigurationMock.getOidcWebFingerEPUrl()).thenReturn(configUrl);
+        getOAuthURL(serverUrl);
+        assertEquals(OAuth2Util.OAuthURL.getOidcWebFingerEPUrl(), oauthUrl);
+    }
+
+    @DataProvider(name = "OAuthTenantSupportURLData2")
+    public Object[][] oAuthTenantSupportURLData2() {
+
+        return new Object[][]{
+                // enableTenantURLSupport
+                // configUrl
+                // serverUrl
+                // tenantDomain
+                // oauthUrl
+                {true, "https://localhost:9443/testUrl", "https://localhost:9443/testUrl", "testDomain", "https" +
+                        "://localhost:9443/t/testDomain/testUrl"},
+                {true, "", "https://localhost:9443/testUrl", "",
+                        "https://localhost:9443/t/carbon.super/testUrl"},
+                {true, "", "https://localhost:9443/testUrl", "testDomain",
+                        "https://localhost:9443/t/testDomain/testUrl"},
+                {false, "", "https://localhost:9443/testUrl", "testDomain",
+                        "https://localhost:9443/testUrl"},
+                {false, "", "https://localhost:9443/testUrl", "",
+                        "https://localhost:9443/testUrl"},
+        };
+    }
+
+    @Test(dataProvider = "OAuthTenantSupportURLData2")
+    public void testGetOidcWebFingerEPUrl(boolean enableTenantURLSupport, String configUrl, String serverUrl,
+                                          String tenantDomain, String oauthUrl) throws Exception {
+
+        when(oauthServerConfigurationMock.getOidcWebFingerEPUrl()).thenReturn(configUrl);
+        when(IdentityTenantUtil.isTenantQualifiedUrlsEnabled()).thenReturn(enableTenantURLSupport);
+        when(IdentityTenantUtil.getTenantDomainFromContext()).thenReturn(tenantDomain);
+        when(PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain()).thenReturn("carbon.super");
         getOAuthURL(serverUrl);
         assertEquals(OAuth2Util.OAuthURL.getOidcWebFingerEPUrl(), oauthUrl);
     }
@@ -1045,36 +1086,77 @@ public class OAuth2UtilTest extends PowerMockIdentityBaseTest {
     @Test(dataProvider = "OAuthURLData2")
     public void testGetOidcDiscoveryEPUrl(String configUrl, String serverUrl,
                                           String tenantDomain, String oauthUrl) throws Exception {
+
         when(oauthServerConfigurationMock.getOidcDiscoveryUrl()).thenReturn(configUrl);
         getOAuthURL(serverUrl);
         assertEquals(OAuth2Util.OAuthURL.getOidcDiscoveryEPUrl(tenantDomain), oauthUrl);
     }
 
     @Test(dataProvider = "OAuthURLData")
-    public void testGetOAuth2UserInfoEPUrl(String configUrl, String serverUrl, String oauthUrl) throws Exception {
+    public void testGetOAuth2UserInfoEPUrlLegacy(String configUrl, String serverUrl, String oauthUrl) throws Exception {
+
         when(oauthServerConfigurationMock.getOauth2UserInfoEPUrl()).thenReturn(configUrl);
         getOAuthURL(serverUrl);
         assertEquals(OAuth2Util.OAuthURL.getOAuth2UserInfoEPUrl(), oauthUrl);
     }
 
+    @Test(dataProvider = "OAuthTenantSupportURLData2")
+    public void testGetOAuth2UserInfoEPUrl(boolean enableTenantURLSupport, String configUrl, String serverUrl,
+                                           String tenantDomain, String oauthUrl) throws Exception {
+
+        when(oauthServerConfigurationMock.getOauth2UserInfoEPUrl()).thenReturn(configUrl);
+        when(IdentityTenantUtil.isTenantQualifiedUrlsEnabled()).thenReturn(enableTenantURLSupport);
+        when(IdentityTenantUtil.getTenantDomainFromContext()).thenReturn(tenantDomain);
+        when(PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain()).thenReturn("carbon.super");
+        getOAuthURL(serverUrl);
+        assertEquals(OAuth2Util.OAuthURL.getOAuth2UserInfoEPUrl(), oauthUrl);
+    }
+
     @Test(dataProvider = "OAuthURLData")
-    public void testGetOAuth2RevocationEPUrl(String configUrl, String serverUrl, String oauthUrl) throws Exception {
+    public void testGetOAuth2RevocationEPUrlLegacy(String configUrl, String serverUrl, String oauthUrl)
+            throws Exception {
 
         when(oauthServerConfigurationMock.getOauth2RevocationEPUrl()).thenReturn(configUrl);
         getOAuthURL(serverUrl);
         assertEquals(OAuth2Util.OAuthURL.getOAuth2RevocationEPUrl(), oauthUrl);
     }
 
+    @Test(dataProvider = "OAuthTenantSupportURLData2")
+    public void testGetOAuth2RevocationEPUrl(boolean enableTenantURLSupport, String configUrl, String serverUrl,
+                                             String tenantDomain, String oauthUrl) throws Exception {
+
+        when(oauthServerConfigurationMock.getOauth2RevocationEPUrl()).thenReturn(configUrl);
+        when(IdentityTenantUtil.isTenantQualifiedUrlsEnabled()).thenReturn(enableTenantURLSupport);
+        when(IdentityTenantUtil.getTenantDomainFromContext()).thenReturn(tenantDomain);
+        when(PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain()).thenReturn("carbon.super");
+        getOAuthURL(serverUrl);
+        assertEquals(OAuth2Util.OAuthURL.getOAuth2RevocationEPUrl(), oauthUrl);
+    }
+
     @Test(dataProvider = "OAuthURLData")
-    public void testGetOAuth2IntrospectionEPUrl(String configUrl, String serverUrl, String oauthUrl) throws Exception {
+    public void testGetOAuth2IntrospectionEPUrlLegacy(String configUrl, String serverUrl, String oauthUrl)
+            throws Exception {
 
         when(oauthServerConfigurationMock.getOauth2IntrospectionEPUrl()).thenReturn(configUrl);
         getOAuthURL(serverUrl);
         assertEquals(OAuth2Util.OAuthURL.getOAuth2IntrospectionEPUrl(), oauthUrl);
     }
 
+    @Test(dataProvider = "OAuthTenantSupportURLData2")
+    public void testGetOAuth2IntrospectionEPUrl(boolean enableTenantURLSupport, String configUrl, String serverUrl,
+                                                String tenantDomain, String oauthUrl) throws Exception {
+
+        when(oauthServerConfigurationMock.getOauth2IntrospectionEPUrl()).thenReturn(configUrl);
+        when(IdentityTenantUtil.isTenantQualifiedUrlsEnabled()).thenReturn(enableTenantURLSupport);
+        when(IdentityTenantUtil.getTenantDomainFromContext()).thenReturn(tenantDomain);
+        when(PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain()).thenReturn("carbon.super");
+        getOAuthURL(serverUrl);
+        assertEquals(OAuth2Util.OAuthURL.getOAuth2IntrospectionEPUrl(), oauthUrl);
+    }
+
     @Test(dataProvider = "OAuthURLData")
     public void testGetOIDCConsentPageUrl(String configUrl, String serverUrl, String oauthUrl) throws Exception {
+
         when(oauthServerConfigurationMock.getOIDCConsentPageUrl()).thenReturn(configUrl);
         getOAuthURL(serverUrl);
         assertEquals(OAuth2Util.OAuthURL.getOIDCConsentPageUrl(), oauthUrl);

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/util/OAuth2UtilTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/util/OAuth2UtilTest.java
@@ -977,11 +977,40 @@ public class OAuth2UtilTest extends PowerMockIdentityBaseTest {
         };
     }
 
-    @Test(dataProvider = "OAuthURLData2")
-    public void testGetOAuth2DCREPUrl(String configUrl, String serverUrl, String tenantDomain, String oauthUrl)
-            throws Exception {
+    @DataProvider(name = "OAuthURLData3")
+    public Object[][] oauthURLData3() {
+        return new Object[][]{
+                // configUrl
+                // serverUrl
+                // tenantDomain
+                // oauthUrl
+                {true, "https://localhost:9443/testUrl", "https://localhost:9443/testUrl", "testDomain", "https" +
+                        "://localhost:9443/t/testDomain/testUrl"},
+                {true, "", "https://localhost:9443/testUrl", "",
+                        "https://localhost:9443/t/carbon.super/testUrl"},
+                {true, "", "https://localhost:9443/testUrl", "testDomain",
+                        "https://localhost:9443/t/testDomain/testUrl"}
+        };
+    }
+
+    @Test(dataProvider = "OAuthURLData3")
+    public void testGetOAuth2JWKSPageUrl(Boolean enableTenantURLSupport, String configUrl, String serverUrl,
+                                         String tenantDomain, String oauthUrl) throws Exception {
+
+        when(oauthServerConfigurationMock.getOAuth2JWKSPageUrl()).thenReturn(configUrl);
+        when(IdentityTenantUtil.isTenantQualifiedUrlsEnabled()).thenReturn(enableTenantURLSupport);
+        when(IdentityTenantUtil.getTenantDomainFromContext()).thenReturn(tenantDomain);
+        when(PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain()).thenReturn("carbon.super");
+        getOAuthURL(serverUrl);
+        assertEquals(OAuth2Util.OAuthURL.getOAuth2JWKSPageUrl(), oauthUrl);
+    }
+
+    @Test(dataProvider = "OAuthURLData3")
+    public void testGetOAuth2DCREPUrl(Boolean enableTenantURLSupport, String configUrl, String serverUrl,
+                                      String tenantDomain, String oauthUrl) throws Exception {
 
         when(oauthServerConfigurationMock.getOAuth2DCREPUrl()).thenReturn(configUrl);
+        when(IdentityTenantUtil.isTenantQualifiedUrlsEnabled()).thenReturn(enableTenantURLSupport);
         when(IdentityTenantUtil.getTenantDomainFromContext()).thenReturn(tenantDomain);
         when(PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain()).thenReturn("carbon.super");
         getOAuthURL(serverUrl);
@@ -989,14 +1018,21 @@ public class OAuth2UtilTest extends PowerMockIdentityBaseTest {
     }
 
     @Test(dataProvider = "OAuthURLData2")
-    public void testGetOAuth2JWKSPageUrl(String configUrl, String serverUrl, String tenantDomain, String oauthUrl)
-            throws Exception {
+    public void testGetOAuth2JWKSPageUrlLegacy(String configUrl, String serverUrl,
+                                         String tenantDomain, String oauthUrl) throws Exception {
 
         when(oauthServerConfigurationMock.getOAuth2JWKSPageUrl()).thenReturn(configUrl);
-        when(IdentityTenantUtil.getTenantDomainFromContext()).thenReturn(tenantDomain);
-        when(PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain()).thenReturn("carbon.super");
         getOAuthURL(serverUrl);
-        assertEquals(OAuth2Util.OAuthURL.getOAuth2JWKSPageUrl(), oauthUrl);
+        assertEquals(OAuth2Util.OAuthURL.getOAuth2JWKSPageUrl(tenantDomain), oauthUrl);
+    }
+
+    @Test(dataProvider = "OAuthURLData2")
+    public void testGetOAuth2DCREPUrlLegacy(String configUrl, String serverUrl,
+                                      String tenantDomain, String oauthUrl) throws Exception {
+
+        when(oauthServerConfigurationMock.getOAuth2DCREPUrl()).thenReturn(configUrl);
+        getOAuthURL(serverUrl);
+        assertEquals(OAuth2Util.OAuthURL.getOAuth2DCREPUrl(tenantDomain), oauthUrl);
     }
 
     @Test(dataProvider = "OAuthURLData")
@@ -1007,8 +1043,8 @@ public class OAuth2UtilTest extends PowerMockIdentityBaseTest {
     }
 
     @Test(dataProvider = "OAuthURLData2")
-    public void testGetOidcDiscoveryEPUrl(String configUrl, String serverUrl, String tenantDomain, String oauthUrl)
-            throws Exception {
+    public void testGetOidcDiscoveryEPUrl(String configUrl, String serverUrl,
+                                          String tenantDomain, String oauthUrl) throws Exception {
         when(oauthServerConfigurationMock.getOidcDiscoveryUrl()).thenReturn(configUrl);
         getOAuthURL(serverUrl);
         assertEquals(OAuth2Util.OAuthURL.getOidcDiscoveryEPUrl(tenantDomain), oauthUrl);

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/openidconnect/DefaultIDTokenBuilderTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/openidconnect/DefaultIDTokenBuilderTest.java
@@ -19,6 +19,7 @@
 package org.wso2.carbon.identity.openidconnect;
 
 import org.mockito.Mockito;
+import org.powermock.reflect.internal.WhiteboxImpl;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
@@ -34,6 +35,7 @@ import org.wso2.carbon.identity.common.testng.WithH2Database;
 import org.wso2.carbon.identity.common.testng.WithKeyStore;
 import org.wso2.carbon.identity.common.testng.WithRealmService;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.oauth2.TestConstants;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2AccessTokenReqDTO;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2AccessTokenRespDTO;
@@ -100,6 +102,12 @@ public class DefaultIDTokenBuilderTest extends IdentityBaseTest {
         idp.setIdentityProviderName("LOCAL");
         idp.setEnable(true);
 
+        Map<String, Object> configuration = new HashMap<>();
+        configuration.put("SSOService.EntityId", "LOCAL");
+        configuration.put("SSOService.SAMLECPEndpoint", "https://localhost:9443/samlecp");
+        configuration.put("SSOService.ArtifactResolutionEndpoint", "https://localhost:9443/samlartresolve");
+        configuration.put("OAuth.OpenIDConnect.IDTokenIssuerID", "https://localhost:9443/oauth2/token");
+        WhiteboxImpl.setInternalState(IdentityUtil.class, "configuration", configuration);
         IdentityProviderManager.getInstance().addResidentIdP(idp, SUPER_TENANT_DOMAIN_NAME);
         defaultIDTokenBuilder =  new DefaultIDTokenBuilder();
 

--- a/components/org.wso2.carbon.identity.oauth/src/test/resources/conf/identity.xml
+++ b/components/org.wso2.carbon.identity.oauth/src/test/resources/conf/identity.xml
@@ -311,6 +311,8 @@
         <IdentityProviderURL>${carbon.protocol}://${carbon.host}:${carbon.management.port}/samlsso</IdentityProviderURL>
         <DefaultLogoutEndpoint>${carbon.protocol}://${carbon.host}:${carbon.management.port}/authenticationendpoint/samlsso_logout.do</DefaultLogoutEndpoint>
         <NotificationEndpoint>${carbon.protocol}://${carbon.host}:${carbon.management.port}/authenticationendpoint/samlsso_notification.do</NotificationEndpoint>
+        <SAMLECPEndpoint>${carbon.protocol}://${carbon.host}:${carbon.management.port}/samlecp</SAMLECPEndpoint>
+        <ArtifactResolutionEndpoint>${carbon.protocol}://${carbon.host}:${carbon.management.port}/samlartresolve</ArtifactResolutionEndpoint>
         <SingleLogoutRetryCount>5</SingleLogoutRetryCount>
         <SingleLogoutRetryInterval>60000</SingleLogoutRetryInterval>
         <!-- in milli seconds -->

--- a/components/org.wso2.carbon.identity.oauth/src/test/resources/repository/conf/identity/identity.xml
+++ b/components/org.wso2.carbon.identity.oauth/src/test/resources/repository/conf/identity/identity.xml
@@ -303,6 +303,8 @@
         <IdentityProviderURL>${carbon.protocol}://${carbon.host}:${carbon.management.port}/samlsso</IdentityProviderURL>
         <DefaultLogoutEndpoint>${carbon.protocol}://${carbon.host}:${carbon.management.port}/authenticationendpoint/samlsso_logout.do</DefaultLogoutEndpoint>
         <NotificationEndpoint>${carbon.protocol}://${carbon.host}:${carbon.management.port}/authenticationendpoint/samlsso_notification.do</NotificationEndpoint>
+        <SAMLECPEndpoint>${carbon.protocol}://${carbon.host}:${carbon.management.port}/samlecp</SAMLECPEndpoint>
+        <ArtifactResolutionEndpoint>${carbon.protocol}://${carbon.host}:${carbon.management.port}/samlartresolve</ArtifactResolutionEndpoint>
         <SingleLogoutRetryCount>5</SingleLogoutRetryCount>
         <SingleLogoutRetryInterval>60000</SingleLogoutRetryInterval>
         <!-- in milli seconds -->

--- a/pom.xml
+++ b/pom.xml
@@ -865,7 +865,7 @@
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!-- Carbon Identity Framework version -->
-        <carbon.identity.framework.version>5.16.119</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.17.10-SNAPSHOT</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.15.0, 6.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 

--- a/pom.xml
+++ b/pom.xml
@@ -865,7 +865,7 @@
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!-- Carbon Identity Framework version -->
-        <carbon.identity.framework.version>5.17.10-SNAPSHOT</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.17.15</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.15.0, 6.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 


### PR DESCRIPTION
#### Proposed changes in this pull request

As per the requirement to make all the endpoints tenant-qualified, the OIDC discovery endpoint should support the form 'https://localhost:9443/t/{tenant.domain}/oauth2/token/.well-known/openid-configuration'

Currently, the endpoint supports tenants in path. But, the URLs that are generated are not tenant-qualified.
Eg: https://localhost:9443/oauth2/token

With the changes in the PR, the OIDC metadata URLs would be tenant-qualified with tenant in path.
Eg: https://localhost:9443/t/wso2.com/oauth2/token

fix https://github.com/wso2/product-is/issues/7932