### PR TITLE
Modify TokenBindingExpiryEventHandler to listen to SESSION_EXPIRE event

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/bindings/handlers/TokenBindingExpiryEventHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/bindings/handlers/TokenBindingExpiryEventHandler.java
@@ -68,7 +68,8 @@ public class TokenBindingExpiryEventHandler extends AbstractEventHandler {
             log.debug(event.getEventName() + " event received to TokenBindingExpiryEventHandler.");
         }
 
-        if (!IdentityEventConstants.EventName.SESSION_TERMINATE.name().equals(event.getEventName())) {
+        if (!IdentityEventConstants.EventName.SESSION_TERMINATE.name().equals(event.getEventName())
+                && !IdentityEventConstants.EventName.SESSION_EXPIRE.name().equals(event.getEventName())) {
             return;
         }
 

--- a/pom.xml
+++ b/pom.xml
@@ -877,7 +877,7 @@
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!-- Carbon Identity Framework version -->
-        <carbon.identity.framework.version>5.17.94</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.18.86</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.15.0, 6.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 


### PR DESCRIPTION
Resolves https://github.com/wso2/product-is/issues/9312

**Description**
With this PR when a session is expired after an idle time out and the user tries to SSO, log in again or log out, the tokens issued for the expired session will be revoked based on the access token binding defined for the OAuth applications. 

Depends on - https://github.com/wso2/carbon-identity-framework/pull/3098