### PR TITLE
Upgrade opensaml version

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/pom.xml
+++ b/components/org.wso2.carbon.identity.oauth/pom.xml
@@ -364,8 +364,8 @@
                             waffle.windows.auth.impl; version="${waffle.imp.pkg.version.range}",
 
                             org.joda.time;version="${joda.wso2.osgi.version.range}",
-                            org.opensaml.*; version="${opensaml2.wso2.osgi.version.range}",
-                            net.shibboleth.utilities.java.support.*; version="${opensaml2.wso2.osgi.version.range}",
+                            org.opensaml.*; version="${opensaml3.wso2.osgi.version.range}",
+                            net.shibboleth.utilities.java.support.*; version="${opensaml3.wso2.osgi.version.range}",
 
                             org.osgi.framework; version="${osgi.framework.imp.pkg.version.range}",
                             org.osgi.service.component; version="${osgi.service.component.imp.pkg.version.range}",

--- a/pom.xml
+++ b/pom.xml
@@ -306,7 +306,7 @@
             <dependency>
                 <groupId>org.wso2.orbit.org.opensaml</groupId>
                 <artifactId>opensaml</artifactId>
-                <version>${opensaml2.wso2.version}</version>
+                <version>${opensaml3.wso2.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.orbit.joda-time</groupId>
@@ -934,8 +934,8 @@
         <json.wso2.version.range>[3.0.0.wso2v1, 4.0.0)</json.wso2.version.range>
 
         <opensaml.version>3.3.1</opensaml.version>
-        <opensaml2.wso2.version>3.3.1.wso2v1</opensaml2.wso2.version>
-        <opensaml2.wso2.osgi.version.range>[3.3.1,3.4.0)</opensaml2.wso2.osgi.version.range>
+        <opensaml3.wso2.version>3.3.1.wso2v2</opensaml3.wso2.version>
+        <opensaml3.wso2.osgi.version.range>[3.3.1,3.4.0)</opensaml3.wso2.osgi.version.range>
 
         <joda.version>2.9.4</joda.version>
         <joda.wso2.version>2.9.4.wso2v1</joda.wso2.version>


### PR DESCRIPTION
Partially fixes https://github.com/wso2/product-is/issues/9984
 
This PR will update the opensaml version and avoid opensaml 3.3.1.wso2v1 getting packed in the product-is.