### PR TITLE
Fixes for error URL in Authorization flow is not spec complaint 

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
+++ b/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
@@ -215,6 +215,7 @@ public final class OAuthConstants {
         public static final String CLIENT_ID = "client_id";
         public static final String REDIRECT_URI = "redirect_uri";
         public static final String STATE = "state";
+        public static final String REQUEST = "request";
 
         private OAuth20Params() {
 

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
@@ -289,9 +289,11 @@ public class OAuth2AuthzEndpoint {
             log.debug("Invalid authorization request");
         }
 
+        OAuth2Parameters oAuth2Parameters = getOAuth2ParamsFromOAuthMessage(oAuthMessage);
         return Response.status(HttpServletResponse.SC_FOUND).location(new URI(getErrorPageURL
                 (oAuthMessage.getRequest(), OAuth2ErrorCodes.INVALID_REQUEST, OAuth2ErrorCodes.OAuth2SubErrorCodes
-                        .INVALID_AUTHORIZATION_REQUEST, "Invalid authorization request", null))).build();
+                        .INVALID_AUTHORIZATION_REQUEST, "Invalid authorization request", null,
+                        oAuth2Parameters))).build();
     }
 
     private void handleRetainCache(OAuthMessage oAuthMessage) {
@@ -362,8 +364,11 @@ public class OAuth2AuthzEndpoint {
         if (log.isDebugEnabled()) {
             log.debug(e.getError(), e);
         }
+
+        OAuth2Parameters oAuth2Parameters = getOAuth2ParamsFromOAuthMessage(oAuthMessage);
         String errorPageURL = getErrorPageURL(oAuthMessage.getRequest(), OAuth2ErrorCodes.INVALID_REQUEST,
-                OAuth2ErrorCodes.OAuth2SubErrorCodes.UNEXPECTED_SERVER_ERROR, e.getMessage(), null);
+                OAuth2ErrorCodes.OAuth2SubErrorCodes.UNEXPECTED_SERVER_ERROR, e.getMessage(), null,
+                oAuth2Parameters);
         if (OAuthServerConfiguration.getInstance().isRedirectToRequestedRedirectUriEnabled()) {
             return Response.status(HttpServletResponse.SC_FOUND).location(new URI(errorPageURL)).build();
 
@@ -576,10 +581,12 @@ public class OAuth2AuthzEndpoint {
             log.debug("Invalid authorization request. \'sessionDataKey\' parameter found but \'consent\' " +
                     "parameter could not be found in request");
         }
+
+        OAuth2Parameters oAuth2Parameters = getOAuth2ParamsFromOAuthMessage(oAuthMessage);
         return Response.status(HttpServletResponse.SC_FOUND).location(new URI(getErrorPageURL(
                 oAuthMessage.getRequest(), OAuth2ErrorCodes.INVALID_REQUEST, OAuth2ErrorCodes
                         .OAuth2SubErrorCodes.INVALID_AUTHORIZATION_REQUEST,
-                "Invalid authorization request", appName))).build();
+                "Invalid authorization request", appName, oAuth2Parameters))).build();
     }
 
     private String manageOIDCSessionState(OAuthMessage oAuthMessage, OIDCSessionState sessionState,
@@ -779,9 +786,12 @@ public class OAuth2AuthzEndpoint {
             log.debug("Invalid authorization request. \'sessionDataKey\' attribute found but " +
                     "corresponding AuthenticationResult does not exist in the cache.");
         }
+
+        OAuth2Parameters oAuth2Parameters = getOAuth2ParamsFromOAuthMessage(oAuthMessage);
         return Response.status(HttpServletResponse.SC_FOUND).location(new URI(
                 getErrorPageURL(oAuthMessage.getRequest(), OAuth2ErrorCodes.INVALID_REQUEST, OAuth2ErrorCodes
-                        .OAuth2SubErrorCodes.INVALID_AUTHORIZATION_REQUEST, "Invalid authorization request", appName)
+                        .OAuth2SubErrorCodes.INVALID_AUTHORIZATION_REQUEST, "Invalid authorization request", appName,
+                        oAuth2Parameters)
         )).build();
     }
 
@@ -1470,6 +1480,8 @@ public class OAuth2AuthzEndpoint {
     private String validatePKCEParameters(OAuthMessage oAuthMessage, OAuth2ClientValidationResponseDTO
             validationResponse, String pkceChallengeCode, String pkceChallengeMethod) {
 
+        OAuth2Parameters oAuth2Parameters = getOAuth2ParamsFromOAuthMessage(oAuthMessage);
+
         // Check if PKCE is mandatory for the application
         if (validationResponse.isPkceMandatory()) {
             if (pkceChallengeCode == null || !OAuth2Util.validatePKCECodeChallenge(pkceChallengeCode,
@@ -1477,7 +1489,7 @@ public class OAuth2AuthzEndpoint {
                 return getErrorPageURL(oAuthMessage.getRequest(), OAuth2ErrorCodes.INVALID_REQUEST, OAuth2ErrorCodes
                         .OAuth2SubErrorCodes.INVALID_PKCE_CHALLENGE_CODE, "PKCE is mandatory for this application. " +
                         "PKCE Challenge is not provided or is not upto RFC 7636 " +
-                        "specification.", null);
+                        "specification.", null, oAuth2Parameters);
             }
         }
         //Check if the code challenge method value is neither "plain" or "s256", if so return error
@@ -1485,7 +1497,8 @@ public class OAuth2AuthzEndpoint {
             if (!OAuthConstants.OAUTH_PKCE_PLAIN_CHALLENGE.equals(pkceChallengeMethod) &&
                     !OAuthConstants.OAUTH_PKCE_S256_CHALLENGE.equals(pkceChallengeMethod)) {
                 return getErrorPageURL(oAuthMessage.getRequest(), OAuth2ErrorCodes.INVALID_REQUEST, OAuth2ErrorCodes
-                        .OAuth2SubErrorCodes.INVALID_PKCE_CHALLENGE_CODE, "Unsupported PKCE Challenge Method", null);
+                        .OAuth2SubErrorCodes.INVALID_PKCE_CHALLENGE_CODE, "Unsupported PKCE Challenge Method", null,
+                        oAuth2Parameters);
             }
         }
 
@@ -1494,7 +1507,7 @@ public class OAuth2AuthzEndpoint {
             if (pkceChallengeMethod == null || OAuthConstants.OAUTH_PKCE_PLAIN_CHALLENGE.equals(pkceChallengeMethod)) {
                 return getErrorPageURL(oAuthMessage.getRequest(), OAuth2ErrorCodes.INVALID_REQUEST, OAuth2ErrorCodes
                         .OAuth2SubErrorCodes.INVALID_PKCE_CHALLENGE_CODE, "This application does not support " +
-                        "\"plain\" transformation algorithm.", null);
+                        "\"plain\" transformation algorithm.", null, oAuth2Parameters);
             }
         }
 
@@ -1503,7 +1516,7 @@ public class OAuth2AuthzEndpoint {
                 pkceChallengeMethod)) {
             return getErrorPageURL(oAuthMessage.getRequest(), OAuth2ErrorCodes.INVALID_REQUEST, OAuth2ErrorCodes
                     .OAuth2SubErrorCodes.INVALID_PKCE_CHALLENGE_CODE, "Code challenge used is not up to RFC 7636 " +
-                    "specifications.", null);
+                    "specifications.", null, oAuth2Parameters);
         }
         return null;
     }
@@ -1598,9 +1611,9 @@ public class OAuth2AuthzEndpoint {
                     log.debug("Request Object Handling failed due to : " + e.getErrorCode() + " for client_id: "
                             + clientId + " of tenantDomain: " + params.getTenantDomain(), e);
                 }
-                return EndpointUtil.getErrorPageURL(oAuthMessage.getRequest(), e.getErrorCode(), OAuth2ErrorCodes
-                                .OAuth2SubErrorCodes.INVALID_REQUEST_OBJECT, e.getErrorMessage(),
-                        null);
+                return EndpointUtil.getErrorPageURL(oAuthMessage.getRequest(), OAuth2ErrorCodes
+                                .OAuth2SubErrorCodes.INVALID_REQUEST_OBJECT, e.getErrorCode(), e.getErrorMessage(),
+                        null, params);
             }
         }
 
@@ -2870,5 +2883,19 @@ public class OAuth2AuthzEndpoint {
 
         req.setAttribute(REQUEST_PARAM_SP, spName);
         req.setAttribute(TENANT_DOMAIN, tenantDomain);
+    }
+
+    /**
+     * Return OAuth2Parameters retrieved from OAuthMessage.
+     * @param oAuthMessage
+     * @return OAuth2Parameters
+     */
+    private OAuth2Parameters getOAuth2ParamsFromOAuthMessage(OAuthMessage oAuthMessage) {
+
+        OAuth2Parameters oAuth2Parameters = new OAuth2Parameters();
+        if (oAuthMessage.getSessionDataCacheEntry() != null) {
+            oAuth2Parameters = getOauth2Params(oAuthMessage);
+        }
+        return oAuth2Parameters;
     }
 }

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
@@ -17,6 +17,9 @@
  */
 package org.wso2.carbon.identity.oauth.endpoint.util;
 
+import com.google.gdata.model.atom.Author;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
 import org.apache.axiom.util.base64.Base64Utils;
 import org.apache.commons.io.Charsets;
 import org.apache.commons.lang.StringUtils;
@@ -71,6 +74,7 @@ import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
+import java.text.ParseException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -392,6 +396,32 @@ public class EndpointUtil {
      */
     public static String getErrorPageURL(HttpServletRequest request, String errorCode, String subErrorCode, String
             errorMessage, String appName) {
+
+        return getErrorPageURL(request, errorCode, subErrorCode, errorMessage, appName, new OAuth2Parameters());
+    }
+
+    /**
+     * Returns the error page URL.
+     * If RedirectToRequestedRedirectUri property is true and if the resource owner denies the access request or if the
+     * request fails for reasons other than a missing or invalid redirection URI, the authorization server informs
+     * the client by adding the error code, error message and state parameters to the query component of the
+     * redirection URI.
+     * <p>
+     * If RedirectToRequestedRedirectUri property is false OR if the request fails due to a missing, invalid, or
+     * mismatching redirection URI, or if the client identifier is missing or invalid, the authorization server SHOULD
+     * inform the resource owner of the error and MUST NOT automatically redirect the user-agent to the invalid
+     * redirection URI.
+     *
+     * @param request           HttpServletRequest
+     * @param errorCode         Error Code
+     * @param subErrorCode      Sub error code to identify the exact reason for invalid request
+     * @param errorMessage      Message of the error
+     * @param appName           Application Name
+     * @param oAuth2Parameters  OAuth2Parameters
+     * @return url of the redirect error page
+     */
+    public static String getErrorPageURL(HttpServletRequest request, String errorCode, String subErrorCode, String
+            errorMessage, String appName, OAuth2Parameters oAuth2Parameters) {
         // By default RedirectToRequestedRedirectUri property is set to true. Therefore by default error page
         // is returned to the uri given in the request.
         // For the backward compatibility, this property can be set to false and then the error page is
@@ -403,7 +433,7 @@ public class EndpointUtil {
             return getErrorPageURL(request, errorCode, errorMessage, appName);
         } else {
             String redirectUri = request.getParameter(OAuthConstants.OAuth20Params.REDIRECT_URI);
-            String state = request.getParameter(OAuthConstants.OAuth20Params.STATE);
+            String state = retrieveStateForErrorURL(request, oAuth2Parameters);
 
             Map<String, String> params = new HashMap<>();
             params.put(PROP_ERROR, errorCode);
@@ -916,6 +946,42 @@ public class EndpointUtil {
     public static void setCibaAuthService(CibaAuthServiceImpl cibaAuthService) {
 
         EndpointUtil.cibaAuthService = cibaAuthService;
+    }
+
+    /**
+     * This method retrieve the state to append to the error page URL.
+     * If the state is available in OAuth2Parameters it will retrieve state from OAuth2Parameters.
+     * If the state is not available in OAuth2Parameters, then the state will be retrieved from request object.
+     * If the state is not available in OAuth2Parameters and request object then state will be retrieved from query params
+     *
+     * @param request
+     * @param oAuth2Parameters
+     * @return state
+     */
+    private static String retrieveStateForErrorURL(HttpServletRequest request, OAuth2Parameters oAuth2Parameters) {
+
+        String state = null;
+        try {
+            if (oAuth2Parameters.getState() != null) {
+                state = oAuth2Parameters.getState();
+                if (log.isDebugEnabled()) {
+                    log.debug("Retrieved state value " + state + " from OAuth2Parameters.");
+                }
+            } else {
+                JWTClaimsSet jwtClaimsSet = SignedJWT.parse(request.getParameter(OAuthConstants.OAuth20Params.REQUEST))
+                        .getJWTClaimsSet();
+                if (jwtClaimsSet.getStringClaim(OAuthConstants.OAuth20Params.STATE) != null) {
+                    state = jwtClaimsSet.getStringClaim(OAuthConstants.OAuth20Params.STATE);
+                    if (log.isDebugEnabled()) {
+                        log.debug("Retrieved state value " + state + " from request object.");
+                    }
+                }
+            }
+        } catch (ParseException e) {
+            log.error("Error occurred while parsing the signed message", e);
+        }
+
+        return state;
     }
 
     /**

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
@@ -17,7 +17,6 @@
  */
 package org.wso2.carbon.identity.oauth.endpoint.util;
 
-import com.google.gdata.model.atom.Author;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
 import org.apache.axiom.util.base64.Base64Utils;
@@ -952,7 +951,8 @@ public class EndpointUtil {
      * This method retrieve the state to append to the error page URL.
      * If the state is available in OAuth2Parameters it will retrieve state from OAuth2Parameters.
      * If the state is not available in OAuth2Parameters, then the state will be retrieved from request object.
-     * If the state is not available in OAuth2Parameters and request object then state will be retrieved from query params
+     * If the state is not available in OAuth2Parameters and request object then state will be retrieved
+     * from query params.
      *
      * @param request
      * @param oAuth2Parameters


### PR DESCRIPTION
### Fixes for error URL in Authorization flow is not spec complaint 
- Change the setting additional params logic to set parameters if the config is enabled or if the error is redirected to the common error page.
- Fixed issue in setting the state value in error URL. Previously the state value was retrieves from the query params. Change the logic to retrieve the state value from OAuth2params or request object according to [1].

Related PR https://github.com/wso2/carbon-identity-framework/pull/2940

Fixes wso2/product-is#8326 and wso2-enterprise/financial-open-banking#5289

[1] https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest

### When should this PR be merged

[Please describe any preconditions that need to be addressed before we
can merge this pull request.]


### Follow up actions

[List any possible follow-up actions here; for instance, testing data
migrations, software that we need to install on staging and production
environments.]

-


### Checklist (for reviewing)

#### General

- [x] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description.
- [x] **Is the PR labeled correctly?**

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled.

#### Code

- [x] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests.
- [x] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/).

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components.
- [ ] **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

#### Security

- [x] **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
- [ ] **Are all UI and API inputs run through forms or serializers?**
- [ ] **Are all external inputs validated and sanitized appropriately?**
- [ ] **Does all branching logic have a default case?**
- [ ] **Does this solution handle outliers and edge cases gracefully?**
- [x] **Are all external communications secured and restricted to SSL?**

#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes should be documented.
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented.
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki.
