### PR TITLE
Add support to handle consent processing when prompt=consent

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
@@ -526,7 +526,13 @@ public class OAuth2AuthzEndpoint {
                     log.debug("Creating user consent receipt for user: " + loggedInUser.toFullQualifiedUsername() +
                             " for client_id: " + clientId + " of tenantDomain: " + spTenantDomain);
                 }
-                getSSOConsentService().processConsent(approvedClaimIds, serviceProvider, loggedInUser, value);
+                if (hasPromptContainsConsent(oauth2Params)) {
+                    getSSOConsentService().processConsent(approvedClaimIds, serviceProvider,
+                            loggedInUser, value, true);
+                } else {
+                    getSSOConsentService().processConsent(approvedClaimIds, serviceProvider,
+                            loggedInUser, value, false);
+                }
             } else {
                 if (log.isDebugEnabled()) {
                     log.debug("Post consent handling not required for user: " + loggedInUser.toFullQualifiedUsername() +

--- a/pom.xml
+++ b/pom.xml
@@ -877,7 +877,7 @@
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!-- Carbon Identity Framework version -->
-        <carbon.identity.framework.version>5.18.144</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.19.13</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.15.0, 6.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 


### PR DESCRIPTION
### Proposed changes in this pull request
> When the authorization request contains `prompt=consent` previous user consent is overridden by the new user consent. But for other cases user consent will be updated as the union of previous and new consents.

### When should this PR be merged

This PR depends on https://github.com/wso2/carbon-identity-framework/pull/3362
