### PR TITLE
Remove tenantdomain from username in password grant error response if tenant qualified url is enabled

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/PasswordGrantHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/PasswordGrantHandler.java
@@ -222,7 +222,12 @@ public class PasswordGrantHandler extends AbstractAuthorizationGrantHandler {
                         (tokenReq.getResourceOwnerUsername()))) {
                     throw new IdentityOAuth2Exception("Authentication failed for " + tenantAwareUserName);
                 }
-                throw new IdentityOAuth2Exception("Authentication failed for " + tokenReq.getResourceOwnerUsername());
+                String username = tokenReq.getResourceOwnerUsername();
+                if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled()) {
+                    // For tenant qualified urls, no need to send fully qualified username in response.
+                    username = tenantAwareUserName;
+                }
+                throw new IdentityOAuth2Exception("Authentication failed for " + username);
             } else if (isPublishPasswordGrantLoginEnabled) {
                 publishAuthenticationData(tokenReq, true, serviceProvider);
             }


### PR DESCRIPTION
### Proposed changes in this pull request

Related to https://github.com/wso2-enterprise/asgardeo-product/issues/2580

Responds back with tenant qualified username if tenant qualified URL is not enabled. If the config is enabled, responds back without the tenant domain part in the usernname