### PR TITLE
Fix the revoke API response for invalid tokens

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/OAuth2Service.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/OAuth2Service.java
@@ -343,8 +343,12 @@ public class OAuth2Service extends AbstractAdmin {
                     }
 
                 } else {
-
-                    accessTokenDO = OAuth2Util.findAccessToken(revokeRequestDTO.getToken(), true);
+                    try {
+                        accessTokenDO = OAuth2Util.findAccessToken(revokeRequestDTO.getToken(), true);
+                    } catch (IllegalArgumentException e) {
+                        log.debug("Invalid Access Token. ACTIVE access token is not found");
+                        accessTokenDO = null;
+                    }
                     if (accessTokenDO == null) {
 
                         refreshTokenDO = OAuthTokenPersistenceFactory.getInstance()


### PR DESCRIPTION
### Proposed changes in this pull request

This PR adds changes to return 200 response when trying to revoke invalid access token.
Fixes wso2/product-apim#9602