### PR TITLE
Add tenant qualified URL support for OAuth flows

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
+++ b/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
@@ -272,6 +272,8 @@ public final class OAuthConstants {
         public static final String OIDC_CONSENT_EP_URL = "/authenticationendpoint/oauth2_consent.do";
         public static final String OAUTH2_CONSENT_EP_URL = "/authenticationendpoint/oauth2_authz.do";
         public static final String OAUTH2_ERROR_EP_URL = "/authenticationendpoint/oauth2_error.do";
+        public static final String OIDC_DEFAULT_LOGOUT_RESPONSE_URL = "/authenticationendpoint/oauth2_logout.do";
+        public static final String OIDC_LOGOUT_CONSENT_EP_URL = "/authenticationendpoint/oauth2_logout_consent.do";
 
         private OAuth20Endpoints() {
 

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
@@ -2483,7 +2483,8 @@ public class OAuth2AuthzEndpoint {
                 if (attribute == AuthenticatorFlowStatus.INCOMPLETE) {
 
                     if (responseWrapper.isRedirect()) {
-                        oAuthMessage.getResponse().sendRedirect(responseWrapper.getRedirectURL());
+                        return Response.status(HttpServletResponse.SC_FOUND).location(
+                                new URI(responseWrapper.getRedirectURL())).build();
                     } else {
                         return Response.status(HttpServletResponse.SC_OK).entity(responseWrapper.getContent()).build();
                     }
@@ -2499,7 +2500,6 @@ public class OAuth2AuthzEndpoint {
             log.error("Error occurred while sending request to authentication framework.");
             return Response.status(HttpServletResponse.SC_INTERNAL_SERVER_ERROR).build();
         }
-        return null;
     }
 
     private String manageOIDCSessionState(HttpServletRequest request, HttpServletResponse response,

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
@@ -59,6 +59,8 @@ import org.wso2.carbon.identity.base.IdentityConstants;
 import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataHandler;
 import org.wso2.carbon.identity.claim.metadata.mgt.exception.ClaimMetadataException;
 import org.wso2.carbon.identity.claim.metadata.mgt.model.ExternalClaim;
+import org.wso2.carbon.identity.core.ServiceURLBuilder;
+import org.wso2.carbon.identity.core.URLBuilderException;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.oauth.cache.AuthorizationGrantCache;
 import org.wso2.carbon.identity.oauth.cache.AuthorizationGrantCacheEntry;
@@ -2390,14 +2392,15 @@ public class OAuth2AuthzEndpoint {
             CommonAuthResponseWrapper responseWrapper = new CommonAuthResponseWrapper(oAuthMessage.getResponse());
             invokeCommonauthFlow(oAuthMessage, responseWrapper);
             return processAuthResponseFromFramework(oAuthMessage, responseWrapper);
-        } catch (ServletException | IOException e) {
+        } catch (ServletException | IOException | URLBuilderException e) {
             log.error("Error occurred while sending request to authentication framework.");
             return Response.status(HttpServletResponse.SC_INTERNAL_SERVER_ERROR).build();
         }
     }
 
-    private Response processAuthResponseFromFramework(OAuthMessage oAuthMessage, CommonAuthResponseWrapper
-            responseWrapper) throws IOException, InvalidRequestParentException, URISyntaxException {
+    private Response processAuthResponseFromFramework(OAuthMessage oAuthMessage,
+                                                      CommonAuthResponseWrapper responseWrapper)
+            throws IOException, InvalidRequestParentException, URISyntaxException, URLBuilderException {
 
         if (isAuthFlowStateExists(oAuthMessage)) {
             if (isFlowStateIncomplete(oAuthMessage)) {
@@ -2430,11 +2433,11 @@ public class OAuth2AuthzEndpoint {
     }
 
     private Response handleIncompleteFlow(OAuthMessage oAuthMessage, CommonAuthResponseWrapper responseWrapper)
-            throws IOException {
+            throws IOException, URISyntaxException, URLBuilderException {
 
         if (responseWrapper.isRedirect()) {
-            oAuthMessage.getResponse().sendRedirect(responseWrapper.getRedirectURL());
-            return null;
+            return Response.status(HttpServletResponse.SC_FOUND)
+                    .location(buildURI(responseWrapper.getRedirectURL())).build();
         } else {
             return Response.status(HttpServletResponse.SC_OK).entity(responseWrapper.getContent()).build();
         }
@@ -2483,8 +2486,8 @@ public class OAuth2AuthzEndpoint {
                 if (attribute == AuthenticatorFlowStatus.INCOMPLETE) {
 
                     if (responseWrapper.isRedirect()) {
-                        return Response.status(HttpServletResponse.SC_FOUND).location(
-                                new URI(responseWrapper.getRedirectURL())).build();
+                        return Response.status(HttpServletResponse.SC_FOUND)
+                                .location(buildURI(responseWrapper.getRedirectURL())).build();
                     } else {
                         return Response.status(HttpServletResponse.SC_OK).entity(responseWrapper.getContent()).build();
                     }
@@ -2496,9 +2499,19 @@ public class OAuth2AuthzEndpoint {
                         .setAttribute(FrameworkConstants.RequestParams.FLOW_STATUS, AuthenticatorFlowStatus.UNKNOWN);
                 return authorize(requestWrapper, responseWrapper);
             }
-        } catch (ServletException | IOException e) {
+        } catch (ServletException | IOException | URLBuilderException e) {
             log.error("Error occurred while sending request to authentication framework.");
             return Response.status(HttpServletResponse.SC_INTERNAL_SERVER_ERROR).build();
+        }
+    }
+
+    private URI buildURI(String redirectUrl) throws URISyntaxException, URLBuilderException {
+
+        URI uri = new URI(redirectUrl);
+        if (uri.isAbsolute()) {
+            return uri;
+        } else {
+            return new URI(ServiceURLBuilder.create().addPath(redirectUrl).build().getAbsolutePublicURL());
         }
     }
 

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
@@ -610,9 +610,9 @@ public class EndpointUtil {
             }
 
             if (isOIDC) {
-                consentPage = OAuth2Util.OAuthURL.getOIDCConsentPageUrl();
+                consentPage = IdentityUtil.resolveURL(OAuth2Util.OAuthURL.getOIDCConsentPageUrl(), true, true);
             } else {
-                consentPage = OAuth2Util.OAuthURL.getOAuth2ConsentPageUrl();
+                consentPage = IdentityUtil.resolveURL(OAuth2Util.OAuthURL.getOAuth2ConsentPageUrl(), true, true);
             }
             if (params != null) {
                 consentPage += "?" + OAuthConstants.OIDC_LOGGED_IN_USER + "=" + URLEncoder.encode(loggedInUser,

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
@@ -610,9 +610,9 @@ public class EndpointUtil {
             }
 
             if (isOIDC) {
-                consentPage = IdentityUtil.resolveURL(OAuth2Util.OAuthURL.getOIDCConsentPageUrl(), true, true);
+                consentPage = OAuth2Util.OAuthURL.getOIDCConsentPageUrl();
             } else {
-                consentPage = IdentityUtil.resolveURL(OAuth2Util.OAuthURL.getOAuth2ConsentPageUrl(), true, true);
+                consentPage = OAuth2Util.OAuthURL.getOAuth2ConsentPageUrl();
             }
             if (params != null) {
                 consentPage += "?" + OAuthConstants.OIDC_LOGGED_IN_USER + "=" + URLEncoder.encode(loggedInUser,

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -1280,31 +1280,17 @@ public class OAuth2Util {
 
         public static String getOIDCConsentPageUrl() {
 
-            String oidcConsentPageUrl = OAuthServerConfiguration.getInstance().getOIDCConsentPageUrl();
-            if (StringUtils.isBlank(oidcConsentPageUrl)) {
-                oidcConsentPageUrl = IdentityUtil.getServerURL(OIDC_CONSENT_EP_URL, false,
-                        false);
-            }
-            return IdentityUtil.resolveURL(oidcConsentPageUrl, false, false);
+            return buildUrl(OIDC_CONSENT_EP_URL, OAuthServerConfiguration.getInstance()::getOIDCConsentPageUrl);
         }
 
         public static String getOAuth2ConsentPageUrl() {
 
-            String oAuth2ConsentPageUrl = OAuthServerConfiguration.getInstance().getOauth2ConsentPageUrl();
-            if (StringUtils.isBlank(oAuth2ConsentPageUrl)) {
-                oAuth2ConsentPageUrl = IdentityUtil.getServerURL(OAUTH2_CONSENT_EP_URL, false,
-                        false);
-            }
-            return IdentityUtil.resolveURL(oAuth2ConsentPageUrl, false, false);
+            return buildUrl(OAUTH2_CONSENT_EP_URL, OAuthServerConfiguration.getInstance()::getOauth2ConsentPageUrl);
         }
 
         public static String getOAuth2ErrorPageUrl() {
 
-            String oAuth2ErrorPageUrl = OAuthServerConfiguration.getInstance().getOauth2ErrorPageUrl();
-            if (StringUtils.isBlank(oAuth2ErrorPageUrl)) {
-                oAuth2ErrorPageUrl = IdentityUtil.getServerURL(OAUTH2_ERROR_EP_URL, false, false);
-            }
-            return IdentityUtil.resolveURL(oAuth2ErrorPageUrl, false, false);
+            return buildUrl(OAUTH2_ERROR_EP_URL, OAuthServerConfiguration.getInstance()::getOauth2ErrorPageUrl);
         }
 
         private static String appendTenantDomainAsPathParamInLegacyMode(String url, String tenantDomain)

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -1285,7 +1285,7 @@ public class OAuth2Util {
                 oidcConsentPageUrl = IdentityUtil.getServerURL(OIDC_CONSENT_EP_URL, false,
                         false);
             }
-            return oidcConsentPageUrl;
+            return IdentityUtil.resolveURL(oidcConsentPageUrl, false, false);
         }
 
         public static String getOAuth2ConsentPageUrl() {
@@ -1295,7 +1295,7 @@ public class OAuth2Util {
                 oAuth2ConsentPageUrl = IdentityUtil.getServerURL(OAUTH2_CONSENT_EP_URL, false,
                         false);
             }
-            return oAuth2ConsentPageUrl;
+            return IdentityUtil.resolveURL(oAuth2ConsentPageUrl, false, false);
         }
 
         public static String getOAuth2ErrorPageUrl() {
@@ -1304,7 +1304,7 @@ public class OAuth2Util {
             if (StringUtils.isBlank(oAuth2ErrorPageUrl)) {
                 oAuth2ErrorPageUrl = IdentityUtil.getServerURL(OAUTH2_ERROR_EP_URL, false, false);
             }
-            return oAuth2ErrorPageUrl;
+            return IdentityUtil.resolveURL(oAuth2ErrorPageUrl, false, false);
         }
 
         private static String appendTenantDomainAsPathParamInLegacyMode(String url, String tenantDomain)

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/util/OAuth2UtilTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/util/OAuth2UtilTest.java
@@ -1295,26 +1295,58 @@ public class OAuth2UtilTest extends PowerMockIdentityBaseTest {
         assertEquals(OAuth2Util.OAuthURL.getOAuth2IntrospectionEPUrl(), oauthUrl);
     }
 
-    @Test(dataProvider = "OAuthURLData")
-    public void testGetOIDCConsentPageUrl(String configUrl, String serverUrl, String oauthUrl) throws Exception {
+    @DataProvider(name = "OIDCConsentPageURLData")
+    public Object[][] getOIDCConsentUrlData() {
+
+        return new Object[][]{
+                // URL from file based config , Expected error page URL
+                {"https://localhost:9443/authenticationendpoint/custom_oidc_consent.do",
+                        "https://localhost:9443/authenticationendpoint/custom_oidc_consent.do"},
+                {"", "https://localhost:9443/authenticationendpoint/oauth2_consent.do"}
+        };
+    }
+
+    @Test(dataProvider = "OIDCConsentPageURLData")
+    public void testGetOIDCConsentPageUrl(String configUrl, String expectedUrl) throws Exception {
 
         when(oauthServerConfigurationMock.getOIDCConsentPageUrl()).thenReturn(configUrl);
-        getOAuthURL(serverUrl);
-        assertEquals(OAuth2Util.OAuthURL.getOIDCConsentPageUrl(), oauthUrl);
+        assertEquals(OAuth2Util.OAuthURL.getOIDCConsentPageUrl(), expectedUrl);
     }
 
-    @Test(dataProvider = "OAuthURLData")
-    public void testGetOAuth2ConsentPageUrl(String configUrl, String serverUrl, String oauthUrl) throws Exception {
+    @DataProvider(name = "OAuthConsentPageURLData")
+    public Object[][] getOAuthConsentUrlData() {
+
+        return new Object[][]{
+                // URL from file based config , Expected error page URL
+                {"https://localhost:9443/authenticationendpoint/custom_consent.do",
+                        "https://localhost:9443/authenticationendpoint/custom_consent.do"},
+                {"", "https://localhost:9443/authenticationendpoint/oauth2_authz.do"}
+        };
+    }
+
+    @Test(dataProvider = "OAuthConsentPageURLData")
+    public void testGetOAuth2ConsentPageUrl(String configUrl, String expectedUrl) throws Exception {
+
         when(oauthServerConfigurationMock.getOauth2ConsentPageUrl()).thenReturn(configUrl);
-        getOAuthURL(serverUrl);
-        assertEquals(OAuth2Util.OAuthURL.getOAuth2ConsentPageUrl(), oauthUrl);
+        assertEquals(OAuth2Util.OAuthURL.getOAuth2ConsentPageUrl(), expectedUrl);
     }
 
-    @Test(dataProvider = "OAuthURLData")
-    public void testGetOAuth2ErrorPageUrl(String configUrl, String serverUrl, String oauthUrl) throws Exception {
-        when(oauthServerConfigurationMock.getOauth2ErrorPageUrl()).thenReturn(configUrl);
-        getOAuthURL(serverUrl);
-        assertEquals(OAuth2Util.OAuthURL.getOAuth2ErrorPageUrl(), oauthUrl);
+    @DataProvider(name = "OAuthErrorPageData")
+    public Object[][] getOAuthErrorPageUrlData() {
+
+        return new Object[][]{
+                // URL from file based config , Expected error page URL
+                {"https://localhost:9443/authenticationendpoint/custom_oauth_error.do",
+                        "https://localhost:9443/authenticationendpoint/custom_oauth_error.do"},
+                {"", "https://localhost:9443/authenticationendpoint/oauth2_error.do"}
+        };
+    }
+
+    @Test(dataProvider = "OAuthErrorPageData")
+    public void testGetOAuth2ErrorPageUrl(String configUrl, String expectedUrl) throws Exception {
+
+        when(OAuthServerConfiguration.getInstance().getOauth2ErrorPageUrl()).thenReturn(configUrl);
+        assertEquals(OAuth2Util.OAuthURL.getOAuth2ErrorPageUrl(), expectedUrl);
     }
 
     private void getOAuthURL(String serverUrl) {

--- a/components/org.wso2.carbon.identity.oidc.session/pom.xml
+++ b/components/org.wso2.carbon.identity.oidc.session/pom.xml
@@ -47,6 +47,16 @@
             <artifactId>commons-codec</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
@@ -73,6 +83,10 @@
         <dependency>
             <groupId>org.wso2.carbon.identity.inbound.auth.oauth2</groupId>
             <artifactId>org.wso2.carbon.identity.oauth</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.inbound.auth.oauth2</groupId>
+            <artifactId>org.wso2.carbon.identity.oauth.common</artifactId>
         </dependency>
         <dependency>
             <groupId>org.wso2.orbit.com.nimbusds</groupId>
@@ -169,6 +183,7 @@
                             org.wso2.carbon.identity.base; version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.core.util;version="${carbon.identity.framework.imp.pkg.version.range}",
 
+                            org.wso2.carbon.identity.oauth.common;version="${identity.inbound.auth.oauth.imp.pkg.version.range}",
                             org.wso2.carbon.identity.oauth.common.exception;version="${identity.inbound.auth.oauth.imp.pkg.version.range}",
                             org.wso2.carbon.identity.oauth.common.token.bindings;version="${identity.inbound.auth.oauth.imp.pkg.version.range}",
                             org.wso2.carbon.identity.oauth.config;version="${identity.inbound.auth.oauth.imp.pkg.version.range}",

--- a/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/handler/OIDCLogoutEventHandler.java
+++ b/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/handler/OIDCLogoutEventHandler.java
@@ -19,17 +19,19 @@ package org.wso2.carbon.identity.oidc.session.handler;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
 import org.wso2.carbon.identity.event.IdentityEventConstants.EventName;
 import org.wso2.carbon.identity.event.IdentityEventConstants.EventProperty;
 import org.wso2.carbon.identity.event.IdentityEventException;
 import org.wso2.carbon.identity.event.event.Event;
 import org.wso2.carbon.identity.event.handler.AbstractEventHandler;
-import org.wso2.carbon.identity.oidc.session.OIDCSessionConstants;
 import org.wso2.carbon.identity.oidc.session.backchannellogout.LogoutRequestSender;
 import org.wso2.carbon.identity.oidc.session.util.OIDCSessionManagementUtil;
 
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
+
+import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.RequestParams.TYPE;
 
 /**
  * Event handler to support cross protocol logout.
@@ -51,8 +53,7 @@ public class OIDCLogoutEventHandler extends AbstractEventHandler {
             Cookie opbsCookie = null;
 
             if (request != null) {
-                if (StringUtils.equals(request.getParameter(COMMON_AUTH_CALLER_PATH),
-                        OIDCSessionConstants.OIDCEndpoints.OIDC_LOGOUT_ENDPOINT)) {
+                if (StringUtils.equals(request.getParameter(TYPE), FrameworkConstants.RequestType.CLAIM_TYPE_OIDC)) {
                     // If a logout request is triggered from an OIDC app then the OIDCLogoutServlet
                     // and OIDCLogoutEventHandler both are triggered and the logout request is handled in both
                     // places.

--- a/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/util/OIDCSessionManagementUtil.java
+++ b/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/util/OIDCSessionManagementUtil.java
@@ -224,7 +224,7 @@ public class OIDCSessionManagementUtil {
             oidcLogoutConsentPageUrl =
                     IdentityUtil.getServerURL("/authenticationendpoint/oauth2_logout_consent.do", false, false);
         }
-        return oidcLogoutConsentPageUrl;
+        return IdentityUtil.resolveURL(oidcLogoutConsentPageUrl, false, false);
     }
 
     /**
@@ -239,7 +239,7 @@ public class OIDCSessionManagementUtil {
             oidcLogoutPageUrl =
                     IdentityUtil.getServerURL("/authenticationendpoint/oauth2_logout.do", false, false);
         }
-        return oidcLogoutPageUrl;
+        return IdentityUtil.resolveURL(oidcLogoutPageUrl, false, false);
     }
 
     /**
@@ -266,7 +266,7 @@ public class OIDCSessionManagementUtil {
             }
         }
 
-        return errorPageUrl;
+        return IdentityUtil.resolveURL(errorPageUrl, false, false);
     }
 
     /**

--- a/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/util/OIDCSessionManagementUtil.java
+++ b/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/util/OIDCSessionManagementUtil.java
@@ -218,13 +218,8 @@ public class OIDCSessionManagementUtil {
      */
     public static String getOIDCLogoutConsentURL() {
 
-        String oidcLogoutConsentPageUrl = OIDCSessionManagementConfiguration.getInstance()
-                .getOIDCLogoutConsentPageUrl();
-        if (StringUtils.isBlank(oidcLogoutConsentPageUrl)) {
-            oidcLogoutConsentPageUrl =
-                    IdentityUtil.getServerURL("/authenticationendpoint/oauth2_logout_consent.do", false, false);
-        }
-        return IdentityUtil.resolveURL(oidcLogoutConsentPageUrl, false, false);
+        return OAuth2Util.buildServiceUrl(OAuthConstants.OAuth20Endpoints.OIDC_LOGOUT_CONSENT_EP_URL,
+                OIDCSessionManagementConfiguration.getInstance().getOIDCLogoutConsentPageUrl());
     }
 
     /**
@@ -234,12 +229,8 @@ public class OIDCSessionManagementUtil {
      */
     public static String getOIDCLogoutURL() {
 
-        String oidcLogoutPageUrl = OIDCSessionManagementConfiguration.getInstance().getOIDCLogoutPageUrl();
-        if (StringUtils.isBlank(oidcLogoutPageUrl)) {
-            oidcLogoutPageUrl =
-                    IdentityUtil.getServerURL("/authenticationendpoint/oauth2_logout.do", false, false);
-        }
-        return IdentityUtil.resolveURL(oidcLogoutPageUrl, false, false);
+        return OAuth2Util.buildServiceUrl(OAuthConstants.OAuth20Endpoints.OIDC_DEFAULT_LOGOUT_RESPONSE_URL,
+                OIDCSessionManagementConfiguration.getInstance().getOIDCLogoutPageUrl());
     }
 
     /**
@@ -251,11 +242,7 @@ public class OIDCSessionManagementUtil {
      */
     public static String getErrorPageURL(String errorCode, String errorMessage) {
 
-        String errorPageUrl = OAuthServerConfiguration.getInstance().getOauth2ErrorPageUrl();
-        if (StringUtils.isBlank(errorPageUrl)) {
-            errorPageUrl = IdentityUtil.getServerURL("/authenticationendpoint/oauth2_error.do", false, false);
-        }
-
+        String errorPageUrl = OAuth2Util.OAuthURL.getOAuth2ErrorPageUrl();
         try {
             errorPageUrl += "?" + OAuthConstants.OAUTH_ERROR_CODE + "=" + URLEncoder.encode(errorCode, "UTF-8") + "&"
                     + OAuthConstants.OAUTH_ERROR_MESSAGE + "=" + URLEncoder.encode(errorMessage, "UTF-8");
@@ -266,7 +253,7 @@ public class OIDCSessionManagementUtil {
             }
         }
 
-        return IdentityUtil.resolveURL(errorPageUrl, false, false);
+        return errorPageUrl;
     }
 
     /**

--- a/components/org.wso2.carbon.identity.oidc.session/src/test/java/org/wso2/carbon/identity/oidc/session/servlet/OIDCLogoutServletTest.java
+++ b/components/org.wso2.carbon.identity.oidc.session/src/test/java/org/wso2/carbon/identity/oidc/session/servlet/OIDCLogoutServletTest.java
@@ -33,6 +33,9 @@ import org.wso2.carbon.identity.application.authentication.framework.CommonAuthe
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
 import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
+import org.wso2.carbon.identity.core.ServiceURL;
+import org.wso2.carbon.identity.core.ServiceURLBuilder;
+import org.wso2.carbon.identity.core.URLBuilderException;
 import org.wso2.carbon.identity.core.util.IdentityConfigParser;
 import org.wso2.carbon.identity.core.util.IdentityDatabaseUtil;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
@@ -40,6 +43,7 @@ import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
 import org.wso2.carbon.identity.oauth.dao.OAuthAppDO;
 import org.wso2.carbon.identity.oauth.tokenprocessor.TokenPersistenceProcessor;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
+import org.wso2.carbon.identity.oidc.session.OIDCSessionConstants;
 import org.wso2.carbon.identity.oidc.session.OIDCSessionManager;
 import org.wso2.carbon.identity.oidc.session.internal.OIDCSessionManagementComponentServiceHolder;
 import org.wso2.carbon.identity.oidc.session.util.OIDCSessionManagementUtil;
@@ -58,6 +62,7 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
+import static org.powermock.api.mockito.PowerMockito.mock;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.when;
 import static org.testng.Assert.assertEquals;
@@ -66,9 +71,9 @@ import static org.testng.Assert.assertTrue;
 @PrepareForTest({OIDCSessionManagementUtil.class, OIDCSessionManager.class, FrameworkUtils.class,
         IdentityConfigParser.class, OAuthServerConfiguration.class, IdentityTenantUtil.class, KeyStoreManager.class,
         CarbonCoreDataHolder.class, IdentityDatabaseUtil.class, OAuth2Util.class,
-        OIDCSessionManagementComponentServiceHolder.class})
-/**
- * Unit test coverage for OIDCLogoutServlet class.
+        OIDCSessionManagementComponentServiceHolder.class, ServiceURLBuilder.class})
+/*
+  Unit test coverage for OIDCLogoutServlet class.
  */
 public class OIDCLogoutServletTest extends TestOIDCSessionBase {
 
@@ -369,6 +374,8 @@ public class OIDCLogoutServletTest extends TestOIDCSessionBase {
         when(keyStoreManager.getKeyStore(anyString())).thenReturn(TestUtil.loadKeyStoreFromFileSystem(TestUtil
                 .getFilePath("wso2carbon.jks"), "wso2carbon", "JKS"));
 
+        mockServiceURLBuilder(OIDCSessionConstants.OIDCEndpoints.OIDC_LOGOUT_ENDPOINT);
+
         ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
         logoutServlet.doGet(request, response);
         verify(response).sendRedirect(captor.capture());
@@ -515,5 +522,17 @@ public class OIDCLogoutServletTest extends TestOIDCSessionBase {
     public void cleanData() throws Exception {
 
         super.cleanData();
+    }
+
+    private void mockServiceURLBuilder(String context) throws URLBuilderException {
+
+        mockStatic(ServiceURLBuilder.class);
+        ServiceURLBuilder serviceURLBuilder = mock(ServiceURLBuilder.class);
+        when(ServiceURLBuilder.create()).thenReturn(serviceURLBuilder);
+        when(serviceURLBuilder.addPath(any())).thenReturn(serviceURLBuilder);
+
+        ServiceURL serviceURL = mock(ServiceURL.class);
+        when(serviceURL.getRelativeURL()).thenReturn(context);
+        when(serviceURLBuilder.build()).thenReturn(serviceURL);
     }
 }


### PR DESCRIPTION
Fixes:
wso2/product-is#8027

Related issues:
wso2/product-is#7993

This PR builds on the changes done by @ashendes in https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/1349

With this PR, when the tenant qualified URL mode is enabled by adding the below config to deployement.toml all outbound redirects in the OAuth/OIDC flows will use tenant qualified URLs.

```
[tenant_context]
enable_tenant_qualified_urls = "true"
```

A few outbound redirects happening in the OAuth flows would be,
1. Redirect to login page
2. Redirect to login / logout consent pages
3. Redirect to the error page