### PR TITLE
Fix back channel logout event name

### DIFF
--- a/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/backchannellogout/DefaultLogoutTokenBuilder.java
+++ b/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/backchannellogout/DefaultLogoutTokenBuilder.java
@@ -72,7 +72,7 @@ public class DefaultLogoutTokenBuilder implements LogoutTokenBuilder {
     private static final String OPENID_IDP_ENTITY_ID = "IdPEntityId";
     private static final String ERROR_GET_RESIDENT_IDP =
             "Error while getting Resident Identity Provider of '%s' tenant.";
-    private static final String BACKCHANNEL_LOGOUT_EVENT = "http://schemas.openidnet/event/backchannel-logout";
+    private static final String BACKCHANNEL_LOGOUT_EVENT = "http://schemas.openid.net/event/backchannel-logout";
 
     public DefaultLogoutTokenBuilder() throws IdentityOAuth2Exception {
 


### PR DESCRIPTION
### Proposed changes in this pull request

Fix the error in the back-channel logout event name in logout token builder.

Related issue - https://github.com/wso2/product-is/issues/7680
