### PR TITLE
Reuse existing refresh token when issuing a new access token

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AbstractAuthorizationGrantHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AbstractAuthorizationGrantHandler.java
@@ -162,7 +162,7 @@ public abstract class AbstractAuthorizationGrantHandler implements Authorization
                 log.debug("No active access token found for client Id: " + consumerKey + ", user: " +
                         authorizedUser + " and scope: " + scope + ". Therefore issuing new token.");
             }
-            return generateNewAccessToken(tokReqMsgCtx, scope, consumerKey, existingTokenBean,
+            return generateNewAccessToken(tokReqMsgCtx, scope, consumerKey, existingTokenBean, true,
                     oauthTokenIssuer);
         }
     }
@@ -337,7 +337,8 @@ public abstract class AbstractAuthorizationGrantHandler implements Authorization
                         .TOKEN_STATE_REVOKED);
         clearExistingTokenFromCache(tokReqMsgCtx, existingTokenBean);
 
-        return generateNewAccessToken(tokReqMsgCtx, scope, consumerKey, null, oauthTokenIssuer);
+        return generateNewAccessToken(tokReqMsgCtx, scope, consumerKey, existingTokenBean, false,
+                oauthTokenIssuer);
     }
 
     private OAuth2AccessTokenRespDTO issueExistingAccessToken(OAuthTokenReqMessageContext tokReqMsgCtx, String scope,
@@ -351,6 +352,7 @@ public abstract class AbstractAuthorizationGrantHandler implements Authorization
 
     private OAuth2AccessTokenRespDTO generateNewAccessToken(OAuthTokenReqMessageContext tokReqMsgCtx, String scope,
                                                             String consumerKey, AccessTokenDO existingTokenBean,
+                                                            boolean expireExistingToken,
                                                             OauthTokenIssuer oauthTokenIssuer)
             throws IdentityOAuth2Exception {
 
@@ -360,10 +362,21 @@ public abstract class AbstractAuthorizationGrantHandler implements Authorization
         AccessTokenDO newTokenBean = createNewTokenBean(tokReqMsgCtx, oAuthAppBean, existingTokenBean, timestamp,
                 validityPeriodInMillis, oauthTokenIssuer);
         setDetailsToMessageContext(tokReqMsgCtx, validityPeriodInMillis, newTokenBean, timestamp);
-        // Persist the access token in database
-        persistAccessTokenInDB(tokReqMsgCtx, existingTokenBean, newTokenBean, timestamp,
-                newTokenBean.getAccessToken());
-        //update cache with newly added token
+
+        /* Check whether the existing token needs to be expired and send the corresponding parameters to the
+        persistAccessTokenInDB method. */
+        if (expireExistingToken) {
+            // Persist the access token in database and mark the existing token as expired.
+            persistAccessTokenInDB(tokReqMsgCtx, existingTokenBean, newTokenBean, timestamp,
+                    newTokenBean.getAccessToken());
+        } else {
+            // Persist the access token in database without updating the existing token.
+            // The existing token should already be updated by this point.
+            persistAccessTokenInDB(tokReqMsgCtx, null, newTokenBean, timestamp,
+                    newTokenBean.getAccessToken());
+        }
+
+        // Update cache with newly added token.
         updateCacheIfEnabled(newTokenBean, OAuth2Util.buildScopeString(tokReqMsgCtx.getScope()), oauthTokenIssuer);
         return createResponseWithTokenBean(newTokenBean, validityPeriodInMillis, scope);
     }
@@ -416,7 +429,11 @@ public abstract class AbstractAuthorizationGrantHandler implements Authorization
             AccessTokenDO existingTokenBean, Timestamp timestamp, long validityPeriodInMillis,
             OAuth2AccessTokenReqDTO tokenReq, AccessTokenDO newTokenBean, OauthTokenIssuer oauthTokenIssuer)
             throws IdentityOAuth2Exception {
-        if (isRefreshTokenValid(existingTokenBean, validityPeriodInMillis, tokenReq.getClientId())) {
+
+        /* Check whether the token renewal per request configuration is configured and the validation of the refresh
+        token. If the token renewal per request configuration is enabled, renew the refresh token as well. */
+        if (!isTokenRenewalPerRequestConfigured() && isRefreshTokenValid(existingTokenBean, validityPeriodInMillis,
+                tokenReq.getClientId())) {
             setRefreshTokenDetailsFromExistingToken(existingTokenBean, newTokenBean);
         } else {
             // no valid refresh token found in existing Token
@@ -888,8 +905,7 @@ public abstract class AbstractAuthorizationGrantHandler implements Authorization
 
         boolean isRenewTokenPerRequestEnabledInIssuer = oauthTokenIssuer.renewAccessTokenPerRequest();
         boolean isRenewTokenPerRequestEnabledInTokReqMsgCtx = oauthIssuerImpl.renewAccessTokenPerRequest(tokReqMsgCtx);
-        boolean isRenewTokenPerRequestEnabledInConfig =
-                OAuthServerConfiguration.getInstance().isTokenRenewalPerRequestEnabled();
+        boolean isRenewTokenPerRequestEnabledInConfig = isTokenRenewalPerRequestConfigured();
         if (log.isDebugEnabled()) {
             log.debug("Access token renew per request: OauthTokenIssuer: " + isRenewTokenPerRequestEnabledInIssuer +
                     ", OAuthTokenReqMessageContext: " + isRenewTokenPerRequestEnabledInTokReqMsgCtx +
@@ -897,6 +913,15 @@ public abstract class AbstractAuthorizationGrantHandler implements Authorization
         }
         return isRenewTokenPerRequestEnabledInIssuer || isRenewTokenPerRequestEnabledInTokReqMsgCtx ||
                 isRenewTokenPerRequestEnabledInConfig;
+    }
+
+    /**
+     * Checks whether the TokenRenewalPerRequest is enabled in the configuration file.
+     *
+     * @return The boolean from the configuration.
+     */
+    private boolean isTokenRenewalPerRequestConfigured() {
+        return OAuthServerConfiguration.getInstance().isTokenRenewalPerRequestEnabled();
     }
 
     private void clearExistingTokenFromCache(OAuthTokenReqMessageContext tokenMsgCtx, AccessTokenDO existingTokenBean) {


### PR DESCRIPTION
Resolves https://github.com/wso2/product-is/issues/10684


### Proposed changes in this pull request

This issue has been introduced while fixing https://github.com/wso2/product-is/issues/4876 since we had not passed `exisitngTokenBean` to `generateNewAccessToken()` to avoid it getting marked as EXPIRED while it is already REVOKED.

Hence, a new parameter called `markExistingTokenExpired` was added for `generateNewAccessToken()` and passed the `exisitngTokenBean` in both of the following scenarios.
- Revoke existing and issue a new token; `markExistingTokenExpired` is false since we have already revoked the token
- Issue a new token since the existing one is expired; `markExistingTokenExpired` is true

Inside `generateNewAccessToken()` we are generating the `newTokenBean` and it will include the refresh token from `exisitngTokenBean` if it is not already expired.

But  the `exisitngTokenBean` is passed to  `persistAccessTokenInDB()` only if `markExistingTokenExpired` is true since it does the token expiry task which is not required when `markExistingTokenExpired` is true.

-

### When should this PR be merged

[Please describe any preconditions that need to be addressed before we
can merge this pull request.]


### Follow up actions

[List any possible follow-up actions here; for instance, testing data
migrations, software that we need to install on staging and production
environments.]

-


### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description.
- [ ] **Is the PR labeled correctly?**

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled.

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests.
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/).

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components.
- [ ] **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

#### Security

- [ ] **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
- [ ] **Are all UI and API inputs run through forms or serializers?**
- [ ] **Are all external inputs validated and sanitized appropriately?**
- [ ] **Does all branching logic have a default case?**
- [ ] **Does this solution handle outliers and edge cases gracefully?**
- [ ] **Are all external communications secured and restricted to SSL?**

#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes should be documented.
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented.
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki.
