### PR TITLE
Skip generating JWT during the token introspection if 'required_claim' parameter is not sent

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/introspection/OAuth2IntrospectionEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/introspection/OAuth2IntrospectionEndpoint.java
@@ -84,10 +84,10 @@ public class OAuth2IntrospectionEndpoint {
                     entity("{\"error\": \"" + INVALID_INPUT + "\"}").build();
         }
 
-        String[] claimsUris;
+        String[] claimsUris = null;
         if (StringUtils.isNotEmpty(requiredClaims)) {
             claimsUris = requiredClaims.split(",");
-        } else {
+        } else if (requiredClaims != null && requiredClaims.length() == 0) {
             claimsUris = new String[0];
         }
 

--- a/components/org.wso2.carbon.identity.oauth.stub/src/main/resources/OAuth2TokenValidationService.wsdl
+++ b/components/org.wso2.carbon.identity.oauth.stub/src/main/resources/OAuth2TokenValidationService.wsdl
@@ -1,6 +1,22 @@
-<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:ax2410="http://dto.oauth2.identity.carbon.wso2.org/xsd" xmlns:ax2412="http://bindings.token.oauth2.identity.carbon.wso2.org/xsd" xmlns:wsaw="http://www.w3.org/2006/05/addressing/wsdl" xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/" xmlns:tns="http://oauth2.identity.carbon.wso2.org" xmlns:http="http://schemas.xmlsoap.org/wsdl/http/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:ns1="http://org.apache.axis2/xsd" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" targetNamespace="http://oauth2.identity.carbon.wso2.org">
+<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:ax2333="http://dto.oauth2.identity.carbon.wso2.org/xsd" xmlns:ax2335="http://bindings.token.oauth2.identity.carbon.wso2.org/xsd" xmlns:ax2337="http://model.framework.authentication.application.identity.carbon.wso2.org/xsd" xmlns:ax2338="http://model.common.application.identity.carbon.wso2.org/xsd" xmlns:wsaw="http://www.w3.org/2006/05/addressing/wsdl" xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:ax2340="http://util.java/xsd" xmlns:ns1="http://org.apache.axis2/xsd" xmlns:tns="http://oauth2.identity.carbon.wso2.org" xmlns:http="http://schemas.xmlsoap.org/wsdl/http/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" targetNamespace="http://oauth2.identity.carbon.wso2.org">
     <wsdl:documentation>OAuth2TokenValidationService</wsdl:documentation>
     <wsdl:types>
+        <xs:schema xmlns:ax2341="http://util.java/xsd" xmlns:ax2339="http://model.common.application.identity.carbon.wso2.org/xsd" attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://model.framework.authentication.application.identity.carbon.wso2.org/xsd">
+            <xs:import namespace="http://model.common.application.identity.carbon.wso2.org/xsd"/>
+            <xs:import namespace="http://util.java/xsd"/>
+            <xs:complexType name="AuthenticatedUser">
+                <xs:complexContent>
+                    <xs:extension base="ax2338:User">
+                        <xs:sequence>
+                            <xs:element minOccurs="0" name="authenticatedSubjectIdentifier" nillable="true" type="xs:string"/>
+                            <xs:element minOccurs="0" name="federatedIdPName" nillable="true" type="xs:string"/>
+                            <xs:element minOccurs="0" name="federatedUser" type="xs:boolean"/>
+                            <xs:element minOccurs="0" name="userAttributes" nillable="true" type="ax2340:Map"/>
+                        </xs:sequence>
+                    </xs:extension>
+                </xs:complexContent>
+            </xs:complexType>
+        </xs:schema>
         <xs:schema attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://bindings.token.oauth2.identity.carbon.wso2.org/xsd">
             <xs:complexType name="TokenBinding">
                 <xs:sequence>
@@ -11,57 +27,74 @@
                 </xs:sequence>
             </xs:complexType>
         </xs:schema>
-        <xs:schema xmlns:ax2411="http://dto.oauth2.identity.carbon.wso2.org/xsd" xmlns:ns="http://org.apache.axis2/xsd" attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://org.apache.axis2/xsd">
+        <xs:schema attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://util.java/xsd">
+            <xs:complexType abstract="true" name="Map">
+                <xs:sequence>
+                    <xs:element minOccurs="0" name="empty" type="xs:boolean"/>
+                </xs:sequence>
+            </xs:complexType>
+        </xs:schema>
+        <xs:schema xmlns:ax2334="http://dto.oauth2.identity.carbon.wso2.org/xsd" xmlns:ns="http://org.apache.axis2/xsd" attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://org.apache.axis2/xsd">
             <xs:import namespace="http://dto.oauth2.identity.carbon.wso2.org/xsd"/>
-            <xs:element name="validate">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="validationReqDTO" nillable="true" type="ax2410:OAuth2TokenValidationRequestDTO"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="validateResponse">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="return" nillable="true" type="ax2410:OAuth2TokenValidationResponseDTO"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
             <xs:element name="findOAuthConsumerIfTokenIsValid">
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element minOccurs="0" name="validationReqDTO" nillable="true" type="ax2410:OAuth2TokenValidationRequestDTO"/>
+                        <xs:element minOccurs="0" name="validationReqDTO" nillable="true" type="ax2333:OAuth2TokenValidationRequestDTO"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
             <xs:element name="findOAuthConsumerIfTokenIsValidResponse">
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element minOccurs="0" name="return" nillable="true" type="ax2410:OAuth2ClientApplicationDTO"/>
+                        <xs:element minOccurs="0" name="return" nillable="true" type="ax2333:OAuth2ClientApplicationDTO"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
             <xs:element name="buildIntrospectionResponse">
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element minOccurs="0" name="validationReq" nillable="true" type="ax2410:OAuth2TokenValidationRequestDTO"/>
+                        <xs:element minOccurs="0" name="validationReq" nillable="true" type="ax2333:OAuth2TokenValidationRequestDTO"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
             <xs:element name="buildIntrospectionResponseResponse">
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element minOccurs="0" name="return" nillable="true" type="ax2410:OAuth2IntrospectionResponseDTO"/>
+                        <xs:element minOccurs="0" name="return" nillable="true" type="ax2333:OAuth2IntrospectionResponseDTO"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="validate">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="validationReqDTO" nillable="true" type="ax2333:OAuth2TokenValidationRequestDTO"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="validateResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="return" nillable="true" type="ax2333:OAuth2TokenValidationResponseDTO"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
         </xs:schema>
-        <xs:schema xmlns:ax2413="http://bindings.token.oauth2.identity.carbon.wso2.org/xsd" attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://dto.oauth2.identity.carbon.wso2.org/xsd">
+        <xs:schema attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://model.common.application.identity.carbon.wso2.org/xsd">
+            <xs:complexType name="User">
+                <xs:sequence>
+                    <xs:element minOccurs="0" name="tenantDomain" nillable="true" type="xs:string"/>
+                    <xs:element minOccurs="0" name="userName" nillable="true" type="xs:string"/>
+                    <xs:element minOccurs="0" name="userStoreDomain" nillable="true" type="xs:string"/>
+                </xs:sequence>
+            </xs:complexType>
+        </xs:schema>
+        <xs:schema xmlns:ax2336="http://bindings.token.oauth2.identity.carbon.wso2.org/xsd" xmlns:ax2342="http://model.framework.authentication.application.identity.carbon.wso2.org/xsd" attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://dto.oauth2.identity.carbon.wso2.org/xsd">
             <xs:import namespace="http://bindings.token.oauth2.identity.carbon.wso2.org/xsd"/>
+            <xs:import namespace="http://model.framework.authentication.application.identity.carbon.wso2.org/xsd"/>
             <xs:complexType name="OAuth2TokenValidationRequestDTO">
                 <xs:sequence>
-                    <xs:element minOccurs="0" name="accessToken" nillable="true" type="ax2410:OAuth2TokenValidationRequestDTO_OAuth2AccessToken"/>
-                    <xs:element maxOccurs="unbounded" minOccurs="0" name="context" nillable="true" type="ax2410:OAuth2TokenValidationRequestDTO_TokenValidationContextParam"/>
+                    <xs:element minOccurs="0" name="accessToken" nillable="true" type="ax2333:OAuth2TokenValidationRequestDTO_OAuth2AccessToken"/>
+                    <xs:element maxOccurs="unbounded" minOccurs="0" name="context" nillable="true" type="ax2333:OAuth2TokenValidationRequestDTO_TokenValidationContextParam"/>
                     <xs:element maxOccurs="unbounded" minOccurs="0" name="requiredClaimURIs" nillable="true" type="xs:string"/>
                 </xs:sequence>
             </xs:complexType>
@@ -78,14 +111,20 @@
                     <xs:element minOccurs="0" name="value" nillable="true" type="xs:string"/>
                 </xs:sequence>
             </xs:complexType>
+            <xs:complexType name="OAuth2ClientApplicationDTO">
+                <xs:sequence>
+                    <xs:element minOccurs="0" name="accessTokenValidationResponse" nillable="true" type="ax2333:OAuth2TokenValidationResponseDTO"/>
+                    <xs:element minOccurs="0" name="consumerKey" nillable="true" type="xs:string"/>
+                </xs:sequence>
+            </xs:complexType>
             <xs:complexType name="OAuth2TokenValidationResponseDTO">
                 <xs:sequence>
-                    <xs:element minOccurs="0" name="authorizationContextToken" nillable="true" type="ax2410:OAuth2TokenValidationResponseDTO_AuthorizationContextToken"/>
+                    <xs:element minOccurs="0" name="authorizationContextToken" nillable="true" type="ax2333:OAuth2TokenValidationResponseDTO_AuthorizationContextToken"/>
                     <xs:element minOccurs="0" name="authorizedUser" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="errorMsg" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="expiryTime" type="xs:long"/>
                     <xs:element maxOccurs="unbounded" minOccurs="0" name="scope" nillable="true" type="xs:string"/>
-                    <xs:element minOccurs="0" name="tokenBinding" nillable="true" type="ax2412:TokenBinding"/>
+                    <xs:element minOccurs="0" name="tokenBinding" nillable="true" type="ax2335:TokenBinding"/>
                     <xs:element minOccurs="0" name="valid" type="xs:boolean"/>
                 </xs:sequence>
             </xs:complexType>
@@ -95,16 +134,12 @@
                     <xs:element minOccurs="0" name="tokenType" nillable="true" type="xs:string"/>
                 </xs:sequence>
             </xs:complexType>
-            <xs:complexType name="OAuth2ClientApplicationDTO">
-                <xs:sequence>
-                    <xs:element minOccurs="0" name="accessTokenValidationResponse" nillable="true" type="ax2410:OAuth2TokenValidationResponseDTO"/>
-                    <xs:element minOccurs="0" name="consumerKey" nillable="true" type="xs:string"/>
-                </xs:sequence>
-            </xs:complexType>
             <xs:complexType name="OAuth2IntrospectionResponseDTO">
                 <xs:sequence>
                     <xs:element minOccurs="0" name="active" type="xs:boolean"/>
                     <xs:element minOccurs="0" name="aud" nillable="true" type="xs:string"/>
+                    <xs:element minOccurs="0" name="aut" nillable="true" type="xs:string"/>
+                    <xs:element minOccurs="0" name="authorizedUser" nillable="true" type="ax2337:AuthenticatedUser"/>
                     <xs:element minOccurs="0" name="bindingReference" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="bindingType" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="clientId" nillable="true" type="xs:string"/>

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dto/OAuth2IntrospectionResponseDTO.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dto/OAuth2IntrospectionResponseDTO.java
@@ -18,6 +18,8 @@
 
 package org.wso2.carbon.identity.oauth2.dto;
 
+import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -113,6 +115,11 @@ public class OAuth2IntrospectionResponseDTO {
      * OPTIONAL. Authorized user type of the token. (APPLICATION or APPLICATION_USER)
      */
     private String aut;
+
+    /*
+     * OPTIONAL. User object for the resource owner who authorized this token.
+     */
+    private AuthenticatedUser authorizedUser;
 
     /*
      * this is used for extensions.
@@ -299,5 +306,15 @@ public class OAuth2IntrospectionResponseDTO {
     public void setAut(String aut) {
 
         this.aut = aut;
+    }
+
+    public AuthenticatedUser getAuthorizedUser() {
+
+        return authorizedUser;
+    }
+
+    public void setAuthorizedUser(AuthenticatedUser authorizedUser) {
+
+        this.authorizedUser = authorizedUser;
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dto/OAuth2IntrospectionResponseDTO.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dto/OAuth2IntrospectionResponseDTO.java
@@ -117,7 +117,7 @@ public class OAuth2IntrospectionResponseDTO {
     private String aut;
 
     /*
-     * OPTIONAL. User object for the resource owner who authorized this token.
+     * OPTIONAL. Represents the resource owner who authorized this token.
      */
     private AuthenticatedUser authorizedUser;
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/TokenValidationHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/TokenValidationHandler.java
@@ -303,7 +303,7 @@ public class TokenValidationHandler {
             responseDTO.setAuthorizedUser(introResp.getUsername());
         }
 
-        if (tokenGenerator != null) {
+        if (tokenGenerator != null && validationRequest.getRequiredClaimURIs() != null) {
             // add user attributes to the introspection response.
             tokenGenerator.generateToken(messageContext);
             if (log.isDebugEnabled()) {
@@ -354,6 +354,9 @@ public class TokenValidationHandler {
         introResp.setClientId(refreshTokenDataDO.getConsumerKey());
         // Adding the AccessTokenDO as a context property for further use.
         messageContext.addProperty("RefreshTokenDO", refreshTokenDataDO);
+        // Add authenticated user object since username attribute may not have the domain appended if the
+        // subject identifier is built based in the SP config.
+        introResp.setAuthorizedUser(refreshTokenDataDO.getAuthzUser());
 
         // Validate access delegation.
         if (!tokenValidator.validateAccessDelegation(messageContext)) {
@@ -465,6 +468,9 @@ public class TokenValidationHandler {
             }
             // adding the AccessTokenDO as a context property for further use
             messageContext.addProperty("AccessTokenDO", accessTokenDO);
+            // Add authenticated user object since username attribute may not have the domain appended if the
+            // subject identifier is built based in the SP config.
+            introResp.setAuthorizedUser(accessTokenDO.getAuthzUser());
         }
 
         if (messageContext.getProperty(OAuth2Util.JWT_ACCESS_TOKEN) != null


### PR DESCRIPTION
The introspection request can have an additional parameter `required_claims` to obtain a JWT with required claims along with the  token validation response[1]. However currently this JWT generation happens without checking whether the `required_claims` parameter is set in the introspection request or not. Generation this JWT is an additional overhead to the token introspection flow when the introspection is called without `required_claims` optional parameter.

Also this PR introduces a new attribute to store the authorized user object as the existing username attribute may not have the domain appended to it, if the subject identifier is built based in the SP config[2].

Resolves : https://github.com/wso2/product-is/issues/11257

[1] https://github.com/wso2/docs-is/issues/1373
[2] https://github.com/wso2-extensions/identity-inbound-auth-oauth/blob/6f5f6caa9f0c4a3724141d0bfb5a786bdaa7f727/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/TokenValidationHandler.java#L525