### PR TITLE
Deprecate OAuth 1.0 and /identity/connect/register APIs

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthService.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthService.java
@@ -43,8 +43,8 @@ import java.util.List;
 
 /**
  * OAuthService admin service implementation.
+ * @deprecated
  */
-@Deprecated
 public class OAuthService {
 
     private static final String OAUTH_LATEST_TIMESTAMP = "OAUTH_LATEST_TIMESTAMP";


### PR DESCRIPTION
### Proposed changes in this pull request

Deprecate OAuth 1.0 and /identity/connect/register APIs 

**Related issues**: https://github.com/wso2/product-is/issues/8564, https://github.com/wso2/product-is/issues/8614

**Related PR**: https://github.com/wso2/carbon-identity-framework/pull/3027