### PR TITLE
Fix issuing revoked access tokens when SMS OTP is set as 2nd step

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AbstractAuthorizationGrantHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AbstractAuthorizationGrantHandler.java
@@ -118,7 +118,7 @@ public abstract class AbstractAuthorizationGrantHandler implements Authorization
         String scope = OAuth2Util.buildScopeString(tokReqMsgCtx.getScope());
         String consumerKey = tokReqMsgCtx.getOauth2AccessTokenReqDTO().getClientId();
         String authorizedUser = tokReqMsgCtx.getAuthorizedUser().toString();
-        String authenticatedIDP = tokReqMsgCtx.getAuthorizedUser().getFederatedIdPName();
+        String authenticatedIDP = OAuth2Util.getAuthenticatedIDP(tokReqMsgCtx.getAuthorizedUser());
         String tokenBindingReference = getTokenBindingReference(tokReqMsgCtx);
 
         OauthTokenIssuer oauthTokenIssuer;

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -3124,12 +3124,12 @@ public class OAuth2Util {
     }
 
     /**
-     * Creates an instance on AuthenticatedUser{@link AuthenticatedUser} for the given parameters.
+     * Creates an instance of AuthenticatedUser{@link AuthenticatedUser} for the given parameters.
      *
      * @param username        username of the user
      * @param userStoreDomain user store domain
      * @param tenantDomain    tenent domain
-     * @param idpName    idp name
+     * @param idpName         idp name
      * @return an instance of AuthenticatedUser{@link AuthenticatedUser}
      */
     public static AuthenticatedUser createAuthenticatedUser(String username, String userStoreDomain, String
@@ -3163,6 +3163,7 @@ public class OAuth2Util {
             }
         } else {
             authenticatedUser.setUserStoreDomain(userStoreDomain);
+            authenticatedUser.setFederatedIdPName(idpName);
         }
 
         return authenticatedUser;


### PR DESCRIPTION
Resolves https://github.com/wso2/product-is/issues/8529

As per the above issue, it will be seen that although the access token is revoked, it will issue the revoked access token again. The reason for this is when revoking the access token it won't clear the cache properly. That is because when clearing the cache it will clear a cache entry with cache key `KdMTzq2VHxPiYu6fqHu34aiei7Aa:sam@carbon.super:openid:null:NONE`. But initially, this access token is added to the OAuthCache with cache key as `KdMTzq2VHxPiYu6fqHu34aiei7Aa:sam@carbon.super:openid:sms-otp-idp:NONE`. The format of the cache key is `[clientId]:[authorizedUser]:[scope]:[authenticatedIDP]:[tokenBindingReference]`. So the difference in these two cache keys is when adding the cache key it will take "sms-otp-idp" as the authenticated IdP of the authorized user. But when clearing the cache it will see the authenticated IdP as null. Because of this mismatch in the cache key, the cache won't be cleared properly in token revocation flow. 

This is reproduced only when SMS-OTP authenticator is configured as the second step. In other cases (e.g: when EMAIL-OTP authenticator is configured as the second step) when adding the access token to the OAuthCache it will take the authenticated IdP as null. But when this is persisted to the DB it will take 'LOCAL' as the authenticated IdP of the authorized user.  

## Proposed Solution
Unless the user is authenticated by a federated IdP, the authenticated IdP of a user should be 'LOCAL'. So in this way, it won't add a null value or an erroneous value like 'sms-otp-idp' to the authenticatedIDP in the cache key. Hence with this fix, it will set the correct value for the authenticated IdP of an authorized user.
