### PR TITLE
Add preprocessing on the refresh token retrieved from the database

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dao/AccessTokenDAOImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dao/AccessTokenDAOImpl.java
@@ -853,7 +853,7 @@ public class AccessTokenDAOImpl extends AbstractOAuthDAO implements AccessTokenD
                     long validityPeriodInMillis = resultSet.getLong(8);
                     long refreshTokenValidityPeriodMillis = resultSet.getLong(9);
                     String tokenType = resultSet.getString(10);
-                    String refreshToken = resultSet.getString(11);
+                    String refreshToken = getPersistenceProcessor().getPreprocessedRefreshToken(resultSet.getString(11));
                     String tokenId = resultSet.getString(12);
                     String grantType = resultSet.getString(13);
                     String subjectIdentifier = resultSet.getString(14);

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dao/AccessTokenDAOImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dao/AccessTokenDAOImpl.java
@@ -853,7 +853,12 @@ public class AccessTokenDAOImpl extends AbstractOAuthDAO implements AccessTokenD
                     long validityPeriodInMillis = resultSet.getLong(8);
                     long refreshTokenValidityPeriodMillis = resultSet.getLong(9);
                     String tokenType = resultSet.getString(10);
-                    String refreshToken = getPersistenceProcessor().getPreprocessedRefreshToken(resultSet.getString(11));
+                    String refreshToken;
+                    if (resultSet.getString(11) != null) {
+                        refreshToken = getPersistenceProcessor().getPreprocessedRefreshToken(resultSet.getString(11));
+                    } else {
+                        refreshToken = resultSet.getString(11);
+                    }
                     String tokenId = resultSet.getString(12);
                     String grantType = resultSet.getString(13);
                     String subjectIdentifier = resultSet.getString(14);

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dao/AccessTokenDAOImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dao/AccessTokenDAOImpl.java
@@ -853,11 +853,9 @@ public class AccessTokenDAOImpl extends AbstractOAuthDAO implements AccessTokenD
                     long validityPeriodInMillis = resultSet.getLong(8);
                     long refreshTokenValidityPeriodMillis = resultSet.getLong(9);
                     String tokenType = resultSet.getString(10);
-                    String refreshToken;
+                    String refreshToken = null;
                     if (resultSet.getString(11) != null) {
                         refreshToken = getPersistenceProcessor().getPreprocessedRefreshToken(resultSet.getString(11));
-                    } else {
-                        refreshToken = resultSet.getString(11);
                     }
                     String tokenId = resultSet.getString(12);
                     String grantType = resultSet.getString(13);


### PR DESCRIPTION
### Proposed changes in this pull request

This PR will subject the refresh token retrieved from the database to a preprocessing based on the configured TokenPersistanceProcessor.

Fixes wso2/product-is#10145.