### PR TITLE
Introduce response_type=none

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/NoneResponseTypeValidator.java
+++ b/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/NoneResponseTypeValidator.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth.common;
+
+import org.apache.oltu.oauth2.common.OAuth;
+import org.apache.oltu.oauth2.common.error.OAuthError;
+import org.apache.oltu.oauth2.common.exception.OAuthProblemException;
+import org.apache.oltu.oauth2.common.validators.AbstractValidator;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ *  Validator for response_type=none requests.
+ */
+public class NoneResponseTypeValidator extends AbstractValidator<HttpServletRequest> {
+
+    @Override
+    public void validateMethod(HttpServletRequest request) throws OAuthProblemException {
+
+        String method = request.getMethod();
+        if (!OAuth.HttpMethod.GET.equals(method) && !OAuth.HttpMethod.POST.equals(method)) {
+            throw OAuthProblemException.error(OAuthError.CodeResponse.INVALID_REQUEST)
+                    .description("Method not correct.");
+        }
+    }
+
+    @Override
+    public void validateContentType(HttpServletRequest request) throws OAuthProblemException {
+
+    }
+}

--- a/components/org.wso2.carbon.identity.oauth.common/src/test/java/org/wso2/carbon/identity/oauth/common/NoneResponseTypeValidatorTest.java
+++ b/components/org.wso2.carbon.identity.oauth.common/src/test/java/org/wso2/carbon/identity/oauth/common/NoneResponseTypeValidatorTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth.common;
+
+import org.apache.oltu.oauth2.common.error.OAuthError;
+import org.apache.oltu.oauth2.common.exception.OAuthProblemException;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import javax.servlet.http.HttpServletRequest;
+
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+
+/**
+ * Test class for NoneResponseType Validator.
+ */
+public class NoneResponseTypeValidatorTest {
+
+    protected NoneResponseTypeValidator testedResponseValidator;
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+
+        testedResponseValidator = new NoneResponseTypeValidator();
+    }
+
+    @AfterMethod
+    public void tearDown() throws Exception {
+
+    }
+
+    @DataProvider(name = "successRequestMethodProvider")
+    public Object[][] getSuccessRequestMethod() {
+
+        return new Object[][]{
+                {"GET"},
+                {"POST"}
+        };
+    }
+
+    @DataProvider(name = "failureRequestMethodProvider")
+    public Object[][] getFailureRequestMethod() {
+
+        return new Object[][]{
+                {"HEAD"},
+                {"DELETE"},
+                {"OPTIONS"},
+                {"PUT"},
+                {""},
+                {null}
+        };
+    }
+
+    @Test(dataProvider = "successRequestMethodProvider")
+    public void testValidateMethodSuccess(String method) throws Exception {
+
+        HttpServletRequest mockRequest = mock(HttpServletRequest.class);
+        when(mockRequest.getMethod()).thenReturn(method);
+        testedResponseValidator.validateMethod(mockRequest);
+        // Nothing to assert here. The above method will only throw an exception if not valid
+    }
+
+    @Test(dataProvider = "failureRequestMethodProvider")
+    public void testValidateMethodFailure(String method) throws Exception {
+
+        HttpServletRequest mockRequest = mock(HttpServletRequest.class);
+        when(mockRequest.getMethod()).thenReturn(method);
+
+        try {
+            testedResponseValidator.validateMethod(mockRequest);
+            fail(method + " method should not be allowed.");
+        } catch (OAuthProblemException e) {
+            assertEquals(e.getError(), OAuthError.CodeResponse.INVALID_REQUEST);
+        }
+    }
+
+}

--- a/components/org.wso2.carbon.identity.oauth.common/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.identity.oauth.common/src/test/resources/testng.xml
@@ -25,6 +25,7 @@
             <class name="org.wso2.carbon.identity.oauth.common.CodeTokenResponseValidatorTest"/>
             <class name="org.wso2.carbon.identity.oauth.common.NTLMAuthenticationValidatorTest"/>
             <class name="org.wso2.carbon.identity.oauth.common.SAML2GrantValidatorTest"/>
+            <class name="org.wso2.carbon.identity.oauth.common.NoneResponseTypeValidatorTest"/>
         </classes>
     </test>
 </suite>

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/handlers/NoneResponseTypeHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/handlers/NoneResponseTypeHandler.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth2.authz.handlers;
+
+import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
+import org.wso2.carbon.identity.oauth2.authz.OAuthAuthzReqMessageContext;
+import org.wso2.carbon.identity.oauth2.dto.OAuth2AuthorizeRespDTO;
+
+/**
+ * Handles requests with response_type=none as defined in the spec https://openid
+ * .net/specs/oauth-v2-multiple-response-types-1_0.html#none.
+ * When supplied as the response_type parameter in an OAuth 2.0 Authorization Request, Authorization Code, Access
+ * Token, Access Token Type, or ID Token is not sent in the successful response. If a redirect_uri is supplied, the
+ * User Agent is redirected there after granting or denying access. If the state parameter is present, it is added to
+ * the response as well.
+ */
+public class NoneResponseTypeHandler extends AbstractResponseTypeHandler {
+
+    @Override
+    public OAuth2AuthorizeRespDTO issue(OAuthAuthzReqMessageContext oauthAuthzMsgCtx) throws IdentityOAuth2Exception {
+
+        return initResponse(oauthAuthzMsgCtx);
+    }
+}

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/authz/handlers/NoneResponseTypeHandlerTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/authz/handlers/NoneResponseTypeHandlerTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth2.authz.handlers;
+
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.oauth.common.OAuthConstants;
+import org.wso2.carbon.identity.oauth2.authz.OAuthAuthzReqMessageContext;
+import org.wso2.carbon.identity.oauth2.dto.OAuth2AuthorizeReqDTO;
+import org.wso2.carbon.identity.oauth2.dto.OAuth2AuthorizeRespDTO;
+
+/**
+ * Unit test covering NoneResponseTypeHandler class.
+ */
+public class NoneResponseTypeHandlerTest {
+
+    @DataProvider(name = "CommonDataProvider")
+    public Object[][] commonDataProvider() {
+
+        return new Object[][]{
+                {"https://localhost:8000/callback1"},
+                {"https://localhost:8000/callback2"}
+        };
+    }
+
+    @Test(dataProvider = "CommonDataProvider")
+    public void testIssue(String callBackUri) throws Exception {
+
+        NoneResponseTypeHandler noneResponseTypeHandler = new NoneResponseTypeHandler();
+
+        OAuth2AuthorizeReqDTO authorizationReqDTO = new OAuth2AuthorizeReqDTO();
+        authorizationReqDTO.setCallbackUrl(callBackUri);
+        authorizationReqDTO.setConsumerKey("SDSDSDS23131231");
+        authorizationReqDTO.setResponseType(OAuthConstants.NONE);
+
+        OAuthAuthzReqMessageContext messageContext = new OAuthAuthzReqMessageContext(authorizationReqDTO);
+        messageContext.setApprovedScope(new String[]{"scope1", "scope2", OAuthConstants.Scope.OPENID});
+
+        OAuth2AuthorizeRespDTO auth2AuthorizeReqDTO = noneResponseTypeHandler.issue(messageContext);
+        // In the "response_type = none", none of the code, id token or the access token is returned. The user-agent
+        // is redirected to the given call back uri.
+        Assert.assertNull(auth2AuthorizeReqDTO.getAccessToken());
+        Assert.assertNull(auth2AuthorizeReqDTO.getAuthorizationCode());
+        Assert.assertNull(auth2AuthorizeReqDTO.getIdToken());
+        Assert.assertEquals(auth2AuthorizeReqDTO.getCallbackURI(), callBackUri);
+    }
+}

--- a/components/org.wso2.carbon.identity.oauth/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.identity.oauth/src/test/resources/testng.xml
@@ -34,6 +34,7 @@
             <class name="org.wso2.carbon.identity.oauth2.authz.AuthorizationHandlerManagerTest"/>
             <class name="org.wso2.carbon.identity.oauth2.authz.handlers.AbstractResponseTypeHandlerTest"/>
             <class name="org.wso2.carbon.identity.oauth2.authz.handlers.TokenResponseTypeHandlerTest"/>
+            <class name="org.wso2.carbon.identity.oauth2.authz.handlers.NoneResponseTypeHandlerTest"/>
             <class name="org.wso2.carbon.identity.oauth2.authcontext.JWTTokenGeneratorTest"/>
             <class name="org.wso2.carbon.identity.openidconnect.RememberMeStoreTest"/>
             <class name="org.wso2.carbon.identity.openidconnect.RequestObjectValidatorImplTest"/>


### PR DESCRIPTION
### Proposed changes in this pull request

This PR adds the capability to have the `response_type=none` in the `oauth2/authorize` endpoint. This implements the **"None Response Type"** of https://openid.net/specs/oauth-v2-multiple-response-types-1_0.html#none