### PR TITLE
Improve requested claims consent experience

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
@@ -511,35 +511,29 @@ public class OAuth2AuthzEndpoint {
             }
 
             List<Integer> approvedClaimIds = getUserConsentClaimIds(oAuthMessage);
-            if (isPostConsentHandlingRequired(approvedClaimIds)) {
-                serviceProvider = getServiceProvider(clientId);
-                /*
-                    With the current implementation of the SSOConsentService we need to send back the original
-                    ConsentClaimsData object we got during pre consent stage. Currently we are repeating the API call
-                    during post consent handling to get the original ConsentClaimsData object (Assuming there is no
-                    change in SP during pre-consent and post-consent).
 
-                    The API on the SSO Consent Service will be improved to avoid having to send the original
-                    ConsentClaimsData object.
-                 */
-                ConsentClaimsData value = getConsentRequiredClaims(loggedInUser, serviceProvider, oauth2Params);
-                // Call framework and create the consent receipt.
-                if (log.isDebugEnabled()) {
-                    log.debug("Creating user consent receipt for user: " + loggedInUser.toFullQualifiedUsername() +
-                            " for client_id: " + clientId + " of tenantDomain: " + spTenantDomain);
-                }
-                if (hasPromptContainsConsent(oauth2Params)) {
-                    getSSOConsentService().processConsent(approvedClaimIds, serviceProvider,
-                            loggedInUser, value, true);
-                } else {
-                    getSSOConsentService().processConsent(approvedClaimIds, serviceProvider,
-                            loggedInUser, value, false);
-                }
+            serviceProvider = getServiceProvider(clientId);
+            /*
+                With the current implementation of the SSOConsentService we need to send back the original
+                ConsentClaimsData object we got during pre consent stage. Currently we are repeating the API call
+                during post consent handling to get the original ConsentClaimsData object (Assuming there is no
+                change in SP during pre-consent and post-consent).
+
+                The API on the SSO Consent Service will be improved to avoid having to send the original
+                ConsentClaimsData object.
+             */
+            ConsentClaimsData value = getConsentRequiredClaims(loggedInUser, serviceProvider, oauth2Params);
+            // Call framework and create the consent receipt.
+            if (log.isDebugEnabled()) {
+                log.debug("Creating user consent receipt for user: " + loggedInUser.toFullQualifiedUsername() +
+                        " for client_id: " + clientId + " of tenantDomain: " + spTenantDomain);
+            }
+            if (hasPromptContainsConsent(oauth2Params)) {
+                getSSOConsentService().processConsent(approvedClaimIds, serviceProvider,
+                        loggedInUser, value, true);
             } else {
-                if (log.isDebugEnabled()) {
-                    log.debug("Post consent handling not required for user: " + loggedInUser.toFullQualifiedUsername() +
-                            " for client_id: " + clientId + " of tenantDomain: " + spTenantDomain + ".");
-                }
+                getSSOConsentService().processConsent(approvedClaimIds, serviceProvider,
+                        loggedInUser, value, false);
             }
         } catch (OAuthSystemException | SSOConsentServiceException e) {
             String msg = "Error while processing consent of user: " + loggedInUser.toFullQualifiedUsername() + " for " +
@@ -558,11 +552,6 @@ public class OAuth2AuthzEndpoint {
         } else {
             return getSSOConsentService().getConsentRequiredClaimsWithExistingConsents(serviceProvider, user);
         }
-    }
-
-    private boolean isPostConsentHandlingRequired(List<Integer> approvedClaimIds) {
-
-        return CollectionUtils.isNotEmpty(approvedClaimIds);
     }
 
     private List<Integer> getUserConsentClaimIds(OAuthMessage oAuthMessage) {

--- a/pom.xml
+++ b/pom.xml
@@ -877,7 +877,7 @@
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!-- Carbon Identity Framework version -->
-        <carbon.identity.framework.version>5.19.32</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.19.51</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.15.0, 6.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 


### PR DESCRIPTION
### Description

Post consent handling should do for both the approved and denied claims. Hense removed the condition `isPostConsentHandlingRequired(approvedClaimIds)`

Resolves: https://github.com/wso2/product-is/issues/9009, https://github.com/wso2-enterprise/asgardeo-product/issues/2144
Related PRs: https://github.com/wso2/carbon-consent-management/pull/180,https://github.com/wso2/carbon-identity-framework/pull/3413
