### PR TITLE
Fix introspection endpoint url in tenant legacy URL mode in OIDC config response

### DIFF
--- a/components/org.wso2.carbon.identity.discovery/src/main/java/org/wso2/carbon/identity/discovery/builders/ProviderConfigBuilder.java
+++ b/components/org.wso2.carbon.identity.discovery/src/main/java/org/wso2/carbon/identity/discovery/builders/ProviderConfigBuilder.java
@@ -71,12 +71,12 @@ public class ProviderConfigBuilder {
         providerConfig.setRevocationEndpointAuthMethodsSupported(OAuth2Util.getSupportedClientAuthenticationMethods()
                 .toArray(new String[0]));
         providerConfig.setResponseModesSupported(OAuth2Util.getSupportedResponseModes().toArray(new String[0]));
-        providerConfig.setIntrospectionEndpoint(OAuth2Util.OAuthURL.getOAuth2IntrospectionEPUrl());
         providerConfig.setIntrospectionEndpointAuthMethodsSupported(OAuth2Util.getSupportedClientAuthenticationMethods()
                 .toArray(new String[0]));
         providerConfig.setCodeChallengeMethodsSupported(OAuth2Util.getSupportedCodeChallengeMethods()
                 .toArray(new String[0]));
         try {
+            providerConfig.setIntrospectionEndpoint(OAuth2Util.OAuthURL.getOAuth2IntrospectionEPUrl(tenantDomain));
             providerConfig.setRegistrationEndpoint(OAuth2Util.OAuthURL.getOAuth2DCREPUrl(tenantDomain));
             providerConfig.setJwksUri(OAuth2Util.OAuthURL.getOAuth2JWKSPageUrl(tenantDomain));
         } catch (URISyntaxException e) {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -1277,7 +1277,7 @@ public class OAuth2Util {
                     OAuthServerConfiguration.getInstance()::getOauth2IntrospectionEPUrl);
 
             if (!IdentityTenantUtil.isTenantQualifiedUrlsEnabled() && isNotSuperTenant(tenantDomain)) {
-                //Append tenant domain to path when the tenant-qualified url mode is disabled.
+                // Append tenant domain to path when the tenant-qualified url mode is disabled.
                 getOAuth2IntrospectionEPUrl =
                         appendTenantDomainAsPathParamInLegacyMode(getOAuth2IntrospectionEPUrl, tenantDomain);
             }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -1264,6 +1264,26 @@ public class OAuth2Util {
                     OAuthServerConfiguration.getInstance()::getOauth2IntrospectionEPUrl);
         }
 
+        /**
+         * This method is used to get the resolved URL for the OAuth2 introspection endpoint.
+         *
+         * @param tenantDomain Tenant Domain.
+         * @return String of the resolved URL for the introspection endpoint.
+         * @throws URISyntaxException URI Syntax Exception.
+         */
+        public static String getOAuth2IntrospectionEPUrl(String tenantDomain) throws URISyntaxException {
+
+            String getOAuth2IntrospectionEPUrl = buildUrl(OAUTH2_INTROSPECT_EP_URL,
+                    OAuthServerConfiguration.getInstance()::getOauth2IntrospectionEPUrl);
+
+            if (!IdentityTenantUtil.isTenantQualifiedUrlsEnabled() && isNotSuperTenant(tenantDomain)) {
+                //Append tenant domain to path when the tenant-qualified url mode is disabled.
+                getOAuth2IntrospectionEPUrl =
+                        appendTenantDomainAsPathParamInLegacyMode(getOAuth2IntrospectionEPUrl, tenantDomain);
+            }
+            return getOAuth2IntrospectionEPUrl;
+        }
+
         public static String getOIDCConsentPageUrl() {
 
             return buildUrl(OIDC_CONSENT_EP_URL, OAuthServerConfiguration.getInstance()::getOIDCConsentPageUrl);

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/util/OAuth2UtilTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/util/OAuth2UtilTest.java
@@ -1251,14 +1251,15 @@ public class OAuth2UtilTest extends PowerMockIdentityBaseTest {
         assertEquals(OAuth2Util.OAuthURL.getOAuth2RevocationEPUrl(), oauthUrl);
     }
 
-    @Test(dataProvider = "OAuthURLData")
-    public void testGetOAuth2IntrospectionEPUrlLegacy(String configUrl, String serverUrl, String oauthUrl)
+    @Test(dataProvider = "OAuthURLData2")
+    public void testGetOAuth2IntrospectionEPUrlLegacy(String configUrl, String serverUrl,
+                                                      String tenantDomain, String oauthUrl)
             throws Exception {
 
         when(oauthServerConfigurationMock.getOauth2IntrospectionEPUrl()).thenReturn(configUrl);
         when(((Supplier<String>) OAuthServerConfiguration.getInstance()::getOauth2IntrospectionEPUrl).get())
                 .thenReturn(serverUrl);
-        assertEquals(OAuth2Util.OAuthURL.getOAuth2IntrospectionEPUrl(), oauthUrl);
+        assertEquals(OAuth2Util.OAuthURL.getOAuth2IntrospectionEPUrl(tenantDomain), oauthUrl);
     }
 
     @DataProvider(name = "OAuthIntrospectionEPData")
@@ -1277,7 +1278,7 @@ public class OAuth2UtilTest extends PowerMockIdentityBaseTest {
                 {true, "", "https://localhost:9443/testUrl", "testDomain",
                         "https://localhost:9443/t/testDomain/oauth2/introspect"},
                 {false, "https://localhost:9443/testUrl", "https://localhost:9443/testUrl", "testDomain",
-                        "https://localhost:9443/testUrl"},
+                        "https://localhost:9443/t/testDomain/testUrl"},
                 {false, "", "https://localhost:9443/testUrl", "",
                         "https://localhost:9443/testUrl"},
         };
@@ -1293,7 +1294,7 @@ public class OAuth2UtilTest extends PowerMockIdentityBaseTest {
         when(PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain()).thenReturn("carbon.super");
         when(((Supplier<String>) OAuthServerConfiguration.getInstance()::getOauth2IntrospectionEPUrl).get())
                 .thenReturn(serverUrl);
-        assertEquals(OAuth2Util.OAuthURL.getOAuth2IntrospectionEPUrl(), oauthUrl);
+        assertEquals(OAuth2Util.OAuthURL.getOAuth2IntrospectionEPUrl(tenantDomain), oauthUrl);
     }
 
     @DataProvider(name = "OIDCConsentPageURLData")


### PR DESCRIPTION
### Proposed changes in this pull request
- Resolves: https://github.com/wso2/product-is/issues/8521
- This will add tenant as a path param to introspection endpoint in OIDC discovery response in legacy tenant URL mode.

### When should this PR be merged
This PR should be merged before https://github.com/wso2/product-is/pull/8527
