### PR TITLE
Improve OIDCSessionDataCache to be a persistence cache

### DIFF
--- a/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/cache/OIDCSessionDataCache.java
+++ b/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/cache/OIDCSessionDataCache.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.oidc.session.cache;
 
+import org.wso2.carbon.identity.application.authentication.framework.store.SessionDataStore;
 import org.wso2.carbon.identity.application.common.cache.BaseCache;
 
 /**
@@ -44,5 +45,44 @@ public class OIDCSessionDataCache extends BaseCache<OIDCSessionDataCacheKey, OID
             }
         }
         return instance;
+    }
+
+    /**
+     * Add OIDCSessionDataCache to cache.
+     *
+     * @param key   OIDCSessionDataCacheKey.
+     * @param entry OIDCSessionDataCacheEntry.
+     */
+    public void addToCache(OIDCSessionDataCacheKey key, OIDCSessionDataCacheEntry entry) {
+
+        super.addToCache(key, entry);
+        SessionDataStore.getInstance().storeSessionData(key.getSessionDataId(), SESSION_DATA_CACHE_NAME, entry);
+    }
+
+    /**
+     * Get OIDCSessionDataCacheEntry from OIDCSessionDataCache.
+     *
+     * @param key OIDCSessionDataCacheKey.
+     * @return OIDCSessionDataCacheEntry.
+     */
+    public OIDCSessionDataCacheEntry getValueFromCache(OIDCSessionDataCacheKey key) {
+
+        OIDCSessionDataCacheEntry cacheEntry = super.getValueFromCache(key);
+        if (cacheEntry == null) {
+            cacheEntry = (OIDCSessionDataCacheEntry) SessionDataStore.getInstance().
+                    getSessionData(key.getSessionDataId(), SESSION_DATA_CACHE_NAME);
+        }
+        return cacheEntry;
+    }
+
+    /**
+     * Clear OIDCSessionDataCache.
+     *
+     * @param key OIDCSessionDataCacheKey.
+     */
+    public void clearCacheEntry(OIDCSessionDataCacheKey key) {
+
+        super.clearCacheEntry(key);
+        SessionDataStore.getInstance().clearSessionData(key.getSessionDataId(), SESSION_DATA_CACHE_NAME);
     }
 }

--- a/components/org.wso2.carbon.identity.oidc.session/src/test/java/org/wso2/carbon/identity/oidc/session/cache/OIDCSessionDataCacheTest.java
+++ b/components/org.wso2.carbon.identity.oidc.session/src/test/java/org/wso2/carbon/identity/oidc/session/cache/OIDCSessionDataCacheTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oidc.session.cache;
+
+import org.testng.annotations.Test;
+import org.wso2.carbon.base.MultitenantConstants;
+import org.wso2.carbon.identity.oidc.session.servlet.TestUtil;
+
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+
+/**
+ * Unit test coverage for OIDCSessionDataCache class.
+ */
+public class OIDCSessionDataCacheTest {
+
+    @Test
+    public void testGetInstance() {
+
+        assertNotNull(OIDCSessionDataCache.getInstance(), "OIDCSessionDataCache is null.");
+    }
+
+    @Test
+    public void testAddToCache() {
+
+        TestUtil.startTenantFlow(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+        OIDCSessionDataCacheKey key = mock(OIDCSessionDataCacheKey.class);
+        OIDCSessionDataCacheEntry entry = mock(OIDCSessionDataCacheEntry.class);
+        OIDCSessionDataCache.getInstance().addToCache(key, entry);
+        assertNotNull(OIDCSessionDataCache.getInstance().getValueFromCache(key),
+                "OIDCSessionDataCache is null.");
+    }
+
+    @Test
+    public void testClearCacheEntry() {
+
+        TestUtil.startTenantFlow(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+        OIDCSessionDataCacheKey key = mock(OIDCSessionDataCacheKey.class);
+        OIDCSessionDataCache.getInstance().clearCacheEntry(key);
+        assertNull(OIDCSessionDataCache.getInstance().getValueFromCache(key),
+                "OIDCSessionDataCache is not null.");
+    }
+}

--- a/components/org.wso2.carbon.identity.oidc.session/src/test/java/org/wso2/carbon/identity/oidc/session/servlet/OIDCLogoutServletTest.java
+++ b/components/org.wso2.carbon.identity.oidc.session/src/test/java/org/wso2/carbon/identity/oidc/session/servlet/OIDCLogoutServletTest.java
@@ -45,12 +45,17 @@ import org.wso2.carbon.identity.oauth.tokenprocessor.TokenPersistenceProcessor;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 import org.wso2.carbon.identity.oidc.session.OIDCSessionConstants;
 import org.wso2.carbon.identity.oidc.session.OIDCSessionManager;
+import org.wso2.carbon.identity.oidc.session.cache.OIDCSessionDataCache;
+import org.wso2.carbon.identity.oidc.session.cache.OIDCSessionDataCacheEntry;
+import org.wso2.carbon.identity.oidc.session.cache.OIDCSessionDataCacheKey;
 import org.wso2.carbon.identity.oidc.session.internal.OIDCSessionManagementComponentServiceHolder;
 import org.wso2.carbon.identity.oidc.session.util.OIDCSessionManagementUtil;
 
 import java.security.KeyStore;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.Cookie;
@@ -71,7 +76,7 @@ import static org.testng.Assert.assertTrue;
 @PrepareForTest({OIDCSessionManagementUtil.class, OIDCSessionManager.class, FrameworkUtils.class,
         IdentityConfigParser.class, OAuthServerConfiguration.class, IdentityTenantUtil.class, KeyStoreManager.class,
         CarbonCoreDataHolder.class, IdentityDatabaseUtil.class, OAuth2Util.class,
-        OIDCSessionManagementComponentServiceHolder.class, ServiceURLBuilder.class})
+        OIDCSessionManagementComponentServiceHolder.class, ServiceURLBuilder.class, OIDCSessionDataCache.class})
 /*
   Unit test coverage for OIDCLogoutServlet class.
  */
@@ -112,6 +117,12 @@ public class OIDCLogoutServletTest extends TestOIDCSessionBase {
 
     @Mock
     KeyStore keyStore;
+
+    @Mock
+    OIDCSessionDataCache oidcSessionDataCache;
+
+    @Mock
+    OIDCSessionDataCacheEntry opbsCacheEntry, sessionIdCacheEntry;
 
     private static final String CLIENT_ID_VALUE = "3T9l2uUf8AzNOfmGS9lPEIsdrR8a";
     private static final String CLIENT_ID_WITH_REGEX_CALLBACK = "cG1H52zfnkFEh3ULT0yTi14bZRUa";
@@ -259,7 +270,7 @@ public class OIDCLogoutServletTest extends TestOIDCSessionBase {
                         idTokenHint, false, INVALID_CALLBACK_URL, null},
                 // opbs cookie and previous sessions are existing, userConsent is empty, sessionDataKey = null,
                 // skipUserConsent=true, a valid idTokenHint, and valid postLogoutUri.
-                {opbsCookie, true, redirectUrl[5], CALLBACK_URL, " ", null, true,
+                {opbsCookie, true, redirectUrl[5], "oauth2_logout_consent.do", " ", null, true,
                         idTokenHint, false, CALLBACK_URL, null},
                 // opbs cookie and previous sessions are existing, userConsent is empty, sessionDataKey = null,
                 // skipUserConsent=true, a valid idTokenHint, isJWTSignedWithSPKey= true.
@@ -280,7 +291,7 @@ public class OIDCLogoutServletTest extends TestOIDCSessionBase {
                 {opbsCookie, true, redirectUrl[8], "application", " ", null, false,
                         idTokenNotAddedToDB, false, INVALID_CALLBACK_URL, null},
                 // AuthenticatorFlowStatus = SUCCESS_COMPLETED
-                {opbsCookie, true, redirectUrl[5], CALLBACK_URL, " ", null, true,
+                {opbsCookie, true, redirectUrl[5], "oauth2_logout_consent.do", " ", null, true,
                         idTokenHint, false, CALLBACK_URL, AuthenticatorFlowStatus.SUCCESS_COMPLETED},
                 // AuthenticatorFlowStatus = INCOMPLETE
                 {opbsCookie, true, redirectUrl[9], "retry", " ", null, true,
@@ -290,7 +301,7 @@ public class OIDCLogoutServletTest extends TestOIDCSessionBase {
                         REGEX_CALLBACK_URL, null},
                 // opbs cookie and previous sessions are existing, userConsent is empty, sessionDataKey = null,
                 // skipUserConsent=true, a valid idTokenHint with tenant domain in realm, and valid postLogoutUri.
-                {opbsCookie, true, redirectUrl[5], CALLBACK_URL, " ", null, true,
+                {opbsCookie, true, redirectUrl[5], "oauth2_logout_consent.do", " ", null, true,
                         idTokenHintWithRealm, false, CALLBACK_URL, null},
 
         };
@@ -378,6 +389,21 @@ public class OIDCLogoutServletTest extends TestOIDCSessionBase {
         mockServiceURLBuilder(OIDCSessionConstants.OIDCEndpoints.OIDC_LOGOUT_ENDPOINT);
 
         ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+
+        mockStatic(OIDCSessionDataCache.class);
+        when(OIDCSessionDataCache.getInstance()).thenReturn(oidcSessionDataCache);
+        OIDCSessionDataCacheKey opbsKey = mock(OIDCSessionDataCacheKey.class);
+        OIDCSessionDataCacheKey sessionIdKey = mock(OIDCSessionDataCacheKey.class);
+        when(opbsKey.getSessionDataId()).thenReturn(OPBROWSER_STATE);
+        when(sessionIdKey.getSessionDataId()).thenReturn(sessionDataKey);
+        when(OIDCSessionDataCache.getInstance().getValueFromCache(opbsKey)).thenReturn(opbsCacheEntry);
+        when(OIDCSessionDataCache.getInstance().getValueFromCache(sessionIdKey)).thenReturn(sessionIdCacheEntry);
+        ConcurrentMap<String, String> paramMap = new ConcurrentHashMap<>();
+        paramMap.put(OIDCSessionConstants.OIDC_CACHE_CLIENT_ID_PARAM, CLIENT_ID_VALUE);
+        paramMap.put(OIDCSessionConstants.OIDC_CACHE_TENANT_DOMAIN_PARAM, SUPER_TENANT_DOMAIN_NAME);
+        when(opbsCacheEntry.getParamMap()).thenReturn(paramMap);
+        when(sessionIdCacheEntry.getParamMap()).thenReturn(paramMap);
+
         logoutServlet.doGet(request, response);
         verify(response).sendRedirect(captor.capture());
         assertTrue(captor.getValue().contains(expected));

--- a/components/org.wso2.carbon.identity.oidc.session/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.identity.oidc.session/src/test/resources/testng.xml
@@ -27,6 +27,7 @@
         <class name="org.wso2.carbon.identity.oidc.session.OIDCSessionManagerTest"/>
         <class name="org.wso2.carbon.identity.oidc.session.OIDCSessionStateTest"/>
         <class name="org.wso2.carbon.identity.oidc.session.cache.OIDCSessionParticipantCacheTest"/>
+        <class name="org.wso2.carbon.identity.oidc.session.cache.OIDCSessionDataCacheTest"/>
         <class name="org.wso2.carbon.identity.oidc.session.config.OIDCSessionManagementConfigurationTest" />
     </classes>
 </test>
@@ -39,6 +40,7 @@
             <class name="org.wso2.carbon.identity.oidc.session.OIDCSessionManagerTest"/>
             <class name="org.wso2.carbon.identity.oidc.session.OIDCSessionStateTest"/>
             <class name="org.wso2.carbon.identity.oidc.session.cache.OIDCSessionParticipantCacheTest"/>
+            <class name="org.wso2.carbon.identity.oidc.session.cache.OIDCSessionDataCacheTest"/>
             <class name="org.wso2.carbon.identity.oidc.session.config.OIDCSessionManagementConfigurationTest" />
         </classes>
     </test>


### PR DESCRIPTION
Resolves https://github.com/wso2/product-is/issues/11313

OIDCSessionDataCache is not implemented as a persistence cache. This causes OIDC logout fails in a multi-node environment if sticky sessions are not enabled. Hence, with this PR the OIDCSessionDataCache is improved to be a persistence cache to overcome this issue. 