### PR TITLE
Restrict cross tenant domain requests in tenant qualifed URL mode

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/OAuth2Service.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/OAuth2Service.java
@@ -67,6 +67,7 @@ import java.util.Map;
 
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.TokenBindings.NONE;
 import static org.wso2.carbon.identity.oauth2.util.OAuth2Util.isValidTokenBinding;
+import static org.wso2.carbon.identity.oauth2.util.OAuth2Util.validateRequestTenantDomain;
 
 /**
  * OAuth2 Service which is used to issue authorization codes or access tokens upon authorizing by the
@@ -133,6 +134,9 @@ public class OAuth2Service extends AbstractAdmin {
         }
 
         try {
+            String appTenantDomain = OAuth2Util.getTenantDomainOfOauthApp(clientId);
+            validateRequestTenantDomain(appTenantDomain);
+
             if (StringUtils.isBlank(clientId)) {
                 throw new InvalidOAuthClientException("Invalid client_id. No OAuth application has been registered " +
                         "with the given client_id");

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuer.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuer.java
@@ -28,7 +28,6 @@ import org.apache.oltu.oauth2.common.message.types.GrantType;
 import org.owasp.encoder.Encode;
 import org.wso2.carbon.identity.base.IdentityConstants;
 import org.wso2.carbon.identity.base.IdentityException;
-import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.oauth.cache.AppInfoCache;
 import org.wso2.carbon.identity.oauth.cache.AuthorizationGrantCache;
@@ -66,6 +65,7 @@ import java.util.concurrent.TimeUnit;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.GrantTypes.REFRESH_TOKEN;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OauthAppStates.APP_STATE_ACTIVE;
 import static org.wso2.carbon.identity.oauth2.Oauth2ScopeConstants.SYSTEM_SCOPE;
+import static org.wso2.carbon.identity.oauth2.util.OAuth2Util.validateRequestTenantDomain;
 
 /**
  * This class is used to issue access tokens and refresh tokens.
@@ -198,7 +198,7 @@ public class AccessTokenIssuer {
         // Indirectly we can say that the tenantDomain of the SP is the tenantDomain of the user who created SP.
         // This is done to avoid having to send the tenantDomain as a query param to the token endpoint
         String tenantDomainOfApp = OAuth2Util.getTenantDomainOfOauthApp(oAuthAppDO);
-        validateTenantDomain(tenantDomainOfApp);
+        validateRequestTenantDomain(tenantDomainOfApp);
 
         tokenReqDTO.setTenantDomain(tenantDomainOfApp);
 
@@ -350,26 +350,6 @@ public class AccessTokenIssuer {
         }
 
         return tokenRespDTO;
-    }
-
-    /**
-     * Validates whether the tenant domain set in context matches with the app's tenant domain in tenant qualified
-     * URL mode.
-     *
-     * @param tenantDomainOfApp Tenant domain of the app.
-     * @throws InvalidOAuthClientException
-     */
-    private void validateTenantDomain(String tenantDomainOfApp) throws InvalidOAuthClientException {
-        
-        if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled()) {
-            // In tenant qualified URL mode we would always have the tenant domain in the context.
-            String tenantDomainFromContext = IdentityTenantUtil.getTenantDomainFromContext();
-            if (!StringUtils.equals(tenantDomainFromContext, tenantDomainOfApp)) {
-                // This means the tenant domain sent in the request and app's tenant domain do not match.
-                throw new InvalidOAuthClientException("A valid client with the given client_id cannot be found in " +
-                        "tenantDomain: " + tenantDomainFromContext);
-            }
-        }
     }
 
     private void addAuthorizedInternalScopes(OAuthTokenReqMessageContext tokReqMsgCtx,

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -3700,4 +3700,24 @@ public class OAuth2Util {
             throw new IdentityOAuth2Exception("Error occurred while generating SHA-1 JWK thumbprint", e);
         }
     }
+
+    /**
+     * Validates whether the tenant domain set in context matches with the app's tenant domain in tenant qualified
+     * URL mode.
+     *
+     * @param tenantDomainOfApp Tenant domain of the app.
+     * @throws InvalidOAuthClientException
+     */
+    public static void validateRequestTenantDomain(String tenantDomainOfApp) throws InvalidOAuthClientException {
+
+        if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled()) {
+            // In tenant qualified URL mode we would always have the tenant domain in the context.
+            String tenantDomainFromContext = IdentityTenantUtil.getTenantDomainFromContext();
+            if (!StringUtils.equals(tenantDomainFromContext, tenantDomainOfApp)) {
+                // This means the tenant domain sent in the request and app's tenant domain do not match.
+                throw new InvalidOAuthClientException("A valid client with the given client_id cannot be found in " +
+                        "tenantDomain: " + tenantDomainFromContext);
+            }
+        }
+    }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuerTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuerTest.java
@@ -245,6 +245,7 @@ public class AccessTokenIssuerTest extends PowerMockIdentityBaseTest {
         mockStatic(IdentityTenantUtil.class);
         when(IdentityTenantUtil.isTenantQualifiedUrlsEnabled()).thenReturn(true);
         when(IdentityTenantUtil.getTenantDomainFromContext()).thenReturn(tenantInContext);
+        when(OAuth2Util.class, "validateRequestTenantDomain", anyString()).thenCallRealMethod();
 
         mockPasswordGrantHandler(true, true, true, true);
 

--- a/components/org.wso2.carbon.identity.oidc.session/src/test/java/org/wso2/carbon/identity/oidc/session/servlet/OIDCLogoutServletTest.java
+++ b/components/org.wso2.carbon.identity.oidc.session/src/test/java/org/wso2/carbon/identity/oidc/session/servlet/OIDCLogoutServletTest.java
@@ -370,6 +370,7 @@ public class OIDCLogoutServletTest extends TestOIDCSessionBase {
         when(IdentityDatabaseUtil.getDBConnection()).thenAnswer(invocationOnMock -> dataSource.getConnection());
         mockStatic(OAuth2Util.class);
         when(OAuth2Util.getAppInformationByClientId(anyString())).thenReturn(oAuthAppDO);
+        when(OAuth2Util.getTenantDomainOfOauthApp(anyString())).thenReturn("wso2.com");
         when(OAuth2Util.getTenantDomainOfOauthApp(any(oAuthAppDO.getClass()))).thenReturn("wso2.com");
         when(keyStoreManager.getKeyStore(anyString())).thenReturn(TestUtil.loadKeyStoreFromFileSystem(TestUtil
                 .getFilePath("wso2carbon.jks"), "wso2carbon", "JKS"));


### PR DESCRIPTION
Restricts cross tenant domain request in 
- /oauth2/authorize requests
- /oidc/logout request

Part of wso2/product-is#8156