### PR TITLE
Ensure claims are retrieved from the correct tenant domain

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/ClaimUtil.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/ClaimUtil.java
@@ -214,7 +214,7 @@ public class ClaimUtil {
                     if (e.getMessage().contains("UserNotFound")) {
                         if (log.isDebugEnabled()) {
                             log.debug(StringUtils.isNotEmpty(authorizedUserName) ? "User with username: "
-                                    + authorizedUserName + ", cannot be found in " + "user store" : "User cannot " +
+                                    + authorizedUserName + ", cannot be found in user store" : "User cannot " +
                                     "found in user store");
                         }
                     }

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/ClaimUtil.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/ClaimUtil.java
@@ -107,8 +107,8 @@ public class ClaimUtil {
             throws UserInfoEndpointException {
 
         try {
-            String username = tokenResponse.getAuthorizedUser();
-            String userTenantDomain = MultitenantUtils.getTenantDomain(tokenResponse.getAuthorizedUser());
+            String username;
+            String userTenantDomain;
             UserRealm realm;
             List<String> claimURIList = new ArrayList<>();
             Map<String, Object> mappedAppClaims = new HashMap<>();
@@ -117,6 +117,9 @@ public class ClaimUtil {
             try {
                 AccessTokenDO accessTokenDO = OAuth2Util.getAccessTokenDOfromTokenIdentifier(
                         OAuth2Util.getAccessTokenIdentifier(tokenResponse));
+                username = accessTokenDO.getAuthzUser().getUserName();
+                userTenantDomain = accessTokenDO.getAuthzUser().getTenantDomain();
+
                 // If the authenticated user is a federated user and had not mapped to local users, no requirement to
                 // retrieve claims from local userstore.
                 if (!OAuthServerConfiguration.getInstance().isMapFederatedUsersToLocal() && accessTokenDO != null) {
@@ -161,7 +164,7 @@ public class ClaimUtil {
                     spToLocalClaimMappings = ClaimMetadataHandler.getInstance().getMappingsMapFromOtherDialectToCarbon
                             (SP_DIALECT, null, userTenantDomain, true);
 
-                    realm = getUserRealm(username, userTenantDomain);
+                    realm = getUserRealm(null, userTenantDomain);
                     Map<String, String> userClaims = getUserClaimsFromUserStore(username, realm, claimURIList);
 
                     if (isNotEmpty(userClaims)) {
@@ -206,16 +209,21 @@ public class ClaimUtil {
                 }
                 mappedAppClaims.put(OAuth2Util.SUB, subjectClaimValue);
             } catch (Exception e) {
+                String authorizedUserName = tokenResponse.getAuthorizedUser();
                 if (e instanceof UserStoreException) {
                     if (e.getMessage().contains("UserNotFound")) {
                         if (log.isDebugEnabled()) {
-                            log.debug("User " + username + " not found in user store");
+                            log.debug(StringUtils.isNotEmpty(authorizedUserName) ? "User with username: "
+                                    + authorizedUserName + ", cannot be found in " + "user store" : "User cannot " +
+                                    "found in user store");
                         }
                     }
                 } else {
-                    log.error("Error while retrieving the claims from user store for " + username, e);
-                    throw new IdentityOAuth2Exception("Error while retrieving the claims from user store for "
-                            + username);
+                    String errMsg = StringUtils.isNotEmpty(authorizedUserName) ? "Error while retrieving the claims " +
+                            "from user store for the username: " + authorizedUserName : "Error while retrieving the " +
+                            "claims from user store";
+                    log.error(errMsg, e);
+                    throw new IdentityOAuth2Exception(errMsg);
                 }
             }
             return mappedAppClaims;

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/util/ClaimUtilTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/util/ClaimUtilTest.java
@@ -253,7 +253,8 @@ public class ClaimUtilTest extends PowerMockIdentityBaseTest {
 
         mockOAuth2Util();
 
-        AccessTokenDO accessTokenDO = getAccessTokenDO(clientId, userStoreDomain, isFederated);
+        AccessTokenDO accessTokenDO = getAccessTokenDO(clientId, getAuthenticatedUser("carbon.super", userStoreDomain,
+                "test-user", isFederated));
         if (mockAccessTokenDO) {
             when(OAuth2Util.getAccessTokenDOfromTokenIdentifier(anyString())).thenReturn(accessTokenDO);
         }
@@ -330,10 +331,28 @@ public class ClaimUtilTest extends PowerMockIdentityBaseTest {
         return accessTokenDO;
     }
 
+    private AccessTokenDO getAccessTokenDO(String clientId, AuthenticatedUser authenticatedUser) {
+        AccessTokenDO accessTokenDO = new AccessTokenDO();
+        accessTokenDO.setConsumerKey(clientId);
+        accessTokenDO.setAuthzUser(authenticatedUser);
+        return accessTokenDO;
+    }
+
     private AuthenticatedUser getAuthenticatedUser(String userStoreDomain, boolean isFederated) {
 
         AuthenticatedUser authenticatedUser = new AuthenticatedUser();
         authenticatedUser.setUserStoreDomain(userStoreDomain);
+        authenticatedUser.setFederatedUser(isFederated);
+        return authenticatedUser;
+    }
+
+    private AuthenticatedUser getAuthenticatedUser(String tenantDomain, String userStoreDomain, String username,
+                                                   boolean isFederated) {
+
+        AuthenticatedUser authenticatedUser = new AuthenticatedUser();
+        authenticatedUser.setTenantDomain(tenantDomain);
+        authenticatedUser.setUserStoreDomain(userStoreDomain);
+        authenticatedUser.setUserName(username);
         authenticatedUser.setFederatedUser(isFederated);
         return authenticatedUser;
     }

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/util/ClaimUtilTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/util/ClaimUtilTest.java
@@ -332,6 +332,7 @@ public class ClaimUtilTest extends PowerMockIdentityBaseTest {
     }
 
     private AccessTokenDO getAccessTokenDO(String clientId, AuthenticatedUser authenticatedUser) {
+    
         AccessTokenDO accessTokenDO = new AccessTokenDO();
         accessTokenDO.setConsumerKey(clientId);
         accessTokenDO.setAuthzUser(authenticatedUser);


### PR DESCRIPTION
### Proposed changes in this pull request

- Fixes wso2/product-is#8217.
- A token response can be subjected to pre-processing, thus it could lose tenant domain context information. For example, when BuildSubjectIdentifierFromSPConfig property is enabled, the token response passed to the method for an /userinfo request does not contain tenant domain in the authorized username, thus leading the user to be considered as belonging in the super tenant.
- Therefore user's claim is retrieved, once the tenant domain is correctly identified from the accessTokenDO data.
