### PR TITLE
Fix token revoke failure during session termination

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dao/AccessTokenDAOImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dao/AccessTokenDAOImpl.java
@@ -2080,13 +2080,13 @@ public class AccessTokenDAOImpl extends AbstractOAuthDAO implements AccessTokenD
             resultSet = prepStmt.executeQuery();
 
             if (resultSet.next()) {
-                return resultSet.getString("ACCESS_TOKEN");
+                String persistedAccessToken = resultSet.getString("ACCESS_TOKEN");
+                return getPersistenceProcessor().getPreprocessedAccessTokenIdentifier(persistedAccessToken);
             }
             return null;
 
         } catch (SQLException e) {
-            String errorMsg = "Error occurred while retrieving 'Access Token' for " +
-                    "token id : " + tokenId;
+            String errorMsg = "Error occurred while retrieving 'Access Token' for token id: " + tokenId;
             throw new IdentityOAuth2Exception(errorMsg, e);
         } finally {
             IdentityDatabaseUtil.closeAllConnections(connection, resultSet, prepStmt);


### PR DESCRIPTION
When token encryption is enabled, getAccessTokenByTokenId() method does not returned the plain token value resulting in a bad token lookup

