### PR TITLE
Allow users with application management view permissions to view the OAuth app using DCRM

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/service/DCRMService.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/service/DCRMService.java
@@ -74,7 +74,8 @@ public class DCRMService {
      */
     public Application getApplication(String clientId) throws DCRMException {
 
-        return buildResponse(getApplicationById(clientId));
+        boolean isApplicationRolePermissionRequired = DCRMUtils.isApplicationRolePermissionRequired();
+        return buildResponse(getApplicationById(clientId, isApplicationRolePermissionRequired));
     }
 
     /**
@@ -223,6 +224,12 @@ public class DCRMService {
 
     private OAuthConsumerAppDTO getApplicationById(String clientId) throws DCRMException {
 
+        return getApplicationById(clientId, true);
+    }
+
+    private OAuthConsumerAppDTO getApplicationById(String clientId, boolean isApplicationRolePermissionRequired)
+            throws DCRMException {
+
         if (StringUtils.isEmpty(clientId)) {
             String errorMessage = "Invalid client_id";
             throw DCRMUtils.generateClientException(
@@ -234,7 +241,7 @@ public class DCRMService {
             if (dto == null || StringUtils.isEmpty(dto.getApplicationName())) {
                 throw DCRMUtils.generateClientException(
                         DCRMConstants.ErrorMessages.NOT_FOUND_APPLICATION_WITH_ID, clientId);
-            } else if (!isUserAuthorized(clientId)) {
+            } else if (isApplicationRolePermissionRequired && !isUserAuthorized(clientId)) {
                 throw DCRMUtils.generateClientException(
                         DCRMConstants.ErrorMessages.FORBIDDEN_UNAUTHORIZED_USER, clientId);
             }

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/util/DCRMUtils.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/util/DCRMUtils.java
@@ -40,6 +40,8 @@ public class DCRMUtils {
     private static final Log log = LogFactory.getLog(DCRMUtils.class);
     private static Pattern spNameRegexPattern = null;
     private static final String SERVICE_PROVIDERS_NAME_REGEX = "ServiceProviders.SPNameRegex";
+    private static final String APPLICATION_ROLE_PERMISSION_REQUIRED =
+            "OAuth.DCRM.ApplicationRolePermissionRequiredToView";
 
     public static boolean isRedirectionUriValid(String redirectUri) {
 
@@ -196,5 +198,17 @@ public class DCRMUtils {
             spValidatorRegex = APP_NAME_VALIDATING_REGEX;
         }
         return spValidatorRegex;
+    }
+
+    /**
+     * To get the config value for application role permission requirement.
+     *
+     * @return Application role permission required or not.
+     */
+    public static boolean isApplicationRolePermissionRequired() {
+
+        String isApplicationRolePermissionRequired = IdentityUtil.getProperty(APPLICATION_ROLE_PERMISSION_REQUIRED);
+        return StringUtils.isEmpty(isApplicationRolePermissionRequired) || Boolean.parseBoolean(
+                isApplicationRolePermissionRequired);
     }
 }


### PR DESCRIPTION
**Description**

This fix will allow users with application management view permissions to view the OAuth app using DCRM. To enable this add the following configuration to "_deployment.toml_" file in "_<IS_HOME>/repository/conf_" directory.

`[oauth.dcrm]
application_role_permission_required_to_view = false`

**Related PR**: https://github.com/wso2/carbon-identity-framework/pull/2933
