### PR TITLE
Made user defined keyset, user_code length, expires_in value configurable

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/device/DeviceEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/device/DeviceEndpoint.java
@@ -169,8 +169,8 @@ public class DeviceEndpoint {
                 .put(Constants.USER_CODE, userCode)
                 .put(Constants.VERIFICATION_URI, redirectionUri)
                 .put(Constants.VERIFICATION_URI_COMPLETE, redirectionUriComplete)
-                .put(Constants.EXPIRES_IN, stringValueInSeconds(Constants.EXPIRES_IN_VALUE))
-                .put(Constants.INTERVAL, stringValueInSeconds(Constants.INTERVAL_VALUE));
+                .put(Constants.EXPIRES_IN, stringValueInSeconds(Constants.EXPIRES_IN_MILLISECONDS))
+                .put(Constants.INTERVAL, stringValueInSeconds(Constants.INTERVAL_MILLISECONDS));
         Response.ResponseBuilder respBuilder = Response.status(HttpServletResponse.SC_OK);
         return respBuilder.entity(jsonObject.toString()).build();
     }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/device/api/DeviceAuthServiceImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/device/api/DeviceAuthServiceImpl.java
@@ -32,7 +32,7 @@ public class DeviceAuthServiceImpl implements DeviceAuthService {
             throws IdentityOAuth2Exception {
 
         DeviceFlowPersistenceFactory.getInstance().getDeviceFlowDAO().insertDeviceFlowParameters(deviceCode,
-                userCode, clientId, Constants.EXPIRES_IN_VALUE, Constants.INTERVAL_VALUE, scopes);
+                userCode, clientId, Constants.EXPIRES_IN_MILLISECONDS, Constants.INTERVAL_MILLISECONDS, scopes);
     }
 
     @Override

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/device/constants/Constants.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/device/constants/Constants.java
@@ -51,11 +51,22 @@ public class Constants {
     public static final String SEPARATED_WITH_SPACE = " ";
     public static final String ERROR = "error";
     public static final String ERROR_DESCRIPTION = "error_description";
+    public static final String DEVICE_DO_ENDPOINT = "/authenticationendpoint/device.do";
+    public static final String DEVICE_SUCCESS_DO_ENDPOINT = "/authenticationendpoint/device_success.do";
+    public static final String IDN_OAUTH2_DEVICE_FLOW = "IDN_OAUTH2_DEVICE_FLOW";
+    public static final String QUANTIFIER = "QUANTIFIER";
+    public static final String USRCDE_QNTFR_CONSTRAINT = "USRCDE_QNTFR_CONSTRAINT";
+
+    public static final String EXPIRY_TIME_PATH = "OAuth.SupportedGrantTypes.SupportedGrantType.ExpiryTime";
+    public static final String CONF_KEY_SET = "OAuth.SupportedGrantTypes.SupportedGrantType.KeySet";
+    public static final String CONF_USER_CODE_LENGTH = "OAuth.SupportedGrantTypes.SupportedGrantType.UserCodeLength";
+    public static final String RESPNSE_TO_STRING_PATH = "OAuth.SupportedGrantTypes.SupportedGrantType.ResponseToString";
 
     // Configurable values.
     public static final int KEY_LENGTH = 6;
-    public static final long EXPIRES_IN_VALUE = 600000L;
-    public static final int INTERVAL_VALUE = 5000;
+    public static final long EXPIRES_IN_VALUE = 600L;  //in seconds
+    public static final int INTERVAL_VALUE = 5000; //in milliseconds
     public static final String KEY_SET = "BCDFGHJKLMNPQRSTVWXYZbcdfghjklmnpqrstvwxyz23456789";
-
+    public static final int DEFAULT_DEVICE_TOKEN_PERSIST_RETRY_COUNT = 5;
+    public static final boolean SET_RESPONSE_TO_STRING = false;
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/device/constants/Constants.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/device/constants/Constants.java
@@ -51,9 +51,9 @@ public class Constants {
     public static final String SEPARATED_WITH_SPACE = " ";
     public static final String ERROR = "error";
     public static final String ERROR_DESCRIPTION = "error_description";
-    public static final String DEVICE_DO_ENDPOINT = "/authenticationendpoint/device.do";
-    public static final String DEVICE_SUCCESS_DO_ENDPOINT = "/authenticationendpoint/device_success.do";
-    public static final String USRCDE_QNTFR_CONSTRAINT = "USRCDE_QNTFR_CONSTRAINT";
+    public static final String DEVICE_ENDPOINT_PATH = "/authenticationendpoint/device.do";
+    public static final String DEVICE_SUCCESS_ENDPOINT_PATH = "/authenticationendpoint/device_success.do";
+    public static final String USERCODE_QUANTIFIER_CONSTRAINT = "USRCDE_QNTFR_CONSTRAINT";
 
     public static final String EXPIRY_TIME_PATH = "OAuth.SupportedGrantTypes.SupportedGrantType.ExpiryTime";
     public static final String CONF_KEY_SET = "OAuth.SupportedGrantTypes.SupportedGrantType.KeySet";
@@ -62,8 +62,8 @@ public class Constants {
 
     // Configurable values.
     public static final int KEY_LENGTH = 6;
-    public static final long EXPIRES_IN_VALUE = 600L;  //in seconds
-    public static final int INTERVAL_VALUE = 5000; //in milliseconds
+    public static final long EXPIRES_IN_MILLISECONDS = 600000L;
+    public static final int  INTERVAL_MILLISECONDS = 5000;
     public static final String KEY_SET = "BCDFGHJKLMNPQRSTVWXYZbcdfghjklmnpqrstvwxyz23456789";
     public static final int DEFAULT_DEVICE_TOKEN_PERSIST_RETRY_COUNT = 5;
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/device/constants/Constants.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/device/constants/Constants.java
@@ -53,8 +53,6 @@ public class Constants {
     public static final String ERROR_DESCRIPTION = "error_description";
     public static final String DEVICE_DO_ENDPOINT = "/authenticationendpoint/device.do";
     public static final String DEVICE_SUCCESS_DO_ENDPOINT = "/authenticationendpoint/device_success.do";
-    public static final String IDN_OAUTH2_DEVICE_FLOW = "IDN_OAUTH2_DEVICE_FLOW";
-    public static final String QUANTIFIER = "QUANTIFIER";
     public static final String USRCDE_QNTFR_CONSTRAINT = "USRCDE_QNTFR_CONSTRAINT";
 
     public static final String EXPIRY_TIME_PATH = "OAuth.SupportedGrantTypes.SupportedGrantType.ExpiryTime";
@@ -68,5 +66,4 @@ public class Constants {
     public static final int INTERVAL_VALUE = 5000; //in milliseconds
     public static final String KEY_SET = "BCDFGHJKLMNPQRSTVWXYZbcdfghjklmnpqrstvwxyz23456789";
     public static final int DEFAULT_DEVICE_TOKEN_PERSIST_RETRY_COUNT = 5;
-    public static final boolean SET_RESPONSE_TO_STRING = false;
 }


### PR DESCRIPTION
**Resolves**: wso2/product-is#7750

**Purpose**
To make configurable the values 'user defined keyset', its 'length', 'expires_in' time configurable in Device Authorization Grant (Device Flow).

**Describe the improvement**
Replaced the constants with configurable values through deployment.toml

**Product Version**
Wso2 IS 5.10.0

**How to reproduce**
Set the configurable values in deployment.toml