### PR TITLE
Introduce the abiltiy to engage multiple scope validation implementaions at Server/Tenant level.

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
@@ -262,7 +262,7 @@ public class OAuthServerConfiguration {
 
     // Property to determine whether data providers should be executed during token introspection.
     private boolean enableIntrospectionDataProviders = false;
-    private boolean isGlobalScopeValidatorEnabled = false;
+    // Property to define the allowed scopes.
     private List<String> allowedScopes = new ArrayList<>();
 
     private OAuthServerConfiguration() {
@@ -419,9 +419,6 @@ public class OAuthServerConfiguration {
         // Read the property for error redirection URI
         parseRedirectToOAuthErrorPageConfig(oauthElem);
 
-        // Read config for role based scope validator.
-        parseEnableGlobalScopeValidatorConfiguration(oauthElem);
-
         // Read config for allowed scopes.
         parseAllowedScopesConfiguration(oauthElem);
     }
@@ -444,24 +441,6 @@ public class OAuthServerConfiguration {
             }
         }
     }
-
-    /**
-     * Parse role-based scope validation configuration.
-     *
-     * @param oauthConfigElem oauthConfigElem.
-     */
-    private void parseEnableGlobalScopeValidatorConfiguration(OMElement oauthConfigElem) {
-
-        OMElement enableGlobalScopeElem = oauthConfigElem.getFirstChildWithName(getQNameWithIdentityNS(
-                ConfigElements.ENABLE_GLOBAL_SCOPE_VALIDATORS));
-        if (enableGlobalScopeElem != null) {
-            isGlobalScopeValidatorEnabled = Boolean.parseBoolean(enableGlobalScopeElem.getText());
-        }
-        if (log.isDebugEnabled()) {
-            log.debug("EnableRoleBasedScopeValidator was set to : " + isGlobalScopeValidatorEnabled);
-        }
-    }
-
 
     private void parseTokenIntrospectionConfig(OMElement oauthElem) {
 
@@ -497,11 +476,6 @@ public class OAuthServerConfiguration {
      */
     public boolean isShowDisplayNameInConsentPage() {
         return showDisplayNameInConsentPage;
-    }
-
-    public boolean isGlobalScopeValidatorEnabled() {
-
-        return isGlobalScopeValidatorEnabled;
     }
 
     public List<String> getAllowedScopes() {
@@ -1237,6 +1211,7 @@ public class OAuthServerConfiguration {
 
     /**
      * Returns if login consent enabled or not.
+     *
      */
     public boolean getOpenIDConnectSkipeUserConsentConfig() {
 
@@ -1252,6 +1227,7 @@ public class OAuthServerConfiguration {
 
     /**
      * Returns if skip logout consent enabled or not.
+     *
      */
     public boolean getOpenIDConnectSkipLogoutConsentConfig() {
 
@@ -1330,7 +1306,6 @@ public class OAuthServerConfiguration {
 
         return enableIntrospectionDataProviders;
     }
-
     /**
      * Return the value of whether the refresh token is allowed for this grant type. Null will be returned if there is
      * no tag or empty tag.
@@ -2204,7 +2179,6 @@ public class OAuthServerConfiguration {
 
     /**
      * Adds oauth token issuer instances used for token generation.
-     *
      * @param tokenType registered token type
      * @return token issuer instance
      * @throws IdentityOAuth2Exception
@@ -2474,8 +2448,7 @@ public class OAuthServerConfiguration {
                         useMultiValueSeparatorForAuthContextToken =
                                 Boolean.parseBoolean(
                                         authContextTokGenConfigElem.getFirstChildWithName(getQNameWithIdentityNS(
-                                                ConfigElements.AUTH_CONTEXT_TOKEN_USE_MULTIVALUE_SEPARATOR)
-                                        ).getText().trim());
+                                        ConfigElements.AUTH_CONTEXT_TOKEN_USE_MULTIVALUE_SEPARATOR)).getText().trim());
                     }
                 }
             }
@@ -3156,9 +3129,7 @@ public class OAuthServerConfiguration {
 
         // Enable/Disable token renewal on each request to the token endpoint
         private static final String RENEW_TOKEN_PER_REQUEST = "RenewTokenPerRequest";
-        // Enable/Disable global scope validation
-        private static final String ENABLE_GLOBAL_SCOPE_VALIDATORS = "EnableGlobalScopeValidators";
-        //Allowed Scopes Config
+        // Allowed Scopes Config.
         private static final String ALLOWED_SCOPES_ELEMENT = "AllowedScopes";
         private static final String SCOPES_ELEMENT = "Scope";
     }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
@@ -263,6 +263,7 @@ public class OAuthServerConfiguration {
     // Property to determine whether data providers should be executed during token introspection.
     private boolean enableIntrospectionDataProviders = false;
     private boolean isGlobalScopeValidatorEnabled = false;
+    private static volatile Set<String> allowedScopesSet;
 
     private OAuthServerConfiguration() {
         buildOAuthServerConfiguration();
@@ -420,6 +421,30 @@ public class OAuthServerConfiguration {
 
         // Read config for role based scope validator.
         parseEnableGlobalScopeValidatorConfiguration(oauthElem);
+
+        // Read config for allowed scopes.
+        parseAllowedScopesConfiguration(oauthElem);
+    }
+
+    /**
+     * Parse allowed scopes configuration.
+     *
+     * @param oauthConfigElem oauthConfigElem.
+     */
+    private void parseAllowedScopesConfiguration(OMElement oauthConfigElem) {
+
+        List<String> allowedScopeList = new ArrayList<>();
+        OMElement allowedScopesElem = oauthConfigElem.getFirstChildWithName(
+                getQNameWithIdentityNS(ConfigElements.ALLOWED_SCOPES_ELEMENT));
+        if (allowedScopesElem != null) {
+            Iterator scopeIterator = allowedScopesElem.getChildrenWithName(getQNameWithIdentityNS(
+                    ConfigElements.SCOPES_ELEMENT));
+            while (scopeIterator.hasNext()) {
+                OMElement scopeElement = (OMElement) scopeIterator.next();
+                allowedScopeList.add(scopeElement.getText());
+            }
+        }
+        allowedScopesSet = new HashSet<String>(allowedScopeList);
     }
 
     /**
@@ -3128,6 +3153,9 @@ public class OAuthServerConfiguration {
         private static final String RENEW_TOKEN_PER_REQUEST = "RenewTokenPerRequest";
         // Enable/Disable global scope validation
         private static final String ENABLE_GLOBAL_SCOPE_VALIDATORS = "EnableGlobalScopeValidators";
+        //Allowed Scopes Config
+        private static final String ALLOWED_SCOPES_ELEMENT = "AllowedScopes";
+        private static final String SCOPES_ELEMENT = "Scope";
     }
 
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
@@ -500,10 +500,12 @@ public class OAuthServerConfiguration {
     }
 
     public boolean isGlobalScopeValidatorEnabled() {
+
         return isGlobalScopeValidatorEnabled;
     }
 
     public List<String> getAllowedScopes() {
+
         return allowedScopes;
     }
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
@@ -88,7 +88,7 @@ public class OAuthServerConfiguration {
     private static final String CONFIG_ELEM_OAUTH = "OAuth";
     // Grant Handler Classes
     private static final String AUTHORIZATION_CODE_GRANT_HANDLER_CLASS =
-            "org.wso2.carbon.identity.oauth2.token.handlers.grant.AuthorizationCodeHandler";
+            "org.wso2.carbon.identity.oauth2.token.handlers.grant.AuthorizationCodeGrantHandler";
     private static final String CLIENT_CREDENTIALS_GRANT_HANDLER_CLASS =
             "org.wso2.carbon.identity.oauth2.token.handlers.grant.ClientCredentialsGrantHandler";
     private static final String PASSWORD_GRANT_HANDLER_CLASS =
@@ -263,7 +263,7 @@ public class OAuthServerConfiguration {
     // Property to determine whether data providers should be executed during token introspection.
     private boolean enableIntrospectionDataProviders = false;
     private boolean isGlobalScopeValidatorEnabled = false;
-    private static volatile Set<String> allowedScopesSet;
+    private List<String> allowedScopes = new ArrayList<>();
 
     private OAuthServerConfiguration() {
         buildOAuthServerConfiguration();
@@ -433,7 +433,6 @@ public class OAuthServerConfiguration {
      */
     private void parseAllowedScopesConfiguration(OMElement oauthConfigElem) {
 
-        List<String> allowedScopeList = new ArrayList<>();
         OMElement allowedScopesElem = oauthConfigElem.getFirstChildWithName(
                 getQNameWithIdentityNS(ConfigElements.ALLOWED_SCOPES_ELEMENT));
         if (allowedScopesElem != null) {
@@ -441,10 +440,9 @@ public class OAuthServerConfiguration {
                     ConfigElements.SCOPES_ELEMENT));
             while (scopeIterator.hasNext()) {
                 OMElement scopeElement = (OMElement) scopeIterator.next();
-                allowedScopeList.add(scopeElement.getText());
+                allowedScopes.add(scopeElement.getText());
             }
         }
-        allowedScopesSet = new HashSet<String>(allowedScopeList);
     }
 
     /**
@@ -502,7 +500,11 @@ public class OAuthServerConfiguration {
     }
 
     public boolean isGlobalScopeValidatorEnabled() {
-        return isGlobalScopeValidatorEnabled; 
+        return isGlobalScopeValidatorEnabled;
+    }
+
+    public List<String> getAllowedScopes() {
+        return allowedScopes;
     }
 
     public String getOAuth1RequestTokenUrl() {
@@ -1233,7 +1235,6 @@ public class OAuthServerConfiguration {
 
     /**
      * Returns if login consent enabled or not.
-     *
      */
     public boolean getOpenIDConnectSkipeUserConsentConfig() {
 
@@ -1249,7 +1250,6 @@ public class OAuthServerConfiguration {
 
     /**
      * Returns if skip logout consent enabled or not.
-     *
      */
     public boolean getOpenIDConnectSkipLogoutConsentConfig() {
 
@@ -1328,6 +1328,7 @@ public class OAuthServerConfiguration {
 
         return enableIntrospectionDataProviders;
     }
+
     /**
      * Return the value of whether the refresh token is allowed for this grant type. Null will be returned if there is
      * no tag or empty tag.
@@ -2201,6 +2202,7 @@ public class OAuthServerConfiguration {
 
     /**
      * Adds oauth token issuer instances used for token generation.
+     *
      * @param tokenType registered token type
      * @return token issuer instance
      * @throws IdentityOAuth2Exception
@@ -2470,7 +2472,8 @@ public class OAuthServerConfiguration {
                         useMultiValueSeparatorForAuthContextToken =
                                 Boolean.parseBoolean(
                                         authContextTokGenConfigElem.getFirstChildWithName(getQNameWithIdentityNS(
-                                        ConfigElements.AUTH_CONTEXT_TOKEN_USE_MULTIVALUE_SEPARATOR)).getText().trim());
+                                                ConfigElements.AUTH_CONTEXT_TOKEN_USE_MULTIVALUE_SEPARATOR)
+                                        ).getText().trim());
                     }
                 }
             }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
@@ -478,6 +478,11 @@ public class OAuthServerConfiguration {
         return showDisplayNameInConsentPage;
     }
 
+    /**
+     * Get the list of alloed scopes.
+     *
+     * @return String returns a list of scope string.
+     */
     public List<String> getAllowedScopes() {
 
         return allowedScopes;

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
@@ -262,6 +262,7 @@ public class OAuthServerConfiguration {
 
     // Property to determine whether data providers should be executed during token introspection.
     private boolean enableIntrospectionDataProviders = false;
+    private boolean isGlobalScopeValidatorEnabled = false;
 
     private OAuthServerConfiguration() {
         buildOAuthServerConfiguration();
@@ -416,7 +417,28 @@ public class OAuthServerConfiguration {
 
         // Read the property for error redirection URI
         parseRedirectToOAuthErrorPageConfig(oauthElem);
+
+        // Read config for role based scope validator.
+        parseEnableGlobalScopeValidatorConfiguration(oauthElem);
     }
+
+    /**
+     * Parse role-based scope validation configuration.
+     *
+     * @param oauthConfigElem oauthConfigElem.
+     */
+    private void parseEnableGlobalScopeValidatorConfiguration(OMElement oauthConfigElem) {
+
+        OMElement enableGlobalScopeElem = oauthConfigElem.getFirstChildWithName(getQNameWithIdentityNS(
+                ConfigElements.ENABLE_GLOBAL_SCOPE_VALIDATORS));
+        if (enableGlobalScopeElem != null) {
+            isGlobalScopeValidatorEnabled = Boolean.parseBoolean(enableGlobalScopeElem.getText());
+        }
+        if (log.isDebugEnabled()) {
+            log.debug("EnableRoleBasedScopeValidator was set to : " + isGlobalScopeValidatorEnabled);
+        }
+    }
+
 
     private void parseTokenIntrospectionConfig(OMElement oauthElem) {
 
@@ -452,6 +474,10 @@ public class OAuthServerConfiguration {
      */
     public boolean isShowDisplayNameInConsentPage() {
         return showDisplayNameInConsentPage;
+    }
+
+    public boolean isGlobalScopeValidatorEnabled() {
+        return isGlobalScopeValidatorEnabled; 
     }
 
     public String getOAuth1RequestTokenUrl() {
@@ -3100,6 +3126,8 @@ public class OAuthServerConfiguration {
 
         // Enable/Disable token renewal on each request to the token endpoint
         private static final String RENEW_TOKEN_PER_REQUEST = "RenewTokenPerRequest";
+        // Enable/Disable global scope validation
+        private static final String ENABLE_GLOBAL_SCOPE_VALIDATORS = "EnableGlobalScopeValidators";
     }
 
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/internal/OAuthComponentServiceHolder.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/internal/OAuthComponentServiceHolder.java
@@ -26,6 +26,7 @@ import org.wso2.carbon.identity.oauth.dto.TokenBindingMetaDataDTO;
 import org.wso2.carbon.identity.oauth.event.OAuthEventInterceptor;
 import org.wso2.carbon.identity.oauth2.OAuth2ScopeService;
 import org.wso2.carbon.identity.oauth2.OAuth2Service;
+import org.wso2.carbon.identity.oauth2.validators.scope.ScopeValidator;
 import org.wso2.carbon.registry.api.RegistryService;
 import org.wso2.carbon.user.core.service.RealmService;
 
@@ -46,6 +47,24 @@ public class OAuthComponentServiceHolder {
     private OAuth2ScopeService oauth2ScopeService;
     private List<TokenBindingMetaDataDTO> tokenBindingMetaDataDTOs = new ArrayList<>();
     private OAuthAdminServiceImpl oAuthAdminService;
+
+    public List<ScopeValidator> getScopeValidators() {
+        return scopeValidators;
+    }
+
+    public void addScopeValidator(ScopeValidator scopeValidator) {
+        scopeValidators.add(scopeValidator);
+    }
+
+    public void removeScopeValidator(ScopeValidator scopeValidator) {
+        scopeValidators.remove(scopeValidator);
+    }
+
+    public void setScopeValidators(List<ScopeValidator> scopeValidators) {
+        this.scopeValidators = scopeValidators;
+    }
+
+    private List<ScopeValidator> scopeValidators = new ArrayList<>();
 
     private OAuthComponentServiceHolder() {
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/internal/OAuthComponentServiceHolder.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/internal/OAuthComponentServiceHolder.java
@@ -49,18 +49,22 @@ public class OAuthComponentServiceHolder {
     private OAuthAdminServiceImpl oAuthAdminService;
 
     public List<ScopeValidator> getScopeValidators() {
+
         return scopeValidators;
     }
 
     public void addScopeValidator(ScopeValidator scopeValidator) {
+
         scopeValidators.add(scopeValidator);
     }
 
     public void removeScopeValidator(ScopeValidator scopeValidator) {
+
         scopeValidators.remove(scopeValidator);
     }
 
     public void setScopeValidators(List<ScopeValidator> scopeValidators) {
+
         this.scopeValidators = scopeValidators;
     }
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/internal/OAuthComponentServiceHolder.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/internal/OAuthComponentServiceHolder.java
@@ -47,28 +47,48 @@ public class OAuthComponentServiceHolder {
     private OAuth2ScopeService oauth2ScopeService;
     private List<TokenBindingMetaDataDTO> tokenBindingMetaDataDTOs = new ArrayList<>();
     private OAuthAdminServiceImpl oAuthAdminService;
+    private List<ScopeValidator> scopeValidators = new ArrayList<>();
 
+
+    /**
+     * Get the list of scope validator implementations available.
+     *
+     * @return ScopeValidaror returns a list ot scope validator.
+     */
     public List<ScopeValidator> getScopeValidators() {
 
         return scopeValidators;
     }
 
+    /**
+     * Add scope validator implementation.
+     *
+     * @param scopeValidator Scope validator implementation.
+     */
     public void addScopeValidator(ScopeValidator scopeValidator) {
 
         scopeValidators.add(scopeValidator);
     }
 
+    /**
+     * Remove scope validator implementation.
+     *
+     * @param scopeValidator Scope validator implementation.
+     */
     public void removeScopeValidator(ScopeValidator scopeValidator) {
 
         scopeValidators.remove(scopeValidator);
     }
 
+    /**
+     * Set a list of scope validator implementations.
+     *
+     * @param scopeValidators List of Scope validator implementation.
+     */
     public void setScopeValidators(List<ScopeValidator> scopeValidators) {
 
         this.scopeValidators = scopeValidators;
     }
-
-    private List<ScopeValidator> scopeValidators = new ArrayList<>();
 
     private OAuthComponentServiceHolder() {
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/internal/OAuthServiceComponent.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/internal/OAuthServiceComponent.java
@@ -249,27 +249,4 @@ public class OAuthServiceComponent {
         OAuthComponentServiceHolder.getInstance().removeTokenBinderInfo(tokenBinderInfo);
     }
 
-    @Reference(
-            name = "scope.validator.service",
-            service = ScopeValidator.class,
-            cardinality = ReferenceCardinality.MULTIPLE,
-            policy = ReferencePolicy.DYNAMIC,
-            unbind = "removeScopeValidatorService"
-    )
-    protected void addScopeValidatorService(ScopeValidator scopeValidator) {
-
-        if (log.isDebugEnabled()) {
-            log.debug("Setting the Scope validator Service");
-        }
-        OAuthComponentServiceHolder.getInstance().addScopeValidator(scopeValidator);
-    }
-
-    protected void removeScopeValidatorService(ScopeValidator scopeValidator) {
-
-        if (log.isDebugEnabled()) {
-            log.debug("Un-setting the Scope validator Service");
-        }
-        OAuthComponentServiceHolder.getInstance().removeScopeValidator(scopeValidator);
-    }
-
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/internal/OAuthServiceComponent.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/internal/OAuthServiceComponent.java
@@ -37,6 +37,7 @@ import org.wso2.carbon.identity.oauth.listener.IdentityOathEventListener;
 import org.wso2.carbon.identity.oauth2.OAuth2ScopeService;
 import org.wso2.carbon.identity.oauth2.OAuth2Service;
 import org.wso2.carbon.identity.oauth2.internal.OAuth2ServiceComponentHolder;
+import org.wso2.carbon.identity.oauth2.validators.scope.ScopeValidator;
 import org.wso2.carbon.registry.core.service.RegistryService;
 import org.wso2.carbon.user.core.listener.UserOperationEventListener;
 import org.wso2.carbon.user.core.service.RealmService;
@@ -247,4 +248,28 @@ public class OAuthServiceComponent {
         }
         OAuthComponentServiceHolder.getInstance().removeTokenBinderInfo(tokenBinderInfo);
     }
+
+    @Reference(
+            name = "scope.validator.service",
+            service = ScopeValidator.class,
+            cardinality = ReferenceCardinality.MULTIPLE,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "removeScopeValidatorService"
+    )
+    protected void addScopeValidatorService(ScopeValidator scopeValidator) {
+
+        if (log.isDebugEnabled()) {
+            log.debug("Setting the Scope validator Service");
+        }
+        OAuthComponentServiceHolder.getInstance().addScopeValidator(scopeValidator);
+    }
+
+    protected void removeScopeValidatorService(ScopeValidator scopeValidator) {
+
+        if (log.isDebugEnabled()) {
+            log.debug("Un-setting the Scope validator Service");
+        }
+        OAuthComponentServiceHolder.getInstance().removeScopeValidator(scopeValidator);
+    }
+
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/internal/OAuthServiceComponent.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/internal/OAuthServiceComponent.java
@@ -37,7 +37,6 @@ import org.wso2.carbon.identity.oauth.listener.IdentityOathEventListener;
 import org.wso2.carbon.identity.oauth2.OAuth2ScopeService;
 import org.wso2.carbon.identity.oauth2.OAuth2Service;
 import org.wso2.carbon.identity.oauth2.internal.OAuth2ServiceComponentHolder;
-import org.wso2.carbon.identity.oauth2.validators.scope.ScopeValidator;
 import org.wso2.carbon.registry.core.service.RegistryService;
 import org.wso2.carbon.user.core.listener.UserOperationEventListener;
 import org.wso2.carbon.user.core.service.RealmService;
@@ -248,5 +247,4 @@ public class OAuthServiceComponent {
         }
         OAuthComponentServiceHolder.getInstance().removeTokenBinderInfo(tokenBinderInfo);
     }
-
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/AuthorizationHandlerManager.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/AuthorizationHandlerManager.java
@@ -132,17 +132,17 @@ public class AuthorizationHandlerManager {
         List<String> allowedScopes = OAuthServerConfiguration.getInstance().getAllowedScopes();
         List<String> requestedAllowedScopes = new ArrayList<>();
         String[] requestedScopes = authzReqMsgCtx.getAuthorizationReqDTO().getScopes();
-        List<String> requestedScopesList = new ArrayList<>();
+        List<String> scopesToBeValidated = new ArrayList<>();
         if (requestedScopes != null) {
             for (String scope : requestedScopes) {
                 if (OAuth2Util.isAllowedScope(allowedScopes, scope)) {
                     requestedAllowedScopes.add(scope);
                 } else {
-                    requestedScopesList.add(scope);
+                    scopesToBeValidated.add(scope);
                 }
             }
-            authzReqMsgCtx.getAuthorizationReqDTO().setScopes(requestedScopesList.toArray(
-                    new String[requestedScopesList.size()]));
+            authzReqMsgCtx.getAuthorizationReqDTO().setScopes(scopesToBeValidated.toArray(
+                    new String[0]));
         }
 
         //Execute Internal SCOPE Validation.
@@ -158,7 +158,7 @@ public class AuthorizationHandlerManager {
         if (valid) {
             //Add authorized internal scopes to the request for sending in the response.
             addAuthorizedInternalScopes(authzReqMsgCtx, authorizedInternalScopes);
-            addAllowedScopes(authzReqMsgCtx, requestedAllowedScopes.toArray(new String[requestedAllowedScopes.size()]));
+            addAllowedScopes(authzReqMsgCtx, requestedAllowedScopes.toArray(new String[0]));
         }
         return authorizeRespDTO;
     }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/AuthorizationHandlerManager.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/AuthorizationHandlerManager.java
@@ -131,17 +131,19 @@ public class AuthorizationHandlerManager {
 
         List<String> allowedScopes = OAuthServerConfiguration.getInstance().getAllowedScopes();
         List<String> requestedAllowedScopes = new ArrayList<>();
-        String[] requestedScope = authzReqMsgCtx.getAuthorizationReqDTO().getScopes();
-        List<String> requestedScopesList = new ArrayList<>();;
-        for (String scope : requestedScope) {
-            if (OAuth2Util.isAllowedScope(allowedScopes, scope)) {
-                requestedAllowedScopes.add(scope);
-            } else {
-                requestedScopesList.add(scope);
+        String[] requestedScopes = authzReqMsgCtx.getAuthorizationReqDTO().getScopes();
+        List<String> requestedScopesList = new ArrayList<>();
+        if (requestedScopes != null) {
+            for (String scope : requestedScopes) {
+                if (OAuth2Util.isAllowedScope(allowedScopes, scope)) {
+                    requestedAllowedScopes.add(scope);
+                } else {
+                    requestedScopesList.add(scope);
+                }
             }
+            authzReqMsgCtx.getAuthorizationReqDTO().setScopes(requestedScopesList.toArray(
+                    new String[requestedScopesList.size()]));
         }
-        authzReqMsgCtx.getAuthorizationReqDTO().setScopes(requestedScopesList.toArray(
-                new String[requestedScopesList.size()]));
 
         //Execute Internal SCOPE Validation.
         JDBCPermissionBasedInternalScopeValidator scopeValidator = new JDBCPermissionBasedInternalScopeValidator();

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/AuthorizationHandlerManager.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/AuthorizationHandlerManager.java
@@ -146,14 +146,10 @@ public class AuthorizationHandlerManager {
             // Setting to true so that if there are no global validators, we could ignore this.
             boolean isGlobalValidScope = true;
             for (ScopeValidator validator : globalScopeValidators) {
-                if (validator.canHandle(authzReqMsgCtx)) {
-                    log.debug("Engaging global scope validator in authorization flow : " + validator.getName());
-                    isGlobalValidScope = validator.validateScope(authzReqMsgCtx);
-                }
-                // If one global validator fails, we skip other validators.
+                log.debug("Engaging global scope validator in authorization flow : " + validator.getName());
+                isGlobalValidScope = validator.validateScope(authzReqMsgCtx);
                 if (!isGlobalValidScope) {
                     log.debug("Scope Validation failed at the global level by : " + validator.getName());
-                    break;
                 }
             }
             //Add authorized internal scopes to the request for sending in the response.

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/AuthorizationHandlerManager.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/AuthorizationHandlerManager.java
@@ -129,11 +129,11 @@ public class AuthorizationHandlerManager {
             return authorizeRespDTO;
         }
 
-        List<String> allowedScope = OAuthServerConfiguration.getInstance().getAllowedScopes();
+        List<String> allowedScopes = OAuthServerConfiguration.getInstance().getAllowedScopes();
         List<String> requestedAllowedScopes = new ArrayList<>();
         String[] requestedScope = authzReqMsgCtx.getAuthorizationReqDTO().getScopes();
         for (String scope : requestedScope) {
-            if (OAuth2Util.isAllowedScope(allowedScope, scope)) {
+            if (OAuth2Util.isAllowedScope(allowedScopes, scope)) {
                 requestedAllowedScopes.add(scope);
             }
         }
@@ -154,22 +154,6 @@ public class AuthorizationHandlerManager {
             addAllowedScopes(authzReqMsgCtx, requestedAllowedScopes.toArray(new String[requestedAllowedScopes.size()]));
         }
         return authorizeRespDTO;
-    }
-
-    /**
-     * Determines if the scope is specified in the whitelist.
-     *
-     * @param scope - The scope key to check
-     * @return - 'true' if the scope is white listed. 'false' if not.
-     */
-    public boolean isAllowedScope(List<String> scopeSkipList, String scope) {
-
-        for (String scopeTobeSkipped : scopeSkipList) {
-            if (scope.matches(scopeTobeSkipped)) {
-                return true;
-            }
-        }
-        return false;
     }
 
     private void addAuthorizedInternalScopes(OAuthAuthzReqMessageContext authzReqMsgCtx,

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/AuthorizationHandlerManager.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/AuthorizationHandlerManager.java
@@ -132,11 +132,16 @@ public class AuthorizationHandlerManager {
         List<String> allowedScopes = OAuthServerConfiguration.getInstance().getAllowedScopes();
         List<String> requestedAllowedScopes = new ArrayList<>();
         String[] requestedScope = authzReqMsgCtx.getAuthorizationReqDTO().getScopes();
+        List<String> requestedScopesList = new ArrayList<>();;
         for (String scope : requestedScope) {
             if (OAuth2Util.isAllowedScope(allowedScopes, scope)) {
                 requestedAllowedScopes.add(scope);
+            } else {
+                requestedScopesList.add(scope);
             }
         }
+        authzReqMsgCtx.getAuthorizationReqDTO().setScopes(requestedScopesList.toArray(
+                new String[requestedScopesList.size()]));
 
         //Execute Internal SCOPE Validation.
         JDBCPermissionBasedInternalScopeValidator scopeValidator = new JDBCPermissionBasedInternalScopeValidator();

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/AuthorizationHandlerManager.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/AuthorizationHandlerManager.java
@@ -145,20 +145,23 @@ public class AuthorizationHandlerManager {
         boolean isGlobalValidScope = true;
         for (ScopeValidator validator : globalScopeValidators) {
             if (validator.canHandle()) {
-                log.debug("Engaging global scope validator " + validator.getName());
+                log.debug("Engaging global scope validator in authorization flow : " + validator.getName());
                 isGlobalValidScope = validator.validateScope(authzReqMsgCtx);
             }
             // if one global validator fails, we skip other validators
             if (!isGlobalValidScope) {
+                log.debug("Scope Validation failed at the global level by : " + validator.getName());
                 break;
             }
         }
-        //authorization at authorization handler manager
-        boolean valid = validateScope(authzReqDTO, authorizeRespDTO, authzReqMsgCtx, authzHandler) &&
-                isGlobalValidScope;
-        if (valid) {
-            //Add authorized internal scopes to the request for sending in the response.
-            addAuthorizedInternalScopes(authzReqMsgCtx, authorizedInternalScopes);
+        //Scope is validated at app level only if it passes at server/global level
+        if (isGlobalValidScope) {
+            //authorization at authorization handler manager
+            boolean valid = validateScope(authzReqDTO, authorizeRespDTO, authzReqMsgCtx, authzHandler);
+            if (valid) {
+                //Add authorized internal scopes to the request for sending in the response.
+                addAuthorizedInternalScopes(authzReqMsgCtx, authorizedInternalScopes);
+            }
         }
         return authorizeRespDTO;
     }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/AuthorizationHandlerManager.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/AuthorizationHandlerManager.java
@@ -29,7 +29,6 @@ import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
 import org.wso2.carbon.identity.oauth.dao.OAuthAppDAO;
 import org.wso2.carbon.identity.oauth.dao.OAuthAppDO;
 import org.wso2.carbon.identity.oauth.dto.OAuthErrorDTO;
-import org.wso2.carbon.identity.oauth.internal.OAuthComponentServiceHolder;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.authz.handlers.ResponseTypeHandler;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2AuthorizeReqDTO;
@@ -37,7 +36,6 @@ import org.wso2.carbon.identity.oauth2.dto.OAuth2AuthorizeRespDTO;
 import org.wso2.carbon.identity.oauth2.model.OAuth2Parameters;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 import org.wso2.carbon.identity.oauth2.validators.JDBCPermissionBasedInternalScopeValidator;
-import org.wso2.carbon.identity.oauth2.validators.scope.ScopeValidator;
 import org.wso2.carbon.utils.CarbonUtils;
 
 import java.util.ArrayList;
@@ -142,16 +140,6 @@ public class AuthorizationHandlerManager {
 
         boolean valid = validateScope(authzReqDTO, authorizeRespDTO, authzReqMsgCtx, authzHandler);
         if (valid) {
-            List<ScopeValidator> globalScopeValidators = OAuthComponentServiceHolder.getInstance().getScopeValidators();
-            // Setting to true so that if there are no global validators, we could ignore this.
-            boolean isGlobalValidScope = true;
-            for (ScopeValidator validator : globalScopeValidators) {
-                log.debug("Engaging global scope validator in authorization flow : " + validator.getName());
-                isGlobalValidScope = validator.validateScope(authzReqMsgCtx);
-                if (!isGlobalValidScope) {
-                    log.debug("Scope Validation failed at the global level by : " + validator.getName());
-                }
-            }
             //Add authorized internal scopes to the request for sending in the response.
             addAuthorizedInternalScopes(authzReqMsgCtx, authorizedInternalScopes);
         }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/handlers/AbstractResponseTypeHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/handlers/AbstractResponseTypeHandler.java
@@ -104,12 +104,16 @@ public abstract class AbstractResponseTypeHandler implements ResponseTypeHandler
         oauthAuthzMsgCtx.setAccessTokenIssuedTime(scopeValidationCallback.getAccessTokenValidityPeriod());
         oauthAuthzMsgCtx.setApprovedScope(scopeValidationCallback.getApprovedScope());
         // Deriving the global level scope validator implementations.
+        // These are global/server level scope validators which are engaged after the app level scope validation.
         List<ScopeValidator> globalScopeValidators = OAuthComponentServiceHolder.getInstance().getScopeValidators();
         for (ScopeValidator validator : globalScopeValidators) {
-            log.debug("Engaging global scope validator in token issuer flow : " + validator.getName());
+            if (log.isDebugEnabled()) {
+                log.debug("Engaging global scope validator in token issuer flow : " + validator.getName());
+            }
             boolean isGlobalValidScope = validator.validateScope(oauthAuthzMsgCtx);
-            if (!isGlobalValidScope) {
-                log.debug("Scope Validation failed at the global level by : " + validator.getName());
+            if (log.isDebugEnabled()) {
+                log.debug("Scope Validation was" + isGlobalValidScope + "at the global level by : "
+                        + validator.getName());
             }
         }
         return scopeValidationCallback.isValidScope();

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/handlers/AbstractResponseTypeHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/handlers/AbstractResponseTypeHandler.java
@@ -29,6 +29,7 @@ import org.wso2.carbon.identity.oauth.callback.OAuthCallbackManager;
 import org.wso2.carbon.identity.oauth.common.OAuthConstants;
 import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
 import org.wso2.carbon.identity.oauth.dao.OAuthAppDO;
+import org.wso2.carbon.identity.oauth.internal.OAuthComponentServiceHolder;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.authz.OAuthAuthzReqMessageContext;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2AuthorizeReqDTO;
@@ -36,6 +37,7 @@ import org.wso2.carbon.identity.oauth2.dto.OAuth2AuthorizeRespDTO;
 import org.wso2.carbon.identity.oauth2.token.OauthTokenIssuer;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 import org.wso2.carbon.identity.oauth2.util.Oauth2ScopeUtils;
+import org.wso2.carbon.identity.oauth2.validators.scope.ScopeValidator;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -101,6 +103,15 @@ public abstract class AbstractResponseTypeHandler implements ResponseTypeHandler
                 .getAuthorizationCodeValidityPeriod());
         oauthAuthzMsgCtx.setAccessTokenIssuedTime(scopeValidationCallback.getAccessTokenValidityPeriod());
         oauthAuthzMsgCtx.setApprovedScope(scopeValidationCallback.getApprovedScope());
+        // Deriving the global level scope validator implementations.
+        List<ScopeValidator> globalScopeValidators = OAuthComponentServiceHolder.getInstance().getScopeValidators();
+        for (ScopeValidator validator : globalScopeValidators) {
+            log.debug("Engaging global scope validator in token issuer flow : " + validator.getName());
+            boolean isGlobalValidScope = validator.validateScope(oauthAuthzMsgCtx);
+            if (!isGlobalValidScope) {
+                log.debug("Scope Validation failed at the global level by : " + validator.getName());
+            }
+        }
         return scopeValidationCallback.isValidScope();
     }
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuth2ServiceComponent.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuth2ServiceComponent.java
@@ -33,9 +33,7 @@ import org.wso2.carbon.identity.application.authentication.framework.Authenticat
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
 import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.application.mgt.listener.ApplicationMgtListener;
-import org.wso2.carbon.identity.base.IdentityRuntimeException;
 import org.wso2.carbon.identity.core.util.IdentityCoreInitializedEvent;
-import org.wso2.carbon.identity.core.util.IdentityDatabaseUtil;
 import org.wso2.carbon.identity.event.handler.AbstractEventHandler;
 import org.wso2.carbon.identity.oauth.common.token.bindings.TokenBinderInfo;
 import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
@@ -48,25 +46,22 @@ import org.wso2.carbon.identity.oauth2.client.authentication.OAuthClientAuthenti
 import org.wso2.carbon.identity.oauth2.client.authentication.OAuthClientAuthnService;
 import org.wso2.carbon.identity.oauth2.client.authentication.PublicClientAuthenticator;
 import org.wso2.carbon.identity.oauth2.dao.OAuthTokenPersistenceFactory;
-import org.wso2.carbon.identity.oauth2.dao.SQLQueries;
 import org.wso2.carbon.identity.oauth2.device.api.DeviceAuthService;
 import org.wso2.carbon.identity.oauth2.device.api.DeviceAuthServiceImpl;
+import org.wso2.carbon.identity.oauth2.keyidprovider.DefaultKeyIDProviderImpl;
+import org.wso2.carbon.identity.oauth2.keyidprovider.KeyIDProvider;
 import org.wso2.carbon.identity.oauth2.listener.TenantCreationEventListener;
 import org.wso2.carbon.identity.oauth2.token.bindings.TokenBinder;
 import org.wso2.carbon.identity.oauth2.token.bindings.handlers.TokenBindingExpiryEventHandler;
 import org.wso2.carbon.identity.oauth2.token.bindings.impl.CookieBasedTokenBinder;
 import org.wso2.carbon.identity.oauth2.token.bindings.impl.SSOSessionBasedTokenBinder;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
+import org.wso2.carbon.identity.oauth2.validators.scope.ScopeValidator;
 import org.wso2.carbon.identity.openidconnect.OpenIDConnectClaimFilter;
 import org.wso2.carbon.identity.openidconnect.OpenIDConnectClaimFilterImpl;
 import org.wso2.carbon.identity.user.store.configuration.listener.UserStoreConfigListener;
 import org.wso2.carbon.registry.core.service.RegistryService;
 import org.wso2.carbon.stratos.common.listeners.TenantMgtListener;
-
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
 
 import static org.wso2.carbon.identity.oauth2.util.OAuth2Util.checkAudienceEnabled;
 import static org.wso2.carbon.identity.oauth2.util.OAuth2Util.checkIDPIdColumnAvailable;
@@ -158,6 +153,15 @@ public class OAuth2ServiceComponent {
                 log.debug("Identity OAuth bundle is activated");
             }
 
+            if (OAuth2ServiceComponentHolder.getKeyIDProvider() == null) {
+                KeyIDProvider defaultKeyIDProvider = new DefaultKeyIDProviderImpl();
+                OAuth2ServiceComponentHolder.setKeyIDProvider(defaultKeyIDProvider);
+                if (log.isDebugEnabled()) {
+                    log.debug("Key ID Provider " + DefaultKeyIDProviderImpl.class.getSimpleName() +
+                            " registered as the default Key ID Provider implementation.");
+                }
+            }
+
             ServiceRegistration tenantMgtListenerSR = bundleContext.registerService(TenantMgtListener.class.getName(),
                     new OAuthTenantMgtListenerImpl(), null);
             if (tenantMgtListenerSR != null) {
@@ -187,13 +191,9 @@ public class OAuth2ServiceComponent {
             } else {
                 log.error("OAuth - ApplicationMgtListener could not be registered.");
             }
-            if (checkPKCESupport()) {
-                OAuth2ServiceComponentHolder.setPkceEnabled(true);
-                log.info("PKCE Support enabled.");
-            } else {
-                OAuth2ServiceComponentHolder.setPkceEnabled(false);
-                log.info("PKCE Support is disabled.");
-            }
+
+            // PKCE enabled by default.
+            OAuth2ServiceComponentHolder.setPkceEnabled(true);
 
             // Register device auth service.
             ServiceRegistration deviceAuthService = bundleContext.registerService(DeviceAuthService.class.getName(),
@@ -295,42 +295,6 @@ public class OAuth2ServiceComponent {
     protected void setIdentityCoreInitializedEventService(IdentityCoreInitializedEvent identityCoreInitializedEvent) {
         /* reference IdentityCoreInitializedEvent service to guarantee that this component will wait until identity core
          is started */
-    }
-
-    private boolean checkPKCESupport() {
-
-        try (Connection connection = IdentityDatabaseUtil.getDBConnection(false)) {
-
-            String sql;
-            if (connection.getMetaData().getDriverName().contains("MySQL")
-                    || connection.getMetaData().getDriverName().contains("H2")) {
-                sql = SQLQueries.RETRIEVE_PKCE_TABLE_MYSQL;
-            } else if (connection.getMetaData().getDatabaseProductName().contains("DB2")) {
-                sql = SQLQueries.RETRIEVE_PKCE_TABLE_DB2SQL;
-            } else if (connection.getMetaData().getDriverName().contains("MS SQL") ||
-                    connection.getMetaData().getDriverName().contains("Microsoft")) {
-                sql = SQLQueries.RETRIEVE_PKCE_TABLE_MSSQL;
-            } else if (connection.getMetaData().getDriverName().contains("PostgreSQL")) {
-                sql = SQLQueries.RETRIEVE_PKCE_TABLE_MYSQL;
-            } else if (connection.getMetaData().getDriverName().contains("Informix")) {
-                // Driver name = "IBM Informix JDBC Driver for IBM Informix Dynamic Server"
-                sql = SQLQueries.RETRIEVE_PKCE_TABLE_INFORMIX;
-            } else {
-                sql = SQLQueries.RETRIEVE_PKCE_TABLE_ORACLE;
-            }
-
-            try (PreparedStatement preparedStatement = connection.prepareStatement(sql);
-                 ResultSet resultSet = preparedStatement.executeQuery()) {
-                // Following statement will throw SQLException if the column is not found
-                resultSet.findColumn("PKCE_MANDATORY");
-                // If we are here then the column exists, so PKCE is supported by the database.
-                return true;
-            }
-
-        } catch (IdentityRuntimeException | SQLException e) {
-            return false;
-        }
-
     }
 
     @Reference(

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuth2ServiceComponent.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuth2ServiceComponent.java
@@ -33,10 +33,13 @@ import org.wso2.carbon.identity.application.authentication.framework.Authenticat
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
 import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.application.mgt.listener.ApplicationMgtListener;
+import org.wso2.carbon.identity.base.IdentityRuntimeException;
 import org.wso2.carbon.identity.core.util.IdentityCoreInitializedEvent;
+import org.wso2.carbon.identity.core.util.IdentityDatabaseUtil;
 import org.wso2.carbon.identity.event.handler.AbstractEventHandler;
 import org.wso2.carbon.identity.oauth.common.token.bindings.TokenBinderInfo;
 import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
+import org.wso2.carbon.identity.oauth.internal.OAuthComponentServiceHolder;
 import org.wso2.carbon.identity.oauth2.OAuth2ScopeService;
 import org.wso2.carbon.identity.oauth2.OAuth2Service;
 import org.wso2.carbon.identity.oauth2.OAuth2TokenValidationService;
@@ -45,10 +48,9 @@ import org.wso2.carbon.identity.oauth2.client.authentication.OAuthClientAuthenti
 import org.wso2.carbon.identity.oauth2.client.authentication.OAuthClientAuthnService;
 import org.wso2.carbon.identity.oauth2.client.authentication.PublicClientAuthenticator;
 import org.wso2.carbon.identity.oauth2.dao.OAuthTokenPersistenceFactory;
+import org.wso2.carbon.identity.oauth2.dao.SQLQueries;
 import org.wso2.carbon.identity.oauth2.device.api.DeviceAuthService;
 import org.wso2.carbon.identity.oauth2.device.api.DeviceAuthServiceImpl;
-import org.wso2.carbon.identity.oauth2.keyidprovider.DefaultKeyIDProviderImpl;
-import org.wso2.carbon.identity.oauth2.keyidprovider.KeyIDProvider;
 import org.wso2.carbon.identity.oauth2.listener.TenantCreationEventListener;
 import org.wso2.carbon.identity.oauth2.token.bindings.TokenBinder;
 import org.wso2.carbon.identity.oauth2.token.bindings.handlers.TokenBindingExpiryEventHandler;
@@ -60,6 +62,11 @@ import org.wso2.carbon.identity.openidconnect.OpenIDConnectClaimFilterImpl;
 import org.wso2.carbon.identity.user.store.configuration.listener.UserStoreConfigListener;
 import org.wso2.carbon.registry.core.service.RegistryService;
 import org.wso2.carbon.stratos.common.listeners.TenantMgtListener;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 
 import static org.wso2.carbon.identity.oauth2.util.OAuth2Util.checkAudienceEnabled;
 import static org.wso2.carbon.identity.oauth2.util.OAuth2Util.checkIDPIdColumnAvailable;
@@ -151,15 +158,6 @@ public class OAuth2ServiceComponent {
                 log.debug("Identity OAuth bundle is activated");
             }
 
-            if (OAuth2ServiceComponentHolder.getKeyIDProvider() == null) {
-                KeyIDProvider defaultKeyIDProvider = new DefaultKeyIDProviderImpl();
-                OAuth2ServiceComponentHolder.setKeyIDProvider(defaultKeyIDProvider);
-                if (log.isDebugEnabled()) {
-                    log.debug("Key ID Provider " + DefaultKeyIDProviderImpl.class.getSimpleName() +
-                            " registered as the default Key ID Provider implementation.");
-                }
-            }
-
             ServiceRegistration tenantMgtListenerSR = bundleContext.registerService(TenantMgtListener.class.getName(),
                     new OAuthTenantMgtListenerImpl(), null);
             if (tenantMgtListenerSR != null) {
@@ -189,9 +187,13 @@ public class OAuth2ServiceComponent {
             } else {
                 log.error("OAuth - ApplicationMgtListener could not be registered.");
             }
-
-            // PKCE enabled by default.
-            OAuth2ServiceComponentHolder.setPkceEnabled(true);
+            if (checkPKCESupport()) {
+                OAuth2ServiceComponentHolder.setPkceEnabled(true);
+                log.info("PKCE Support enabled.");
+            } else {
+                OAuth2ServiceComponentHolder.setPkceEnabled(false);
+                log.info("PKCE Support is disabled.");
+            }
 
             // Register device auth service.
             ServiceRegistration deviceAuthService = bundleContext.registerService(DeviceAuthService.class.getName(),
@@ -293,6 +295,42 @@ public class OAuth2ServiceComponent {
     protected void setIdentityCoreInitializedEventService(IdentityCoreInitializedEvent identityCoreInitializedEvent) {
         /* reference IdentityCoreInitializedEvent service to guarantee that this component will wait until identity core
          is started */
+    }
+
+    private boolean checkPKCESupport() {
+
+        try (Connection connection = IdentityDatabaseUtil.getDBConnection(false)) {
+
+            String sql;
+            if (connection.getMetaData().getDriverName().contains("MySQL")
+                    || connection.getMetaData().getDriverName().contains("H2")) {
+                sql = SQLQueries.RETRIEVE_PKCE_TABLE_MYSQL;
+            } else if (connection.getMetaData().getDatabaseProductName().contains("DB2")) {
+                sql = SQLQueries.RETRIEVE_PKCE_TABLE_DB2SQL;
+            } else if (connection.getMetaData().getDriverName().contains("MS SQL") ||
+                    connection.getMetaData().getDriverName().contains("Microsoft")) {
+                sql = SQLQueries.RETRIEVE_PKCE_TABLE_MSSQL;
+            } else if (connection.getMetaData().getDriverName().contains("PostgreSQL")) {
+                sql = SQLQueries.RETRIEVE_PKCE_TABLE_MYSQL;
+            } else if (connection.getMetaData().getDriverName().contains("Informix")) {
+                // Driver name = "IBM Informix JDBC Driver for IBM Informix Dynamic Server"
+                sql = SQLQueries.RETRIEVE_PKCE_TABLE_INFORMIX;
+            } else {
+                sql = SQLQueries.RETRIEVE_PKCE_TABLE_ORACLE;
+            }
+
+            try (PreparedStatement preparedStatement = connection.prepareStatement(sql);
+                 ResultSet resultSet = preparedStatement.executeQuery()) {
+                // Following statement will throw SQLException if the column is not found
+                resultSet.findColumn("PKCE_MANDATORY");
+                // If we are here then the column exists, so PKCE is supported by the database.
+                return true;
+            }
+
+        } catch (IdentityRuntimeException | SQLException e) {
+            return false;
+        }
+
     }
 
     @Reference(
@@ -417,4 +455,28 @@ public class OAuth2ServiceComponent {
     protected void unsetKeyIDProvider(KeyIDProvider keyIDProvider) {
 
     }
+
+    @Reference(
+            name = "scope.validator.service",
+            service = ScopeValidator.class,
+            cardinality = ReferenceCardinality.MULTIPLE,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "removeScopeValidatorService"
+    )
+    protected void addScopeValidatorService(ScopeValidator scopeValidator) {
+
+        if (log.isDebugEnabled()) {
+            log.debug("Adding the Scope validator Service : " + scopeValidator.getName());
+        }
+        OAuthComponentServiceHolder.getInstance().addScopeValidator(scopeValidator);
+    }
+
+    protected void removeScopeValidatorService(ScopeValidator scopeValidator) {
+
+        if (log.isDebugEnabled()) {
+            log.debug("Removing the Scope validator Service : " + scopeValidator.getName());
+        }
+        OAuthComponentServiceHolder.getInstance().removeScopeValidator(scopeValidator);
+    }
+
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuer.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuer.java
@@ -272,16 +272,16 @@ public class AccessTokenIssuer {
         List<String> allowedScopes = OAuthServerConfiguration.getInstance().getAllowedScopes();
         List<String> requestedAllowedScopes = new ArrayList<>();
         String[] requestedScopes = tokReqMsgCtx.getScope();
-        List<String> requestedScopesList = new ArrayList<>();
+        List<String> scopesToBeValidated = new ArrayList<>();
         if (requestedScopes != null) {
             for (String scope : requestedScopes) {
                 if (OAuth2Util.isAllowedScope(allowedScopes, scope)) {
                     requestedAllowedScopes.add(scope);
                 } else {
-                    requestedScopesList.add(scope);
+                    scopesToBeValidated.add(scope);
                 }
             }
-            tokReqMsgCtx.setScope(requestedScopesList.toArray(new String[requestedScopesList.size()]));
+            tokReqMsgCtx.setScope(scopesToBeValidated.toArray(new String[0]));
         }
 
         //Execute Internal SCOPE Validation.
@@ -296,7 +296,7 @@ public class AccessTokenIssuer {
         if (isValidScope) {
             //Add authorized internal scopes to the request for sending in the response.
             addAuthorizedInternalScopes(tokReqMsgCtx, authorizedInternalScopes);
-            addAllowedScopes(tokReqMsgCtx, requestedAllowedScopes.toArray(new String[requestedAllowedScopes.size()]));
+            addAllowedScopes(tokReqMsgCtx, requestedAllowedScopes.toArray(new String[0]));
         } else {
             if (log.isDebugEnabled()) {
                 log.debug("Invalid scope provided by client Id: " + tokenReqDTO.getClientId());

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuer.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuer.java
@@ -52,7 +52,6 @@ import org.wso2.carbon.identity.oauth2.token.bindings.TokenBinding;
 import org.wso2.carbon.identity.oauth2.token.handlers.grant.AuthorizationGrantHandler;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 import org.wso2.carbon.identity.oauth2.validators.JDBCPermissionBasedInternalScopeValidator;
-import org.wso2.carbon.identity.oauth2.validators.scope.ScopeValidator;
 import org.wso2.carbon.identity.openidconnect.IDTokenBuilder;
 import org.wso2.carbon.utils.CarbonUtils;
 
@@ -279,18 +278,7 @@ public class AccessTokenIssuer {
         // the other scope validators.
         removeInternalScopes(tokReqMsgCtx);
         boolean isValidScope = authzGrantHandler.validateScope(tokReqMsgCtx);
-        // The server level validation is engaged only if it passed in app level.
         if (isValidScope) {
-            List<ScopeValidator> globalScopeValidators = OAuthComponentServiceHolder.getInstance().getScopeValidators();
-            // Setting to true so that if there are no global validators, we could ignore this.
-            boolean isGlobalValidScope = true;
-            for (ScopeValidator validator : globalScopeValidators) {
-                log.debug("Engaging global scope validator in token issuer flow : " + validator.getName());
-                isGlobalValidScope = validator.validateScope(tokReqMsgCtx);
-                if (!isGlobalValidScope) {
-                    log.debug("Scope Validation failed at the global level by : " + validator.getName());
-                }
-            }
             //Add authorized internal scopes to the request for sending in the response.
             addAuthorizedInternalScopes(tokReqMsgCtx, authorizedInternalScopes);
         } else {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuer.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuer.java
@@ -269,11 +269,11 @@ public class AccessTokenIssuer {
             return tokenRespDTO;
         }
 
-        List<String> allowedScope = OAuthServerConfiguration.getInstance().getAllowedScopes();
+        List<String> allowedScopes = OAuthServerConfiguration.getInstance().getAllowedScopes();
         List<String> requestedAllowedScopes = new ArrayList<>();
         String[] requestedScope = tokReqMsgCtx.getScope();
         for (String scope : requestedScope) {
-            if (OAuth2Util.isAllowedScope(allowedScope, scope)) {
+            if (OAuth2Util.isAllowedScope(allowedScopes, scope)) {
                 requestedAllowedScopes.add(scope);
             }
         }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuer.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuer.java
@@ -283,15 +283,21 @@ public class AccessTokenIssuer {
         boolean isGlobalValidScope = true;
         for (ScopeValidator validator : globalScopeValidators) {
             if (validator.canHandle()) {
-                log.debug("Engaging global scope validator " + validator.getName());
+                log.debug("Engaging global scope validator in token issuer flow : " + validator.getName());
                 isGlobalValidScope = validator.validateScope(tokReqMsgCtx);
             }
             // if one global validator fails, we skip other validators
             if (!isGlobalValidScope) {
+                log.debug("Scope Validation failed at the global level by : " + validator.getName());
                 break;
             }
         }
-        boolean isValidScope = authzGrantHandler.validateScope(tokReqMsgCtx) && isGlobalValidScope;
+        //setting to false so that it becomes true only if scope validation passes at both global and app level
+        boolean isValidScope = false;
+        //Scope is validated at app level only if it passes at server/global level
+        if (isGlobalValidScope) {
+            isValidScope = authzGrantHandler.validateScope(tokReqMsgCtx);
+        }
         if (isValidScope) {
             //Add authorized internal scopes to the request for sending in the response.
             addAuthorizedInternalScopes(tokReqMsgCtx, authorizedInternalScopes);

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuer.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuer.java
@@ -272,11 +272,15 @@ public class AccessTokenIssuer {
         List<String> allowedScopes = OAuthServerConfiguration.getInstance().getAllowedScopes();
         List<String> requestedAllowedScopes = new ArrayList<>();
         String[] requestedScope = tokReqMsgCtx.getScope();
+        List<String> requestedScopesList = new ArrayList<>();
         for (String scope : requestedScope) {
             if (OAuth2Util.isAllowedScope(allowedScopes, scope)) {
                 requestedAllowedScopes.add(scope);
+            } else {
+                requestedScopesList.add(scope);
             }
         }
+        tokReqMsgCtx.setScope(requestedScopesList.toArray(new String[requestedScopesList.size()]));
 
         //Execute Internal SCOPE Validation.
         JDBCPermissionBasedInternalScopeValidator scopeValidator = new JDBCPermissionBasedInternalScopeValidator();
@@ -290,7 +294,7 @@ public class AccessTokenIssuer {
         if (isValidScope) {
             //Add authorized internal scopes to the request for sending in the response.
             addAuthorizedInternalScopes(tokReqMsgCtx, authorizedInternalScopes);
-            addAllowedScopes(tokReqMsgCtx, requestedAllowedScopes);
+            addAllowedScopes(tokReqMsgCtx, requestedAllowedScopes.toArray(new String[requestedAllowedScopes.size()]));
         } else {
             if (log.isDebugEnabled()) {
                 log.debug("Invalid scope provided by client Id: " + tokenReqDTO.getClientId());
@@ -370,18 +374,10 @@ public class AccessTokenIssuer {
         tokReqMsgCtx.setScope(scopesToReturn);
     }
 
-    private void addAllowedScopes(OAuthTokenReqMessageContext tokReqMsgCtx, List<String> allowedScopes) {
+    private void addAllowedScopes(OAuthTokenReqMessageContext tokReqMsgCtx, String[] allowedScopes) {
 
         String[] scopes = tokReqMsgCtx.getScope();
-        // Duplicate scopes are removed from the list as there is no separate store for approved scopes
-        // available at OAuthTokenReqMessageContext.
-        for (String scope : scopes) {
-            if (allowedScopes.contains(scope)) {
-                allowedScopes.remove(scope);
-            }
-        }
-        String[] scopesToReturn = (String[]) ArrayUtils.addAll(scopes, allowedScopes.toArray(
-                new String[allowedScopes.size()]));
+        String[] scopesToReturn = (String[]) ArrayUtils.addAll(scopes, allowedScopes);
         tokReqMsgCtx.setScope(scopesToReturn);
     }
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuer.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuer.java
@@ -271,16 +271,18 @@ public class AccessTokenIssuer {
 
         List<String> allowedScopes = OAuthServerConfiguration.getInstance().getAllowedScopes();
         List<String> requestedAllowedScopes = new ArrayList<>();
-        String[] requestedScope = tokReqMsgCtx.getScope();
+        String[] requestedScopes = tokReqMsgCtx.getScope();
         List<String> requestedScopesList = new ArrayList<>();
-        for (String scope : requestedScope) {
-            if (OAuth2Util.isAllowedScope(allowedScopes, scope)) {
-                requestedAllowedScopes.add(scope);
-            } else {
-                requestedScopesList.add(scope);
+        if (requestedScopes != null) {
+            for (String scope : requestedScopes) {
+                if (OAuth2Util.isAllowedScope(allowedScopes, scope)) {
+                    requestedAllowedScopes.add(scope);
+                } else {
+                    requestedScopesList.add(scope);
+                }
             }
+            tokReqMsgCtx.setScope(requestedScopesList.toArray(new String[requestedScopesList.size()]));
         }
-        tokReqMsgCtx.setScope(requestedScopesList.toArray(new String[requestedScopesList.size()]));
 
         //Execute Internal SCOPE Validation.
         JDBCPermissionBasedInternalScopeValidator scopeValidator = new JDBCPermissionBasedInternalScopeValidator();

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuer.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuer.java
@@ -285,14 +285,10 @@ public class AccessTokenIssuer {
             // Setting to true so that if there are no global validators, we could ignore this.
             boolean isGlobalValidScope = true;
             for (ScopeValidator validator : globalScopeValidators) {
-                if (validator.canHandle(tokReqMsgCtx)) {
-                    log.debug("Engaging global scope validator in token issuer flow : " + validator.getName());
-                    isGlobalValidScope = validator.validateScope(tokReqMsgCtx);
-                }
-                // If one global validator fails, we skip other validators
+                log.debug("Engaging global scope validator in token issuer flow : " + validator.getName());
+                isGlobalValidScope = validator.validateScope(tokReqMsgCtx);
                 if (!isGlobalValidScope) {
                     log.debug("Scope Validation failed at the global level by : " + validator.getName());
-                    break;
                 }
             }
             //Add authorized internal scopes to the request for sending in the response.

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AbstractAuthorizationGrantHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AbstractAuthorizationGrantHandler.java
@@ -39,6 +39,7 @@ import org.wso2.carbon.identity.oauth.common.OAuthConstants;
 import org.wso2.carbon.identity.oauth.common.exception.InvalidOAuthClientException;
 import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
 import org.wso2.carbon.identity.oauth.dao.OAuthAppDO;
+import org.wso2.carbon.identity.oauth.internal.OAuthComponentServiceHolder;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.OAuth2Service;
 import org.wso2.carbon.identity.oauth2.dao.OAuthTokenPersistenceFactory;
@@ -50,6 +51,7 @@ import org.wso2.carbon.identity.oauth2.token.OauthTokenIssuer;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 import org.wso2.carbon.identity.oauth2.util.Oauth2ScopeUtils;
 import org.wso2.carbon.identity.oauth2.validators.OAuth2ScopeHandler;
+import org.wso2.carbon.identity.oauth2.validators.scope.ScopeValidator;
 
 import java.sql.Timestamp;
 import java.util.ArrayList;
@@ -250,6 +252,18 @@ public abstract class AbstractAuthorizationGrantHandler implements Authorization
                 }
             }
         }
+        // Deriving the list of global level scope validation implementations.
+        List<ScopeValidator> globalScopeValidators = OAuthComponentServiceHolder.getInstance().getScopeValidators();
+        // Setting to true so that if there are no global validators, we could ignore this.
+        boolean isGlobalValidScope = true;
+        for (ScopeValidator validator : globalScopeValidators) {
+            log.debug("Engaging global scope validator in token issuer flow : " + validator.getName());
+            isGlobalValidScope = validator.validateScope(tokReqMsgCtx);
+            if (!isGlobalValidScope) {
+                log.debug("Scope Validation failed at the global level by : " + validator.getName());
+            }
+        }
+
         return isValid && scopeValidationCallback.isValidScope();
     }
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AbstractAuthorizationGrantHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AbstractAuthorizationGrantHandler.java
@@ -253,14 +253,16 @@ public abstract class AbstractAuthorizationGrantHandler implements Authorization
             }
         }
         // Deriving the list of global level scope validation implementations.
+        // These are global/server level scope validators which are engaged after the app level scope validation.
         List<ScopeValidator> globalScopeValidators = OAuthComponentServiceHolder.getInstance().getScopeValidators();
-        // Setting to true so that if there are no global validators, we could ignore this.
-        boolean isGlobalValidScope = true;
         for (ScopeValidator validator : globalScopeValidators) {
-            log.debug("Engaging global scope validator in token issuer flow : " + validator.getName());
-            isGlobalValidScope = validator.validateScope(tokReqMsgCtx);
-            if (!isGlobalValidScope) {
-                log.debug("Scope Validation failed at the global level by : " + validator.getName());
+            if (log.isDebugEnabled()) {
+                log.debug("Engaging global scope validator in token issuer flow : " + validator.getName());
+            }
+            boolean isGlobalValidScope = validator.validateScope(tokReqMsgCtx);
+            if (log.isDebugEnabled()) {
+                log.debug("Scope Validation was" + isGlobalValidScope + "at the global level by : "
+                        + validator.getName());
             }
         }
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -3858,14 +3858,19 @@ public class OAuth2Util {
     }
 
     /**
-     * Determines if the scope is specified in the whitelist.
+     * Determines if the scope is specified in the allowed scopes list.
      *
-     * @param scope - The scope key to check.
+     * @param allowedScopesList Allowed scopes list
+     * @param scope             The scope key to check.
      * @return - 'true' if the scope is allowed. 'false' if not.
      */
-    public static boolean isAllowedScope(List<String> scopeSkipList, String scope) {
-        for (String scopeTobeSkipped : scopeSkipList) {
+    public static boolean isAllowedScope(List<String> allowedScopesList, String scope) {
+
+        for (String scopeTobeSkipped : allowedScopesList) {
             if (scope.matches(scopeTobeSkipped)) {
+                if (log.isDebugEnabled()) {
+                    log.debug(scope + " is found in the allowed list of scopes.");
+                }
                 return true;
             }
         }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -3813,4 +3813,19 @@ public class OAuth2Util {
             }
         }
     }
+
+    /**
+     * Determines if the scope is specified in the whitelist.
+     *
+     * @param scope - The scope key to check.
+     * @return - 'true' if the scope is allowed. 'false' if not.
+     */
+    public static boolean isAllowedScope(List<String> scopeSkipList, String scope) {
+        for (String scopeTobeSkipped : scopeSkipList) {
+            if (scope.matches(scopeTobeSkipped)) {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/DefaultOAuth2TokenValidator.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/DefaultOAuth2TokenValidator.java
@@ -115,12 +115,16 @@ public class DefaultOAuth2TokenValidator implements OAuth2TokenValidator {
         }
 
         // Deriving the global level scope validator implementations.
+        // These are global/server level scope validators which are engaged after the app level scope validation.
         List<ScopeValidator> globalScopeValidators = OAuthComponentServiceHolder.getInstance().getScopeValidators();
         for (ScopeValidator validator : globalScopeValidators) {
-            log.debug("Engaging global scope validator in token issuer flow : " + validator.getName());
+            if (log.isDebugEnabled()) {
+                log.debug("Engaging global scope validator in token issuer flow : " + validator.getName());
+            }
             boolean isGlobalValidScope = validator.validateScope(messageContext);
-            if (!isGlobalValidScope) {
-                log.debug("Scope Validation failed at the global level by : " + validator.getName());
+            if (log.isDebugEnabled()) {
+                log.debug("Scope Validation was" + isGlobalValidScope + "at the global level by : "
+                        + validator.getName());
             }
         }
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/TokenValidationHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/TokenValidationHandler.java
@@ -491,7 +491,10 @@ public class TokenValidationHandler {
         if (!tokenValidator.validateScope(messageContext)) {
             // This is redundant. But sake of readability.
             introResp.setActive(false);
-            return buildIntrospectionErrorResponse("Scope validation failed at app level");
+            if (log.isDebugEnabled()) {
+                log.debug("Scope validation has failed at app level");
+            }
+            return buildIntrospectionErrorResponse("Scope validation failed");
         }
 
         addAllowedScopes(messageContext, requestedAllowedScopes.toArray(new String[0]));

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/TokenValidationHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/TokenValidationHandler.java
@@ -414,16 +414,16 @@ public class TokenValidationHandler {
                 accessTokenDO = OAuth2Util.findAccessToken(validationRequest.getAccessToken().getIdentifier(), false);
                 List<String> allowedScopes = OAuthServerConfiguration.getInstance().getAllowedScopes();
                 String[] requestedScopes = accessTokenDO.getScope();
-                List<String> requestedScopesList = new ArrayList<>();;
+                List<String> scopesToBeValidated = new ArrayList<>();;
                 if (requestedScopes != null) {
                     for (String scope : requestedScopes) {
                         if (OAuth2Util.isAllowedScope(allowedScopes, scope)) {
                             requestedAllowedScopes.add(scope);
                         } else {
-                            requestedScopesList.add(scope);
+                            scopesToBeValidated.add(scope);
                         }
                     }
-                    accessTokenDO.setScope(requestedScopesList.toArray(new String[requestedScopesList.size()]));
+                    accessTokenDO.setScope(scopesToBeValidated.toArray(new String[0]));
                 }
             } catch (IllegalArgumentException e) {
                 // access token not found in the system.
@@ -494,7 +494,7 @@ public class TokenValidationHandler {
             return buildIntrospectionErrorResponse("Scope validation failed at app level");
         }
 
-        addAllowedScopes(messageContext, requestedAllowedScopes.toArray(new String[requestedAllowedScopes.size()]));
+        addAllowedScopes(messageContext, requestedAllowedScopes.toArray(new String[0]));
         // All set. mark the token active.
         introResp.setActive(true);
         return introResp;

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/TokenValidationHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/TokenValidationHandler.java
@@ -412,10 +412,10 @@ public class TokenValidationHandler {
         } else {
             try {
                 accessTokenDO = OAuth2Util.findAccessToken(validationRequest.getAccessToken().getIdentifier(), false);
-                List<String> allowedScope = OAuthServerConfiguration.getInstance().getAllowedScopes();
+                List<String> allowedScopes = OAuthServerConfiguration.getInstance().getAllowedScopes();
                 String[] requestedScope = accessTokenDO.getScope();
                 for (String scope : requestedScope) {
-                    if (OAuth2Util.isAllowedScope(allowedScope, scope)) {
+                    if (OAuth2Util.isAllowedScope(allowedScopes, scope)) {
                         requestedAllowedScopes.add(scope);
                     }
                 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/TokenValidationHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/TokenValidationHandler.java
@@ -414,11 +414,15 @@ public class TokenValidationHandler {
                 accessTokenDO = OAuth2Util.findAccessToken(validationRequest.getAccessToken().getIdentifier(), false);
                 List<String> allowedScopes = OAuthServerConfiguration.getInstance().getAllowedScopes();
                 String[] requestedScope = accessTokenDO.getScope();
+                List<String> requestedScopesList = new ArrayList<>();;
                 for (String scope : requestedScope) {
                     if (OAuth2Util.isAllowedScope(allowedScopes, scope)) {
                         requestedAllowedScopes.add(scope);
+                    } else {
+                        requestedScopesList.add(scope);
                     }
                 }
+                accessTokenDO.setScope(requestedScopesList.toArray(new String[requestedScopesList.size()]));
             } catch (IllegalArgumentException e) {
                 // access token not found in the system.
                 return buildIntrospectionErrorResponse(e.getMessage());

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/TokenValidationHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/TokenValidationHandler.java
@@ -413,16 +413,18 @@ public class TokenValidationHandler {
             try {
                 accessTokenDO = OAuth2Util.findAccessToken(validationRequest.getAccessToken().getIdentifier(), false);
                 List<String> allowedScopes = OAuthServerConfiguration.getInstance().getAllowedScopes();
-                String[] requestedScope = accessTokenDO.getScope();
+                String[] requestedScopes = accessTokenDO.getScope();
                 List<String> requestedScopesList = new ArrayList<>();;
-                for (String scope : requestedScope) {
-                    if (OAuth2Util.isAllowedScope(allowedScopes, scope)) {
-                        requestedAllowedScopes.add(scope);
-                    } else {
-                        requestedScopesList.add(scope);
+                if (requestedScopes != null) {
+                    for (String scope : requestedScopes) {
+                        if (OAuth2Util.isAllowedScope(allowedScopes, scope)) {
+                            requestedAllowedScopes.add(scope);
+                        } else {
+                            requestedScopesList.add(scope);
+                        }
                     }
+                    accessTokenDO.setScope(requestedScopesList.toArray(new String[requestedScopesList.size()]));
                 }
-                accessTokenDO.setScope(requestedScopesList.toArray(new String[requestedScopesList.size()]));
             } catch (IllegalArgumentException e) {
                 // access token not found in the system.
                 return buildIntrospectionErrorResponse(e.getMessage());

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/TokenValidationHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/TokenValidationHandler.java
@@ -414,7 +414,7 @@ public class TokenValidationHandler {
                 accessTokenDO = OAuth2Util.findAccessToken(validationRequest.getAccessToken().getIdentifier(), false);
                 List<String> allowedScopes = OAuthServerConfiguration.getInstance().getAllowedScopes();
                 String[] requestedScopes = accessTokenDO.getScope();
-                List<String> scopesToBeValidated = new ArrayList<>();;
+                List<String> scopesToBeValidated = new ArrayList<>();
                 if (requestedScopes != null) {
                     for (String scope : requestedScopes) {
                         if (OAuth2Util.isAllowedScope(allowedScopes, scope)) {
@@ -492,7 +492,7 @@ public class TokenValidationHandler {
             // This is redundant. But sake of readability.
             introResp.setActive(false);
             if (log.isDebugEnabled()) {
-                log.debug("Scope validation has failed at app level");
+                log.debug("Scope validation has failed at app level.");
             }
             return buildIntrospectionErrorResponse("Scope validation failed");
         }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/TokenValidationHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/TokenValidationHandler.java
@@ -682,16 +682,12 @@ public class TokenValidationHandler {
         // Setting to true so that if there are no global validators, we could ignore this.
         boolean isGlobalValidScope = true;
         for (ScopeValidator validator : globalScopeValidators) {
-            if (validator.canHandle(messageContext)) {
-                log.debug("Engaging global scope validator at token validation flow : " + validator.getName());
-                isGlobalValidScope = validator.validateScope(messageContext);
-            }
-            // If one global validator fails, we skip other validators.
+            log.debug("Engaging global scope validator at token validation flow : " + validator.getName());
+            isGlobalValidScope = validator.validateScope(messageContext);
             if (!isGlobalValidScope) {
                 log.debug("Scope Validation failed at global level by : " + validator.getName());
-                return false;
             }
         }
-        return isGlobalValidScope;
+        return true;
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/scope/ScopeValidator.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/scope/ScopeValidator.java
@@ -51,12 +51,11 @@ public interface ScopeValidator {
     boolean validateScope(OAuthTokenReqMessageContext tokenReqMessageContext) throws IdentityOAuth2Exception;
 
     /**
-     * Validates scopes in the token request and manipulate the permitted scopes within the request. Engage it after
-     * application-level validators at TokenValidator level.
+     * Validates the scopes present in the token in the token validation flow.
+     * Engage it after application-level validators at TokenValidator level.
      *
      * @param tokenValidationMessageContext OAuth2TokenValidationMessageContext.
-     * @return True if the user has enough permission to generate tokens with requested scopes or
-     * no scopes are requested, otherwise false.
+     * @return True if scopes present in the tokens are validated successfully, otherwise false.
      * @throws IdentityOAuth2Exception Identity Oauth Exception.
      */
     boolean validateScope(OAuth2TokenValidationMessageContext tokenValidationMessageContext)

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/scope/ScopeValidator.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/scope/ScopeValidator.java
@@ -31,9 +31,26 @@ public interface ScopeValidator {
     /**
      * Checks whether the validator can be engaged.
      *
+     * @param authzReqMessageContext Authorization request.
      * @return True if it can handle, otherwise false.
      */
-    boolean canHandle();
+    boolean canHandle(OAuthAuthzReqMessageContext authzReqMessageContext);
+
+    /**
+     * Checks whether the validator can be engaged.
+     *
+     * @param tokenReqMessageContext OAuthTokenReqMessageContext.
+     * @return True if it can handle, otherwise false.
+     */
+    boolean canHandle(OAuthTokenReqMessageContext tokenReqMessageContext);
+
+    /**
+     * Checks whether the validator can be engaged.
+     *
+     * @param tokenValidationMessageContext OAuth2TokenValidationMessageContext..
+     * @return True if it can handle, otherwise false.
+     */
+    boolean canHandle(OAuth2TokenValidationMessageContext tokenValidationMessageContext);
 
     /**
      * Validates scopes in the authorization request and manipulate the permitted scopes within the request. Engage
@@ -42,7 +59,7 @@ public interface ScopeValidator {
      * @param authzReqMessageContext Authorization request.
      * @return True if the user has enough permission to generate tokens or authorization codes with requested
      * scopes or no scopes are requested, otherwise false.
-     * @throws IdentityOAuth2Exception
+     * @throws IdentityOAuth2Exception Identity Oauth Exception.
      */
     boolean validateScope(OAuthAuthzReqMessageContext authzReqMessageContext) throws IdentityOAuth2Exception;
 
@@ -53,7 +70,7 @@ public interface ScopeValidator {
      * @param tokenReqMessageContext OAuthTokenReqMessageContext.
      * @return True if the user has enough permission to generate tokens with requested scopes or
      * no scopes are requested, otherwise false.
-     * @throws IdentityOAuth2Exception
+     * @throws IdentityOAuth2Exception Identity Oauth Exception.
      */
     boolean validateScope(OAuthTokenReqMessageContext tokenReqMessageContext) throws IdentityOAuth2Exception;
 
@@ -64,7 +81,7 @@ public interface ScopeValidator {
      * @param tokenValidationMessageContext OAuth2TokenValidationMessageContext.
      * @return True if the user has enough permission to generate tokens with requested scopes or
      * no scopes are requested, otherwise false.
-     * @throws IdentityOAuth2Exception
+     * @throws IdentityOAuth2Exception Identity Oauth Exception.
      */
     boolean validateScope(OAuth2TokenValidationMessageContext tokenValidationMessageContext)
             throws IdentityOAuth2Exception;

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/scope/ScopeValidator.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/scope/ScopeValidator.java
@@ -29,30 +29,6 @@ import org.wso2.carbon.identity.oauth2.validators.OAuth2TokenValidationMessageCo
 public interface ScopeValidator {
 
     /**
-     * Checks whether the validator can be engaged.
-     *
-     * @param authzReqMessageContext Authorization request.
-     * @return True if it can handle, otherwise false.
-     */
-    boolean canHandle(OAuthAuthzReqMessageContext authzReqMessageContext);
-
-    /**
-     * Checks whether the validator can be engaged.
-     *
-     * @param tokenReqMessageContext OAuthTokenReqMessageContext.
-     * @return True if it can handle, otherwise false.
-     */
-    boolean canHandle(OAuthTokenReqMessageContext tokenReqMessageContext);
-
-    /**
-     * Checks whether the validator can be engaged.
-     *
-     * @param tokenValidationMessageContext OAuth2TokenValidationMessageContext..
-     * @return True if it can handle, otherwise false.
-     */
-    boolean canHandle(OAuth2TokenValidationMessageContext tokenValidationMessageContext);
-
-    /**
      * Validates scopes in the authorization request and manipulate the permitted scopes within the request. Engage
      * it after application-level validators at ResponseTypeHandler level.
      *

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/scope/ScopeValidator.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/scope/ScopeValidator.java
@@ -93,3 +93,4 @@ public interface ScopeValidator {
      */
     String getName();
 }
+


### PR DESCRIPTION
The following PR adds the capability to engage multiple server/tenant level scope validation in the flows. 

- at authorization (AuthorizationHandlerManager)
- at token issuance (AccessTokenIssuer)
- at introspection (TokenValidationHandler)

This provides another level of scope validation prior to the application level scope validation. The implementations could be enaged by implementing the interface(ScopeValidator) as OSGI services.

Issues addressed by the PR
- [https://github.com/wso2/product-is/issues/8245](https://github.com/wso2/product-is/issues/8245)
- [https://github.com/wso2/product-is/issues/8248](https://github.com/wso2/product-is/issues/8248)
