### PR TITLE
Filter unregistered scopes and remove oidc scopes from consent page url

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/factory/OAuth2ScopeServiceFactory.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/factory/OAuth2ScopeServiceFactory.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth.endpoint.factory;
+
+import org.springframework.beans.factory.config.AbstractFactoryBean;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.identity.oauth2.OAuth2ScopeService;
+
+/**
+ * Factory Beans serves as a factory for creating other beans within the IOC container. This factory bean is used to
+ * instantiate the OAuth2ScopeService type of object inside the container.
+ */
+public class OAuth2ScopeServiceFactory extends AbstractFactoryBean<OAuth2ScopeService> {
+
+    private OAuth2ScopeService oAuth2ScopeService;
+
+    @Override
+    public Class<OAuth2ScopeService> getObjectType() {
+
+        return OAuth2ScopeService.class;
+    }
+
+    @Override
+    protected OAuth2ScopeService createInstance() throws Exception {
+
+        if (this.oAuth2ScopeService != null) {
+            return this.oAuth2ScopeService;
+        } else {
+            OAuth2ScopeService oAuth2ScopeService = (OAuth2ScopeService) PrivilegedCarbonContext
+                    .getThreadLocalCarbonContext().getOSGiService(OAuth2ScopeService.class, null);
+            if (oAuth2ScopeService != null) {
+                this.oAuth2ScopeService = oAuth2ScopeService;
+            }
+            return oAuth2ScopeService;
+        }
+    }
+}

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/factory/OAuthAdminServiceFactory.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/factory/OAuthAdminServiceFactory.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth.endpoint.factory;
+
+import org.springframework.beans.factory.config.AbstractFactoryBean;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.identity.oauth.OAuthAdminServiceImpl;
+
+/**
+ * Factory Beans serves as a factory for creating other beans within the IOC container. This factory bean is used to
+ * instantiate the OAuthAdminService type of object inside the container.
+ */
+public class OAuthAdminServiceFactory extends AbstractFactoryBean<OAuthAdminServiceImpl> {
+
+    private OAuthAdminServiceImpl oAuthAdminService;
+
+    @Override
+    public Class<OAuthAdminServiceImpl> getObjectType() {
+
+        return OAuthAdminServiceImpl.class;
+    }
+
+    @Override
+    protected OAuthAdminServiceImpl createInstance() throws Exception {
+
+        if (this.oAuthAdminService != null) {
+            return this.oAuthAdminService;
+        } else {
+            OAuthAdminServiceImpl oAuthAdminService = (OAuthAdminServiceImpl) PrivilegedCarbonContext
+                    .getThreadLocalCarbonContext().getOSGiService(OAuthAdminServiceImpl.class, null);
+            if (oAuthAdminService != null) {
+                this.oAuthAdminService = oAuthAdminService;
+            }
+            return oAuthAdminService;
+        }
+    }
+}

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/webapp/WEB-INF/cxf-servlet.xml
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/webapp/WEB-INF/cxf-servlet.xml
@@ -61,6 +61,8 @@
     <bean id="oAuthClientAuthnFactoryBean" class="org.wso2.carbon.identity.oauth.client.authn.filter.OAuthClientAuthnServiceFactory"/>
     <bean id="endpointUtilBean" class="org.wso2.carbon.identity.oauth.endpoint.util.EndpointUtil">
         <property name="oAuth2Service" ref="oAuth2ServiceFactoryBean"/>
+        <property name="oAuth2ScopeService" ref="oAuth2ScopeServiceFactoryBean"/>
+        <property name="oAuthAdminService" ref="oAuthAdminServiceFactoryBean"/>
         <property name="SSOConsentService"  ref="ssoConsentServiceFactoryBean"/>
         <property name="oauthServerConfiguration"  ref="oauthServerConfigurationFactoryBean"/>
         <property name="requestObjectService"  ref="requestObjectServiceFactoryBean"/>
@@ -68,6 +70,8 @@
     </bean>
     <bean id="oidcProviderResponseBuilderBean" class="org.wso2.carbon.identity.oauth.endpoint.oidcdiscovery.impl.OIDProviderJSONResponseBuilder"/>
     <bean id="oAuth2ServiceFactoryBean" class="org.wso2.carbon.identity.oauth.endpoint.factory.OAuth2ServiceFactory"/>
+    <bean id="oAuth2ScopeServiceFactoryBean" class="org.wso2.carbon.identity.oauth.endpoint.factory.OAuth2ScopeServiceFactory"/>
+    <bean id="oAuthAdminServiceFactoryBean" class="org.wso2.carbon.identity.oauth.endpoint.factory.OAuthAdminServiceFactory"/>
     <bean id="ssoConsentServiceFactoryBean" class="org.wso2.carbon.identity.oauth.endpoint.factory.SSOConsentServiceFactory"/>
     <bean id="oauthServerConfigurationFactoryBean" class="org.wso2.carbon.identity.oauth.endpoint.factory.OAuthServerConfigurationFactory"/>
     <bean id="requestObjectServiceFactoryBean" class="org.wso2.carbon.identity.oauth.endpoint.factory.RequestObjectServiceFactory"/>

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtilTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtilTest.java
@@ -46,6 +46,7 @@ import org.wso2.carbon.identity.discovery.DefaultOIDCProcessor;
 import org.wso2.carbon.identity.discovery.OIDCProcessor;
 import org.wso2.carbon.identity.discovery.builders.DefaultOIDCProviderRequestBuilder;
 import org.wso2.carbon.identity.discovery.builders.OIDCProviderRequestBuilder;
+import org.wso2.carbon.identity.oauth.OAuthAdminServiceImpl;
 import org.wso2.carbon.identity.oauth.cache.SessionDataCache;
 import org.wso2.carbon.identity.oauth.cache.SessionDataCacheEntry;
 import org.wso2.carbon.identity.oauth.cache.SessionDataCacheKey;
@@ -131,6 +132,9 @@ public class EndpointUtilTest extends PowerMockIdentityBaseTest {
 
     @Mock
     OAuth2Service mockedOAuth2Service;
+
+    @Mock
+    OAuthAdminServiceImpl mockedOAuthAdminService;
 
     @Mock
     SSOConsentService mockedSSOConsentService;
@@ -246,6 +250,9 @@ public class EndpointUtilTest extends PowerMockIdentityBaseTest {
             when(mockedSessionDataCache.getValueFromCache(any(SessionDataCacheKey.class))).
                     thenReturn(null);
         }
+
+        EndpointUtil.setOAuthAdminService(mockedOAuthAdminService);
+        when(mockedOAuthAdminService.getScopeNames()).thenReturn(new String[0]);
 
         String consentUrl;
         try {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
@@ -266,6 +266,9 @@ public class OAuthServerConfiguration {
     // Property to define the allowed scopes.
     private List<String> allowedScopes = new ArrayList<>();
 
+    // Property to check whether to drop unregistered scopes.
+    private boolean dropUnregisteredScopes = false;
+
     private OAuthServerConfiguration() {
         buildOAuthServerConfiguration();
     }
@@ -422,6 +425,9 @@ public class OAuthServerConfiguration {
 
         // Read config for allowed scopes.
         parseAllowedScopesConfiguration(oauthElem);
+
+        // Read config for dropping unregistered scopes.
+        parseDropUnregisteredScopes(oauthElem);
     }
 
     /**
@@ -466,6 +472,15 @@ public class OAuthServerConfiguration {
         }
     }
 
+    private void parseDropUnregisteredScopes(OMElement oauthElem) {
+
+        OMElement dropUnregisteredScopesElement =
+                oauthElem.getFirstChildWithName(getQNameWithIdentityNS(ConfigElements.DROP_UNREGISTERED_SCOPES));
+        if (dropUnregisteredScopesElement != null) {
+            dropUnregisteredScopes = Boolean.parseBoolean(dropUnregisteredScopesElement.getText());
+        }
+    }
+
     public Set<OAuthCallbackHandlerMetaData> getCallbackHandlerMetaData() {
         return callbackHandlerMetaData;
     }
@@ -477,6 +492,16 @@ public class OAuthServerConfiguration {
      */
     public boolean isShowDisplayNameInConsentPage() {
         return showDisplayNameInConsentPage;
+    }
+
+    /**
+     * Returns the value of DropUnregisteredScopes configuration.
+     *
+     * @return value of DropUnregisteredScopes configuration.
+     */
+    public boolean isDropUnregisteredScopes() {
+
+        return dropUnregisteredScopes;
     }
 
     /**
@@ -3153,6 +3178,8 @@ public class OAuthServerConfiguration {
         // Allowed Scopes Config.
         private static final String ALLOWED_SCOPES_ELEMENT = "AllowedScopes";
         private static final String SCOPES_ELEMENT = "Scope";
+
+        private static final String DROP_UNREGISTERED_SCOPES = "DropUnregisteredScopes";
     }
 
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/AuthorizationHandlerManager.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/AuthorizationHandlerManager.java
@@ -154,6 +154,17 @@ public class AuthorizationHandlerManager {
         // the other scope validators.
         removeInternalScopes(authzReqMsgCtx);
 
+        boolean isDropUnregisteredScopes = OAuthServerConfiguration.getInstance().isDropUnregisteredScopes();
+        if (isDropUnregisteredScopes) {
+            if (log.isDebugEnabled()) {
+                log.debug("DropUnregisteredScopes config is enabled. Attempting to drop unregistered scopes.");
+            }
+            String[] filteredScopes = OAuth2Util.dropUnregisteredScopes(
+                    authzReqMsgCtx.getAuthorizationReqDTO().getScopes(),
+                    authzReqMsgCtx.getAuthorizationReqDTO().getTenantDomain());
+            authzReqMsgCtx.getAuthorizationReqDTO().setScopes(filteredScopes);
+        }
+
         boolean valid = validateScope(authzReqDTO, authorizeRespDTO, authzReqMsgCtx, authzHandler);
         if (valid) {
             //Add authorized internal scopes to the request for sending in the response.

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuer.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuer.java
@@ -297,6 +297,18 @@ public class AccessTokenIssuer {
         // Thus remove the scopes from the tokReqMsgCtx. Will be added to the response after executing
         // the other scope validators.
         removeInternalScopes(tokReqMsgCtx);
+
+        boolean isDropUnregisteredScopes = OAuthServerConfiguration.getInstance().isDropUnregisteredScopes();
+        if (isDropUnregisteredScopes) {
+            if (log.isDebugEnabled()) {
+                log.debug("DropUnregisteredScopes config is enabled. Attempting to drop unregistered scopes.");
+            }
+            String[] filteredScopes = OAuth2Util.dropUnregisteredScopes(
+                    tokReqMsgCtx.getScope(),
+                    tokReqMsgCtx.getOauth2AccessTokenReqDTO().getTenantDomain());
+            tokReqMsgCtx.setScope(filteredScopes);
+        }
+
         boolean isValidScope = authzGrantHandler.validateScope(tokReqMsgCtx);
         if (isValidScope) {
             //Add authorized internal scopes to the request for sending in the response.


### PR DESCRIPTION
Resolves https://github.com/wso2/product-is/issues/11207

Configuration required to drop unregistered scopes.
```
[oauth]
drop_unregistered_scopes = "true"
```

By enabling above config, any unregistered scopes(excluding internal scopes and allowed scopes) passed in a OAuth based authz request will be dropped.
Default value : false