### PR TITLE
Fix failure to run unit tests directly from IDE test run

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/pom.xml
+++ b/components/org.wso2.carbon.identity.oauth/pom.xml
@@ -44,6 +44,16 @@
             <artifactId>tomcat-coyote</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>commons-lang.wso2</groupId>
             <artifactId>commons-lang</artifactId>
         </dependency>

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/util/OAuth2UtilTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/util/OAuth2UtilTest.java
@@ -36,6 +36,7 @@ import org.wso2.carbon.CarbonConstants;
 import org.wso2.carbon.base.MultitenantConstants;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
+import org.wso2.carbon.identity.common.testng.WithCarbonHome;
 import org.wso2.carbon.identity.core.internal.IdentityCoreServiceComponent;
 import org.wso2.carbon.identity.core.util.IdentityConfigParser;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
@@ -94,6 +95,7 @@ import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
+@WithCarbonHome
 @PrepareForTest({OAuthServerConfiguration.class, OAuthCache.class, IdentityUtil.class, OAuthConsumerDAO.class,
         OAuth2Util.class, OAuthComponentServiceHolder.class, AppInfoCache.class, IdentityConfigParser.class,
         PrivilegedCarbonContext.class, IdentityTenantUtil.class, CarbonUtils.class,
@@ -1027,7 +1029,7 @@ public class OAuth2UtilTest extends PowerMockIdentityBaseTest {
                 {true, "https://localhost:9443/testUrl", "https://localhost:9443/testUrl", "testDomain",
                         "https://localhost:9443/t/testDomain/oauth2/jwks"},
                 {true, "", "https://localhost:9443/testUrl", "",
-                        "https://localhost:9443/t/carbon.super/oauth2/jwks"},
+                        "https://localhost:9443/oauth2/jwks"},
                 {false, "", "https://localhost:9443/testUrl", "testDomain",
                         "https://localhost:9443/t/testDomain/testUrl"},
                 {false, "", "https://localhost:9443/testUrl", "testDomain",
@@ -1037,7 +1039,7 @@ public class OAuth2UtilTest extends PowerMockIdentityBaseTest {
         };
     }
 
-    @Test(dataProvider = "OAuthTenantSupportURLData1")
+    @Test(dataProvider = "OAuthJWKSPageUrlData")
     public void testGetOAuth2JWKSPageUrl(Boolean enableTenantURLSupport, String configUrl, String serverUrl,
                                          String tenantDomain, String oauthUrl) throws Exception {
 

--- a/pom.xml
+++ b/pom.xml
@@ -401,6 +401,18 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-api</artifactId>
+                <version>${log4j.api.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-core</artifactId>
+                <scope>test</scope>
+                <version>${log4j.core.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.wso2.carbon.identity.inbound.auth.oauth2</groupId>
                 <artifactId>org.wso2.carbon.identity.oauth.endpoint</artifactId>
                 <version>${project.version}</version>
@@ -978,6 +990,10 @@
 
         <!-- Pax Logging Version -->
         <pax.logging.api.version>1.10.1</pax.logging.api.version>
+
+        <!-- Log4j -->
+        <log4j.api.version>2.12.0</log4j.api.version>
+        <log4j.core.version>2.12.0</log4j.core.version>
 
         <maven.checkstyleplugin.version>3.1.0</maven.checkstyleplugin.version>
         <spotbugs-maven-plugin.version>3.1.12</spotbugs-maven-plugin.version>


### PR DESCRIPTION
### Proposed changes in this pull request

Fixes the below error encountered when trying to run unit tests using IDE run

```
org.testng.TestNGException: 
Error creating object factory: class org.wso2.carbon.identity.oauth.endpoint.authz.OAuth2AuthzEndpointTest
	at org.testng.internal.TestNGClassFinder.<init>(TestNGClassFinder.java:86)
	at org.testng.TestRunner.initMethods(TestRunner.java:424)
	at org.testng.TestRunner.init(TestRunner.java:247)
	at org.testng.TestRunner.init(TestRunner.java:217)
	at org.testng.TestRunner.<init>(TestRunner.java:161)
	at org.testng.SuiteRunner$DefaultTestRunnerFactory.newTestRunner(SuiteRunner.java:556)
	at org.testng.SuiteRunner.init(SuiteRunner.java:168)
	at org.testng.SuiteRunner.<init>(SuiteRunner.java:117)
	at org.testng.TestNG.createSuiteRunner(TestNG.java:1319)
	at org.testng.TestNG.createSuiteRunners(TestNG.java:1306)
	at org.testng.TestNG.runSuitesLocally(TestNG.java:1160)
	at org.testng.TestNG.run(TestNG.java:1064)
	at com.intellij.rt.testng.IDEARemoteTestNG.run(IDEARemoteTestNG.java:66)
	at com.intellij.rt.testng.RemoteTestNGStarter.main(RemoteTestNGStarter.java:110)
Caused by: java.lang.ClassCastException: org.ops4j.pax.logging.log4jv2.Log4jv2Logger cannot be cast to org.apache.logging.log4j.core.Logger
	at org.wso2.carbon.identity.testutil.log.LogUtil.configureAndAddConsoleAppender(LogUtil.java:43)
	at org.wso2.carbon.identity.testutil.powermock.PowerMockIdentityBaseTest.<init>(PowerMockIdentityBaseTest.java:54)
	at org.wso2.carbon.identity.oauth.endpoint.util.TestOAuthEndpointBase.<init>(TestOAuthEndpointBase.java:31)
	at org.wso2.carbon.identity.oauth.endpoint.authz.OAuth2AuthzEndpointTest.<init>(OAuth2AuthzEndpointTest.java:149)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
	at java.lang.Class.newInstance(Class.java:442)
	at org.testng.internal.TestNGClassFinder.<init>(TestNGClassFinder.java:77)
	... 13 more
```

This fix is only for the org.wso2.carbon.identity.oauth module. We can extend the same for the other modules too.
