### PR TITLE
Fix expiration time issue for unlimited exp time token

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/TokenValidationHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/TokenValidationHandler.java
@@ -437,8 +437,13 @@ public class TokenValidationHandler {
             }
 
             // should be in seconds
-            introResp.setExp((accessTokenDO.getValidityPeriodInMillis() + accessTokenDO.getIssuedTime().getTime())
-                    / 1000);
+            if (accessTokenDO.getValidityPeriodInMillis() < 0) {
+                introResp.setExp(Long.MAX_VALUE);
+            } else {
+                introResp.setExp(
+                        (accessTokenDO.getValidityPeriodInMillis() + accessTokenDO.getIssuedTime().getTime()) / 1000);
+            }
+
             // should be in seconds
             introResp.setIat(accessTokenDO.getIssuedTime().getTime() / 1000);
             // Not before time will be the same as issued time.


### PR DESCRIPTION
Fix expiration time calculation issue when there is an unlimited expiration time set for an access token. This issue occurs in APIM migrated setup.

Steps:

Create an application and generate a token with unlimited expiration time (-1) in the old setup (say APIM 2.6) and invoke the an API using this token. (Can invoke the API without token getting expired)
Migrate to APIM 3.2 and try to invoke the same API.
API invocation fails after first invocation.

APIM 3.2 uses /introspect API provided in IS to calculate the expiration time and this pr fixes the issue we identified during this flow

Fixes https://github.com/wso2/product-apim/issues/9372