### PR TITLE
Skip current token from being revoked at password update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -877,7 +877,7 @@
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!-- Carbon Identity Framework version -->
-        <carbon.identity.framework.version>5.18.86</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.18.122</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.15.0, 6.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 


### PR DESCRIPTION
Resolves token preserving part of : https://github.com/wso2/product-is/issues/9461

With this improvement, it is possible to skip the current session/token from being terminated/revoked at password update, which stops the user from being logged out from the current session. This feature can be enabled the following configuration in deployment.toml

```
[identity_mgt]
password_update.preserve_logged_in_session=true
```

This PR depends on : https://github.com/wso2/carbon-identity-framework/pull/3124