### PR TITLE
Fix the issue with token revocation when account disabling/locking

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthUtil.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthUtil.java
@@ -25,6 +25,7 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.xml.security.utils.Base64;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
 import org.wso2.carbon.identity.application.common.model.User;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.oauth.cache.OAuthCache;
 import org.wso2.carbon.identity.oauth.cache.OAuthCacheKey;
@@ -32,18 +33,35 @@ import org.wso2.carbon.identity.oauth.dao.OAuthAppDO;
 import org.wso2.carbon.identity.oauth.dto.OAuthConsumerAppDTO;
 import org.wso2.carbon.identity.oauth.event.OAuthEventInterceptor;
 import org.wso2.carbon.identity.oauth.internal.OAuthComponentServiceHolder;
+import org.wso2.carbon.identity.oauth.util.ClaimCache;
+import org.wso2.carbon.identity.oauth.util.ClaimCacheKey;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2ClientException;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2ServerException;
+import org.wso2.carbon.identity.oauth2.dao.OAuthTokenPersistenceFactory;
 import org.wso2.carbon.identity.oauth2.model.AccessTokenDO;
+import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 import org.wso2.carbon.registry.core.utils.UUIDGenerator;
+import org.wso2.carbon.user.core.UserStoreException;
+import org.wso2.carbon.user.core.UserStoreManager;
 import org.wso2.carbon.user.core.util.UserCoreUtil;
 import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
+
+import static org.wso2.carbon.identity.application.authentication.framework.util
+        .FrameworkConstants.CURRENT_SESSION_IDENTIFIER;
+import static org.wso2.carbon.identity.application.authentication.framework.util
+        .FrameworkConstants.Config.PRESERVE_LOGGED_IN_SESSION_AT_PASSWORD_UPDATE;
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.TokenBindings.NONE;
 
 /**
  * OAuth utility functionality.
@@ -369,5 +387,178 @@ public final class OAuthUtil {
                 LOG.error("Error while triggering listener for pre token revocation by system.", e);
             }
         }
+    }
+
+    /**
+     * Remove user claims from ClaimCache
+     *
+     * @param userName
+     */
+    public static boolean removeUserClaimsFromCache(String userName, UserStoreManager userStoreManager)
+            throws UserStoreException {
+
+        ClaimCache claimCache = ClaimCache.getInstance();
+        AuthenticatedUser authenticatedUser = new AuthenticatedUser();
+        authenticatedUser.setUserName(userName);
+        authenticatedUser.setTenantDomain(IdentityTenantUtil.getTenantDomain(userStoreManager.getTenantId()));
+        authenticatedUser.setUserStoreDomain(UserCoreUtil.getDomainName(userStoreManager.getRealmConfiguration()));
+        ClaimCacheKey cacheKey = new ClaimCacheKey(authenticatedUser);
+        if (cacheKey != null) {
+            claimCache.clearCacheEntry(cacheKey);
+        }
+        return true;
+    }
+
+    /**
+     * This method will revoke the accesstokens of user.
+     * @param username username.
+     * @param userStoreManager userStoreManager.
+     * @return true if revocation is successfull. Else return false
+     * @throws UserStoreException
+     */
+    public static boolean revokeTokens(String username, UserStoreManager userStoreManager) throws UserStoreException {
+
+        String userStoreDomain = UserCoreUtil.getDomainName(userStoreManager.getRealmConfiguration());
+        String tenantDomain = IdentityTenantUtil.getTenantDomain(userStoreManager.getTenantId());
+        AuthenticatedUser authenticatedUser = new AuthenticatedUser();
+        authenticatedUser.setUserStoreDomain(userStoreDomain);
+        authenticatedUser.setTenantDomain(tenantDomain);
+        authenticatedUser.setUserName(username);
+
+        /* This userStoreDomain variable is used for access token table partitioning. So it is set to null when access
+        token table partitioning is not enabled.*/
+        userStoreDomain = null;
+        if (OAuth2Util.checkAccessTokenPartitioningEnabled() && OAuth2Util.checkUserNameAssertionEnabled()) {
+            try {
+                userStoreDomain = OAuth2Util.getUserStoreForFederatedUser(authenticatedUser);
+            } catch (IdentityOAuth2Exception e) {
+                LOG.error("Error occurred while getting user store domain for User ID : " + authenticatedUser, e);
+                throw new UserStoreException(e);
+            }
+        }
+
+        Set<String> clientIds;
+        try {
+            // get all the distinct client Ids authorized by this user
+            clientIds = OAuthTokenPersistenceFactory.getInstance()
+                    .getTokenManagementDAO().getAllTimeAuthorizedClientIds(authenticatedUser);
+        } catch (IdentityOAuth2Exception e) {
+            LOG.error("Error occurred while retrieving apps authorized by User ID : " + authenticatedUser, e);
+            throw new UserStoreException(e);
+        }
+        for (String clientId : clientIds) {
+            Set<AccessTokenDO> accessTokenDOs;
+            try {
+                // retrieve all ACTIVE or EXPIRED access tokens for particular client authorized by this user
+                accessTokenDOs = OAuthTokenPersistenceFactory.getInstance().getAccessTokenDAO()
+                        .getAccessTokens(clientId, authenticatedUser, userStoreDomain, true);
+            } catch (IdentityOAuth2Exception e) {
+                String errorMsg = "Error occurred while retrieving access tokens issued for " +
+                        "Client ID : " + clientId + ", User ID : " + authenticatedUser;
+                LOG.error(errorMsg, e);
+                throw new UserStoreException(e);
+            }
+
+            boolean isTokenPreservingAtPasswordUpdateEnabled =
+                    Boolean.parseBoolean(IdentityUtil.getProperty(PRESERVE_LOGGED_IN_SESSION_AT_PASSWORD_UPDATE));
+            String currentTokenBindingReference = "";
+            if (isTokenPreservingAtPasswordUpdateEnabled) {
+                if (IdentityUtil.threadLocalProperties.get().get(CURRENT_SESSION_IDENTIFIER) != null) {
+                    currentTokenBindingReference =
+                            (String) IdentityUtil.threadLocalProperties.get().get(CURRENT_SESSION_IDENTIFIER);
+                }
+            }
+
+            Set<String> scopes = new HashSet<>();
+            List<AccessTokenDO> accessTokens = new ArrayList<>();
+            boolean tokenBindingEnabled = false;
+            for (AccessTokenDO accessTokenDO : accessTokenDOs) {
+                // Clear cache
+                String tokenBindingReference = NONE;
+                if (accessTokenDO.getTokenBinding() != null && StringUtils
+                        .isNotBlank(accessTokenDO.getTokenBinding().getBindingReference())) {
+                    tokenBindingReference = accessTokenDO.getTokenBinding().getBindingReference();
+                    tokenBindingEnabled = true;
+                    // Skip current token from being revoked.
+                    if (StringUtils.equals(accessTokenDO.getTokenBinding().getBindingValue(),
+                            currentTokenBindingReference)) {
+                        continue;
+                    }
+                }
+                OAuthUtil.clearOAuthCache(accessTokenDO.getConsumerKey(), accessTokenDO.getAuthzUser(),
+                        OAuth2Util.buildScopeString(accessTokenDO.getScope()), tokenBindingReference);
+                OAuthUtil.clearOAuthCache(accessTokenDO.getConsumerKey(), accessTokenDO.getAuthzUser(),
+                        OAuth2Util.buildScopeString(accessTokenDO.getScope()));
+                OAuthUtil.clearOAuthCache(accessTokenDO.getConsumerKey(), accessTokenDO.getAuthzUser());
+                OAuthUtil.clearOAuthCache(accessTokenDO.getAccessToken());
+                // Get unique scopes list
+                scopes.add(OAuth2Util.buildScopeString(accessTokenDO.getScope()));
+                accessTokens.add(accessTokenDO);
+            }
+
+            if (!tokenBindingEnabled && OAuth2Util.isHashDisabled()) {
+                return revokeLatestTokensWithScopes(scopes, clientId, authenticatedUser);
+            } else {
+                // If the hashed token is enabled, there can be multiple active tokens with a user with same scope.
+                // Also, if token binding is enabled, there can be multiple active tokens for the same user, scope
+                // and client combination.
+                // So need to revoke all the tokens.
+                try {
+                    return revokeTokens(accessTokens);
+                } catch (IdentityOAuth2Exception e) {
+                    String errorMsg = "Error occurred while revoking Access Token";
+                    LOG.error(errorMsg, e);
+                    throw new UserStoreException(e);
+                }
+            }
+        }
+        return true;
+    }
+
+    private static boolean revokeTokens(List<AccessTokenDO> accessTokens) throws IdentityOAuth2Exception {
+
+        if (!accessTokens.isEmpty()) {
+            // Revoking token from database.
+            for (AccessTokenDO accessToken : accessTokens) {
+                OAuthUtil.invokePreRevocationBySystemListeners(accessToken, Collections.emptyMap());
+                OAuthTokenPersistenceFactory.getInstance().getAccessTokenDAO()
+                        .revokeAccessTokens(new String[]{accessToken.getAccessToken()}, OAuth2Util.isHashEnabled());
+                OAuthUtil.invokePostRevocationBySystemListeners(accessToken, Collections.emptyMap());
+            }
+        }
+        return true;
+    }
+
+    private static boolean revokeLatestTokensWithScopes(Set<String> scopes, String clientId,
+                                                        AuthenticatedUser authenticatedUser) throws
+            UserStoreException {
+
+        for (String scope : scopes) {
+            AccessTokenDO scopedToken = null;
+            try {
+                // Retrieve latest access token for particular client, user and scope combination
+                // if its ACTIVE or EXPIRED.
+                scopedToken = OAuthTokenPersistenceFactory.getInstance().getAccessTokenDAO()
+                        .getLatestAccessToken(clientId, authenticatedUser, authenticatedUser.getUserStoreDomain(),
+                                scope, true);
+            } catch (IdentityOAuth2Exception e) {
+                String errorMsg = "Error occurred while retrieving latest access token issued for Client ID : " +
+                        clientId + ", User ID : " + authenticatedUser + " and Scope : " + scope;
+                LOG.error(errorMsg, e);
+                throw new UserStoreException(e);
+            }
+            if (scopedToken != null) {
+                try {
+                    // Revoking token from database
+                    revokeTokens(Collections.singletonList(scopedToken));
+                } catch (IdentityOAuth2Exception e) {
+                    String errorMsg = "Error occurred while revoking " + "Access Token : "
+                            + scopedToken.getAccessToken() + " for user " + authenticatedUser;
+                    LOG.error(errorMsg, e);
+                    throw new UserStoreException(e);
+                }
+            }
+        }
+        return true;
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/internal/OAuthServiceComponent.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/internal/OAuthServiceComponent.java
@@ -27,6 +27,7 @@ import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
 import org.wso2.carbon.identity.core.util.IdentityCoreInitializedEvent;
+import org.wso2.carbon.identity.event.handler.AbstractEventHandler;
 import org.wso2.carbon.identity.oauth.OAuthAdminServiceImpl;
 import org.wso2.carbon.identity.oauth.cache.OAuthCache;
 import org.wso2.carbon.identity.oauth.common.OAuthConstants;
@@ -34,6 +35,7 @@ import org.wso2.carbon.identity.oauth.common.token.bindings.TokenBinderInfo;
 import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
 import org.wso2.carbon.identity.oauth.event.OAuthEventInterceptor;
 import org.wso2.carbon.identity.oauth.listener.IdentityOathEventListener;
+import org.wso2.carbon.identity.oauth.listener.IdentityOauthEventHandler;
 import org.wso2.carbon.identity.oauth.listener.OAuthApplicationMgtListener;
 import org.wso2.carbon.identity.oauth2.OAuth2ScopeService;
 import org.wso2.carbon.identity.oauth2.OAuth2Service;
@@ -67,6 +69,12 @@ public class OAuthServiceComponent {
             serviceRegistration = context.getBundleContext().registerService(UserOperationEventListener.class.getName(),
                     listener, null);
             log.debug("Identity Oath Event Listener is enabled");
+
+            context.getBundleContext().registerService(AbstractEventHandler.class.getName(),
+                    new IdentityOauthEventHandler(), null);
+            if (log.isDebugEnabled()) {
+                log.debug("Identity Oauth Event handler is enabled");
+            }
 
             OAuth2Service oauth2Service = new OAuth2Service();
             context.getBundleContext().registerService(OAuth2Service.class.getName(), oauth2Service, null);

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/listener/IdentityOathEventListener.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/listener/IdentityOathEventListener.java
@@ -20,7 +20,6 @@ package org.wso2.carbon.identity.oauth.listener;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.ArrayUtils;
-import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
@@ -32,7 +31,6 @@ import org.wso2.carbon.identity.oauth.OAuthUtil;
 import org.wso2.carbon.identity.oauth.cache.AuthorizationGrantCache;
 import org.wso2.carbon.identity.oauth.cache.AuthorizationGrantCacheKey;
 import org.wso2.carbon.identity.oauth.util.ClaimCache;
-import org.wso2.carbon.identity.oauth.util.ClaimCacheKey;
 import org.wso2.carbon.identity.oauth.util.ClaimMetaDataCache;
 import org.wso2.carbon.identity.oauth.util.ClaimMetaDataCacheEntry;
 import org.wso2.carbon.identity.oauth.util.ClaimMetaDataCacheKey;
@@ -40,7 +38,6 @@ import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.dao.OAuthTokenPersistenceFactory;
 import org.wso2.carbon.identity.oauth2.model.AccessTokenDO;
 import org.wso2.carbon.identity.oauth2.model.AuthzCodeDO;
-import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 import org.wso2.carbon.user.core.UserCoreConstants;
 import org.wso2.carbon.user.core.UserStoreException;
 import org.wso2.carbon.user.core.UserStoreManager;
@@ -48,17 +45,10 @@ import org.wso2.carbon.user.core.util.UserCoreUtil;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.
-        CURRENT_SESSION_IDENTIFIER;
-import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.Config.
-        PRESERVE_LOGGED_IN_SESSION_AT_PASSWORD_UPDATE;
-import static org.wso2.carbon.identity.oauth.common.OAuthConstants.TokenBindings.NONE;
 
 /**
  * This is an implementation of UserOperationEventListener. This defines
@@ -95,7 +85,7 @@ public class IdentityOathEventListener extends AbstractIdentityUserOperationEven
 
         removeClaimCacheEntry(username, userStoreManager);
 
-        return revokeTokens(username, userStoreManager);
+        return OAuthUtil.revokeTokens(username, userStoreManager);
 
     }
 
@@ -128,9 +118,7 @@ public class IdentityOathEventListener extends AbstractIdentityUserOperationEven
         if (!isEnable()) {
             return true;
         }
-        return revokeTokensOfLockedUser(userName, userStoreManager) &&
-                revokeTokensOfDisabledUser(userName, userStoreManager)
-                && removeUserClaimsFromCache(userName, userStoreManager);
+        return true;
     }
 
     @Override
@@ -140,9 +128,7 @@ public class IdentityOathEventListener extends AbstractIdentityUserOperationEven
         if (!isEnable()) {
             return true;
         }
-        return revokeTokensOfLockedUser(userName, userStoreManager) &&
-                revokeTokensOfDisabledUser(userName, userStoreManager)
-                && removeUserClaimsFromCache(userName, userStoreManager);
+        return true;
     }
 
     @Override
@@ -163,7 +149,7 @@ public class IdentityOathEventListener extends AbstractIdentityUserOperationEven
         if (!isEnable()) {
             return true;
         }
-        return revokeTokens(userName, userStoreManager);
+        return OAuthUtil.revokeTokens(userName, userStoreManager);
     }
 
     @Override
@@ -173,7 +159,7 @@ public class IdentityOathEventListener extends AbstractIdentityUserOperationEven
         if (!isEnable()) {
             return true;
         }
-        return revokeTokens(userName, userStoreManager);
+        return OAuthUtil.revokeTokens(userName, userStoreManager);
     }
 
     @Override
@@ -195,9 +181,9 @@ public class IdentityOathEventListener extends AbstractIdentityUserOperationEven
             return true;
         }
         if (ArrayUtils.isNotEmpty(deletedRoles)) {
-            revokeTokens(userName, userStoreManager);
+            OAuthUtil.revokeTokens(userName, userStoreManager);
         }
-        return removeUserClaimsFromCache(userName, userStoreManager);
+        return OAuthUtil.removeUserClaimsFromCache(userName, userStoreManager);
     }
 
     @Override
@@ -228,10 +214,10 @@ public class IdentityOathEventListener extends AbstractIdentityUserOperationEven
         userList.addAll(Arrays.asList(deletedUsers));
         userList.addAll(Arrays.asList(newUsers));
         for (String username : userList) {
-            removeUserClaimsFromCache(username, userStoreManager);
+            OAuthUtil.removeUserClaimsFromCache(username, userStoreManager);
         }
         for (String deletedUser : deletedUsers) {
-            revokeTokens(deletedUser, userStoreManager);
+            OAuthUtil.revokeTokens(deletedUser, userStoreManager);
         }
         return true;
     }
@@ -243,7 +229,7 @@ public class IdentityOathEventListener extends AbstractIdentityUserOperationEven
                 (String) IdentityUtil.threadLocalProperties.get().get(IdentityCoreConstants.USER_ACCOUNT_STATE);
 
         if (errorCode != null && (errorCode.equalsIgnoreCase(UserCoreConstants.ErrorCode.USER_IS_LOCKED))) {
-            return revokeTokens(userName, userStoreManager);
+            return OAuthUtil.revokeTokens(userName, userStoreManager);
         }
         return true;
     }
@@ -255,152 +241,7 @@ public class IdentityOathEventListener extends AbstractIdentityUserOperationEven
                 (String) IdentityUtil.threadLocalProperties.get().get(IdentityCoreConstants.USER_ACCOUNT_STATE);
 
         if (errorCode != null && errorCode.equalsIgnoreCase(IdentityCoreConstants.USER_ACCOUNT_DISABLED_ERROR_CODE)) {
-            return revokeTokens(userName, userStoreManager);
-        }
-        return true;
-    }
-
-    private boolean revokeTokens(String username, UserStoreManager userStoreManager) throws UserStoreException {
-
-        String userStoreDomain = UserCoreUtil.getDomainName(userStoreManager.getRealmConfiguration());
-        String tenantDomain = IdentityTenantUtil.getTenantDomain(userStoreManager.getTenantId());
-        AuthenticatedUser authenticatedUser = new AuthenticatedUser();
-        authenticatedUser.setUserStoreDomain(userStoreDomain);
-        authenticatedUser.setTenantDomain(tenantDomain);
-        authenticatedUser.setUserName(username);
-
-        /* This userStoreDomain variable is used for access token table partitioning. So it is set to null when access
-        token table partitioning is not enabled.*/
-        userStoreDomain = null;
-        if (OAuth2Util.checkAccessTokenPartitioningEnabled() && OAuth2Util.checkUserNameAssertionEnabled()) {
-            try {
-                userStoreDomain = OAuth2Util.getUserStoreForFederatedUser(authenticatedUser);
-            } catch (IdentityOAuth2Exception e) {
-                log.error("Error occurred while getting user store domain for User ID : " + authenticatedUser, e);
-                throw new UserStoreException(e);
-            }
-        }
-
-        Set<String> clientIds;
-        try {
-            // get all the distinct client Ids authorized by this user
-            clientIds = OAuthTokenPersistenceFactory.getInstance()
-                    .getTokenManagementDAO().getAllTimeAuthorizedClientIds(authenticatedUser);
-        } catch (IdentityOAuth2Exception e) {
-            log.error("Error occurred while retrieving apps authorized by User ID : " + authenticatedUser, e);
-            throw new UserStoreException(e);
-        }
-        for (String clientId : clientIds) {
-            Set<AccessTokenDO> accessTokenDOs;
-            try {
-                // retrieve all ACTIVE or EXPIRED access tokens for particular client authorized by this user
-                accessTokenDOs = OAuthTokenPersistenceFactory.getInstance().getAccessTokenDAO()
-                        .getAccessTokens(clientId, authenticatedUser, userStoreDomain, true);
-            } catch (IdentityOAuth2Exception e) {
-                String errorMsg = "Error occurred while retrieving access tokens issued for " +
-                        "Client ID : " + clientId + ", User ID : " + authenticatedUser;
-                log.error(errorMsg, e);
-                throw new UserStoreException(e);
-            }
-
-            boolean isTokenPreservingAtPasswordUpdateEnabled =
-                    Boolean.parseBoolean(IdentityUtil.getProperty(PRESERVE_LOGGED_IN_SESSION_AT_PASSWORD_UPDATE));
-            String currentTokenBindingReference = "";
-            if (isTokenPreservingAtPasswordUpdateEnabled) {
-                if (IdentityUtil.threadLocalProperties.get().get(CURRENT_SESSION_IDENTIFIER) != null) {
-                    currentTokenBindingReference =
-                            (String) IdentityUtil.threadLocalProperties.get().get(CURRENT_SESSION_IDENTIFIER);
-                }
-            }
-
-            Set<String> scopes = new HashSet<>();
-            List<AccessTokenDO> accessTokens = new ArrayList<>();
-            boolean tokenBindingEnabled = false;
-            for (AccessTokenDO accessTokenDO : accessTokenDOs) {
-                // Clear cache
-                String tokenBindingReference = NONE;
-                if (accessTokenDO.getTokenBinding() != null && StringUtils
-                        .isNotBlank(accessTokenDO.getTokenBinding().getBindingReference())) {
-                    tokenBindingReference = accessTokenDO.getTokenBinding().getBindingReference();
-                    tokenBindingEnabled = true;
-                    // Skip current token from being revoked.
-                    if (StringUtils.equals(accessTokenDO.getTokenBinding().getBindingValue(),
-                            currentTokenBindingReference)) {
-                        continue;
-                    }
-                }
-                OAuthUtil.clearOAuthCache(accessTokenDO.getConsumerKey(), accessTokenDO.getAuthzUser(),
-                        OAuth2Util.buildScopeString(accessTokenDO.getScope()), tokenBindingReference);
-                OAuthUtil.clearOAuthCache(accessTokenDO.getConsumerKey(), accessTokenDO.getAuthzUser(),
-                        OAuth2Util.buildScopeString(accessTokenDO.getScope()));
-                OAuthUtil.clearOAuthCache(accessTokenDO.getConsumerKey(), accessTokenDO.getAuthzUser());
-                OAuthUtil.clearOAuthCache(accessTokenDO.getAccessToken());
-                // Get unique scopes list
-                scopes.add(OAuth2Util.buildScopeString(accessTokenDO.getScope()));
-                accessTokens.add(accessTokenDO);
-            }
-
-            if (!tokenBindingEnabled && OAuth2Util.isHashDisabled()) {
-                return revokeLatestTokensWithScopes(scopes, clientId, authenticatedUser);
-            } else {
-                // If the hashed token is enabled, there can be multiple active tokens with a user with same scope.
-                // Also, if token binding is enabled, there can be multiple active tokens for the same user, scope
-                // and client combination.
-                // So need to revoke all the tokens.
-                try {
-                    return revokeTokens(accessTokens);
-                } catch (IdentityOAuth2Exception e) {
-                    String errorMsg = "Error occurred while revoking Access Token";
-                    log.error(errorMsg, e);
-                    throw new UserStoreException(e);
-                }
-            }
-        }
-        return true;
-    }
-
-    private boolean revokeTokens(List<AccessTokenDO> accessTokens) throws IdentityOAuth2Exception {
-
-        if (!accessTokens.isEmpty()) {
-            // Revoking token from database.
-            for (AccessTokenDO accessToken : accessTokens) {
-                OAuthUtil.invokePreRevocationBySystemListeners(accessToken, Collections.emptyMap());
-                OAuthTokenPersistenceFactory.getInstance().getAccessTokenDAO()
-                        .revokeAccessTokens(new String[]{accessToken.getAccessToken()}, OAuth2Util.isHashEnabled());
-                OAuthUtil.invokePostRevocationBySystemListeners(accessToken, Collections.emptyMap());
-            }
-        }
-        return true;
-    }
-
-    private boolean revokeLatestTokensWithScopes(Set<String> scopes, String clientId,
-                                                 AuthenticatedUser authenticatedUser) throws UserStoreException {
-
-        for (String scope : scopes) {
-            AccessTokenDO scopedToken = null;
-            try {
-                // Retrieve latest access token for particular client, user and scope combination
-                // if its ACTIVE or EXPIRED.
-                scopedToken = OAuthTokenPersistenceFactory.getInstance().getAccessTokenDAO()
-                        .getLatestAccessToken(clientId, authenticatedUser, authenticatedUser.getUserStoreDomain(),
-                                scope, true);
-            } catch (IdentityOAuth2Exception e) {
-                String errorMsg = "Error occurred while retrieving latest access token issued for Client ID : " +
-                        clientId + ", User ID : " + authenticatedUser + " and Scope : " + scope;
-                log.error(errorMsg, e);
-                throw new UserStoreException(e);
-            }
-            if (scopedToken != null) {
-                try {
-                    // Revoking token from database
-                    revokeTokens(Collections.singletonList(scopedToken));
-                } catch (IdentityOAuth2Exception e) {
-                    String errorMsg = "Error occurred while revoking " + "Access Token : "
-                            + scopedToken.getAccessToken() + " for user " + authenticatedUser;
-                    log.error(errorMsg, e);
-                    throw new UserStoreException(e);
-                }
-            }
+            return OAuthUtil.revokeTokens(userName, userStoreManager);
         }
         return true;
     }
@@ -454,26 +295,6 @@ public class IdentityOathEventListener extends AbstractIdentityUserOperationEven
                 AuthorizationGrantCache.getInstance().clearCacheEntryByTokenId(cacheKey, tokenId);
             }
         }
-    }
-
-    /**
-     * Remove user claims from ClaimCache
-     *
-     * @param userName
-     */
-    private boolean removeUserClaimsFromCache(String userName, UserStoreManager userStoreManager)
-            throws UserStoreException {
-
-        ClaimCache claimCache = ClaimCache.getInstance();
-        AuthenticatedUser authenticatedUser = new AuthenticatedUser();
-        authenticatedUser.setUserName(userName);
-        authenticatedUser.setTenantDomain(IdentityTenantUtil.getTenantDomain(userStoreManager.getTenantId()));
-        authenticatedUser.setUserStoreDomain(UserCoreUtil.getDomainName(userStoreManager.getRealmConfiguration()));
-        ClaimCacheKey cacheKey = new ClaimCacheKey(authenticatedUser);
-        if (cacheKey != null) {
-            claimCache.clearCacheEntry(cacheKey);
-        }
-        return true;
     }
 
     /**

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/listener/IdentityOauthEventHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/listener/IdentityOauthEventHandler.java
@@ -109,11 +109,10 @@ public class IdentityOauthEventHandler extends AbstractEventHandler {
         String errorCode =
                 (String) IdentityUtil.threadLocalProperties.get().get(IdentityCoreConstants.USER_ACCOUNT_STATE);
 
-        if (errorCode != null && (errorCode.equalsIgnoreCase(UserCoreConstants.ErrorCode.USER_IS_LOCKED))) {
+        if (UserCoreConstants.ErrorCode.USER_IS_LOCKED.equalsIgnoreCase(errorCode)) {
             if (log.isDebugEnabled()) {
                 log.debug(String.format("User %s is locked. Hence revoking user's access tokens.", userName));
             }
-            log.info(String.format("User %s is locked. Hence revoking user's access tokens.", userName));
             revokeTokens(userName, userStoreManager);
         }
     }
@@ -123,11 +122,10 @@ public class IdentityOauthEventHandler extends AbstractEventHandler {
 
         String errorCode =
                 (String) IdentityUtil.threadLocalProperties.get().get(IdentityCoreConstants.USER_ACCOUNT_STATE);
-        if (errorCode != null && errorCode.equalsIgnoreCase(IdentityCoreConstants.USER_ACCOUNT_DISABLED_ERROR_CODE)) {
+        if (IdentityCoreConstants.USER_ACCOUNT_DISABLED_ERROR_CODE.equalsIgnoreCase(errorCode)) {
             if (log.isDebugEnabled()) {
                 log.debug(String.format("User %s is disabled. Hence revoking user's access tokens.", userName));
             }
-            log.info(String.format("User %s is disabled. Hence revoking user's access tokens.", userName));
             revokeTokens(userName, userStoreManager);
         }
     }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/listener/IdentityOauthEventHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/listener/IdentityOauthEventHandler.java
@@ -1,0 +1,282 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth.listener;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
+import org.wso2.carbon.identity.base.IdentityRuntimeException;
+import org.wso2.carbon.identity.core.bean.context.MessageContext;
+import org.wso2.carbon.identity.core.handler.InitConfig;
+import org.wso2.carbon.identity.core.util.IdentityCoreConstants;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.event.IdentityEventConstants;
+import org.wso2.carbon.identity.event.IdentityEventException;
+import org.wso2.carbon.identity.event.event.Event;
+import org.wso2.carbon.identity.event.handler.AbstractEventHandler;
+import org.wso2.carbon.identity.oauth.OAuthUtil;
+import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
+import org.wso2.carbon.identity.oauth2.dao.OAuthTokenPersistenceFactory;
+import org.wso2.carbon.identity.oauth2.model.AccessTokenDO;
+import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
+import org.wso2.carbon.user.core.UserCoreConstants;
+import org.wso2.carbon.user.core.UserStoreException;
+import org.wso2.carbon.user.core.UserStoreManager;
+import org.wso2.carbon.user.core.util.UserCoreUtil;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants
+        .CURRENT_SESSION_IDENTIFIER;
+import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.Config
+        .PRESERVE_LOGGED_IN_SESSION_AT_PASSWORD_UPDATE;
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.TokenBindings.NONE;
+
+/**
+ * This is an event handler listening to for some of the core user management operations.
+ */
+public class IdentityOauthEventHandler extends AbstractEventHandler {
+
+    private static final Log log = LogFactory.getLog(IdentityOauthEventHandler.class);
+
+    public String getName() {
+
+        return "identityOauthEventHandler";
+    }
+
+    public String getFriendlyName() {
+
+        return "Identity Oauth Event Handler";
+    }
+
+    @Override
+    public void init(InitConfig configuration) throws IdentityRuntimeException {
+
+        super.init(configuration);
+    }
+
+    @Override
+    public int getPriority(MessageContext messageContext) {
+
+        return 50;
+    }
+
+
+    @Override
+    public void handleEvent(Event event) throws IdentityEventException {
+
+        if (IdentityEventConstants.Event.POST_SET_USER_CLAIMS.equals(event.getEventName())) {
+            String username = (String) event.getEventProperties().get(IdentityEventConstants.EventProperty.USER_NAME);
+            UserStoreManager userStoreManager =
+                    (UserStoreManager) event.getEventProperties()
+                            .get(IdentityEventConstants.EventProperty.USER_STORE_MANAGER);
+            try {
+                revokeTokensOfLockedUser(username, userStoreManager);
+                revokeTokensOfDisabledUser(username, userStoreManager);
+            } catch (UserStoreException e) {
+                String errorMsg = "Error occurred while revoking  access token for User : " + username;
+                log.error(errorMsg, e);
+                throw new IdentityEventException(errorMsg);
+            }
+        }
+    }
+
+    private void revokeTokensOfLockedUser(String userName, UserStoreManager userStoreManager)
+            throws UserStoreException {
+
+        String errorCode =
+                (String) IdentityUtil.threadLocalProperties.get().get(IdentityCoreConstants.USER_ACCOUNT_STATE);
+
+        if (errorCode != null && (errorCode.equalsIgnoreCase(UserCoreConstants.ErrorCode.USER_IS_LOCKED))) {
+            if (log.isDebugEnabled()) {
+                log.debug(String.format("User %s is locked. Hence revoking user's access tokens.", userName));
+            }
+            log.info(String.format("User %s is locked. Hence revoking user's access tokens.", userName));
+            revokeTokens(userName, userStoreManager);
+        }
+    }
+
+    private void revokeTokensOfDisabledUser(String userName, UserStoreManager userStoreManager)
+            throws UserStoreException {
+
+        String errorCode =
+                (String) IdentityUtil.threadLocalProperties.get().get(IdentityCoreConstants.USER_ACCOUNT_STATE);
+        if (errorCode != null && errorCode.equalsIgnoreCase(IdentityCoreConstants.USER_ACCOUNT_DISABLED_ERROR_CODE)) {
+            if (log.isDebugEnabled()) {
+                log.debug(String.format("User %s is disabled. Hence revoking user's access tokens.", userName));
+            }
+            log.info(String.format("User %s is disabled. Hence revoking user's access tokens.", userName));
+            revokeTokens(userName, userStoreManager);
+        }
+    }
+
+    private void revokeTokens(String username, UserStoreManager userStoreManager) throws UserStoreException {
+
+        String userStoreDomain = UserCoreUtil.getDomainName(userStoreManager.getRealmConfiguration());
+        String tenantDomain = IdentityTenantUtil.getTenantDomain(userStoreManager.getTenantId());
+        AuthenticatedUser authenticatedUser = new AuthenticatedUser();
+        authenticatedUser.setUserStoreDomain(userStoreDomain);
+        authenticatedUser.setTenantDomain(tenantDomain);
+        authenticatedUser.setUserName(username);
+
+        /* This userStoreDomain variable is used for access token table partitioning. So it is set to null when access
+        token table partitioning is not enabled.*/
+        userStoreDomain = null;
+        if (OAuth2Util.checkAccessTokenPartitioningEnabled() && OAuth2Util.checkUserNameAssertionEnabled()) {
+            try {
+                userStoreDomain = OAuth2Util.getUserStoreForFederatedUser(authenticatedUser);
+            } catch (IdentityOAuth2Exception e) {
+                log.error("Error occurred while getting user store domain for User ID: " +
+                        authenticatedUser, e);
+                throw new UserStoreException(e);
+            }
+        }
+
+        Set<String> clientIds;
+        try {
+            // get all the distinct client Ids authorized by this user
+            clientIds =
+                    OAuthTokenPersistenceFactory.getInstance().getTokenManagementDAO()
+                            .getAllTimeAuthorizedClientIds(authenticatedUser);
+        } catch (IdentityOAuth2Exception e) {
+            log.error("Error occurred while retrieving apps authorized by User ID : " + authenticatedUser, e);
+            throw new UserStoreException(e);
+        }
+        for (String clientId : clientIds) {
+            Set<AccessTokenDO> accessTokenDOs;
+            try {
+                // retrieve all ACTIVE or EXPIRED access tokens for particular client authorized by this user
+                accessTokenDOs =
+                        OAuthTokenPersistenceFactory.getInstance().getAccessTokenDAO().getAccessTokens(clientId,
+                                authenticatedUser, userStoreDomain, true);
+            } catch (IdentityOAuth2Exception e) {
+                String errorMsg =
+                        "Error occurred while retrieving access tokens issued for " + "Client ID : " + clientId + ", "
+                                + "User ID : " + authenticatedUser;
+                log.error(errorMsg, e);
+                throw new UserStoreException(e);
+            }
+
+            boolean isTokenPreservingAtPasswordUpdateEnabled =
+                    Boolean.parseBoolean(IdentityUtil.getProperty(PRESERVE_LOGGED_IN_SESSION_AT_PASSWORD_UPDATE));
+            String currentTokenBindingReference = "";
+            if (isTokenPreservingAtPasswordUpdateEnabled) {
+                if (IdentityUtil.threadLocalProperties.get().get(CURRENT_SESSION_IDENTIFIER) != null) {
+                    currentTokenBindingReference =
+                            (String) IdentityUtil.threadLocalProperties.get().get(CURRENT_SESSION_IDENTIFIER);
+                }
+            }
+
+            Set<String> scopes = new HashSet<>();
+            List<AccessTokenDO> accessTokens = new ArrayList<>();
+            boolean tokenBindingEnabled = false;
+            for (AccessTokenDO accessTokenDO : accessTokenDOs) {
+                // Clear cache
+                String tokenBindingReference = NONE;
+                if (accessTokenDO.getTokenBinding() != null && StringUtils.isNotBlank(accessTokenDO.
+                        getTokenBinding().getBindingReference())) {
+                    tokenBindingReference = accessTokenDO.getTokenBinding().getBindingReference();
+                    tokenBindingEnabled = true;
+                    // Skip current token from being revoked.
+                    if (StringUtils.equals(accessTokenDO.getTokenBinding().getBindingValue(),
+                            currentTokenBindingReference)) {
+                        continue;
+                    }
+                }
+                OAuthUtil.clearOAuthCache(accessTokenDO.getConsumerKey(), accessTokenDO.getAuthzUser(),
+                        OAuth2Util.buildScopeString(accessTokenDO.getScope()), tokenBindingReference);
+                OAuthUtil.clearOAuthCache(accessTokenDO.getConsumerKey(), accessTokenDO.getAuthzUser(),
+                        OAuth2Util.buildScopeString(accessTokenDO.getScope()));
+                OAuthUtil.clearOAuthCache(accessTokenDO.getConsumerKey(), accessTokenDO.getAuthzUser());
+                OAuthUtil.clearOAuthCache(accessTokenDO.getAccessToken());
+                // Get unique scopes list
+                scopes.add(OAuth2Util.buildScopeString(accessTokenDO.getScope()));
+                accessTokens.add(accessTokenDO);
+            }
+
+            if (!tokenBindingEnabled && OAuth2Util.isHashDisabled()) {
+                revokeLatestTokensWithScopes(scopes, clientId, authenticatedUser);
+            } else {
+                // If the hashed token is enabled, there can be multiple active tokens with a user with same scope.
+                // Also, if token binding is enabled, there can be multiple active tokens for the same user, scope
+                // and client combination.
+                // So need to revoke all the tokens.
+                try {
+                    revokeTokens(accessTokens);
+                } catch (IdentityOAuth2Exception e) {
+                    String errorMsg = "Error occurred while revoking Access Token";
+                    log.error(errorMsg, e);
+                    throw new UserStoreException(e);
+                }
+            }
+        }
+    }
+
+    private void revokeTokens(List<AccessTokenDO> accessTokens) throws IdentityOAuth2Exception {
+
+        if (!accessTokens.isEmpty()) {
+            // Revoking token from database.
+            for (AccessTokenDO accessToken : accessTokens) {
+                OAuthUtil.invokePreRevocationBySystemListeners(accessToken, Collections.emptyMap());
+                OAuthTokenPersistenceFactory.getInstance().getAccessTokenDAO().revokeAccessTokens(new String[]
+                        {accessToken.getAccessToken()}, OAuth2Util.isHashEnabled());
+                OAuthUtil.invokePostRevocationBySystemListeners(accessToken, Collections.emptyMap());
+            }
+        }
+    }
+
+    private void revokeLatestTokensWithScopes(Set<String> scopes, String clientId,
+                                              AuthenticatedUser authenticatedUser) throws UserStoreException {
+
+        for (String scope : scopes) {
+            AccessTokenDO scopedToken = null;
+            try {
+                // Retrieve latest access token for particular client, user and scope combination
+                // if its ACTIVE or EXPIRED.
+                scopedToken =
+                        OAuthTokenPersistenceFactory.getInstance().getAccessTokenDAO().getLatestAccessToken(clientId,
+                                authenticatedUser, authenticatedUser.getUserStoreDomain(), scope, true);
+            } catch (IdentityOAuth2Exception e) {
+                String errorMsg =
+                        "Error occurred while retrieving latest access token issued for Client ID : " + clientId + ","
+                                + " User ID : " + authenticatedUser + " and Scope : " + scope;
+                log.error(errorMsg, e);
+                throw new UserStoreException(e);
+            }
+            if (scopedToken != null) {
+                try {
+                    // Revoking token from database
+                    revokeTokens(Collections.singletonList(scopedToken));
+                } catch (IdentityOAuth2Exception e) {
+                    String errorMsg =
+                            "Error occurred while revoking " + "Access Token : " + scopedToken.getAccessToken() +
+                                    " " + "for user " + authenticatedUser;
+                    log.error(errorMsg, e);
+                    throw new UserStoreException(e);
+                }
+            }
+        }
+    }
+}

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/listener/IdentityOauthEventHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/listener/IdentityOauthEventHandler.java
@@ -18,44 +18,24 @@
 
 package org.wso2.carbon.identity.oauth.listener;
 
-import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
 import org.wso2.carbon.identity.base.IdentityRuntimeException;
 import org.wso2.carbon.identity.core.bean.context.MessageContext;
 import org.wso2.carbon.identity.core.handler.InitConfig;
 import org.wso2.carbon.identity.core.util.IdentityCoreConstants;
-import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.event.IdentityEventConstants;
 import org.wso2.carbon.identity.event.IdentityEventException;
 import org.wso2.carbon.identity.event.event.Event;
 import org.wso2.carbon.identity.event.handler.AbstractEventHandler;
 import org.wso2.carbon.identity.oauth.OAuthUtil;
-import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
-import org.wso2.carbon.identity.oauth2.dao.OAuthTokenPersistenceFactory;
-import org.wso2.carbon.identity.oauth2.model.AccessTokenDO;
-import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 import org.wso2.carbon.user.core.UserCoreConstants;
 import org.wso2.carbon.user.core.UserStoreException;
 import org.wso2.carbon.user.core.UserStoreManager;
-import org.wso2.carbon.user.core.util.UserCoreUtil;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
-import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants
-        .CURRENT_SESSION_IDENTIFIER;
-import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.Config
-        .PRESERVE_LOGGED_IN_SESSION_AT_PASSWORD_UPDATE;
-import static org.wso2.carbon.identity.oauth.common.OAuthConstants.TokenBindings.NONE;
 
 /**
- * This is an event handler listening to for some of the core user management operations.
+ * This is an event handler listening for some of the core user management operations.
  */
 public class IdentityOauthEventHandler extends AbstractEventHandler {
 
@@ -80,14 +60,19 @@ public class IdentityOauthEventHandler extends AbstractEventHandler {
     @Override
     public int getPriority(MessageContext messageContext) {
 
-        return 50;
+        int priority = super.getPriority(messageContext);
+        if (priority == -1) {
+            priority = 51;
+        }
+        return priority;
     }
 
 
     @Override
     public void handleEvent(Event event) throws IdentityEventException {
 
-        if (IdentityEventConstants.Event.POST_SET_USER_CLAIMS.equals(event.getEventName())) {
+        if (IdentityEventConstants.Event.POST_SET_USER_CLAIMS.equals(event.getEventName()) ||
+                IdentityEventConstants.Event.POST_SET_USER_CLAIM.equals(event.getEventName())) {
             String username = (String) event.getEventProperties().get(IdentityEventConstants.EventProperty.USER_NAME);
             UserStoreManager userStoreManager =
                     (UserStoreManager) event.getEventProperties()
@@ -95,6 +80,7 @@ public class IdentityOauthEventHandler extends AbstractEventHandler {
             try {
                 revokeTokensOfLockedUser(username, userStoreManager);
                 revokeTokensOfDisabledUser(username, userStoreManager);
+                OAuthUtil.removeUserClaimsFromCache(username, userStoreManager);
             } catch (UserStoreException e) {
                 String errorMsg = "Error occurred while revoking  access token for User : " + username;
                 log.error(errorMsg, e);
@@ -113,7 +99,7 @@ public class IdentityOauthEventHandler extends AbstractEventHandler {
             if (log.isDebugEnabled()) {
                 log.debug(String.format("User %s is locked. Hence revoking user's access tokens.", userName));
             }
-            revokeTokens(userName, userStoreManager);
+            OAuthUtil.revokeTokens(userName, userStoreManager);
         }
     }
 
@@ -126,155 +112,7 @@ public class IdentityOauthEventHandler extends AbstractEventHandler {
             if (log.isDebugEnabled()) {
                 log.debug(String.format("User %s is disabled. Hence revoking user's access tokens.", userName));
             }
-            revokeTokens(userName, userStoreManager);
-        }
-    }
-
-    private void revokeTokens(String username, UserStoreManager userStoreManager) throws UserStoreException {
-
-        String userStoreDomain = UserCoreUtil.getDomainName(userStoreManager.getRealmConfiguration());
-        String tenantDomain = IdentityTenantUtil.getTenantDomain(userStoreManager.getTenantId());
-        AuthenticatedUser authenticatedUser = new AuthenticatedUser();
-        authenticatedUser.setUserStoreDomain(userStoreDomain);
-        authenticatedUser.setTenantDomain(tenantDomain);
-        authenticatedUser.setUserName(username);
-
-        /* This userStoreDomain variable is used for access token table partitioning. So it is set to null when access
-        token table partitioning is not enabled.*/
-        userStoreDomain = null;
-        if (OAuth2Util.checkAccessTokenPartitioningEnabled() && OAuth2Util.checkUserNameAssertionEnabled()) {
-            try {
-                userStoreDomain = OAuth2Util.getUserStoreForFederatedUser(authenticatedUser);
-            } catch (IdentityOAuth2Exception e) {
-                log.error("Error occurred while getting user store domain for User ID: " +
-                        authenticatedUser, e);
-                throw new UserStoreException(e);
-            }
-        }
-
-        Set<String> clientIds;
-        try {
-            // get all the distinct client Ids authorized by this user
-            clientIds =
-                    OAuthTokenPersistenceFactory.getInstance().getTokenManagementDAO()
-                            .getAllTimeAuthorizedClientIds(authenticatedUser);
-        } catch (IdentityOAuth2Exception e) {
-            log.error("Error occurred while retrieving apps authorized by User ID : " + authenticatedUser, e);
-            throw new UserStoreException(e);
-        }
-        for (String clientId : clientIds) {
-            Set<AccessTokenDO> accessTokenDOs;
-            try {
-                // retrieve all ACTIVE or EXPIRED access tokens for particular client authorized by this user
-                accessTokenDOs =
-                        OAuthTokenPersistenceFactory.getInstance().getAccessTokenDAO().getAccessTokens(clientId,
-                                authenticatedUser, userStoreDomain, true);
-            } catch (IdentityOAuth2Exception e) {
-                String errorMsg =
-                        "Error occurred while retrieving access tokens issued for " + "Client ID : " + clientId + ", "
-                                + "User ID : " + authenticatedUser;
-                log.error(errorMsg, e);
-                throw new UserStoreException(e);
-            }
-
-            boolean isTokenPreservingAtPasswordUpdateEnabled =
-                    Boolean.parseBoolean(IdentityUtil.getProperty(PRESERVE_LOGGED_IN_SESSION_AT_PASSWORD_UPDATE));
-            String currentTokenBindingReference = "";
-            if (isTokenPreservingAtPasswordUpdateEnabled) {
-                if (IdentityUtil.threadLocalProperties.get().get(CURRENT_SESSION_IDENTIFIER) != null) {
-                    currentTokenBindingReference =
-                            (String) IdentityUtil.threadLocalProperties.get().get(CURRENT_SESSION_IDENTIFIER);
-                }
-            }
-
-            Set<String> scopes = new HashSet<>();
-            List<AccessTokenDO> accessTokens = new ArrayList<>();
-            boolean tokenBindingEnabled = false;
-            for (AccessTokenDO accessTokenDO : accessTokenDOs) {
-                // Clear cache
-                String tokenBindingReference = NONE;
-                if (accessTokenDO.getTokenBinding() != null && StringUtils.isNotBlank(accessTokenDO.
-                        getTokenBinding().getBindingReference())) {
-                    tokenBindingReference = accessTokenDO.getTokenBinding().getBindingReference();
-                    tokenBindingEnabled = true;
-                    // Skip current token from being revoked.
-                    if (StringUtils.equals(accessTokenDO.getTokenBinding().getBindingValue(),
-                            currentTokenBindingReference)) {
-                        continue;
-                    }
-                }
-                OAuthUtil.clearOAuthCache(accessTokenDO.getConsumerKey(), accessTokenDO.getAuthzUser(),
-                        OAuth2Util.buildScopeString(accessTokenDO.getScope()), tokenBindingReference);
-                OAuthUtil.clearOAuthCache(accessTokenDO.getConsumerKey(), accessTokenDO.getAuthzUser(),
-                        OAuth2Util.buildScopeString(accessTokenDO.getScope()));
-                OAuthUtil.clearOAuthCache(accessTokenDO.getConsumerKey(), accessTokenDO.getAuthzUser());
-                OAuthUtil.clearOAuthCache(accessTokenDO.getAccessToken());
-                // Get unique scopes list
-                scopes.add(OAuth2Util.buildScopeString(accessTokenDO.getScope()));
-                accessTokens.add(accessTokenDO);
-            }
-
-            if (!tokenBindingEnabled && OAuth2Util.isHashDisabled()) {
-                revokeLatestTokensWithScopes(scopes, clientId, authenticatedUser);
-            } else {
-                // If the hashed token is enabled, there can be multiple active tokens with a user with same scope.
-                // Also, if token binding is enabled, there can be multiple active tokens for the same user, scope
-                // and client combination.
-                // So need to revoke all the tokens.
-                try {
-                    revokeTokens(accessTokens);
-                } catch (IdentityOAuth2Exception e) {
-                    String errorMsg = "Error occurred while revoking Access Token";
-                    log.error(errorMsg, e);
-                    throw new UserStoreException(e);
-                }
-            }
-        }
-    }
-
-    private void revokeTokens(List<AccessTokenDO> accessTokens) throws IdentityOAuth2Exception {
-
-        if (!accessTokens.isEmpty()) {
-            // Revoking token from database.
-            for (AccessTokenDO accessToken : accessTokens) {
-                OAuthUtil.invokePreRevocationBySystemListeners(accessToken, Collections.emptyMap());
-                OAuthTokenPersistenceFactory.getInstance().getAccessTokenDAO().revokeAccessTokens(new String[]
-                        {accessToken.getAccessToken()}, OAuth2Util.isHashEnabled());
-                OAuthUtil.invokePostRevocationBySystemListeners(accessToken, Collections.emptyMap());
-            }
-        }
-    }
-
-    private void revokeLatestTokensWithScopes(Set<String> scopes, String clientId,
-                                              AuthenticatedUser authenticatedUser) throws UserStoreException {
-
-        for (String scope : scopes) {
-            AccessTokenDO scopedToken = null;
-            try {
-                // Retrieve latest access token for particular client, user and scope combination
-                // if its ACTIVE or EXPIRED.
-                scopedToken =
-                        OAuthTokenPersistenceFactory.getInstance().getAccessTokenDAO().getLatestAccessToken(clientId,
-                                authenticatedUser, authenticatedUser.getUserStoreDomain(), scope, true);
-            } catch (IdentityOAuth2Exception e) {
-                String errorMsg =
-                        "Error occurred while retrieving latest access token issued for Client ID : " + clientId + ","
-                                + " User ID : " + authenticatedUser + " and Scope : " + scope;
-                log.error(errorMsg, e);
-                throw new UserStoreException(e);
-            }
-            if (scopedToken != null) {
-                try {
-                    // Revoking token from database
-                    revokeTokens(Collections.singletonList(scopedToken));
-                } catch (IdentityOAuth2Exception e) {
-                    String errorMsg =
-                            "Error occurred while revoking " + "Access Token : " + scopedToken.getAccessToken() +
-                                    " " + "for user " + authenticatedUser;
-                    log.error(errorMsg, e);
-                    throw new UserStoreException(e);
-                }
-            }
+            OAuthUtil.revokeTokens(userName, userStoreManager);
         }
     }
 }


### PR DESCRIPTION
### Proposed changes in this pull request

A new identity claim is created in the AccountLockHandler and AccountDisableHandler during in postSetUserClaimsValue event[1] flow. So this will trigger doPreSetUserClaimValues event again and it will remove the exisiting IdentityCoreConstants.USER_ACCOUNT_STATE from the threadlocal [2] . Due to this, the accountLock/accountDisable status will be removed from the threadlocal. 

In this PR, introduced a new OAuthEventHandler with higher priority than AccountLockHandler and AccounntDisableHandler

[1]https://github.com/wso2-extensions/identity-event-handler-account-lock/blob/master/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/AccountLockHandler.java#L561
[2]https://github.com/wso2-extensions/identity-governance/blob/master/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/listener/IdentityMgtEventListener.java#L157

-

### When should this PR be merged

Related PRs 
https://github.com/wso2-extensions/identity-event-handler-account-lock/pull/78
https://github.com/wso2/carbon-identity-framework/pull/3250



