### PR TITLE
Fix cluster message doesn't removes the OAuth token

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/listener/OAuthCacheRemoveListener.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/listener/OAuthCacheRemoveListener.java
@@ -53,18 +53,18 @@ public class OAuthCacheRemoveListener extends AbstractCacheListener<OAuthCacheKe
             log.debug("OAuth cache removed for consumer id : " + accessTokenDO.getConsumerKey());
         }
 
+        String userName = accessTokenDO.getAuthzUser().toString();
         boolean isUsernameCaseSensitive = IdentityUtil
                 .isUserStoreInUsernameCaseSensitive(accessTokenDO.getAuthzUser().getUserName());
         String cacheKeyString;
         if (isUsernameCaseSensitive) {
-            cacheKeyString = accessTokenDO.getConsumerKey() + ":" + accessTokenDO.getAuthzUser().getUserName() + ":"
-                    + OAuth2Util.buildScopeString(accessTokenDO.getScope()) + ":"
-                    + accessTokenDO.getAuthzUser().getFederatedIdPName();
+            cacheKeyString = accessTokenDO.getConsumerKey() + ":" + userName + ":" +
+                    OAuth2Util.buildScopeString(accessTokenDO.getScope()) + ":" +
+                    accessTokenDO.getAuthzUser().getFederatedIdPName();
         } else {
-            cacheKeyString =
-                    accessTokenDO.getConsumerKey() + ":" + accessTokenDO.getAuthzUser().getUserName().toLowerCase()
-                            + ":" + OAuth2Util.buildScopeString(accessTokenDO.getScope()) + ":"
-                            + accessTokenDO.getAuthzUser().getFederatedIdPName();
+            cacheKeyString = accessTokenDO.getConsumerKey() + ":" + userName.toLowerCase() + ":" +
+                    OAuth2Util.buildScopeString(accessTokenDO.getScope()) + ":" +
+                    accessTokenDO.getAuthzUser().getFederatedIdPName();
         }
 
         OAuthCacheKey oauthcacheKey = new OAuthCacheKey(cacheKeyString);


### PR DESCRIPTION
Resolves: https://github.com/wso2/product-is/issues/9053

**This PR fixes the not matching cache entry when removing.** 

Fix adds the Domain Name to the username when removing the cache to match with the cache entry key inserted.