### PR TITLE
Redirect to callback URL during error scenarios according to the response type

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
+++ b/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
@@ -216,6 +216,7 @@ public final class OAuthConstants {
         public static final String CLIENT_ID = "client_id";
         public static final String REDIRECT_URI = "redirect_uri";
         public static final String STATE = "state";
+        public static final String RESPONSE_TYPE = "response_type";
         public static final String REQUEST = "request";
 
         private OAuth20Params() {

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
@@ -429,22 +429,13 @@ public class EndpointUtil {
             return getErrorPageURL(request, errorCode, errorMessage, appName);
         } else {
             String redirectUri = request.getParameter(OAuthConstants.OAuth20Params.REDIRECT_URI);
-            String state = retrieveStateForErrorURL(oAuth2Parameters);
 
-            Map<String, String> params = new HashMap<>();
-            params.put(PROP_ERROR, errorCode);
-            params.put(PROP_ERROR_DESCRIPTION, errorMessage);
-            if (state != null) {
-                params.put(OAuthConstants.OAuth20Params.STATE, state);
-            }
-
-            try {
-                redirectUri = FrameworkUtils.buildURLWithQueryParams(redirectUri, params);
-            } catch (UnsupportedEncodingException e) {
-                //ignore
-                if (log.isDebugEnabled()) {
-                    log.debug("Error while encoding the error page url", e);
-                }
+            // If the redirect url is not set in the request, page is redirected to common OAuth error page.
+            if (StringUtils.isBlank(redirectUri)) {
+                redirectUri = getErrorPageURL(request, errorCode, errorMessage, appName);
+            } else {
+                String state = retrieveStateForErrorURL(oAuth2Parameters);
+                redirectUri = getUpdatedRedirectURL(request, redirectUri, errorCode, errorMessage, state, appName);
             }
             return redirectUri;
         }
@@ -967,12 +958,52 @@ public class EndpointUtil {
     }
 
     /**
+     * Return updated redirect URL.
+     *
+     * @param request       HttpServletRequest
+     * @param redirectUri   Redirect Uri
+     * @param errorCode     Error Code
+     * @param errorMessage  Message of the error
+     * @param state         State from the request
+     * @param appName       Application Name
+     * @return Updated Redirect URL
+     */
+    private static String getUpdatedRedirectURL(HttpServletRequest request, String redirectUri, String errorCode,
+                                                String errorMessage, String state, String appName) {
+
+        String updatedRedirectUri = redirectUri;
+        try {
+            OAuthProblemException ex = OAuthProblemException.error(errorCode).description(errorMessage);
+            if (OAuth2Util.isImplicitResponseType(request.getParameter(OAuthConstants.OAuth20Params.RESPONSE_TYPE))
+                    || OAuth2Util.isHybridResponseType(request.getParameter(OAuthConstants.OAuth20Params.
+                    RESPONSE_TYPE))) {
+                updatedRedirectUri = OAuthASResponse.errorResponse(HttpServletResponse.SC_FOUND)
+                        .error(ex).location(redirectUri).setState(state).setParam(OAuth.OAUTH_ACCESS_TOKEN, null)
+                        .buildQueryMessage().getLocationUri();
+            } else {
+                updatedRedirectUri = OAuthASResponse.errorResponse(HttpServletResponse.SC_FOUND)
+                        .error(ex).location(redirectUri).setState(state).buildQueryMessage().getLocationUri();
+            }
+
+        } catch (OAuthSystemException e) {
+            log.error("Server error occurred while building error redirect url for application: " + appName, e);
+        }
+        return updatedRedirectUri;
+    }
+
+    /**
      * Method to retrieve the <AllowAdditionalParamsFromErrorUrl> config from the OAuth Configuration.
      * @return Retrieved config (true or false)
      */
     private static boolean isAllowAdditionalParamsFromErrorUrlEnabled() {
 
-        return Boolean.parseBoolean(IdentityUtil.getProperty(ALLOW_ADDITIONAL_PARAMS_FROM_ERROR_URL));
+        String isAllowAdditionalParamsEnabled = IdentityUtil.getProperty(ALLOW_ADDITIONAL_PARAMS_FROM_ERROR_URL);
+
+        if (StringUtils.isNotBlank(isAllowAdditionalParamsEnabled)) {
+            return Boolean.parseBoolean(isAllowAdditionalParamsEnabled);
+        } else {
+            return true;
+        }
     }
 
     /**

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
@@ -997,13 +997,7 @@ public class EndpointUtil {
      */
     private static boolean isAllowAdditionalParamsFromErrorUrlEnabled() {
 
-        String isAllowAdditionalParamsEnabled = IdentityUtil.getProperty(ALLOW_ADDITIONAL_PARAMS_FROM_ERROR_URL);
-
-        if (StringUtils.isNotBlank(isAllowAdditionalParamsEnabled)) {
-            return Boolean.parseBoolean(isAllowAdditionalParamsEnabled);
-        } else {
-            return true;
-        }
+        return Boolean.parseBoolean(IdentityUtil.getProperty(ALLOW_ADDITIONAL_PARAMS_FROM_ERROR_URL));
     }
 
     /**


### PR DESCRIPTION
Front porting the fix from the PR https://github.com/wso2-support/identity-inbound-auth-oauth/pull/631 into master

Related Issues

wso2/product-is#5277 (Code fixed for the PR: #617)

wso2/product-is#7673
