### PR TITLE
Fix wso2/product-is#9534: Support application/json content type in the request to the OAuth 2.0 token endpoint

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/IDTokenTokenResponseValidator.java
+++ b/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/IDTokenTokenResponseValidator.java
@@ -18,9 +18,21 @@
 
 package org.wso2.carbon.identity.oauth.common;
 
+import org.apache.oltu.oauth2.common.exception.OAuthProblemException;
+
+import javax.servlet.http.HttpServletRequest;
+
+import static org.wso2.carbon.identity.oauth.common.OAuthCommonUtil.validateContentTypes;
+
 /**
  * Validator for IDtoken token response.
  */
 public class IDTokenTokenResponseValidator extends IDTokenResponseValidator {
 
+
+    @Override
+    public void validateContentType(HttpServletRequest request) throws OAuthProblemException {
+
+        validateContentTypes(request);
+    }
 }

--- a/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/NTLMAuthenticationValidator.java
+++ b/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/NTLMAuthenticationValidator.java
@@ -18,9 +18,12 @@
 package org.wso2.carbon.identity.oauth.common;
 
 import org.apache.oltu.oauth2.common.OAuth;
+import org.apache.oltu.oauth2.common.exception.OAuthProblemException;
 import org.apache.oltu.oauth2.common.validators.AbstractValidator;
 
 import javax.servlet.http.HttpServletRequest;
+
+import static org.wso2.carbon.identity.oauth.common.OAuthCommonUtil.validateContentTypes;
 
 /**
  * This class used for NTL authentication validation.
@@ -33,4 +36,9 @@ public class NTLMAuthenticationValidator extends AbstractValidator<HttpServletRe
         requiredParams.add(OAuthConstants.WINDOWS_TOKEN);
     }
 
+    @Override
+    public void validateContentType(HttpServletRequest request) throws OAuthProblemException {
+
+        validateContentTypes(request);
+    }
 }

--- a/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthCommonUtil.java
+++ b/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthCommonUtil.java
@@ -1,0 +1,53 @@
+package org.wso2.carbon.identity.oauth.common;
+
+import org.apache.oltu.oauth2.common.exception.OAuthProblemException;
+import org.apache.oltu.oauth2.common.utils.OAuthUtils;
+
+import java.util.List;
+
+import javax.servlet.http.HttpServletRequest;
+
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.ALLOWED_CONTENT_TYPES;
+
+/**
+ * Common utility functions for OAuth related operations.
+ */
+public class OAuthCommonUtil {
+
+    /**
+     * Check whether HTTP content type header is an allowed content type.
+     *
+     * @param contentTypeHeader Content-Type header sent in HTTP request.
+     * @param allowedContentTypes Allowed list of content types.
+     * @return true if the content type is allowed, else, false.
+     */
+    public static boolean isAllowedContentType(String contentTypeHeader, List<String> allowedContentTypes) {
+
+        if (contentTypeHeader == null || allowedContentTypes == null) {
+            return false;
+        }
+
+        String[] requestContentTypes = contentTypeHeader.split(";");
+        for (String requestContentType : requestContentTypes) {
+            if (allowedContentTypes.contains(requestContentType)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Validate whether the HTTP request's content type are either "application/x-www-form-urlencoded" or
+     * "application/json".
+     *
+     * @param request HTTP request to be validated.
+     * @throws OAuthProblemException if HTTP request is has an unsupported content type.
+     */
+    public static void validateContentTypes(HttpServletRequest request) throws OAuthProblemException {
+
+        String contentType = request.getContentType();
+        if (!isAllowedContentType(contentType, ALLOWED_CONTENT_TYPES)) {
+            throw OAuthUtils.handleBadContentTypeException(String.join(" or ", ALLOWED_CONTENT_TYPES));
+        }
+    }
+}

--- a/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthCommonUtil.java
+++ b/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthCommonUtil.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.wso2.carbon.identity.oauth.common;
 
 import org.apache.oltu.oauth2.common.exception.OAuthProblemException;

--- a/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
+++ b/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
@@ -18,6 +18,9 @@
 
 package org.wso2.carbon.identity.oauth.common;
 
+import java.util.Arrays;
+import java.util.List;
+
 /**
  * This class define OAuth related constants.
  */
@@ -31,6 +34,8 @@ public final class OAuthConstants {
     //OAuth2 request headers.
     public static final String HTTP_REQ_HEADER_AUTHZ = "Authorization";
     public static final String HTTP_REQ_HEADER_AUTH_METHOD_BASIC = "Basic";
+    public static final List<String> ALLOWED_CONTENT_TYPES = Arrays.asList("application/x-www-form-urlencoded",
+                                                                           "application/json");
 
     // OAuth2 response headers
     public static final String HTTP_RESP_HEADER_CACHE_CONTROL = "Cache-Control";

--- a/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/SAML2GrantValidator.java
+++ b/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/SAML2GrantValidator.java
@@ -18,9 +18,12 @@
 package org.wso2.carbon.identity.oauth.common;
 
 import org.apache.oltu.oauth2.common.OAuth;
+import org.apache.oltu.oauth2.common.exception.OAuthProblemException;
 import org.apache.oltu.oauth2.common.validators.AbstractValidator;
 
 import javax.servlet.http.HttpServletRequest;
+
+import static org.wso2.carbon.identity.oauth.common.OAuthCommonUtil.validateContentTypes;
 
 /**
  * This class used to validate the SAML2 grant.
@@ -33,4 +36,9 @@ public class SAML2GrantValidator extends AbstractValidator<HttpServletRequest> {
         requiredParams.add(OAuth.OAUTH_ASSERTION);
     }
 
+    @Override
+    public void validateContentType(HttpServletRequest request) throws OAuthProblemException {
+
+        validateContentTypes(request);
+    }
 }

--- a/components/org.wso2.carbon.identity.oauth.common/src/test/java/org/wso2/carbon/identity/oauth/common/IDTokenTokenResponseValidatorTest.java
+++ b/components/org.wso2.carbon.identity.oauth.common/src/test/java/org/wso2/carbon/identity/oauth/common/IDTokenTokenResponseValidatorTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth.common;
+
+import org.apache.oltu.oauth2.common.exception.OAuthProblemException;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import javax.servlet.http.HttpServletRequest;
+
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+/**
+ * Test class for IDTokenTokenResponseValidator.
+ */
+public class IDTokenTokenResponseValidatorTest {
+
+    private IDTokenTokenResponseValidator testedValidator;
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+
+        testedValidator = new IDTokenTokenResponseValidator();
+    }
+
+    @DataProvider(name = "Content Type Provider")
+    public Object[][] getContentType() {
+
+        return new Object[][]{
+                {"application/x-www-form-urlencoded", true},
+                {"application/json", true},
+                {"application/xml", false},
+        };
+    }
+
+    @Test(dataProvider = "Content Type Provider")
+    public void testValidateContentType(String contentType, boolean shouldPass) throws Exception {
+
+        HttpServletRequest mockRequest = mock(HttpServletRequest.class);
+        when(mockRequest.getContentType()).thenReturn(contentType);
+        try {
+            testedValidator.validateContentType(mockRequest);
+            if (!shouldPass) {
+                Assert.fail(contentType + " should not be an allowed content type");
+            }
+        } catch (OAuthProblemException e) {
+            if (shouldPass) {
+                Assert.fail(contentType + " should be an allowed content type");
+            }
+        }
+    }
+}

--- a/components/org.wso2.carbon.identity.oauth.common/src/test/java/org/wso2/carbon/identity/oauth/common/IDTokenTokenResponseValidatorTest.java
+++ b/components/org.wso2.carbon.identity.oauth.common/src/test/java/org/wso2/carbon/identity/oauth/common/IDTokenTokenResponseValidatorTest.java
@@ -48,6 +48,7 @@ public class IDTokenTokenResponseValidatorTest {
         return new Object[][]{
                 {"application/x-www-form-urlencoded", true},
                 {"application/json", true},
+                {"application/json; charset=utf-8", true},
                 {"application/xml", false},
         };
     }

--- a/components/org.wso2.carbon.identity.oauth.common/src/test/java/org/wso2/carbon/identity/oauth/common/NTLMAuthenticationValidatorTest.java
+++ b/components/org.wso2.carbon.identity.oauth.common/src/test/java/org/wso2/carbon/identity/oauth/common/NTLMAuthenticationValidatorTest.java
@@ -95,6 +95,7 @@ public class NTLMAuthenticationValidatorTest {
         return new Object[][]{
                 {"application/x-www-form-urlencoded", true},
                 {"application/json", true},
+                {"application/json; charset=utf-8", true},
                 {"application/xml", false},
         };
     }

--- a/components/org.wso2.carbon.identity.oauth.common/src/test/java/org/wso2/carbon/identity/oauth/common/NTLMAuthenticationValidatorTest.java
+++ b/components/org.wso2.carbon.identity.oauth.common/src/test/java/org/wso2/carbon/identity/oauth/common/NTLMAuthenticationValidatorTest.java
@@ -4,6 +4,7 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.oltu.oauth2.common.OAuth;
 import org.apache.oltu.oauth2.common.error.OAuthError;
 import org.apache.oltu.oauth2.common.exception.OAuthProblemException;
+import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
@@ -84,6 +85,33 @@ public class NTLMAuthenticationValidatorTest {
             } catch (OAuthProblemException e) {
                 assertTrue(e.getMessage().startsWith(OAuthError.TokenResponse.INVALID_REQUEST), "Invalid error " +
                         "message received. Received was: " + e.getMessage());
+            }
+        }
+    }
+
+    @DataProvider(name = "Content Type Provider")
+    public Object[][] getContentType() {
+
+        return new Object[][]{
+                {"application/x-www-form-urlencoded", true},
+                {"application/json", true},
+                {"application/xml", false},
+        };
+    }
+
+    @Test(dataProvider = "Content Type Provider")
+    public void testValidateContentType(String contentType, boolean shouldPass) throws Exception {
+
+        HttpServletRequest mockRequest = mock(HttpServletRequest.class);
+        when(mockRequest.getContentType()).thenReturn(contentType);
+        try {
+            testedValidator.validateContentType(mockRequest);
+            if (!shouldPass) {
+                Assert.fail(contentType + " should not be an allowed content type");
+            }
+        } catch (OAuthProblemException e) {
+            if (shouldPass) {
+                Assert.fail(contentType + " should be an allowed content type");
             }
         }
     }

--- a/components/org.wso2.carbon.identity.oauth.common/src/test/java/org/wso2/carbon/identity/oauth/common/OAuthCommonUtilTest.java
+++ b/components/org.wso2.carbon.identity.oauth.common/src/test/java/org/wso2/carbon/identity/oauth/common/OAuthCommonUtilTest.java
@@ -40,6 +40,7 @@ public class OAuthCommonUtilTest {
         return new Object[][]{
                 {"application/x-www-form-urlencoded", true},
                 {"application/json", true},
+                {"application/json; charset=utf-8", true},
                 {"application/xml", false},
         };
     }

--- a/components/org.wso2.carbon.identity.oauth.common/src/test/java/org/wso2/carbon/identity/oauth/common/OAuthCommonUtilTest.java
+++ b/components/org.wso2.carbon.identity.oauth.common/src/test/java/org/wso2/carbon/identity/oauth/common/OAuthCommonUtilTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth.common;
+
+import org.apache.oltu.oauth2.common.exception.OAuthProblemException;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import javax.servlet.http.HttpServletRequest;
+
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.when;
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.ALLOWED_CONTENT_TYPES;
+
+/**
+ * Test class for OAuthCommonUtil.
+ */
+public class OAuthCommonUtilTest {
+
+    @DataProvider(name = "Content Type Provider")
+    public Object[][] getContentType() {
+
+        return new Object[][]{
+                {"application/x-www-form-urlencoded", true},
+                {"application/json", true},
+                {"application/xml", false},
+        };
+    }
+
+    @Test(dataProvider = "Content Type Provider")
+    public void testIsAllowedContentType(String contentType, boolean shouldPass) throws Exception {
+
+        boolean isAllowed = OAuthCommonUtil.isAllowedContentType(contentType, ALLOWED_CONTENT_TYPES);
+
+        if (shouldPass) {
+            Assert.assertEquals(isAllowed, true, contentType + " should be an allowed content type");
+        } else {
+            Assert.assertEquals(isAllowed, false, contentType + " should not be an allowed content type");
+        }
+    }
+
+    @Test(dataProvider = "Content Type Provider")
+    public void testValidateContentTypes(String contentType, boolean shouldPass) throws Exception {
+
+        HttpServletRequest mockRequest = mock(HttpServletRequest.class);
+        when(mockRequest.getContentType()).thenReturn(contentType);
+        try {
+            OAuthCommonUtil.validateContentTypes(mockRequest);
+            if (!shouldPass) {
+                Assert.fail(contentType + " should not be an allowed content type");
+            }
+        } catch (OAuthProblemException e) {
+            if (shouldPass) {
+                Assert.fail(contentType + " should be an allowed content type");
+            }
+        }
+    }
+}

--- a/components/org.wso2.carbon.identity.oauth.common/src/test/java/org/wso2/carbon/identity/oauth/common/SAML2GrantValidatorTest.java
+++ b/components/org.wso2.carbon.identity.oauth.common/src/test/java/org/wso2/carbon/identity/oauth/common/SAML2GrantValidatorTest.java
@@ -84,6 +84,7 @@ public class SAML2GrantValidatorTest {
         return new Object[][]{
                 {"application/x-www-form-urlencoded", true},
                 {"application/json", true},
+                {"application/json; charset=utf-8", true},
                 {"application/xml", false},
         };
     }

--- a/components/org.wso2.carbon.identity.oauth.common/src/test/java/org/wso2/carbon/identity/oauth/common/SAML2GrantValidatorTest.java
+++ b/components/org.wso2.carbon.identity.oauth.common/src/test/java/org/wso2/carbon/identity/oauth/common/SAML2GrantValidatorTest.java
@@ -4,6 +4,7 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.oltu.oauth2.common.OAuth;
 import org.apache.oltu.oauth2.common.error.OAuthError;
 import org.apache.oltu.oauth2.common.exception.OAuthProblemException;
+import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
@@ -73,6 +74,33 @@ public class SAML2GrantValidatorTest {
             } catch (OAuthProblemException e) {
                 assertTrue(e.getMessage().startsWith(OAuthError.TokenResponse.INVALID_REQUEST), "Invalid error " +
                         "message received");
+            }
+        }
+    }
+
+    @DataProvider(name = "Content Type Provider")
+    public Object[][] getContentType() {
+
+        return new Object[][]{
+                {"application/x-www-form-urlencoded", true},
+                {"application/json", true},
+                {"application/xml", false},
+        };
+    }
+
+    @Test(dataProvider = "Content Type Provider")
+    public void testValidateContentType(String contentType, boolean shouldPass) throws Exception {
+
+        HttpServletRequest mockRequest = mock(HttpServletRequest.class);
+        when(mockRequest.getContentType()).thenReturn(contentType);
+        try {
+            testedValidator.validateContentType(mockRequest);
+            if (!shouldPass) {
+                Assert.fail(contentType + " should not be an allowed content type");
+            }
+        } catch (OAuthProblemException e) {
+            if (shouldPass) {
+                Assert.fail(contentType + " should be an allowed content type");
             }
         }
     }

--- a/components/org.wso2.carbon.identity.oauth.common/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.identity.oauth.common/src/test/resources/testng.xml
@@ -26,6 +26,8 @@
             <class name="org.wso2.carbon.identity.oauth.common.NTLMAuthenticationValidatorTest"/>
             <class name="org.wso2.carbon.identity.oauth.common.SAML2GrantValidatorTest"/>
             <class name="org.wso2.carbon.identity.oauth.common.NoneResponseTypeValidatorTest"/>
+            <class name="org.wso2.carbon.identity.oauth.common.IDTokenTokenResponseValidatorTest"/>
+            <class name="org.wso2.carbon.identity.oauth.common.OAuthCommonUtilTest"/>
         </classes>
     </test>
 </suite>

--- a/components/org.wso2.carbon.identity.oauth.endpoint/pom.xml
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/pom.xml
@@ -150,6 +150,16 @@
             <artifactId>spring-web</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
 
         <!--Test Dependencies-->
         <dependency>

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/OAuthRequestWrapper.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/OAuthRequestWrapper.java
@@ -39,6 +39,7 @@ public class OAuthRequestWrapper extends HttpServletRequestWrapper {
     private Map<String, List<String>> form;
     private Enumeration<String> parameterNames;
 
+    @Deprecated
     public OAuthRequestWrapper(HttpServletRequest request, MultivaluedMap<String, String> form) {
 
         this(request, (Map<String, List<String>>) form);

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/OAuthRequestWrapper.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/OAuthRequestWrapper.java
@@ -18,9 +18,13 @@
 
 package org.wso2.carbon.identity.oauth.endpoint;
 
+import org.apache.commons.collections.CollectionUtils;
+
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import javax.servlet.http.HttpServletRequest;
@@ -32,15 +36,20 @@ import javax.ws.rs.core.MultivaluedMap;
  */
 public class OAuthRequestWrapper extends HttpServletRequestWrapper {
 
-    private MultivaluedMap<String, String> form;
+    private Map<String, List<String>> form;
     private Enumeration<String> parameterNames;
 
     public OAuthRequestWrapper(HttpServletRequest request, MultivaluedMap<String, String> form) {
 
+        this(request, (Map<String, List<String>>) form);
+    }
+
+    public OAuthRequestWrapper(HttpServletRequest request, Map<String, List<String>> form) {
+
         super(request);
         this.form = form;
 
-        Set<String> parameterNameSet = new HashSet<String>();
+        Set<String> parameterNameSet = new HashSet<>();
         // Add post parameters
         parameterNameSet.addAll(form.keySet());
         // Add servlet request parameters
@@ -57,7 +66,9 @@ public class OAuthRequestWrapper extends HttpServletRequestWrapper {
 
         String value = super.getParameter(name);
         if (value == null) {
-            value = form.getFirst(name);
+            if (CollectionUtils.isNotEmpty(form.get(name))) {
+                value = form.get(name).get(0);
+            }
         }
         return value;
     }

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
@@ -723,6 +723,7 @@ public class EndpointUtil {
         return validateParams(request, paramMap);
     }
 
+    @Deprecated
     public static boolean validateParams(HttpServletRequest request, MultivaluedMap<String, String> paramMap) {
 
         return validateParams(request, (Map<String, List<String>>) paramMap);

--- a/components/org.wso2.carbon.identity.oauth/pom.xml
+++ b/components/org.wso2.carbon.identity.oauth/pom.xml
@@ -379,6 +379,7 @@
                             org.wso2.carbon.identity.application.authentication.framework.*;version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.user.store.configuration.*;version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.oauth.common.token.bindings.*;version="${identity.inbound.auth.oauth.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.oauth.common.*;version="${identity.inbound.auth.oauth.imp.pkg.version.range}",
                             org.wso2.carbon.identity.saml.common.util.*; version="${saml.common.util.version.range}",
 
                             org.wso2.carbon.base; version="${carbon.base.imp.pkg.version.range}",

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/SAML1GrantValidator.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/SAML1GrantValidator.java
@@ -19,9 +19,12 @@
 package org.wso2.carbon.identity.oauth2.validators;
 
 import org.apache.oltu.oauth2.common.OAuth;
+import org.apache.oltu.oauth2.common.exception.OAuthProblemException;
 import org.apache.oltu.oauth2.common.validators.AbstractValidator;
 
 import javax.servlet.http.HttpServletRequest;
+
+import static org.wso2.carbon.identity.oauth.common.OAuthCommonUtil.validateContentTypes;
 
 /**
  * SAML 1 bearer grant validator.
@@ -32,5 +35,11 @@ public class SAML1GrantValidator extends AbstractValidator<HttpServletRequest> {
 
         requiredParams.add(OAuth.OAUTH_GRANT_TYPE);
         requiredParams.add(OAuth.OAUTH_ASSERTION);
+    }
+
+    @Override
+    public void validateContentType(HttpServletRequest request) throws OAuthProblemException {
+
+        validateContentTypes(request);
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/grant/AuthorizationCodeGrantValidator.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/grant/AuthorizationCodeGrantValidator.java
@@ -17,6 +17,11 @@
 package org.wso2.carbon.identity.oauth2.validators.grant;
 
 import org.apache.oltu.oauth2.as.validator.AuthorizationCodeValidator;
+import org.apache.oltu.oauth2.common.exception.OAuthProblemException;
+
+import javax.servlet.http.HttpServletRequest;
+
+import static org.wso2.carbon.identity.oauth.common.OAuthCommonUtil.validateContentTypes;
 
 /**
  * Grant validator for Authorization Code Grant Type
@@ -29,5 +34,11 @@ public class AuthorizationCodeGrantValidator extends AuthorizationCodeValidator 
         // org.wso2.carbon.identity.oauth2.token.handlers.clientauth.ClientAuthenticationHandler extensions point.
         // Therefore client_id and client_secret are not mandatory since client can authenticate with other means.
         enforceClientAuthentication = false;
+    }
+
+    @Override
+    public void validateContentType(HttpServletRequest request) throws OAuthProblemException {
+
+        validateContentTypes(request);
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/grant/ClientCredentialGrantValidator.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/grant/ClientCredentialGrantValidator.java
@@ -17,6 +17,11 @@
 package org.wso2.carbon.identity.oauth2.validators.grant;
 
 import org.apache.oltu.oauth2.as.validator.ClientCredentialValidator;
+import org.apache.oltu.oauth2.common.exception.OAuthProblemException;
+
+import javax.servlet.http.HttpServletRequest;
+
+import static org.wso2.carbon.identity.oauth.common.OAuthCommonUtil.validateContentTypes;
 
 /**
  * Grant validator for Client Credential Grant Type
@@ -29,5 +34,11 @@ public class ClientCredentialGrantValidator extends ClientCredentialValidator {
         // org.wso2.carbon.identity.oauth2.token.handlers.clientauth.ClientAuthenticationHandler extensions point.
         // Therefore client_id and client_secret are not mandatory since client can authenticate with other means.
         enforceClientAuthentication = false;
+    }
+
+    @Override
+    public void validateContentType(HttpServletRequest request) throws OAuthProblemException {
+
+        validateContentTypes(request);
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/grant/PasswordGrantValidator.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/grant/PasswordGrantValidator.java
@@ -17,6 +17,11 @@
 package org.wso2.carbon.identity.oauth2.validators.grant;
 
 import org.apache.oltu.oauth2.as.validator.PasswordValidator;
+import org.apache.oltu.oauth2.common.exception.OAuthProblemException;
+
+import javax.servlet.http.HttpServletRequest;
+
+import static org.wso2.carbon.identity.oauth.common.OAuthCommonUtil.validateContentTypes;
 
 /**
  * Grant validator for Resource Owner Password Grant Type.
@@ -29,5 +34,11 @@ public class PasswordGrantValidator extends PasswordValidator {
         // org.wso2.carbon.identity.oauth2.token.handlers.clientauth.ClientAuthenticationHandler extensions point.
         // Therefore client_id and client_secret are not mandatory since client can authenticate with other means.
         enforceClientAuthentication = false;
+    }
+
+    @Override
+    public void validateContentType(HttpServletRequest request) throws OAuthProblemException {
+
+        validateContentTypes(request);
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/grant/RefreshTokenGrantValidator.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/grant/RefreshTokenGrantValidator.java
@@ -17,6 +17,11 @@
 package org.wso2.carbon.identity.oauth2.validators.grant;
 
 import org.apache.oltu.oauth2.as.validator.RefreshTokenValidator;
+import org.apache.oltu.oauth2.common.exception.OAuthProblemException;
+
+import javax.servlet.http.HttpServletRequest;
+
+import static org.wso2.carbon.identity.oauth.common.OAuthCommonUtil.validateContentTypes;
 
 /**
  * Grant validator for Refresh Token Grant Type
@@ -29,5 +34,11 @@ public class RefreshTokenGrantValidator extends RefreshTokenValidator {
         // org.wso2.carbon.identity.oauth2.token.handlers.clientauth.ClientAuthenticationHandler extensions point.
         // Therefore client_id and client_secret are not mandatory since client can authenticate with other means.
         enforceClientAuthentication = false;
+    }
+
+    @Override
+    public void validateContentType(HttpServletRequest request) throws OAuthProblemException {
+
+        validateContentTypes(request);
     }
 }


### PR DESCRIPTION
Fix wso2/product-is#9534

WIth the fix, requests to token endpoint supports application/json content type in addition to application/x-www-form-urlencoded