### PR TITLE
Update subject type supported from "pairwise" to "public"

### DIFF
--- a/components/org.wso2.carbon.identity.discovery/src/main/java/org/wso2/carbon/identity/discovery/builders/ProviderConfigBuilder.java
+++ b/components/org.wso2.carbon.identity.discovery/src/main/java/org/wso2/carbon/identity/discovery/builders/ProviderConfigBuilder.java
@@ -110,7 +110,7 @@ public class ProviderConfigBuilder {
         providerConfig.setResponseTypesSupported(supportedResponseTypeNames.toArray(new
                 String[supportedResponseTypeNames.size()]));
 
-        providerConfig.setSubjectTypesSupported(new String[]{"pairwise"});
+        providerConfig.setSubjectTypesSupported(new String[]{"public"});
 
         providerConfig.setCheckSessionIframe(buildServiceUrl(IdentityConstants.OAuth.CHECK_SESSION,
                 IdentityUtil.getProperty(IdentityConstants.OAuth.OIDC_CHECK_SESSION_EP_URL)));


### PR DESCRIPTION
### Proposed changes in this pull request

fix the issue Discovery endpoint shows pairwise subject identifier is supported but it is not.
https://github.com/wso2/product-is/issues/6749

providerConfig.setSubjectTypesSupported(new String[]{"public"});



