### PR TITLE
Validate request tenant domain in tenant qualified URL mode

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/pom.xml
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/pom.xml
@@ -34,6 +34,16 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.wso2.orbit.org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
         </dependency>

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/token/OAuth2TokenEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/token/OAuth2TokenEndpoint.java
@@ -19,12 +19,12 @@
 package org.wso2.carbon.identity.oauth.endpoint.token;
 
 import org.apache.commons.collections.MapUtils;
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.cxf.interceptor.InInterceptors;
 import org.apache.oltu.oauth2.as.response.OAuthASResponse;
 import org.apache.oltu.oauth2.as.response.OAuthASResponse.OAuthTokenResponseBuilder;
-import org.apache.oltu.oauth2.common.OAuth;
 import org.apache.oltu.oauth2.common.error.OAuthError;
 import org.apache.oltu.oauth2.common.exception.OAuthProblemException;
 import org.apache.oltu.oauth2.common.exception.OAuthSystemException;
@@ -34,11 +34,9 @@ import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.oauth.client.authn.filter.OAuthClientAuthenticatorProxy;
 import org.wso2.carbon.identity.oauth.common.OAuth2ErrorCodes;
 import org.wso2.carbon.identity.oauth.common.OAuthConstants;
-import org.wso2.carbon.identity.oauth.common.exception.OAuthClientException;
 import org.wso2.carbon.identity.oauth.endpoint.OAuthRequestWrapper;
 import org.wso2.carbon.identity.oauth.endpoint.exception.InvalidApplicationClientException;
 import org.wso2.carbon.identity.oauth.endpoint.exception.InvalidRequestParentException;
-import org.wso2.carbon.identity.oauth.endpoint.exception.TokenEndpointAccessDeniedException;
 import org.wso2.carbon.identity.oauth.endpoint.exception.TokenEndpointBadRequestException;
 import org.wso2.carbon.identity.oauth.endpoint.util.EndpointUtil;
 import org.wso2.carbon.identity.oauth2.ResponseHeader;
@@ -149,7 +147,7 @@ public class OAuth2TokenEndpoint {
     }
 
     private void validateOAuthApplication(OAuthClientAuthnContext oAuthClientAuthnContext)
-            throws InvalidApplicationClientException, TokenEndpointBadRequestException {
+            throws InvalidApplicationClientException {
 
         if (isNotBlank(oAuthClientAuthnContext.getClientId()) && !oAuthClientAuthnContext
                 .isMultipleAuthenticatorsEngaged()) {
@@ -173,8 +171,7 @@ public class OAuth2TokenEndpoint {
 
         // Set custom parameters in token response if supported
         if (MapUtils.isNotEmpty(oauth2AccessTokenResp.getParameters())) {
-            oauth2AccessTokenResp.getParameters().forEach((paramKey, paramValue) -> oAuthRespBuilder.setParam
-                    (paramKey, paramValue));
+            oauth2AccessTokenResp.getParameters().forEach(oAuthRespBuilder::setParam);
         }
 
         OAuthResponse response = oAuthRespBuilder.buildJSONMessage();
@@ -201,7 +198,7 @@ public class OAuth2TokenEndpoint {
 
         // if there is an auth failure, HTTP 401 Status Code should be sent back to the client.
         if (OAuth2ErrorCodes.INVALID_CLIENT.equals(oauth2AccessTokenResp.getErrorCode())) {
-            return handleBasicAuthFailure(oauth2AccessTokenResp.getErrorCode(), oauth2AccessTokenResp.getErrorMsg());
+            return handleBasicAuthFailure(oauth2AccessTokenResp.getErrorMsg());
         } else if (SQL_ERROR.equals(oauth2AccessTokenResp.getErrorCode())) {
             return handleSQLError();
         } else if (OAuth2ErrorCodes.SERVER_ERROR.equals(oauth2AccessTokenResp.getErrorCode())) {
@@ -228,64 +225,15 @@ public class OAuth2TokenEndpoint {
         }
     }
 
-    private String getConsumerKey(HttpServletRequestWrapper httpRequest) {
+    private Response handleBasicAuthFailure(String errorMessage) throws OAuthSystemException {
 
-        if (log.isDebugEnabled()) {
-            log.debug("Consumer key:" + httpRequest.getParameter(OAuth.OAUTH_CLIENT_ID));
+        if (StringUtils.isBlank(errorMessage)) {
+            errorMessage = "Client Authentication failed.";
         }
-        return httpRequest.getParameter(OAuth.OAUTH_CLIENT_ID);
-    }
-
-    private void validateAuthorizationHeader(HttpServletRequest request, MultivaluedMap<String, String> paramMap)
-            throws TokenEndpointAccessDeniedException {
-
-        try {
-            // The client MUST NOT use more than one authentication method in each request
-            if (isClientCredentialsExistsAsParams(paramMap)) {
-                if (log.isDebugEnabled()) {
-                    log.debug("Client Id and Client Secret found in request body and Authorization header" +
-                            ". Credentials should be sent in either request body or Authorization header, not both");
-                }
-                throw new TokenEndpointAccessDeniedException("Client Authentication failed");
-            }
-            String[] credentials = getClientCredentials(request);
-            // add the credentials available in Authorization header to the parameter map
-            paramMap.add(OAuth.OAUTH_CLIENT_ID, credentials[0]);
-            paramMap.add(OAuth.OAUTH_CLIENT_SECRET, credentials[1]);
-
-            if (log.isDebugEnabled()) {
-                log.debug("Client credentials extracted from the Authorization Header");
-            }
-
-        } catch (OAuthClientException e) {
-            // malformed credential string is considered as an auth failure.
-            if (log.isDebugEnabled()) {
-                log.error("Error while extracting credentials from authorization header", e);
-            }
-        }
-    }
-
-    private boolean isClientCredentialsExistsAsParams(MultivaluedMap<String, String> paramMap) {
-
-        return paramMap.containsKey(OAuth.OAUTH_CLIENT_ID) && paramMap.containsKey(OAuth.OAUTH_CLIENT_SECRET);
-    }
-
-    private String[] getClientCredentials(HttpServletRequest request) throws OAuthClientException {
-
-        return EndpointUtil.extractCredentialsFromAuthzHeader(
-                request.getHeader(OAuthConstants.HTTP_REQ_HEADER_AUTHZ));
-    }
-
-    private boolean isAuthorizationHeaderExists(HttpServletRequest request) {
-
-        return request.getHeader(OAuthConstants.HTTP_REQ_HEADER_AUTHZ) != null;
-    }
-
-    private Response handleBasicAuthFailure(String errorCode, String errorMessage) throws OAuthSystemException {
 
         OAuthResponse response = OAuthASResponse.errorResponse(HttpServletResponse.SC_UNAUTHORIZED)
                 .setError(OAuth2ErrorCodes.INVALID_CLIENT)
-                .setErrorDescription("Client Authentication failed.").buildJSONMessage();
+                .setErrorDescription(errorMessage).buildJSONMessage();
         return Response.status(response.getResponseStatus())
                 .header(OAuthConstants.HTTP_RESP_HEADER_AUTHENTICATE, EndpointUtil.getRealmInfo())
                 .entity(response.getBody()).build();
@@ -328,7 +276,7 @@ public class OAuth2TokenEndpoint {
         tokenReqDTO.setClientId(oauthClientAuthnContext.getClientId());
         tokenReqDTO.setClientSecret(oauthRequest.getClientSecret());
         tokenReqDTO.setCallbackURI(oauthRequest.getRedirectURI());
-        tokenReqDTO.setScope(oauthRequest.getScopes().toArray(new String[oauthRequest.getScopes().size()]));
+        tokenReqDTO.setScope(oauthRequest.getScopes().toArray(new String[0]));
         tokenReqDTO.setTenantDomain(oauthRequest.getTenantDomain());
         tokenReqDTO.setPkceCodeVerifier(oauthRequest.getPkceCodeVerifier());
         // Set all request parameters to the OAuth2AccessTokenReqDTO

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuerTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuerTest.java
@@ -228,7 +228,7 @@ public class AccessTokenIssuerTest extends PowerMockIdentityBaseTest {
     }
 
     /**
-     * Tests whether cross tenant token requests fail.
+     * Tests whether cross tenant token requests fail in tenant qualified URL mode.
      *
      * @throws Exception
      */

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuerTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuerTest.java
@@ -36,6 +36,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.ObjectFactory;
 import org.testng.annotations.Test;
 import org.wso2.carbon.identity.base.IdentityException;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.oauth.cache.AppInfoCache;
 import org.wso2.carbon.identity.oauth.common.OAuth2ErrorCodes;
 import org.wso2.carbon.identity.oauth.common.OAuthConstants;
@@ -84,7 +85,8 @@ import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OauthAppState
         OAuth2Util.class,
         AppInfoCache.class,
         JDBCPermissionBasedInternalScopeValidator.class,
-        CarbonUtils.class
+        CarbonUtils.class,
+        IdentityTenantUtil.class
 })
 public class AccessTokenIssuerTest extends PowerMockIdentityBaseTest {
 
@@ -102,9 +104,6 @@ public class AccessTokenIssuerTest extends PowerMockIdentityBaseTest {
     private OAuth2AccessTokenRespDTO mockOAuth2AccessTokenRespDTO;
 
     @Mock
-    private OAuth2AccessTokenReqDTO tokenReqDTO;
-
-    @Mock
     private JDBCPermissionBasedInternalScopeValidator scopeValidator;
 
     private static final String DUMMY_GRANT_TYPE = "dummy_grant_type";
@@ -119,6 +118,7 @@ public class AccessTokenIssuerTest extends PowerMockIdentityBaseTest {
 
         mockStatic(OAuthServerConfiguration.class);
         when(OAuthServerConfiguration.getInstance()).thenReturn(oAuthServerConfiguration);
+        when(oAuthServerConfiguration.getTimeStampSkewInSeconds()).thenReturn(3600L);
 
         mockStatic(OAuth2Util.class);
         when(OAuth2Util.getAppInformationByClientId(anyString())).thenReturn(mockOAuthAppDO);
@@ -160,55 +160,41 @@ public class AccessTokenIssuerTest extends PowerMockIdentityBaseTest {
         // isAuthorizedAccessDelegation,
         // isValidScope,
         // isAuthenticatedClient,
-        // canAuthenticate,
         // isTokenIssuingSuccess
         return new Object[][]{
-                {true, true, true, true, true, true, true, false},
-                {true, true, false, true, true, true, true, false},
-                {true, true, true, false, true, true, true, false},
-                {true, true, true, true, false, true, true, false},
-                {true, true, true, true, true, false, true, false},
-                {true, true, false, true, true, true, true, false},
-                {true, true, true, false, true, true, true, false},
-                {true, true, true, true, false, true, true, false},
-                {true, true, true, true, true, false, true, false}
+                {true, true, true, true, true, true},
+                {false, true, true, true, true, false},
+                {true, false, true, true, true, false},
+                {true, true, false, true, true, false},
+                {true, true, true, false, true, false},
+                {true, true, true, true, false, false},
         };
     }
 
     @Test(dataProvider = "AccessTokenIssue")
-    public void testIssue(boolean isOfTypeApplicationUser,
-                          boolean isAuthorizedClient,
+    public void testIssue(boolean isAuthorizedClient,
                           boolean isValidGrant,
                           boolean isAuthorizedAccessDelegation,
                           boolean isValidScope,
                           boolean isAuthenticatedClient,
-                          boolean canAuthenticate,
-                          boolean success) throws IdentityException {
+                          boolean isTokenIssueSuccess) throws IdentityException {
 
-        when(oAuthServerConfiguration.getTimeStampSkewInSeconds()).thenReturn(3600L);
+        mockPasswordGrantHandler(isAuthorizedClient, isValidGrant, isAuthorizedAccessDelegation, isValidScope);
 
-        Map<String, AuthorizationGrantHandler> authzGrantHandlers = new Hashtable<>();
+        OAuth2AccessTokenReqDTO reqDTO = new OAuth2AccessTokenReqDTO();
+        reqDTO.setGrantType(OAuthConstants.GrantTypes.PASSWORD);
+        reqDTO.setClientId(SOME_CLIENT_ID);
 
-        when(passwordGrantHandler.isOfTypeApplicationUser()).thenReturn(isOfTypeApplicationUser);
-        when(passwordGrantHandler.isAuthorizedClient(any(OAuthTokenReqMessageContext.class)))
-                .thenReturn(isAuthorizedClient);
-        when(passwordGrantHandler.validateGrant(any(OAuthTokenReqMessageContext.class))).thenReturn(isValidGrant);
-        when(passwordGrantHandler.authorizeAccessDelegation(any(OAuthTokenReqMessageContext.class)))
-                .thenReturn(isAuthorizedAccessDelegation);
-        when(passwordGrantHandler.validateScope(any(OAuthTokenReqMessageContext.class))).thenReturn(isValidScope);
-        when(passwordGrantHandler.issue(any(OAuthTokenReqMessageContext.class)))
-                .thenReturn(mockOAuth2AccessTokenRespDTO);
-        authzGrantHandlers.put("password", passwordGrantHandler);
-        when(passwordGrantHandler.isConfidentialClient()).thenReturn(true);
+        OAuthClientAuthnContext oAuthClientAuthnContext = new OAuthClientAuthnContext();
+        oAuthClientAuthnContext.setAuthenticated(isAuthenticatedClient);
+        reqDTO.setoAuthClientAuthnContext(oAuthClientAuthnContext);
 
-        when(oAuthServerConfiguration.getSupportedGrantTypes()).thenReturn(authzGrantHandlers);
         AccessTokenIssuer tokenIssuer = AccessTokenIssuer.getInstance();
+        OAuth2AccessTokenRespDTO tokenRespDTO = tokenIssuer.issue(reqDTO);
 
-        when(tokenReqDTO.getGrantType()).thenReturn("password");
-        when(tokenReqDTO.getClientId()).thenReturn(SOME_CLIENT_ID);
-
-        OAuth2AccessTokenRespDTO tokenRespDTO = tokenIssuer.issue(tokenReqDTO);
-        Assert.assertEquals(tokenRespDTO.isError(), !success);
+        if (isTokenIssueSuccess) {
+            Assert.assertFalse(tokenRespDTO.isError());
+        }
     }
 
     /**
@@ -230,6 +216,39 @@ public class AccessTokenIssuerTest extends PowerMockIdentityBaseTest {
         assertTrue(tokenRespDTO.isError());
         assertEquals(tokenRespDTO.getErrorCode(), OAuthError.TokenResponse.INVALID_REQUEST, "Error Code has been " +
                 "changed. Previously it was: " + OAuthError.TokenResponse.INVALID_REQUEST);
+    }
+
+    @DataProvider(name = "tenantDataProvider")
+    public Object[][] getTenantDomainData() {
+
+        return new Object[][]{
+                {"non_super_tenant.com"},
+                {null}
+        };
+    }
+
+    /**
+     * Tests whether cross tenant token requests fail.
+     *
+     * @throws Exception
+     */
+    @Test (dataProvider = "tenantDataProvider" , expectedExceptions = InvalidOAuthClientException.class)
+    public void testCrossTenantTokenRequestError(String tenantInContext) throws Exception {
+
+        OAuth2AccessTokenReqDTO reqDTO = new OAuth2AccessTokenReqDTO();
+        reqDTO.setGrantType("password");
+
+        OAuthClientAuthnContext oAuthClientAuthnContext = new OAuthClientAuthnContext();
+        oAuthClientAuthnContext.setAuthenticated(true);
+        reqDTO.setoAuthClientAuthnContext(oAuthClientAuthnContext);
+
+        mockStatic(IdentityTenantUtil.class);
+        when(IdentityTenantUtil.isTenantQualifiedUrlsEnabled()).thenReturn(true);
+        when(IdentityTenantUtil.getTenantDomainFromContext()).thenReturn(tenantInContext);
+
+        mockPasswordGrantHandler(true, true, true, true);
+
+        AccessTokenIssuer.getInstance().issue(reqDTO);
     }
 
     /**
@@ -740,6 +759,27 @@ public class AccessTokenIssuerTest extends PowerMockIdentityBaseTest {
         when(idTokenBuilder.buildIDToken(any(OAuthTokenReqMessageContext.class), any(OAuth2AccessTokenRespDTO.class)))
                 .thenThrow(new IDTokenValidationFailureException("ID Token Validation failed"));
         return idTokenBuilder;
+    }
+
+    private void mockPasswordGrantHandler(boolean isAuthorizedClient, boolean isValidGrant,
+                                          boolean isAuthorizedAccessDelegation, boolean isValidScope)
+            throws IdentityOAuth2Exception {
+
+        Map<String, AuthorizationGrantHandler> authzGrantHandlers = new Hashtable<>();
+
+        when(passwordGrantHandler.isOfTypeApplicationUser()).thenReturn(true);
+        when(passwordGrantHandler.isAuthorizedClient(any(OAuthTokenReqMessageContext.class)))
+                .thenReturn(isAuthorizedClient);
+        when(passwordGrantHandler.validateGrant(any(OAuthTokenReqMessageContext.class))).thenReturn(isValidGrant);
+        when(passwordGrantHandler.authorizeAccessDelegation(any(OAuthTokenReqMessageContext.class)))
+                .thenReturn(isAuthorizedAccessDelegation);
+        when(passwordGrantHandler.validateScope(any(OAuthTokenReqMessageContext.class))).thenReturn(isValidScope);
+        when(passwordGrantHandler.issue(any(OAuthTokenReqMessageContext.class)))
+                .thenReturn(new OAuth2AccessTokenRespDTO());
+        authzGrantHandlers.put("password", passwordGrantHandler);
+        when(passwordGrantHandler.isConfidentialClient()).thenReturn(true);
+
+        when(oAuthServerConfiguration.getSupportedGrantTypes()).thenReturn(authzGrantHandlers);
     }
 
     @ObjectFactory


### PR DESCRIPTION
In tenant qualified URL mode we have the tenant domain sent in path param as a value in the thread-local context. 

For example https://localhost:9443/t/wso2.com/oauth2/token

- With this PR, we validate the tenant domain in the context against the tenant domain derived from the client_id. This will prevent cross tenant access.

For example, if you create an OAuth app in tenant domain foo.com and use the URL of bar.com as the token endpoint https://localhost:9443/t/bar.com/oauth2/token for the request, you will get an error

```
{
    "error_description": "Invalid Client",
    "error": "invalid_client"
}
```

- Pass error message set in the AccessTokenIssuer level to the Response build by the endpoint.