### PR TITLE
 Fix Handle Account State feature for disabled accounts.

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/listener/IdentityOathEventListener.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/listener/IdentityOathEventListener.java
@@ -241,8 +241,14 @@ public class IdentityOathEventListener extends AbstractIdentityUserOperationEven
 
         String errorCode =
                 (String) IdentityUtil.threadLocalProperties.get().get(IdentityCoreConstants.USER_ACCOUNT_STATE);
-
+        if (StringUtils.isEmpty(errorCode)) {
+            errorCode =
+                    (String) IdentityUtil.threadLocalProperties.get()
+                            .get(IdentityCoreConstants.USER_ACCOUNT_STATE_WITH_USERNAME + userName);
+        }
         if (errorCode != null && (errorCode.equalsIgnoreCase(UserCoreConstants.ErrorCode.USER_IS_LOCKED))) {
+            IdentityUtil.threadLocalProperties.get()
+                    .remove(IdentityCoreConstants.USER_ACCOUNT_STATE_WITH_USERNAME + userName);
             return revokeTokens(userName, userStoreManager);
         }
         return true;
@@ -253,8 +259,14 @@ public class IdentityOathEventListener extends AbstractIdentityUserOperationEven
 
         String errorCode =
                 (String) IdentityUtil.threadLocalProperties.get().get(IdentityCoreConstants.USER_ACCOUNT_STATE);
-
+        if (StringUtils.isEmpty(errorCode)) {
+            errorCode =
+                    (String) IdentityUtil.threadLocalProperties.get()
+                            .get(IdentityCoreConstants.USER_ACCOUNT_STATE_WITH_USERNAME + userName);
+        }
         if (errorCode != null && errorCode.equalsIgnoreCase(IdentityCoreConstants.USER_ACCOUNT_DISABLED_ERROR_CODE)) {
+            IdentityUtil.threadLocalProperties.get()
+                    .remove(IdentityCoreConstants.USER_ACCOUNT_STATE_WITH_USERNAME + userName);
             return revokeTokens(userName, userStoreManager);
         }
         return true;

--- a/pom.xml
+++ b/pom.xml
@@ -877,7 +877,7 @@
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!-- Carbon Identity Framework version -->
-        <carbon.identity.framework.version>5.18.144</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.18.177</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.15.0, 6.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 


### PR DESCRIPTION
### Proposed changes in this pull request

This fix resolves the issues caused by the removal of account state property from the IdentityUtil.threadLocalProperties.
The newly introduced key helps keep track of the error code in the threadLocalProperties when the account is disabled.

### Before merging
- [x] merge PR https://github.com/wso2/carbon-identity-framework/pull/3238
- [ ] Bump framework version in IS