### PR TITLE
Scope validation for not associated federated user using idp role maping

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/OAuth2Constants.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/OAuth2Constants.java
@@ -31,4 +31,5 @@ public class OAuth2Constants {
         public static final String SSO_SESSION_BASED_TOKEN_BINDER = "sso-session";
 
     }
+    public static final String GROUPS = "groups";
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuth2ServiceComponent.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuth2ServiceComponent.java
@@ -60,6 +60,7 @@ import org.wso2.carbon.identity.oauth2.validators.scope.ScopeValidator;
 import org.wso2.carbon.identity.openidconnect.OpenIDConnectClaimFilter;
 import org.wso2.carbon.identity.openidconnect.OpenIDConnectClaimFilterImpl;
 import org.wso2.carbon.identity.user.store.configuration.listener.UserStoreConfigListener;
+import org.wso2.carbon.idp.mgt.IdpManager;
 import org.wso2.carbon.registry.core.service.RegistryService;
 import org.wso2.carbon.stratos.common.listeners.TenantMgtListener;
 
@@ -443,4 +444,19 @@ public class OAuth2ServiceComponent {
         OAuthComponentServiceHolder.getInstance().removeScopeValidator(scopeValidator);
     }
 
+    @Reference(
+            name = "IdentityProviderManager",
+            service = org.wso2.carbon.idp.mgt.IdpManager.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetIdpManager")
+    protected void setIdpManager(IdpManager idpManager) {
+
+        OAuth2ServiceComponentHolder.getInstance().setIdpManager(idpManager);
+    }
+
+    protected void unsetIdpManager(IdpManager idpManager) {
+
+        OAuth2ServiceComponentHolder.getInstance().setIdpManager(null);
+    }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuth2ServiceComponentHolder.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuth2ServiceComponentHolder.java
@@ -27,6 +27,7 @@ import org.wso2.carbon.identity.oauth2.client.authentication.OAuthClientAuthenti
 import org.wso2.carbon.identity.oauth2.keyidprovider.KeyIDProvider;
 import org.wso2.carbon.identity.oauth2.token.bindings.TokenBinder;
 import org.wso2.carbon.identity.openidconnect.ClaimProvider;
+import org.wso2.carbon.idp.mgt.IdpManager;
 import org.wso2.carbon.registry.core.service.RegistryService;
 
 import java.util.ArrayList;
@@ -51,6 +52,7 @@ public class OAuth2ServiceComponentHolder {
     private OAuthAdminServiceImpl oauthAdminService;
     private static AuthenticationDataPublisher authenticationDataPublisherProxy;
     private static KeyIDProvider keyIDProvider = null;
+    private IdpManager idpManager;
 
     private OAuth2ServiceComponentHolder() {
 
@@ -242,5 +244,25 @@ public class OAuth2ServiceComponentHolder {
     public static void setKeyIDProvider(KeyIDProvider keyIDProvider) {
 
         OAuth2ServiceComponentHolder.keyIDProvider = keyIDProvider;
+    }
+
+    /**
+     * Set Idp manager Instance.
+     *
+     * @param idpManager IdpManager.
+     */
+    public void setIdpManager(IdpManager idpManager) {
+
+        this.idpManager = idpManager;
+    }
+
+    /**
+     * Get IdpManager Instance.
+     *
+     * @return IdpManager.
+     */
+    public IdpManager getIdpManager() {
+
+        return idpManager;
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/JDBCPermissionBasedInternalScopeValidator.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/JDBCPermissionBasedInternalScopeValidator.java
@@ -19,22 +19,33 @@
 package org.wso2.carbon.identity.oauth2.validators;
 
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
+import org.wso2.carbon.identity.application.common.model.ClaimConfig;
+import org.wso2.carbon.identity.application.common.model.ClaimMapping;
+import org.wso2.carbon.identity.application.common.model.IdentityProvider;
+import org.wso2.carbon.identity.application.common.model.RoleMapping;
+import org.wso2.carbon.identity.application.common.model.ServiceProvider;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.oauth.cache.OAuthScopeBindingCache;
 import org.wso2.carbon.identity.oauth.cache.OAuthScopeBindingCacheKey;
 import org.wso2.carbon.identity.oauth.internal.OAuthComponentServiceHolder;
+import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2ScopeServerException;
+import org.wso2.carbon.identity.oauth2.OAuth2Constants;
 import org.wso2.carbon.identity.oauth2.authz.OAuthAuthzReqMessageContext;
 import org.wso2.carbon.identity.oauth2.bean.Scope;
 import org.wso2.carbon.identity.oauth2.bean.ScopeBinding;
 import org.wso2.carbon.identity.oauth2.dao.OAuthTokenPersistenceFactory;
 import org.wso2.carbon.identity.oauth2.token.OAuthTokenReqMessageContext;
+import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 import org.wso2.carbon.user.api.AuthorizationManager;
 import org.wso2.carbon.user.api.UserStoreException;
 
@@ -42,7 +53,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static org.wso2.carbon.identity.oauth2.Oauth2ScopeConstants.SYSTEM_SCOPE;
@@ -61,6 +74,7 @@ public class JDBCPermissionBasedInternalScopeValidator {
     private static final String ADMIN_PERMISSION_ROOT = "/permission/admin";
     private static final String INTERNAL_SCOPE_PREFIX = "internal_";
     private static final String EVERYONE_PERMISSION = "everyone_permission";
+    private static final String ATTRIBUTE_SEPARATOR = FrameworkUtils.getMultiAttributeSeparator();
 
     public String[] validateScope(OAuthTokenReqMessageContext tokReqMsgCtx) {
 
@@ -70,8 +84,8 @@ public class JDBCPermissionBasedInternalScopeValidator {
         if (ArrayUtils.isEmpty(requestedScopes)) {
             return requestedScopes;
         }
-        List<Scope> userAllowedScopes = getUserAllowedScopes(tokReqMsgCtx.getAuthorizedUser(), requestedScopes);
-
+        List<Scope> userAllowedScopes = getUserAllowedScopes(tokReqMsgCtx.getAuthorizedUser(), requestedScopes,
+                tokReqMsgCtx.getOauth2AccessTokenReqDTO().getClientId());
         String[] userAllowedScopesAsArray = getScopes(userAllowedScopes);
         if (ArrayUtils.contains(requestedScopes, SYSTEM_SCOPE)) {
             return userAllowedScopesAsArray;
@@ -96,7 +110,8 @@ public class JDBCPermissionBasedInternalScopeValidator {
             return requestedScopes;
         }
         List<Scope> userAllowedScopes =
-                getUserAllowedScopes(authzReqMessageContext.getAuthorizationReqDTO().getUser(), requestedScopes);
+                getUserAllowedScopes(authzReqMessageContext.getAuthorizationReqDTO().getUser(), requestedScopes,
+                        authzReqMessageContext.getAuthorizationReqDTO().getConsumerKey());
 
         String[] userAllowedScopesAsArray = getScopes(userAllowedScopes);
         if (ArrayUtils.contains(requestedScopes, SYSTEM_SCOPE)) {
@@ -132,8 +147,8 @@ public class JDBCPermissionBasedInternalScopeValidator {
                 .map(Scope::getName).toArray(String[]::new);
     }
 
-    private List<Scope> getUserAllowedScopes(AuthenticatedUser authenticatedUser, String[] requestedScopes) {
-
+    private List<Scope> getUserAllowedScopes(AuthenticatedUser authenticatedUser, String[] requestedScopes,
+                                             String clientId) {
         List<Scope> userAllowedScopes = new ArrayList<>();
 
         try {
@@ -145,7 +160,31 @@ public class JDBCPermissionBasedInternalScopeValidator {
             startTenantFlow(authenticatedUser.getTenantDomain(), tenantId);
             AuthorizationManager authorizationManager = OAuthComponentServiceHolder.getInstance().getRealmService()
                     .getTenantUserRealm(tenantId).getAuthorizationManager();
-            String[] allowedUIResourcesForUser = getAllowedUIResourcesOfUser(authenticatedUser, authorizationManager);
+            String[] allowedUIResourcesForUser;
+            /*
+            Here we handle scope validation for federated user and local user separately.
+            For local users - user store is used to get user roles.
+            For federated user - get user roles from user attributes.
+            Note that if there is association between a federated user and local user () 'Assert identity using
+            mapped local subject identifier' flag will be set as true. So authenticated user will be associated
+            local user not federated user.
+             */
+            if (authenticatedUser.isFederatedUser()) {
+                /*
+                There is a flow where 'Assert identity using mapped local subject identifier' flag enabled but the
+                federated user doesn't have any association in localIDP, to handle this case we check for 'Assert
+                identity using mapped local subject identifier' flag and get roles from userStore.
+                 */
+                if (isSPAlwaysSendMappedLocalSubjectId(clientId)) {
+                    allowedUIResourcesForUser = getAllowedUIResourcesOfUser(authenticatedUser, authorizationManager);
+                } else {
+                    // Handle not account associated federated users.
+                    allowedUIResourcesForUser =
+                            getAllowedUIResourcesForNotAssociatedFederatedUser(authenticatedUser, authorizationManager);
+                }
+            } else {
+                allowedUIResourcesForUser = getAllowedUIResourcesOfUser(authenticatedUser, authorizationManager);
+            }
             Set<Scope> allScopes = getScopesOfPermissionType(tenantId);
             if (ArrayUtils.contains(allowedUIResourcesForUser, ROOT) || ArrayUtils.contains(allowedUIResourcesForUser,
                     PERMISSION_ROOT)) {
@@ -184,12 +223,97 @@ public class JDBCPermissionBasedInternalScopeValidator {
             }
         } catch (UserStoreException e) {
             log.error("Error while accessing Authorization Manager.", e);
+        } catch (IdentityOAuth2Exception e) {
+            log.error("Error while accessing identity provider manager.", e);
         } catch (IdentityOAuth2ScopeServerException e) {
             log.error("Error while retrieving oAuth2 scopes.", e);
         } finally {
             endTenantFlow();
         }
         return userAllowedScopes;
+    }
+
+    private boolean isSPAlwaysSendMappedLocalSubjectId(String clientId) throws IdentityOAuth2Exception {
+
+        ServiceProvider serviceProvider = OAuth2Util.getServiceProvider(clientId);
+        if (serviceProvider != null) {
+            ClaimConfig claimConfig = serviceProvider.getClaimConfig();
+            if (claimConfig != null) {
+                return claimConfig.isAlwaysSendMappedLocalSubjectId();
+            }
+            throw new IdentityOAuth2Exception(
+                    "Unable to find claim configuration for service provider of client id " + clientId);
+        }
+        throw new IdentityOAuth2Exception("Unable to find service provider for client id " + clientId);
+    }
+
+    /**
+     * Method user to get list of federated users permissions using idp role mapping for not account associated
+     * federated users.
+     * @param authenticatedUser    FederatedAuthenticatedUser
+     * @param authorizationManager AuthorizationManager
+     * @return List of permissions
+     * @throws UserStoreException      UserStoreException
+     * @throws IdentityOAuth2Exception IdentityOAuth2Exception
+     */
+    private String[] getAllowedUIResourcesForNotAssociatedFederatedUser(AuthenticatedUser authenticatedUser,
+                                                                        AuthorizationManager authorizationManager)
+            throws UserStoreException, IdentityOAuth2Exception {
+
+        List<String> userRolesList = new ArrayList<>();
+        List<String> allowedUIResourcesListForUser = new ArrayList<>();
+        IdentityProvider identityProvider =
+                OAuth2Util.getIdentityProvider(authenticatedUser.getFederatedIdPName(),
+                        authenticatedUser.getTenantDomain());
+        /*
+        Values of Groups consists mapped local roles and Internal/everyone corresponding to
+        authenticated user.
+        Role mapping consists mapped federated roles with local roles corresponding to IDP.
+        By cross checking role mapped local roles and values of groups we can filter valid local roles which mapped
+        to a federated role of authenticated user.
+         */
+        List<String> valuesOfGroups = getValuesOfGroupsFromUserAttributes(authenticatedUser.getUserAttributes());
+        if (CollectionUtils.isNotEmpty(valuesOfGroups)) {
+            for (RoleMapping roleMapping : identityProvider.getPermissionAndRoleConfig().getRoleMappings()) {
+                if (roleMapping != null && roleMapping.getLocalRole() != null) {
+                    if (valuesOfGroups.contains(roleMapping.getLocalRole().getLocalRoleName())) {
+                        userRolesList.add(roleMapping.getLocalRole().getLocalRoleName());
+                    }
+                }
+            }
+        }
+        // Loop through each local role and get permissions.
+        for (String userRole : userRolesList) {
+            for (String allowedUIResource : authorizationManager.getAllowedUIResourcesForRole(userRole, "/")) {
+                if (!allowedUIResourcesListForUser.contains(allowedUIResource)) {
+                    allowedUIResourcesListForUser.add(allowedUIResource);
+                }
+            }
+        }
+        // Add everyone permission to allowed permission.
+        allowedUIResourcesListForUser.add(EVERYONE_PERMISSION);
+
+        return allowedUIResourcesListForUser.toArray(new String[0]);
+    }
+
+    /**
+     * Get groups params Roles from User attributes.
+     *
+     * @param userAttributes User Attributes
+     * @return User attribute map
+     */
+    private List<String> getValuesOfGroupsFromUserAttributes(Map<ClaimMapping, String> userAttributes) {
+
+        if (MapUtils.isNotEmpty(userAttributes)) {
+            for (Map.Entry<ClaimMapping, String> entry : userAttributes.entrySet()) {
+                if (entry.getKey().getRemoteClaim() != null) {
+                    if (StringUtils.equals(entry.getKey().getRemoteClaim().getClaimUri(), OAuth2Constants.GROUPS)) {
+                        return Arrays.asList(entry.getValue().split(Pattern.quote(ATTRIBUTE_SEPARATOR)));
+                    }
+                }
+            }
+        }
+        return null;
     }
 
     private String[] getAllowedUIResourcesOfUser(AuthenticatedUser authenticatedUser,

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/JDBCScopeValidator.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/JDBCScopeValidator.java
@@ -19,7 +19,9 @@
 package org.wso2.carbon.identity.oauth2.validators;
 
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -27,6 +29,12 @@ import org.wso2.carbon.CarbonConstants;
 import org.wso2.carbon.base.MultitenantConstants;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
+import org.wso2.carbon.identity.application.common.model.ClaimConfig;
+import org.wso2.carbon.identity.application.common.model.ClaimMapping;
+import org.wso2.carbon.identity.application.common.model.IdentityProvider;
+import org.wso2.carbon.identity.application.common.model.RoleMapping;
+import org.wso2.carbon.identity.application.common.model.ServiceProvider;
 import org.wso2.carbon.identity.application.common.model.User;
 import org.wso2.carbon.identity.base.IdentityConstants;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
@@ -38,6 +46,7 @@ import org.wso2.carbon.identity.oauth.cache.OAuthCacheKey;
 import org.wso2.carbon.identity.oauth.internal.OAuthComponentServiceHolder;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2ScopeServerException;
+import org.wso2.carbon.identity.oauth2.OAuth2Constants;
 import org.wso2.carbon.identity.oauth2.authz.OAuthAuthzReqMessageContext;
 import org.wso2.carbon.identity.oauth2.bean.Scope;
 import org.wso2.carbon.identity.oauth2.dao.OAuthTokenPersistenceFactory;
@@ -45,6 +54,7 @@ import org.wso2.carbon.identity.oauth2.internal.OAuth2ServiceComponentHolder;
 import org.wso2.carbon.identity.oauth2.model.AccessTokenDO;
 import org.wso2.carbon.identity.oauth2.model.ResourceScopeCacheEntry;
 import org.wso2.carbon.identity.oauth2.token.OAuthTokenReqMessageContext;
+import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.user.api.UserStoreManager;
 import org.wso2.carbon.user.core.UserCoreConstants;
@@ -55,7 +65,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 /**
  * The JDBC Scope Validation implementation. This validates the Resource's scope (stored in IDN_OAUTH2_RESOURCE_SCOPE)
@@ -73,6 +85,7 @@ public class JDBCScopeValidator extends OAuth2ScopeValidator {
             "retrieveRolesFromUserStoreForScopeValidation";
     private static final String SCOPE_VALIDATOR_NAME = "Role based scope validator";
     private static final String OPENID = "openid";
+    private static final String ATTRIBUTE_SEPARATOR = FrameworkUtils.getMultiAttributeSeparator();
 
     private static final Log log = LogFactory.getLog(JDBCScopeValidator.class);
 
@@ -181,7 +194,8 @@ public class JDBCScopeValidator extends OAuth2ScopeValidator {
     public boolean validateScope(OAuthTokenReqMessageContext tokReqMsgCtx) throws
             UserStoreException, IdentityOAuth2Exception {
 
-        return validateScope(tokReqMsgCtx.getScope(), tokReqMsgCtx.getAuthorizedUser());
+        return validateScope(tokReqMsgCtx.getScope(), tokReqMsgCtx.getAuthorizedUser(),
+                tokReqMsgCtx.getOauth2AccessTokenReqDTO().getClientId());
     }
 
     @Override
@@ -189,7 +203,8 @@ public class JDBCScopeValidator extends OAuth2ScopeValidator {
             UserStoreException, IdentityOAuth2Exception {
 
         return validateScope(authzReqMessageContext.getAuthorizationReqDTO().getScopes(),
-                authzReqMessageContext.getAuthorizationReqDTO().getUser());
+                authzReqMessageContext.getAuthorizationReqDTO().getUser(),
+                authzReqMessageContext.getAuthorizationReqDTO().getConsumerKey());
     }
 
     /**
@@ -197,11 +212,12 @@ public class JDBCScopeValidator extends OAuth2ScopeValidator {
      *
      * @param requestedScopes Scopes to be validated.
      * @param user Authenticated user.
+     * @param clientId        Client ID.
      * @return True is all scopes are valid. False otherwise.
      * @throws UserStoreException If were unable to get tenant or user roles.
      * @throws IdentityOAuth2Exception by an Underline method.
      */
-    private boolean validateScope(String[] requestedScopes, AuthenticatedUser user)
+    private boolean validateScope(String[] requestedScopes, AuthenticatedUser user, String clientId)
             throws UserStoreException, IdentityOAuth2Exception {
 
         // Remove openid scope from the list if available
@@ -224,20 +240,115 @@ public class JDBCScopeValidator extends OAuth2ScopeValidator {
             return true;
         }
 
+        String[] userRoles = null;
         int tenantId = getTenantId(user);
-        String[] userRoles = getUserRoles(user);
 
-        for (String scope : requestedScopes) {
-            if (!isScopeValid(scope, tenantId)) {
-                //If the scope is not registered return false
-                log.error("Requested scope " + scope + " is invalid");
-                return false;
+        /*
+        Here we handle scope validation for federated user and local user separately.
+        For local users - user store is used to get user roles.
+        For federated user - get user roles from user attributes.
+        Note that if there is association between a federated user and local user () 'Assert identity using mapped local
+        subject identifier' flag will be set as true. So authenticated user will be associated local user not
+        federated user.
+         */
+        if (user.isFederatedUser()) {
+            /*
+            There is a flow where 'Assert identity using mapped local subject identifier' flag enabled but the
+            federated user doesn't have any association in localIDP, to handle this case we check for 'Assert
+            identity using mapped local subject identifier' flag and get roles from userStore.
+             */
+            if (isSPAlwaysSendMappedLocalSubjectId(clientId)) {
+                userRoles = getUserRoles(user);
+            } else {
+                // Handle not account associated federated users.
+                userRoles = getUserRolesForNotAssociatedFederatedUser(user);
             }
-            if (!isUserAuthorizedForScope(scope, userRoles, tenantId)) {
-                return false;
+        } else {
+            userRoles = getUserRoles(user);
+        }
+        if (ArrayUtils.isNotEmpty(userRoles)) {
+            for (String scope : requestedScopes) {
+                if (!isScopeValid(scope, tenantId)) {
+                    // If the scope is not registered return false.
+                    log.error("Requested scope " + scope + " is invalid");
+                    return false;
+                }
+                if (!isUserAuthorizedForScope(scope, userRoles, tenantId)) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("User " + user.getUserName() + "in not authorised for scope " + scope);
+                    }
+                    return false;
+                }
             }
+        } else {
+            return false;
         }
         return true;
+    }
+
+    private boolean isSPAlwaysSendMappedLocalSubjectId(String clientId) throws IdentityOAuth2Exception {
+
+        ServiceProvider serviceProvider = OAuth2Util.getServiceProvider(clientId);
+        if (serviceProvider != null) {
+            ClaimConfig claimConfig = serviceProvider.getClaimConfig();
+            if (claimConfig != null) {
+                return claimConfig.isAlwaysSendMappedLocalSubjectId();
+            }
+            throw new IdentityOAuth2Exception("Unable to find claim configuration for service provider of client " +
+                        "id " + clientId);
+        }
+        throw new IdentityOAuth2Exception("Unable to find service provider for client id " + clientId);
+    }
+
+    private String[] getUserRolesForNotAssociatedFederatedUser(AuthenticatedUser user)
+            throws IdentityOAuth2Exception {
+
+        List<String> userRolesList = new ArrayList<>();
+        IdentityProvider identityProvider =
+                OAuth2Util.getIdentityProvider(user.getFederatedIdPName(), user.getTenantDomain());
+        /*
+        Values of Groups consists unmapped federated roles, mapped local roles and Internal/everyone corresponding to
+        authenticated user.
+        Role mapping consists mapped federated roles with local roles corresponding to IDP.
+        By cross checking federated role mapped local roles and values of groups we can filter valid local roles which
+        mapped to the federated role of authenticated user.
+         */
+        List<String> valuesOfGroups = getValuesOfGroupsFromUserAttributes(user.getUserAttributes());
+        if (CollectionUtils.isNotEmpty(valuesOfGroups)) {
+            for (RoleMapping roleMapping : identityProvider.getPermissionAndRoleConfig().getRoleMappings()) {
+                if (roleMapping != null && roleMapping.getLocalRole() != null) {
+                    if (valuesOfGroups.contains(roleMapping.getLocalRole().getLocalRoleName())) {
+                        userRolesList.add(roleMapping.getLocalRole().getLocalRoleName());
+                    }
+                }
+            }
+        }
+        // By default we provide Internal/everyone role for all users.
+        String internalEveryoneRole = OAuth2Util.getInternalEveryoneRole(user);
+        if (StringUtils.isNotBlank(internalEveryoneRole)) {
+            userRolesList.add(internalEveryoneRole);
+        }
+        return userRolesList.toArray(new String[0]);
+    }
+
+    /**
+     * Get groups params Roles from User attributes.
+     *
+     * @param userAttributes User Attributes
+     * @return User attribute map
+     */
+    private List<String> getValuesOfGroupsFromUserAttributes(Map<ClaimMapping, String> userAttributes) {
+
+        if (MapUtils.isNotEmpty(userAttributes)) {
+            for (Map.Entry<ClaimMapping, String> entry : userAttributes.entrySet()) {
+                if (entry.getKey().getRemoteClaim() != null) {
+                    if (StringUtils.equals(entry.getKey().getRemoteClaim().getClaimUri(), OAuth2Constants.GROUPS)) {
+                        return Arrays.asList(entry.getValue().split(Pattern.quote(ATTRIBUTE_SEPARATOR)));
+                    }
+                }
+            }
+        }
+        return null;
     }
 
     @Override


### PR DESCRIPTION
Public Issue : wso2/product-is#10527
Logic 

- Isolate getUserRoles flow for the federated user.
- User attributes consist of unmapped federated roles, mapped local roles and Internal/everyone corresponding to the authenticated user. But we can't isolate them.
- Role mapping consists of mapped federated roles with local roles corresponding to IDP.
- By cross-checking role mapped local roles and user attributes we can filter valid local roles which mapped to the federated role of an authenticated user.
