### PR TITLE
Add JWTSignatureValidationUtils to validate the JWT tokens 

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/JWTSignatureValidationUtils.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/JWTSignatureValidationUtils.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth2.util;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.JWSVerifier;
+import com.nimbusds.jose.crypto.RSASSAVerifier;
+import com.nimbusds.jwt.SignedJWT;
+import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.application.common.model.IdentityProvider;
+import org.wso2.carbon.identity.application.common.model.IdentityProviderProperty;
+import org.wso2.carbon.identity.application.common.util.IdentityApplicationManagementUtil;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
+import org.wso2.carbon.identity.oauth2.validators.jwt.JWKSBasedJWTValidator;
+
+import java.security.PublicKey;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateExpiredException;
+import java.security.cert.CertificateNotYetValidException;
+import java.security.cert.X509Certificate;
+import java.security.interfaces.RSAPublicKey;
+
+/**
+ * Utility methods for JWT Signature Validation
+ */
+public class JWTSignatureValidationUtils {
+
+    private static final Log log = LogFactory.getLog(JWTSignatureValidationUtils.class);
+
+    private static final String JWKS_URI = "jwksUri";
+    private static final String JWKS_VALIDATION_ENABLE_CONFIG = "JWTValidatorConfigs.Enable";
+    private static final String ENFORCE_CERTIFICATE_VALIDITY
+            = "JWTValidatorConfigs.EnforceCertificateExpiryTimeValidity";
+
+    private static String tenantDomain;
+
+    /**
+     * Method to validate the signature of the JWT
+     *
+     * @param signedJWT signed JWT whose signature is to be verified
+     * @param idp       Identity provider who issued the signed JWT
+     * @return whether signature is valid, true if valid else false
+     * @throws JOSEException
+     * @throws IdentityOAuth2Exception
+     */
+    public static boolean validateSignature(SignedJWT signedJWT, IdentityProvider idp)
+            throws JOSEException, IdentityOAuth2Exception {
+
+        boolean isJWKSEnabled = false;
+        boolean hasJWKSUri = false;
+        String jwksUri = null;
+
+        String isJWKSEnalbedProperty = IdentityUtil.getProperty(JWKS_VALIDATION_ENABLE_CONFIG);
+        isJWKSEnabled = Boolean.parseBoolean(isJWKSEnalbedProperty);
+        if (isJWKSEnabled) {
+            if (log.isDebugEnabled()) {
+                log.debug("JWKS based JWT validation enabled.");
+            }
+        }
+
+        IdentityProviderProperty[] identityProviderProperties = idp.getIdpProperties();
+        if (!ArrayUtils.isEmpty(identityProviderProperties)) {
+            for (IdentityProviderProperty identityProviderProperty : identityProviderProperties) {
+                if (StringUtils.equals(identityProviderProperty.getName(), JWKS_URI)) {
+                    hasJWKSUri = true;
+                    jwksUri = identityProviderProperty.getValue();
+                    if (log.isDebugEnabled()) {
+                        log.debug("JWKS endpoint set for the identity provider : " + idp.getIdentityProviderName() +
+                                ", jwks_uri : " + jwksUri);
+                    }
+                    break;
+                } else {
+                    if (log.isDebugEnabled()) {
+                        log.debug("JWKS endpoint not specified for the identity provider : " + idp
+                                .getIdentityProviderName());
+                    }
+                }
+            }
+        }
+
+        if (isJWKSEnabled && hasJWKSUri) {
+            JWKSBasedJWTValidator jwksBasedJWTValidator = new JWKSBasedJWTValidator();
+            return jwksBasedJWTValidator.validateSignature(signedJWT.getParsedString(), jwksUri, signedJWT.getHeader
+                    ().getAlgorithm().getName(), null);
+        } else {
+            JWSVerifier verifier = null;
+            JWSHeader header = signedJWT.getHeader();
+            X509Certificate x509Certificate = resolveSignerCertificate(header, idp);
+            if (x509Certificate == null) {
+                handleException(
+                        "Unable to locate certificate for Identity Provider " + idp.getDisplayName() + "; JWT " +
+                                header.toString());
+            }
+
+            checkValidity(x509Certificate);
+
+            String alg = signedJWT.getHeader().getAlgorithm().getName();
+            if (StringUtils.isEmpty(alg)) {
+                handleException("Algorithm must not be null.");
+            } else {
+                if (log.isDebugEnabled()) {
+                    log.debug("Signature Algorithm found in the JWT Header: " + alg);
+                }
+                if (alg.startsWith("RS")) {
+                    // At this point 'x509Certificate' will never be null.
+                    PublicKey publicKey = x509Certificate.getPublicKey();
+                    if (publicKey instanceof RSAPublicKey) {
+                        verifier = new RSASSAVerifier((RSAPublicKey) publicKey);
+                    } else {
+                        handleException("Public key is not an RSA public key.");
+                    }
+                } else {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Signature Algorithm not supported yet : " + alg);
+                    }
+                }
+                if (verifier == null) {
+                    handleException("Could not create a signature verifier for algorithm type: " + alg);
+                }
+            }
+
+            // At this point 'verifier' will never be null;
+            return signedJWT.verify(verifier);
+        }
+    }
+
+    /**
+     * Check the validity of the x509Certificate.
+     *
+     * @param x509Certificate x509Certificate
+     * @throws IdentityOAuth2Exception
+     */
+    private static void checkValidity(X509Certificate x509Certificate) throws IdentityOAuth2Exception {
+
+        String isEnforceCertificateValidity = IdentityUtil.getProperty(ENFORCE_CERTIFICATE_VALIDITY);
+        if (StringUtils.isNotEmpty(isEnforceCertificateValidity)
+                && !Boolean.parseBoolean(isEnforceCertificateValidity)) {
+            if (log.isDebugEnabled()) {
+                log.debug("Check for the certificate validity is disabled.");
+            }
+            return;
+        }
+
+        try {
+            x509Certificate.checkValidity();
+        } catch (CertificateExpiredException e) {
+            throw new IdentityOAuth2Exception("X509Certificate has expired.", e);
+        } catch (CertificateNotYetValidException e) {
+            throw new IdentityOAuth2Exception("X509Certificate is not yet valid.", e);
+        }
+    }
+
+    /**
+     * The default implementation resolves one certificate to Identity Provider and ignores the JWT header.
+     * Override this method, to resolve and enforce the certificate in any other way
+     * such as x5t attribute of the header.
+     *
+     * @param header The JWT header. Some of the x attributes may provide certificate information.
+     * @param idp    The identity provider, if you need it.
+     * @return the resolved X509 Certificate, to be used to validate the JWT signature.
+     * @throws IdentityOAuth2Exception something goes wrong.
+     */
+    protected static X509Certificate resolveSignerCertificate(JWSHeader header,
+                                                              IdentityProvider idp) throws IdentityOAuth2Exception {
+
+        X509Certificate x509Certificate = null;
+        try {
+            x509Certificate = (X509Certificate) IdentityApplicationManagementUtil
+                    .decodeCertificate(idp.getCertificate());
+        } catch (CertificateException e) {
+            handleException("Error occurred while decoding public certificate of Identity Provider "
+                    + idp.getIdentityProviderName() + " for tenant domain " + tenantDomain);
+        }
+        return x509Certificate;
+    }
+
+    private static void handleException(String errorMessage) throws IdentityOAuth2Exception {
+
+        log.error(errorMessage);
+        throw new IdentityOAuth2Exception(errorMessage);
+    }
+}

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/JWTSignatureValidationUtils.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/JWTSignatureValidationUtils.java
@@ -67,38 +67,15 @@ public class JWTSignatureValidationUtils {
     public static boolean validateSignature(SignedJWT signedJWT, IdentityProvider idp)
             throws JOSEException, IdentityOAuth2Exception {
 
-        boolean isJWKSEnabled = false;
-        String jwksUri = null;
+        String jwksUri = getJWKSUri(idp);
 
-        isJWKSEnabled = isJWKSEnabled();
-
-        jwksUri = getJWKSUri(idp);
-
-        if (isJWKSEnabled && (jwksUri != null)) {
+        if (jwksUri != null) {
             return validateUsingJWKSUri(signedJWT, jwksUri);
         } else {
             return validateUsingCertificate(signedJWT, idp);
         }
     }
-
-    /**
-     * Method to check whether the JWKS is enabled.
-     *
-     * @return boolean value depending on whether the JWKS is enabled.
-     */
-    private static boolean isJWKSEnabled() {
-
-        boolean isJWKSEnabled = false;
-        String isJWKSEnalbedProperty = IdentityUtil.getProperty(JWKS_VALIDATION_ENABLE_CONFIG);
-        isJWKSEnabled = Boolean.parseBoolean(isJWKSEnalbedProperty);
-        if (isJWKSEnabled) {
-            if (log.isDebugEnabled()) {
-                log.debug("JWKS based JWT validation enabled.");
-            }
-        }
-        return isJWKSEnabled;
-    }
-
+    
     /**
      * Method to get the JWKS Uri of the identity provider.
      *

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/JWTSignatureValidationUtils.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/JWTSignatureValidationUtils.java
@@ -53,8 +53,6 @@ public class JWTSignatureValidationUtils {
     private static final String ENFORCE_CERTIFICATE_VALIDITY
             = "JWTValidatorConfigs.EnforceCertificateExpiryTimeValidity";
 
-    private static String tenantDomain;
-
     /**
      * Method to validate the signature of the JWT
      *
@@ -190,7 +188,7 @@ public class JWTSignatureValidationUtils {
                     .decodeCertificate(idp.getCertificate());
         } catch (CertificateException e) {
             handleException("Error occurred while decoding public certificate of Identity Provider "
-                    + idp.getIdentityProviderName() + " for tenant domain " + tenantDomain);
+                    + idp.getIdentityProviderName());
         }
         return x509Certificate;
     }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/JWTSignatureValidationUtils.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/JWTSignatureValidationUtils.java
@@ -157,7 +157,7 @@ public class JWTSignatureValidationUtils {
     /**
      * Check the validity of the x509Certificate.
      *
-     * @param x509Certificate x509Certificate
+     * @param x509Certificate x509Certificate.
      * @throws IdentityOAuth2Exception
      */
     private static void checkValidity(X509Certificate x509Certificate) throws IdentityOAuth2Exception {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/JWTSignatureValidationUtils.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/JWTSignatureValidationUtils.java
@@ -42,7 +42,7 @@ import java.security.cert.X509Certificate;
 import java.security.interfaces.RSAPublicKey;
 
 /**
- * Utility methods for JWT Signature Validation
+ * Utility class for JWT Signature Validation related functionalities.
  */
 public class JWTSignatureValidationUtils {
 
@@ -54,9 +54,9 @@ public class JWTSignatureValidationUtils {
             = "JWTValidatorConfigs.EnforceCertificateExpiryTimeValidity";
 
     /**
-     * Method to validate the signature of the JWT
+     * Method to validate the signature of the JWT.
      *
-     * @param signedJWT signed JWT whose signature is to be verified
+     * @param signedJWT signed JWT whose signature is to be verified.
      * @param idp       Identity provider who issued the signed JWT
      * @return whether signature is valid, true if valid else false
      * @throws JOSEException

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/JWTSignatureValidationUtils.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/JWTSignatureValidationUtils.java
@@ -69,13 +69,31 @@ public class JWTSignatureValidationUtils {
 
         String jwksUri = getJWKSUri(idp);
 
-        if (jwksUri != null) {
+        if (isJWKSEnabled() && (jwksUri != null)) {
             return validateUsingJWKSUri(signedJWT, jwksUri);
         } else {
             return validateUsingCertificate(signedJWT, idp);
         }
     }
-    
+
+    /**
+     * Method to check whether the JWKS is enabled.
+     *
+     * @return boolean value depending on whether the JWKS is enabled.
+     */
+    private static boolean isJWKSEnabled() {
+
+        boolean isJWKSEnabled;
+        String isJWKSEnalbedProperty = IdentityUtil.getProperty(JWKS_VALIDATION_ENABLE_CONFIG);
+        isJWKSEnabled = Boolean.parseBoolean(isJWKSEnalbedProperty);
+        if (isJWKSEnabled) {
+            if (log.isDebugEnabled()) {
+                log.debug("JWKS based JWT validation enabled.");
+            }
+        }
+        return isJWKSEnabled;
+    }
+
     /**
      * Method to get the JWKS Uri of the identity provider.
      *


### PR DESCRIPTION
### Proposed changes in this pull request

Add `JWTSignatureValidationUtils` to OAuth2 utils
This is currently used in the `JWTBearerGrant` handler and will be used in the OIDC federated idp initiated logout.
