### PR TITLE
Deprecate OAuth 1.0 and /identity/connect/register APIs

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/factory/HttpRegistrationResponseFactory.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/factory/HttpRegistrationResponseFactory.java
@@ -17,6 +17,7 @@
  */
 package org.wso2.carbon.identity.oauth.dcr.factory;
 
+import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.json.simple.JSONArray;
@@ -44,6 +45,7 @@ public class HttpRegistrationResponseFactory extends HttpIdentityResponseFactory
     public static final String INVALID_SOFTWARE_STATEMENT = "invalid_software_statement";
     public static final String UNAPPROVED_SOFTWARE_STATEMENT = "unapproved_software_statement";
     public static final String BACKEND_FAILED = "backend_failed";
+    public static final String FORBIDDEN = "forbidden";
     private static final Log log = LogFactory.getLog(HttpRegistrationResponseFactory.class);
 
     @Override
@@ -84,6 +86,12 @@ public class HttpRegistrationResponseFactory extends HttpIdentityResponseFactory
         String errorMessage = "";
         if (ErrorCodes.META_DATA_VALIDATION_FAILED.name().equals(exception.getErrorCode())) {
             errorMessage = generateErrorResponse(INVALID_CLIENT_METADATA, exception.getMessage()).toJSONString();
+        } else if (ErrorCodes.FORBIDDEN.name().equals(exception.getErrorCode())) {
+            errorMessage = StringEscapeUtils.unescapeJava(generateErrorResponse(FORBIDDEN,
+                    exception.getMessage()).toJSONString());
+            builder.setBody(errorMessage);
+            builder.setStatusCode(HttpServletResponse.SC_FORBIDDEN);
+            return builder;
         } else if (ErrorCodes.BAD_REQUEST.name().equals(exception.getErrorCode())) {
             errorMessage = generateErrorResponse(BACKEND_FAILED, exception.getMessage()).toJSONString();
         }

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/util/ErrorCodes.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/util/ErrorCodes.java
@@ -22,5 +22,6 @@ package org.wso2.carbon.identity.oauth.dcr.util;
  */
 public enum ErrorCodes {
     META_DATA_VALIDATION_FAILED,
-    BAD_REQUEST;
+    BAD_REQUEST,
+    FORBIDDEN;
 }

--- a/components/org.wso2.carbon.identity.oauth.ui/src/main/resources/web/oauth/add.jsp
+++ b/components/org.wso2.carbon.identity.oauth.ui/src/main/resources/web/oauth/add.jsp
@@ -23,6 +23,7 @@
 <%@ page import="org.wso2.carbon.identity.oauth.stub.dto.TokenBindingMetaDataDTO" %>
 <%@ page import="org.wso2.carbon.identity.oauth.ui.client.OAuthAdminClient" %>
 <%@ page import="org.wso2.carbon.identity.oauth.ui.util.OAuthUIUtil" %>
+<%@ page import="org.wso2.carbon.identity.core.util.IdentityUtil"%>
 <%@ page import="org.wso2.carbon.ui.CarbonUIMessage" %>
 <%@ page import="org.wso2.carbon.ui.CarbonUIUtil" %>
 <%@ page import="org.wso2.carbon.utils.ServerConstants" %>
@@ -448,10 +449,19 @@
                                 <tr>
                                     <td class="leftCol-med"><fmt:message key='oauth.version'/><span
                                             class="required">*</span></td>
-                                    <td><input id="oauthVersion10a" name="oauthVersion" type="radio"
-                                               value="<%=OAuthConstants.OAuthVersions.VERSION_1A%>"/>1.0a
-                                        <input id="oauthVersion20" name="oauthVersion" type="radio"
-                                               value="<%=OAuthConstants.OAuthVersions.VERSION_2%>" CHECKED/>2.0
+                                    <td>
+                                    <%
+                                    String OAuth1FieldDisabled = "disabled";
+                                    boolean isOAuth1Enabled = IdentityUtil.isLegacyFeatureEnabled("oauth", "1.0");
+                                    if (isOAuth1Enabled) {
+                                          OAuth1FieldDisabled = "";
+                                    }
+                                    %>
+                                    <input id="oauthVersion10a" name="oauthVersion" type="radio"
+                                          value="<%=OAuthConstants.OAuthVersions.VERSION_1A%>"
+                                          <%=OAuth1FieldDisabled%>/>1.0a
+                                    <input id="oauthVersion20" name="oauthVersion" type="radio"
+                                          value="<%=OAuthConstants.OAuthVersions.VERSION_2%>" CHECKED/>2.0
                                     </td>
                                 </tr>
                                 <%if (applicationSPName != null) {%>

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/Error.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/Error.java
@@ -18,12 +18,14 @@ package org.wso2.carbon.identity.oauth;
 /**
  * Container for error codes related to OAuth consumer apps management.
  */
+@Deprecated
 public enum Error {
 
     // Client errors starts with 60, server errors starts with 65.
     INVALID_REQUEST("60001"),
     INVALID_OAUTH_CLIENT("60002"),
     AUTHENTICATED_USER_NOT_FOUND("60003"),
+    FORBIDDEN("60004"),
 
     UNEXPECTED_SERVER_ERROR("65001");
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/IdentityOAuthServerException.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/IdentityOAuthServerException.java
@@ -18,6 +18,7 @@ package org.wso2.carbon.identity.oauth;
 /**
  * Exception for server errors.
  */
+@Deprecated
 public class IdentityOAuthServerException extends IdentityOAuthAdminException {
 
     public IdentityOAuthServerException(String message) {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthService.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthService.java
@@ -43,6 +43,7 @@ import java.util.List;
 
 /**
  * OAuthService admin service implementation.
+ * @Deprecated
  */
 public class OAuthService {
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/cache/CacheKey.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/cache/CacheKey.java
@@ -25,6 +25,7 @@ import java.io.Serializable;
  * Cache key class. Any value that acts as a cache key must encapsulated with a class
  * overriding from this class.
  */
+@Deprecated
 public abstract class CacheKey implements Serializable {
 
     private static final long serialVersionUID = 5884270521313791351L;

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/callback/DefaultCallbackHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/callback/DefaultCallbackHandler.java
@@ -30,6 +30,7 @@ import javax.security.auth.callback.UnsupportedCallbackException;
  * Default OAuth callback handler
  */
 @SuppressWarnings("unused")
+@Deprecated
 public class DefaultCallbackHandler extends AbstractOAuthCallbackHandler {
 
     @Override

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/callback/OAuthCallbackHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/callback/OAuthCallbackHandler.java
@@ -45,6 +45,7 @@ import javax.security.auth.callback.UnsupportedCallbackException;
  * <p/>
  * After handling the callback, it can set whether the given callback is authorized or not.
  */
+@Deprecated
 public interface OAuthCallbackHandler extends CallbackHandler {
 
     /**

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/callback/OAuthCallbackHandlerRegistry.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/callback/OAuthCallbackHandlerRegistry.java
@@ -39,6 +39,7 @@ import javax.security.auth.callback.Callback;
  * <Code>OAuthCallbackHandler</Code>, etc which are called during the OAuth token
  * issuance process.
  */
+@Deprecated
 public class OAuthCallbackHandlerRegistry {
 
     private static final Log log = LogFactory.getLog(OAuthCallbackHandlerRegistry.class);

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dto/OAuthConsumerDTO.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dto/OAuthConsumerDTO.java
@@ -21,6 +21,7 @@ package org.wso2.carbon.identity.oauth.dto;
 /**
  * OAuth consumer dto.
  */
+@Deprecated
 public class OAuthConsumerDTO {
 
     // oauth_signature

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dto/OAuthIDTokenAlgorithmDTO.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dto/OAuthIDTokenAlgorithmDTO.java
@@ -23,6 +23,7 @@ import java.util.List;
 /**
  * Class to transfer ID token encryption related algorithms.
  */
+@Deprecated
 public class OAuthIDTokenAlgorithmDTO {
 
     private String defaultIdTokenEncryptionAlgorithm;

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dto/OAuthMetaDataDTO.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dto/OAuthMetaDataDTO.java
@@ -21,6 +21,7 @@ package org.wso2.carbon.identity.oauth.dto;
 /**
  * OAuth metadata dto.
  */
+@Deprecated
 public class OAuthMetaDataDTO {
 
     private String requestTokenUrl;

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dto/OAuthRevocationRequestDTO.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dto/OAuthRevocationRequestDTO.java
@@ -21,6 +21,7 @@ package org.wso2.carbon.identity.oauth.dto;
 /**
  * OAuth token revocation request dto.
  */
+@Deprecated
 public class OAuthRevocationRequestDTO {
 
     private String[] apps;

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dto/OAuthRevocationResponseDTO.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dto/OAuthRevocationResponseDTO.java
@@ -21,6 +21,7 @@ package org.wso2.carbon.identity.oauth.dto;
 /**
  * OAuth revocation response dto.
  */
+@Deprecated
 public class OAuthRevocationResponseDTO {
 
     private boolean error;

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dto/OAuthTokenExpiryTimeDTO.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dto/OAuthTokenExpiryTimeDTO.java
@@ -21,6 +21,7 @@ package org.wso2.carbon.identity.oauth.dto;
 /**
  * OAuth token expiry time dto.
  */
+@Deprecated
 public class OAuthTokenExpiryTimeDTO {
 
     private long userAccessTokenExpiryTime;

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dto/TokenBindingMetaDataDTO.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dto/TokenBindingMetaDataDTO.java
@@ -22,6 +22,7 @@ import java.util.List;
 /**
  * This class represents the token binding meta data DTO.
  */
+@Deprecated
 public class TokenBindingMetaDataDTO implements Serializable {
 
     private static final long serialVersionUID = 6372165740005823232L;

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/event/AbstractOAuthEventInterceptor.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/event/AbstractOAuthEventInterceptor.java
@@ -40,6 +40,7 @@ import java.util.Map;
 /**
  * Oauth Event Interceptor implemented for publishing oauth data to DAS
  */
+@Deprecated
 public class AbstractOAuthEventInterceptor extends AbstractIdentityHandler implements OAuthEventInterceptor {
 
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/internal/OAuthServiceComponent.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/internal/OAuthServiceComponent.java
@@ -48,6 +48,7 @@ import org.wso2.carbon.user.core.service.RealmService;
         name = "identity.oauth.component",
         immediate = true
 )
+@Deprecated
 public class OAuthServiceComponent {
 
     private static final Log log = LogFactory.getLog(OAuthServiceComponent.class);

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/listener/ClaimCacheRemoveListener.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/listener/ClaimCacheRemoveListener.java
@@ -29,6 +29,7 @@ import javax.cache.event.CacheEntryRemovedListener;
 /**
  * Claim Cache Remove Listener.
  */
+@Deprecated
 public class ClaimCacheRemoveListener extends AbstractCacheListener<ClaimCacheKey, UserClaims>
         implements CacheEntryRemovedListener<ClaimCacheKey, UserClaims> {
     @Override

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/listener/ClaimMetaDataCacheRemoveListener.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/listener/ClaimMetaDataCacheRemoveListener.java
@@ -27,6 +27,7 @@ import javax.cache.event.CacheEntryRemovedListener;
 /**
  * Claim Meta Data Cache Remove Listener.
  */
+@Deprecated
 public class ClaimMetaDataCacheRemoveListener
         extends AbstractCacheListener<ClaimMetaDataCacheEntry, ClaimMetaDataCacheEntry>
         implements CacheEntryRemovedListener<ClaimMetaDataCacheEntry, ClaimMetaDataCacheEntry> {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/listener/IdentityOathEventListener.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/listener/IdentityOathEventListener.java
@@ -63,6 +63,7 @@ import static org.wso2.carbon.identity.oauth.common.OAuthConstants.TokenBindings
  * additional operations
  * for some of the core user management operations
  */
+@Deprecated
 public class IdentityOathEventListener extends AbstractIdentityUserOperationEventListener {
 
     private static final Log log = LogFactory.getLog(IdentityOathEventListener.class);

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/listener/OAuthCacheRemoveListener.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/listener/OAuthCacheRemoveListener.java
@@ -34,6 +34,7 @@ import javax.cache.event.CacheEntryRemovedListener;
 /**
  * Cache listener to clear OAuth cache.
  */
+@Deprecated
 public class OAuthCacheRemoveListener extends AbstractCacheListener<OAuthCacheKey, CacheEntry>
         implements CacheEntryRemovedListener<OAuthCacheKey, CacheEntry> {
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/tokenprocessor/EncryptionDecryptionPersistenceProcessor.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/tokenprocessor/EncryptionDecryptionPersistenceProcessor.java
@@ -29,6 +29,7 @@ import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
  * An implementation of <Code>TokenPersistenceProcessor</Code>
  * which is used when storing encrypted tokens.
  */
+@Deprecated
 public class EncryptionDecryptionPersistenceProcessor implements TokenPersistenceProcessor {
 
     protected static final Log LOG = LogFactory.getLog(EncryptionDecryptionPersistenceProcessor.class);

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/tokenvaluegenerator/SHA256Generator.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/tokenvaluegenerator/SHA256Generator.java
@@ -29,6 +29,7 @@ import java.util.UUID;
 /**
  * Token value generator class to generate SHA-256 hash as a token value (256 bits, 64 Hex Characters).
  */
+@Deprecated
 public class SHA256Generator implements ValueGenerator {
 
     @Override

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/user/UserInfoAccessTokenValidator.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/user/UserInfoAccessTokenValidator.java
@@ -24,6 +24,7 @@ import javax.servlet.http.HttpServletRequest;
 /**
  * Validates the Access Token
  */
+@Deprecated
 public interface UserInfoAccessTokenValidator {
 
     /**

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/util/UserClaimsTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/util/UserClaimsTest.java
@@ -27,6 +27,7 @@ import static org.testng.Assert.assertEquals;
 /**
  * Test Class for the UserClaims.
  */
+@Deprecated
 public class UserClaimsTest {
 
     TreeMap<String, String> testval = new TreeMap<>();

--- a/components/org.wso2.carbon.identity.oidc.dcr/pom.xml
+++ b/components/org.wso2.carbon.identity.oidc.dcr/pom.xml
@@ -151,6 +151,7 @@
                             org.wso2.carbon.identity.application.common.model; version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.application.mgt;version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.application.authentication.framework.*;version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.core.util;version="${carbon.identity.framework.version}",
 
                             org.wso2.carbon.identity.oauth.dcr.*;version="${identity.inbound.auth.oauth.imp.pkg.version.range}",
                             org.wso2.carbon.identity.oauth2.util;version="${identity.inbound.auth.oauth.imp.pkg.version.range}",

--- a/components/org.wso2.carbon.identity.oidc.dcr/pom.xml
+++ b/components/org.wso2.carbon.identity.oidc.dcr/pom.xml
@@ -151,7 +151,7 @@
                             org.wso2.carbon.identity.application.common.model; version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.application.mgt;version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.application.authentication.framework.*;version="${carbon.identity.framework.imp.pkg.version.range}",
-                            org.wso2.carbon.identity.core.util;version="${carbon.identity.framework.version}",
+                            org.wso2.carbon.identity.core.util;version="${carbon.identity.framework.imp.pkg.version.range}",
 
                             org.wso2.carbon.identity.oauth.dcr.*;version="${identity.inbound.auth.oauth.imp.pkg.version.range}",
                             org.wso2.carbon.identity.oauth2.util;version="${identity.inbound.auth.oauth.imp.pkg.version.range}",

--- a/components/org.wso2.carbon.identity.oidc.dcr/src/main/java/org/wso2/carbon/identity/oidc/dcr/OIDCDCRClientException.java
+++ b/components/org.wso2.carbon.identity.oidc.dcr/src/main/java/org/wso2/carbon/identity/oidc/dcr/OIDCDCRClientException.java
@@ -22,6 +22,7 @@ import org.wso2.carbon.identity.oauth.dcr.DCRClientException;
 /**
  * Exception class used to handle OIDC DCR client exception.
  */
+@Deprecated
 public class OIDCDCRClientException extends DCRClientException {
 
     public OIDCDCRClientException(String message) {

--- a/components/org.wso2.carbon.identity.oidc.dcr/src/main/java/org/wso2/carbon/identity/oidc/dcr/OIDCDCRException.java
+++ b/components/org.wso2.carbon.identity.oidc.dcr/src/main/java/org/wso2/carbon/identity/oidc/dcr/OIDCDCRException.java
@@ -23,6 +23,7 @@ import org.wso2.carbon.identity.oauth.dcr.DCRException;
 /**
  * Custom exception to be thrown inside DynamicClientRegistration related functionality.
  */
+@Deprecated
 public class OIDCDCRException extends DCRException {
 
     private static final long serialVersionUID = -3151279311929070297L;

--- a/components/org.wso2.carbon.identity.oidc.dcr/src/main/java/org/wso2/carbon/identity/oidc/dcr/OIDCDCRRuntimeException.java
+++ b/components/org.wso2.carbon.identity.oidc.dcr/src/main/java/org/wso2/carbon/identity/oidc/dcr/OIDCDCRRuntimeException.java
@@ -22,6 +22,7 @@ import org.wso2.carbon.identity.oauth.dcr.DCRRuntimeException;
 /**
  * Handles OIDC DCR runtime related exceptions.
  */
+@Deprecated
 public class OIDCDCRRuntimeException extends DCRRuntimeException {
 
     protected OIDCDCRRuntimeException(String errorDescription) {

--- a/components/org.wso2.carbon.identity.oidc.dcr/src/main/java/org/wso2/carbon/identity/oidc/dcr/context/OIDCDCRMessageContext.java
+++ b/components/org.wso2.carbon.identity.oidc.dcr/src/main/java/org/wso2/carbon/identity/oidc/dcr/context/OIDCDCRMessageContext.java
@@ -25,6 +25,7 @@ import java.util.Map;
 /**
  * Context class related to OIDC DCR Message.
  */
+@Deprecated
 public class OIDCDCRMessageContext extends DCRMessageContext {
 
     private static final long serialVersionUID = -5300677220286769250L;

--- a/components/org.wso2.carbon.identity.oidc.dcr/src/main/java/org/wso2/carbon/identity/oidc/dcr/factory/HttpOIDCRegistrationResponseFactory.java
+++ b/components/org.wso2.carbon.identity.oidc.dcr/src/main/java/org/wso2/carbon/identity/oidc/dcr/factory/HttpOIDCRegistrationResponseFactory.java
@@ -33,6 +33,7 @@ import javax.ws.rs.core.MediaType;
 /**
  * Factory class responsible for http OIDC registration response.
  */
+@Deprecated
 public class HttpOIDCRegistrationResponseFactory extends HttpRegistrationResponseFactory {
 
     private static final Log log = LogFactory.getLog(HttpOIDCRegistrationResponseFactory.class);

--- a/components/org.wso2.carbon.identity.oidc.dcr/src/main/java/org/wso2/carbon/identity/oidc/dcr/factory/OIDCRegistrationRequestFactory.java
+++ b/components/org.wso2.carbon.identity.oidc.dcr/src/main/java/org/wso2/carbon/identity/oidc/dcr/factory/OIDCRegistrationRequestFactory.java
@@ -41,6 +41,7 @@ import javax.ws.rs.HttpMethod;
 /**
  * OIDCRegistrationRequestFactory build the request for DCR Registry Request.
  */
+@Deprecated
 public class OIDCRegistrationRequestFactory extends RegistrationRequestFactory {
 
     private static final Log log = LogFactory.getLog(OIDCRegistrationRequestFactory.class);

--- a/components/org.wso2.carbon.identity.oidc.dcr/src/main/java/org/wso2/carbon/identity/oidc/dcr/handler/OIDCRegistrationHandler.java
+++ b/components/org.wso2.carbon.identity.oidc.dcr/src/main/java/org/wso2/carbon/identity/oidc/dcr/handler/OIDCRegistrationHandler.java
@@ -33,6 +33,7 @@ import org.wso2.carbon.identity.oauth.dcr.service.DCRManagementService;
 /**
  * Handler class responsible for OIDC registration.
  */
+@Deprecated
 public class OIDCRegistrationHandler extends RegistrationHandler {
 
     private static final Log log = LogFactory.getLog(OIDCRegistrationHandler.class);

--- a/components/org.wso2.carbon.identity.oidc.dcr/src/main/java/org/wso2/carbon/identity/oidc/dcr/internal/OIDCDCRDataHolder.java
+++ b/components/org.wso2.carbon.identity.oidc.dcr/src/main/java/org/wso2/carbon/identity/oidc/dcr/internal/OIDCDCRDataHolder.java
@@ -24,6 +24,7 @@ import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
  * This is the DataHolder class of DynamicClientRegistration bundle. This holds a reference to the
  * ApplicationManagementService.
  */
+@Deprecated
 public class OIDCDCRDataHolder {
 
     private static OIDCDCRDataHolder

--- a/components/org.wso2.carbon.identity.oidc.dcr/src/main/java/org/wso2/carbon/identity/oidc/dcr/internal/OIDCDCRServiceComponent.java
+++ b/components/org.wso2.carbon.identity.oidc.dcr/src/main/java/org/wso2/carbon/identity/oidc/dcr/internal/OIDCDCRServiceComponent.java
@@ -40,6 +40,7 @@ import org.wso2.carbon.identity.oidc.dcr.processor.OIDCDCRProcessor;
         name = "identity.oidc.dcr",
         immediate = true
 )
+@Deprecated
 public class OIDCDCRServiceComponent {
 
     private static final Log log = LogFactory.getLog(OIDCDCRServiceComponent.class);

--- a/components/org.wso2.carbon.identity.oidc.dcr/src/main/java/org/wso2/carbon/identity/oidc/dcr/model/OIDCRegistrationRequest.java
+++ b/components/org.wso2.carbon.identity.oidc.dcr/src/main/java/org/wso2/carbon/identity/oidc/dcr/model/OIDCRegistrationRequest.java
@@ -28,6 +28,7 @@ import javax.servlet.http.HttpServletResponse;
 /**
  * DCR Request data for Register a oauth application.
  */
+@Deprecated
 public class OIDCRegistrationRequest extends RegistrationRequest {
 
     private static final long serialVersionUID = -2728761431889772896L;

--- a/components/org.wso2.carbon.identity.oidc.dcr/src/main/java/org/wso2/carbon/identity/oidc/dcr/model/OIDCRegistrationRequestProfile.java
+++ b/components/org.wso2.carbon.identity.oidc.dcr/src/main/java/org/wso2/carbon/identity/oidc/dcr/model/OIDCRegistrationRequestProfile.java
@@ -25,6 +25,7 @@ import java.util.List;
 /**
  * This class represents the necessary data used to register an OIDC application.
  */
+@Deprecated
 public class OIDCRegistrationRequestProfile extends RegistrationRequestProfile {
 
     private static final long serialVersionUID = -76875661310642695L;

--- a/components/org.wso2.carbon.identity.oidc.dcr/src/main/java/org/wso2/carbon/identity/oidc/dcr/model/OIDCRegistrationResponse.java
+++ b/components/org.wso2.carbon.identity.oidc.dcr/src/main/java/org/wso2/carbon/identity/oidc/dcr/model/OIDCRegistrationResponse.java
@@ -24,6 +24,7 @@ import org.wso2.carbon.identity.oauth.dcr.model.RegistrationResponse;
 /**
  * OIDC DCR Response data returned for registration request.
  */
+@Deprecated
 public class OIDCRegistrationResponse extends RegistrationResponse {
 
     private static final long serialVersionUID = 4698835928698402469L;

--- a/components/org.wso2.carbon.identity.oidc.dcr/src/main/java/org/wso2/carbon/identity/oidc/dcr/model/OIDCRegistrationResponseProfile.java
+++ b/components/org.wso2.carbon.identity.oidc.dcr/src/main/java/org/wso2/carbon/identity/oidc/dcr/model/OIDCRegistrationResponseProfile.java
@@ -22,6 +22,7 @@ import org.wso2.carbon.identity.oauth.dcr.model.RegistrationResponseProfile;
 /**
  * This class represents an OIDC application populated with necessary data.
  */
+@Deprecated
 public class OIDCRegistrationResponseProfile extends RegistrationResponseProfile {
 
     private static final long serialVersionUID = -9055024954155011631L;

--- a/components/org.wso2.carbon.identity.oidc.dcr/src/main/java/org/wso2/carbon/identity/oidc/dcr/processor/OIDCDCRProcessor.java
+++ b/components/org.wso2.carbon.identity.oidc.dcr/src/main/java/org/wso2/carbon/identity/oidc/dcr/processor/OIDCDCRProcessor.java
@@ -21,10 +21,13 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.identity.application.authentication.framework.inbound.IdentityRequest;
 import org.wso2.carbon.identity.application.authentication.framework.inbound.IdentityResponse;
+import org.wso2.carbon.identity.base.IdentityException;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.oauth.dcr.DCRException;
 import org.wso2.carbon.identity.oauth.dcr.context.DCRMessageContext;
 import org.wso2.carbon.identity.oauth.dcr.exception.RegistrationException;
 import org.wso2.carbon.identity.oauth.dcr.processor.DCRProcessor;
+import org.wso2.carbon.identity.oauth.dcr.util.ErrorCodes;
 import org.wso2.carbon.identity.oidc.dcr.context.OIDCDCRMessageContext;
 import org.wso2.carbon.identity.oidc.dcr.model.OIDCRegistrationRequest;
 import org.wso2.carbon.identity.oidc.dcr.util.OIDCDCRConstants;
@@ -34,6 +37,7 @@ import java.util.regex.Matcher;
 /**
  * OIDC DCR Processor class.
  */
+@Deprecated
 public class OIDCDCRProcessor extends DCRProcessor {
 
     private static final Log log = LogFactory.getLog(OIDCDCRProcessor.class);
@@ -44,6 +48,24 @@ public class OIDCDCRProcessor extends DCRProcessor {
         if (log.isDebugEnabled()) {
             log.debug("Request processing started by OIDCDCRProcessor.");
         }
+
+        boolean isIdentityConnectDCREnabled =
+                IdentityUtil.isLegacyFeatureEnabled(OIDCDCRConstants.OIDC_DCR_ID, OIDCDCRConstants.OIDC_DCR_VERSION);
+
+        if (!isIdentityConnectDCREnabled) {
+            if (log.isDebugEnabled()) {
+                log.debug("Identity Connect DCR endpoint was deprecated. To enable the DCR API endpoint " +
+                        "add the following config to deployment.toml file. \n" +
+                        "[[legacy_feature]] \n" +
+                        "id = identity/connect/dcr  \n" +
+                        "enable = true");
+            }
+            String errorMessage =
+                    "/identity/connect/register API was deprecated. Refer the WSO2 official documentation for " +
+                            "more information (https://is.docs.wso2.com).";
+            throw IdentityException.error(RegistrationException.class, ErrorCodes.FORBIDDEN.toString(), errorMessage);
+        }
+
         OIDCDCRMessageContext oidcdcrMessageContext = new OIDCDCRMessageContext(identityRequest);
         IdentityResponse.IdentityResponseBuilder identityResponseBuilder = null;
         if (identityRequest instanceof OIDCRegistrationRequest) {

--- a/components/org.wso2.carbon.identity.oidc.dcr/src/main/java/org/wso2/carbon/identity/oidc/dcr/util/OIDCDCRConstants.java
+++ b/components/org.wso2.carbon.identity.oidc.dcr/src/main/java/org/wso2/carbon/identity/oidc/dcr/util/OIDCDCRConstants.java
@@ -22,8 +22,11 @@ import java.util.regex.Pattern;
 /**
  * This class holds the constants used by DynamicClientRegistration component.
  */
+@Deprecated
 public final class OIDCDCRConstants {
 
     public static final Pattern OIDC_DCR_ENDPOINT_REGISTER_URL_PATTERN =
             Pattern.compile("(.*)/identity/connect/register/?");
+    public static final String OIDC_DCR_ID = "identity/connect/dcr";
+    public static final String OIDC_DCR_VERSION = "";
 }

--- a/pom.xml
+++ b/pom.xml
@@ -877,7 +877,7 @@
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!-- Carbon Identity Framework version -->
-        <carbon.identity.framework.version>5.18.86</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.17.66</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.15.0, 6.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 
@@ -945,7 +945,7 @@
         <tomcat.wso2.imp.pkg.version.range>[9.0.0, 9.5.0)</tomcat.wso2.imp.pkg.version.range>
 
         <google.guava.version>27.0-jre</google.guava.version>
-        <org.apache.cxf.version>3.3.7</org.apache.cxf.version>
+        <org.apache.cxf.version>3.2.8</org.apache.cxf.version>
         <encoder.wso2.version>1.2.0.wso2v1</encoder.wso2.version>
         <json-simple.version>1.1.wso2v1</json-simple.version>
 
@@ -969,7 +969,7 @@
         <com.fasterxml.jackson.core.version>2.9.9</com.fasterxml.jackson.core.version>
         <com.fasterxml.jackson.version>2.9.7</com.fasterxml.jackson.version>
         <spring-web.version>4.1.6.RELEASE</spring-web.version>
-        <swagger-jaxrs.version>1.6.2</swagger-jaxrs.version>
+        <swagger-jaxrs.version>1.5.20</swagger-jaxrs.version>
         <!-- httpclient dependency Version-->
         <http.client.version>4.3.6.wso2v1</http.client.version>
         <http.core.version>4.3.3.wso2v1</http.core.version>

--- a/pom.xml
+++ b/pom.xml
@@ -877,7 +877,7 @@
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!-- Carbon Identity Framework version -->
-        <carbon.identity.framework.version>5.17.66</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.18.86</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.15.0, 6.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 
@@ -945,7 +945,7 @@
         <tomcat.wso2.imp.pkg.version.range>[9.0.0, 9.5.0)</tomcat.wso2.imp.pkg.version.range>
 
         <google.guava.version>27.0-jre</google.guava.version>
-        <org.apache.cxf.version>3.2.8</org.apache.cxf.version>
+        <org.apache.cxf.version>3.3.7</org.apache.cxf.version>
         <encoder.wso2.version>1.2.0.wso2v1</encoder.wso2.version>
         <json-simple.version>1.1.wso2v1</json-simple.version>
 
@@ -969,7 +969,7 @@
         <com.fasterxml.jackson.core.version>2.9.9</com.fasterxml.jackson.core.version>
         <com.fasterxml.jackson.version>2.9.7</com.fasterxml.jackson.version>
         <spring-web.version>4.1.6.RELEASE</spring-web.version>
-        <swagger-jaxrs.version>1.5.20</swagger-jaxrs.version>
+        <swagger-jaxrs.version>1.6.2</swagger-jaxrs.version>
         <!-- httpclient dependency Version-->
         <http.client.version>4.3.6.wso2v1</http.client.version>
         <http.core.version>4.3.3.wso2v1</http.core.version>


### PR DESCRIPTION
### Proposed changes in this pull request

Deprecate OAuth 1.0 and /identity/connect/register APIs 

**Related issues**: https://github.com/wso2/product-is/issues/8564, https://github.com/wso2/product-is/issues/8614

**Related PR**: https://github.com/wso2/carbon-identity-framework/pull/3027