### PR TITLE
Fix updating OAuth2 Applications through DCR endpoint

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/service/DCRMService.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/service/DCRMService.java
@@ -203,8 +203,7 @@ public class DCRMService {
             }
             // Need to create a deep clone, since modifying the fields of the original object,
             // will modify the cached SP object.
-            Gson gson = new Gson();
-            ServiceProvider clonedSP = gson.fromJson(gson.toJson(sp), ServiceProvider.class);
+            ServiceProvider clonedSP = cloneServiceProvider(sp);
             clonedSP.setApplicationName(clientName);
             updateServiceProvider(clonedSP, tenantDomain, applicationOwner);
         }
@@ -709,5 +708,18 @@ public class DCRMService {
             throw new DCRMServerException(String.format(DCRMConstants.ErrorMessages.FAILED_TO_VALIDATE_TENANT_DOMAIN
                     .getMessage(), clientId));
         }
+    }
+
+    /**
+     * Create a deep copy of the input Service Provider.
+     *
+     * @param serviceProvider Service Provider.
+     * @return Clone of serviceProvider.
+     */
+    private ServiceProvider cloneServiceProvider(ServiceProvider serviceProvider) {
+
+        Gson gson = new Gson();
+        ServiceProvider clonedServiceProvider = gson.fromJson(gson.toJson(serviceProvider), ServiceProvider.class);
+        return clonedServiceProvider;
     }
 }


### PR DESCRIPTION
## Description
In the Oauth2 DCR updateApplication [1] method, the original service provider object retrieved from the cache was updated. Since this corrupts the data in the cache, through this PR changes, deep copy of service provider object will be created through JSON Serialization with the external library Gson.

Resolves: [Internal server error when updating OAuth2 Applications through DCR endpoint](https://github.com/wso2/product-is/issues/10940)