### PR TITLE
Fix issues in token revoke, refresh token expiry extension and access token validation

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
@@ -144,6 +144,7 @@ public class OAuthServerConfiguration {
     private boolean cacheEnabled = false;
     private boolean isTokenRenewalPerRequestEnabled = false;
     private boolean isRefreshTokenRenewalEnabled = true;
+    private boolean isExtendRenewedTokenExpiryTimeEnabled = false;
     private boolean assertionsUserNameEnabled = false;
     private boolean accessTokenPartitioningEnabled = false;
     private boolean redirectToRequestedRedirectUriEnabled = true;
@@ -704,6 +705,10 @@ public class OAuthServerConfiguration {
 
     public boolean isRefreshTokenRenewalEnabled() {
         return isRefreshTokenRenewalEnabled;
+    }
+
+    public boolean isExtendRenewedTokenExpiryTimeEnabled() {
+        return isExtendRenewedTokenExpiryTimeEnabled;
     }
 
     public Map<String, OauthTokenIssuer> getOauthTokenIssuerMap() {
@@ -1820,6 +1825,15 @@ public class OAuthServerConfiguration {
         }
         if (log.isDebugEnabled()) {
             log.debug("RenewRefreshTokenForRefreshGrant was set to : " + isRefreshTokenRenewalEnabled);
+        }
+
+        OMElement enableExtendRenewedTokenExpTimeElem = oauthConfigElem.getFirstChildWithName(getQNameWithIdentityNS(
+                ConfigElements.EXTEND_RENEWED_REFRESH_TOKEN_EXPIRY_TIME));
+        if (enableExtendRenewedTokenExpTimeElem != null) {
+            isExtendRenewedTokenExpiryTimeEnabled = Boolean.parseBoolean(enableExtendRenewedTokenExpTimeElem.getText());
+        }
+        if (log.isDebugEnabled()) {
+            log.debug("ExtendRenewedRefreshTokenExpiryTime was set to : " + isExtendRenewedTokenExpiryTimeEnabled);
         }
     }
 
@@ -3052,6 +3066,8 @@ public class OAuthServerConfiguration {
         private static final String ENABLE_CACHE = "EnableOAuthCache";
         // Enable/Disable refresh token renewal on each refresh_token grant request
         private static final String RENEW_REFRESH_TOKEN_FOR_REFRESH_GRANT = "RenewRefreshTokenForRefreshGrant";
+        // Enable/Disable extend the lifetime of the new refresh token
+        private static final String EXTEND_RENEWED_REFRESH_TOKEN_EXPIRY_TIME = "ExtendRenewedRefreshTokenExpiryTime";
         // TokenPersistenceProcessor
         private static final String TOKEN_PERSISTENCE_PROCESSOR = "TokenPersistenceProcessor";
         // Token issuer generator.

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/RefreshGrantHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/RefreshGrantHandler.java
@@ -559,6 +559,10 @@ public class RefreshGrantHandler extends AbstractAuthorizationGrantHandler {
             refreshToken = tokenReq.getRefreshToken();
             refreshTokenIssuedTime = validationBean.getIssuedTime();
             refreshTokenValidityPeriod = validationBean.getValidityPeriodInMillis();
+        } else if (!OAuthServerConfiguration.getInstance().isExtendRenewedTokenExpiryTimeEnabled()) {
+            // If refresh token renewal enabled and extend token expiry disabled, set the old token issued and validity.
+            refreshTokenIssuedTime = validationBean.getIssuedTime();
+            refreshTokenValidityPeriod = validationBean.getValidityPeriodInMillis();
         }
         if (refreshTokenIssuedTime == null) {
             refreshTokenIssuedTime = timestamp;


### PR DESCRIPTION
### Proposed changes in this pull request
> Fixing https://github.com/wso2/product-is/issues/9739, https://github.com/wso2/product-is/issues/8312
> This PR adds capability enable/disable refresh token expiry token extension upon new refresh token generation. 

```
[oauth.token_renewal]
extend_refresh_token_expiry_time_on_renewal = false
```

### Depends one
> https://github.com/wso2/carbon-identity-framework/pull/3225

### Before merging
- [ ] Merge https://github.com/wso2/carbon-identity-framework/pull/3225
- [x] PR_BUILDER