### PR TITLE
Token generation flow broken on error when obtaining claims

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/CustomClaimsCallbackHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/CustomClaimsCallbackHandler.java
@@ -18,6 +18,7 @@
 package org.wso2.carbon.identity.openidconnect;
 
 import com.nimbusds.jwt.JWTClaimsSet;
+import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.authz.OAuthAuthzReqMessageContext;
 import org.wso2.carbon.identity.oauth2.token.OAuthTokenReqMessageContext;
 
@@ -26,8 +27,10 @@ import org.wso2.carbon.identity.oauth2.token.OAuthTokenReqMessageContext;
  */
 public interface CustomClaimsCallbackHandler {
 
-    public JWTClaimsSet handleCustomClaims(JWTClaimsSet.Builder builder, OAuthTokenReqMessageContext request);
+    public JWTClaimsSet handleCustomClaims(JWTClaimsSet.Builder builder, OAuthTokenReqMessageContext request)
+            throws IdentityOAuth2Exception;
 
-    public JWTClaimsSet handleCustomClaims(JWTClaimsSet.Builder builder, OAuthAuthzReqMessageContext request);
+    public JWTClaimsSet handleCustomClaims(JWTClaimsSet.Builder builder, OAuthAuthzReqMessageContext request)
+            throws IdentityOAuth2Exception;
 
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/DefaultIDTokenBuilder.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/DefaultIDTokenBuilder.java
@@ -415,7 +415,7 @@ public class DefaultIDTokenBuilder implements org.wso2.carbon.identity.openidcon
     }
 
     private JWTClaimsSet handleOIDCCustomClaims(OAuthTokenReqMessageContext tokReqMsgCtx, JWTClaimsSet.Builder
-            jwtClaimsSetBuilder) {
+            jwtClaimsSetBuilder) throws IdentityOAuth2Exception {
         CustomClaimsCallbackHandler claimsCallBackHandler =
                 OAuthServerConfiguration.getInstance().getOpenIDConnectCustomClaimsCallbackHandler();
         return claimsCallBackHandler.handleCustomClaims(jwtClaimsSetBuilder, tokReqMsgCtx);
@@ -586,7 +586,8 @@ public class DefaultIDTokenBuilder implements org.wso2.carbon.identity.openidcon
     }
 
     private JWTClaimsSet handleCustomOIDCClaims(OAuthAuthzReqMessageContext request,
-                                                JWTClaimsSet.Builder jwtClaimsSetBuilder) {
+                                                JWTClaimsSet.Builder jwtClaimsSetBuilder)
+            throws IdentityOAuth2Exception {
 
         CustomClaimsCallbackHandler claimsCallBackHandler =
                 OAuthServerConfiguration.getInstance().getOpenIDConnectCustomClaimsCallbackHandler();

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuerTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuerTest.java
@@ -499,7 +499,7 @@ public class JWTTokenIssuerTest extends PowerMockIdentityBaseTest {
         assertNotNull(jwtClaimsSet.getClaim("TOKEN_CONTEXT_CLAIM"));
     }
 
-    private void mockCustomClaimsCallbackHandler() {
+    private void mockCustomClaimsCallbackHandler() throws IdentityOAuth2Exception {
         CustomClaimsCallbackHandler claimsCallBackHandler = mock(CustomClaimsCallbackHandler.class);
 
         doAnswer(new Answer<JWTClaimsSet>() {

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/openidconnect/DefaultOIDCClaimsCallbackHandlerTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/openidconnect/DefaultOIDCClaimsCallbackHandlerTest.java
@@ -61,6 +61,7 @@ import org.wso2.carbon.identity.oauth.cache.AuthorizationGrantCacheEntry;
 import org.wso2.carbon.identity.oauth.cache.AuthorizationGrantCacheKey;
 import org.wso2.carbon.identity.oauth.common.OAuthConstants;
 import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
+import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.TestConstants;
 import org.wso2.carbon.identity.oauth2.authz.OAuthAuthzReqMessageContext;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2AccessTokenReqDTO;
@@ -971,7 +972,7 @@ public class DefaultOIDCClaimsCallbackHandlerTest {
     }
 
     private JWTClaimsSet getJwtClaimSet(JWTClaimsSet.Builder jwtClaimsSetBuilder,
-                                        OAuthTokenReqMessageContext requestMsgCtx) {
+                                        OAuthTokenReqMessageContext requestMsgCtx) throws IdentityOAuth2Exception {
 
         OAuthServerConfiguration mockOAuthServerConfiguration = PowerMockito.mock(OAuthServerConfiguration.class);
         DataSource dataSource = mock(DataSource.class);
@@ -1012,7 +1013,7 @@ public class DefaultOIDCClaimsCallbackHandlerTest {
     }
 
     private JWTClaimsSet getJwtClaimSet(JWTClaimsSet.Builder jwtClaimsSetBuilder,
-                                        OAuthAuthzReqMessageContext requestMsgCtx) {
+                                        OAuthAuthzReqMessageContext requestMsgCtx) throws IdentityOAuth2Exception {
 
         OAuthServerConfiguration mockOAuthServerConfiguration = PowerMockito.mock(OAuthServerConfiguration.class);
         DataSource dataSource = mock(DataSource.class);


### PR DESCRIPTION
#### Description:
Currently, token generation flow continues with an empty claim map if an error is encountered when obtaining claims. This has been changed to either break the flow or continue normally depending on a config value.

#### Fixes:
https://github.com/wso2/product-is/issues/8168