### PR TITLE
[Fix] User claims not retuning in an access token for a federated user via implicit grant type 

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/DefaultOIDCClaimsCallbackHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/DefaultOIDCClaimsCallbackHandler.java
@@ -127,7 +127,7 @@ public class DefaultOIDCClaimsCallbackHandler implements CustomClaimsCallbackHan
     }
 
     /**
-     * Get response map
+     * Get response map.
      *
      * @param requestMsgCtx Token request message context
      * @return Mapped claimed
@@ -421,7 +421,7 @@ public class DefaultOIDCClaimsCallbackHandler implements CustomClaimsCallbackHan
     }
 
     /**
-     * Get claims map
+     * Get claims map.
      *
      * @param userAttributes User Attributes
      * @return User attribute map
@@ -574,7 +574,7 @@ public class DefaultOIDCClaimsCallbackHandler implements CustomClaimsCallbackHan
     }
 
     /**
-     * Get user claims in OIDC claim dialect
+     * Get user claims in OIDC claim dialect.
      *
      * @param oidcToLocalClaimMappings OIDC dialect to Local dialect claim mappings
      * @param userClaims               User claims in local dialect
@@ -624,7 +624,7 @@ public class DefaultOIDCClaimsCallbackHandler implements CustomClaimsCallbackHan
     }
 
     /**
-     * Get user attribute cached against the access token
+     * Get user attribute cached against the access token.
      *
      * @param accessToken Access token
      * @return User attributes cached against the access token
@@ -646,7 +646,7 @@ public class DefaultOIDCClaimsCallbackHandler implements CustomClaimsCallbackHan
     }
 
     /**
-     * Get user attributes cached against the authorization code
+     * Get user attributes cached against the authorization code.
      *
      * @param authorizationCode Authorization Code
      * @return User attributes cached against the authorization code


### PR DESCRIPTION
Resolves https://github.com/wso2/product-is/issues/8377

### Proposed changes in this pull request
When obtaining the access token, the user claims are not cached.
In that scenario, check whether the authenticated user is federated or not. If federated, get the user claims from `OAuthAuthzReqMessageContext`.