### PR TITLE
Fix issue with token revocation when account is locked/disabled

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/listener/IdentityOathEventListener.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/listener/IdentityOathEventListener.java
@@ -241,8 +241,15 @@ public class IdentityOathEventListener extends AbstractIdentityUserOperationEven
 
         String errorCode =
                 (String) IdentityUtil.threadLocalProperties.get().get(IdentityCoreConstants.USER_ACCOUNT_STATE);
+        if (StringUtils.isEmpty(errorCode)) {
+            errorCode =
+                    (String) IdentityUtil.threadLocalProperties.get()
+                            .get(IdentityCoreConstants.USER_ACCOUNT_STATE_WITH_USERNAME + userName);
+        }
 
         if (errorCode != null && (errorCode.equalsIgnoreCase(UserCoreConstants.ErrorCode.USER_IS_LOCKED))) {
+            IdentityUtil.threadLocalProperties.get()
+                    .remove(IdentityCoreConstants.USER_ACCOUNT_STATE_WITH_USERNAME + userName);
             return revokeTokens(userName, userStoreManager);
         }
         return true;
@@ -253,8 +260,14 @@ public class IdentityOathEventListener extends AbstractIdentityUserOperationEven
 
         String errorCode =
                 (String) IdentityUtil.threadLocalProperties.get().get(IdentityCoreConstants.USER_ACCOUNT_STATE);
-
+        if (StringUtils.isEmpty(errorCode)) {
+            errorCode =
+                    (String) IdentityUtil.threadLocalProperties.get()
+                            .get(IdentityCoreConstants.USER_ACCOUNT_STATE_WITH_USERNAME + userName);
+        }
         if (errorCode != null && errorCode.equalsIgnoreCase(IdentityCoreConstants.USER_ACCOUNT_DISABLED_ERROR_CODE)) {
+            IdentityUtil.threadLocalProperties.get()
+                    .remove(IdentityCoreConstants.USER_ACCOUNT_STATE_WITH_USERNAME + userName);
             return revokeTokens(userName, userStoreManager);
         }
         return true;


### PR DESCRIPTION
### Proposed changes in this pull request

This fixes the issue with token revocation when the account is locked/disabled. Front port this PR https://github.com/wso2-support/identity-inbound-auth-oauth/pull/744


### When should this PR be merged

- [ ] Merge this framework PR https://github.com/wso2/carbon-identity-framework/pull/3216

- [ ] Bump framework version in oauth component

- [ ] Merge the PR in https://github.com/wso2-extensions/identity-event-handler-account-lock/pull/75/files

- [ ] Merge this PR


