### PR TITLE
Fix state not sending with redirect url when user denies consent

### DIFF
--- a/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/servlet/OIDCLogoutServlet.java
+++ b/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/servlet/OIDCLogoutServlet.java
@@ -258,6 +258,9 @@ public class OIDCLogoutServlet extends HttpServlet {
                 Map<String, String> params = new HashMap<>();
                 params.put(OAuthConstants.OAUTH_ERROR, OAuth2ErrorCodes.ACCESS_DENIED);
                 params.put(OAuthConstants.OAUTH_ERROR_DESCRIPTION, "End User denied the logout request");
+                if (cacheEntry.getState() != null) {
+                    params.put(OAuthConstants.OAuth20Params.STATE, cacheEntry.getState());
+                }
                 redirectURL = FrameworkUtils.buildURLWithQueryParams(
                         cacheEntry.getPostLogoutRedirectUri(), params);
             }


### PR DESCRIPTION
### Proposed changes in this pull request
Fix for https://github.com/wso2/product-is/issues/10040. We should send the state parameter in the redirect URL when the user denies the consent for logout.  

