### PR TITLE
Change default behavior for refresh token expiry time extension

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
@@ -144,7 +144,7 @@ public class OAuthServerConfiguration {
     private boolean cacheEnabled = false;
     private boolean isTokenRenewalPerRequestEnabled = false;
     private boolean isRefreshTokenRenewalEnabled = true;
-    private boolean isExtendRenewedTokenExpiryTimeEnabled = false;
+    private boolean isExtendRenewedTokenExpiryTimeEnabled = true;
     private boolean assertionsUserNameEnabled = false;
     private boolean accessTokenPartitioningEnabled = false;
     private boolean redirectToRequestedRedirectUriEnabled = true;


### PR DESCRIPTION
### Proposed changes in this pull request
> Changing the default behavior of refresh token expiry time extension on token renewal. 
> https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/1490