### PR TITLE
Use OAuth2Utils getIssuer method in LogoutTokenBuilder

### DIFF
--- a/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/backchannellogout/DefaultLogoutTokenBuilder.java
+++ b/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/backchannellogout/DefaultLogoutTokenBuilder.java
@@ -30,10 +30,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.base.MultitenantConstants;
 import org.wso2.carbon.core.util.KeyStoreManager;
-import org.wso2.carbon.identity.application.common.model.FederatedAuthenticatorConfig;
 import org.wso2.carbon.identity.application.common.model.IdentityProvider;
-import org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants;
-import org.wso2.carbon.identity.application.common.util.IdentityApplicationManagementUtil;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.oauth.common.exception.InvalidOAuthClientException;
 import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
@@ -59,6 +56,8 @@ import java.util.UUID;
 
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
+
+import static org.wso2.carbon.identity.oauth2.util.OAuth2Util.getIdTokenIssuer;
 
 /**
  * This is the logout token generator for the OpenID Connect back-channel logout Implementation. This
@@ -295,18 +294,7 @@ public class DefaultLogoutTokenBuilder implements LogoutTokenBuilder {
      */
     private String getIssuer(String tenantDomain) throws IdentityOAuth2Exception {
 
-        IdentityProvider identityProvider = getResidentIdp(tenantDomain);
-        FederatedAuthenticatorConfig[] fedAuthnConfigs =
-                identityProvider.getFederatedAuthenticatorConfigs();
-        // Get OIDC authenticator.
-        FederatedAuthenticatorConfig oidcAuthenticatorConfig =
-                IdentityApplicationManagementUtil.getFederatedAuthenticator(fedAuthnConfigs,
-                        IdentityApplicationConstants.Authenticator.OIDC.NAME);
-        // Setting issuer.
-        String issuer =
-                IdentityApplicationManagementUtil.getProperty(oidcAuthenticatorConfig.getProperties(),
-                        OPENID_IDP_ENTITY_ID).getValue();
-        return issuer;
+        return getIdTokenIssuer(tenantDomain);
     }
 
     /**


### PR DESCRIPTION
### Proposed changes in this pull request

Use `getIssuer` method in OAuth2Utils to get the token issuer when building the logout token.

Related to  - https://github.com/wso2/product-is/issues/9254