### PR TITLE
Add binding_ref and binding_type to self-contained access token

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuer.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuer.java
@@ -81,6 +81,8 @@ public class JWTTokenIssuer extends OauthTokenIssuerImpl {
     private static final String AUTHORIZATION_PARTY = "azp";
     private static final String AUDIENCE = "aud";
     private static final String SCOPE = "scope";
+    private static final String TOKEN_BINDING_REF = "binding_ref";
+    private static final String TOKEN_BINDING_TYPE = "binding_type";
 
     // To keep track of the expiry time provided in the original jwt assertion, when JWT grant type is used.
     private static final String EXPIRY_TIME_JWT = "EXPIRY_TIME_JWT";
@@ -495,6 +497,8 @@ public class JWTTokenIssuer extends OauthTokenIssuerImpl {
         } else {
             jwtClaimsSet = handleCustomClaims(jwtClaimsSetBuilder, tokenReqMessageContext);
         }
+        // Include token binding.
+        jwtClaimsSet = handleTokenBinding(jwtClaimsSetBuilder, tokenReqMessageContext);
 
         return jwtClaimsSet;
     }
@@ -684,5 +688,16 @@ public class JWTTokenIssuer extends OauthTokenIssuerImpl {
         // If grant handler is null ideally we would not come to this point as the flow will be broken before. So we
         // can guarantee grantHandler will not be null
         return grantHandler.isOfTypeApplicationUser();
+    }
+
+    private JWTClaimsSet handleTokenBinding(JWTClaimsSet.Builder jwtClaimsSetBuilder,
+                                            OAuthTokenReqMessageContext tokReqMsgCtx) {
+
+        if (tokReqMsgCtx != null && tokReqMsgCtx.getTokenBinding() != null) {
+            // Include token binding into the jwt token.
+            jwtClaimsSetBuilder.claim(TOKEN_BINDING_REF, tokReqMsgCtx.getTokenBinding().getBindingReference());
+            jwtClaimsSetBuilder.claim(TOKEN_BINDING_TYPE, tokReqMsgCtx.getTokenBinding().getBindingType());
+        }
+        return jwtClaimsSetBuilder.build();
     }
 }


### PR DESCRIPTION

Resolves https://github.com/wso2/product-is/issues/8672.

Now the self-contained access token will look like below: It includes binding_ref now.

```
{
  "sub": "admin",
  "aud": "5Yv1EPU6rMek8MufqGpGPeoEfVYa",
  "nbf": 1594387288,
  "azp": "5Yv1EPU6rMek8MufqGpGPeoEfVYa",
  "scope": "test",
  "iss": "https://localhost:9443/oauth2/token",
  "exp": 1594390888,
  "iat": 1594387288,
  "binding_ref": "14be65fcc8b7534ed45daadbfe9d62bd",
  "jti": "d3f7b656-e060-4d72-8f78-fb08c8d423ae"
}
```