### PR TITLE
Add dcr and oauth scope APIs as jars inside the identity rest dispatcher

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.dcr.endpoint/pom.xml
+++ b/components/org.wso2.carbon.identity.oauth.dcr.endpoint/pom.xml
@@ -175,6 +175,36 @@
                 </configuration>
             </plugin-->
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>make-a-jar</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-install-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>Add-2-local-repository</id>
+                        <phase>package</phase>
+                        <configuration>
+                            <packaging>jar</packaging>
+                            <file>${project.build.directory}\${artifactId}-${version}.jar</file>
+                        </configuration>
+                        <goals>
+                            <goal>install-file</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
                 <executions>

--- a/components/org.wso2.carbon.identity.oauth.dcr.endpoint/src/main/resources/META-INF/cxf/oauth2-dcr-v1-1-cxf.xml
+++ b/components/org.wso2.carbon.identity.oauth.dcr.endpoint/src/main/resources/META-INF/cxf/oauth2-dcr-v1-1-cxf.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~  WSO2 Inc. licenses this file to you under the Apache License,
+  ~  Version 2.0 (the "License"); you may not use this file except
+  ~  in compliance with the License.
+  ~  You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing,
+  ~  software distributed under the License is distributed on an
+  ~  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~  KIND, either express or implied.  See the License for the
+  ~  specific language governing permissions and limitations
+  ~  under the License.
+  -->
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:jaxrs="http://cxf.apache.org/jaxrs" xmlns:context="http://www.springframework.org/schema/context" xsi:schemaLocation=" http://www.springframework.org/schema/beans  http://www.springframework.org/schema/beans/spring-beans-3.0.xsd http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd http://cxf.apache.org/jaxrs http://cxf.apache.org/schemas/jaxrs.xsd">
+
+    <bean class="org.wso2.carbon.identity.oauth2.dcr.endpoint.impl.RegisterApiServiceImpl"/>
+    <bean id="DCRMUtilBean" class="org.wso2.carbon.identity.oauth2.dcr.endpoint.util.DCRMUtils">
+        <property name="oAuth2DCRMService" ref="oAuth2DCRMServiceFactoryBean"/>
+    </bean>
+    <bean id="oAuth2DCRMServiceFactoryBean" class="org.wso2.carbon.identity.oauth2.dcr.endpoint.factory.OAuth2DCRMServiceFactory"/>
+
+</beans>

--- a/components/org.wso2.carbon.identity.oauth.dcr.endpoint/src/main/webapp/WEB-INF/beans.xml
+++ b/components/org.wso2.carbon.identity.oauth.dcr.endpoint/src/main/webapp/WEB-INF/beans.xml
@@ -5,6 +5,8 @@
     <context:annotation-config/>
     <bean class="org.springframework.context.support.PropertySourcesPlaceholderConfigurer"/>
     <bean class="org.springframework.beans.factory.config.PreferencesPlaceholderConfigurer"/>
+    <!-- For Identity Server, the jaxrs:server configuration is maintained in beans.xml of wso2/identity-rest-dispatcher
+         These configuration is maintained here as other products packing this webapp as .war -->
     <jaxrs:server id="services" address="/">
         <jaxrs:serviceBeans>
             <bean class="org.wso2.carbon.identity.oauth2.dcr.endpoint.RegisterApi"/>

--- a/components/org.wso2.carbon.identity.oauth.scope.endpoint/pom.xml
+++ b/components/org.wso2.carbon.identity.oauth.scope.endpoint/pom.xml
@@ -205,6 +205,36 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>make-a-jar</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-install-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>Add-2-local-repository</id>
+                        <phase>package</phase>
+                        <configuration>
+                            <packaging>jar</packaging>
+                            <file>${project.build.directory}\${artifactId}-${version}.jar</file>
+                        </configuration>
+                        <goals>
+                            <goal>install-file</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
                 <executions>

--- a/components/org.wso2.carbon.identity.oauth.scope.endpoint/src/main/resources/cxf/oauth2-v1-cxf.xml
+++ b/components/org.wso2.carbon.identity.oauth.scope.endpoint/src/main/resources/cxf/oauth2-v1-cxf.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~  WSO2 Inc. licenses this file to you under the Apache License,
+  ~  Version 2.0 (the "License"); you may not use this file except
+  ~  in compliance with the License.
+  ~  You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing,
+  ~  software distributed under the License is distributed on an
+  ~  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~  KIND, either express or implied.  See the License for the
+  ~  specific language governing permissions and limitations
+  ~  under the License.
+  -->
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:jaxrs="http://cxf.apache.org/jaxrs"
+       xmlns:context="http://www.springframework.org/schema/context" xmlns="http://www.springframework.org/schema/beans"
+       xsi:schemaLocation=" http://www.springframework.org/schema/beans  http://www.springframework.org/schema/beans/spring-beans-3.0.xsd http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd http://cxf.apache.org/jaxrs http://cxf.apache.org/schemas/jaxrs.xsd">
+
+    <bean class="org.wso2.carbon.identity.oauth.scope.endpoint.impl.ScopesApiServiceImpl"/>
+
+</beans>

--- a/components/org.wso2.carbon.identity.oauth.scope.endpoint/src/main/webapp/WEB-INF/beans.xml
+++ b/components/org.wso2.carbon.identity.oauth.scope.endpoint/src/main/webapp/WEB-INF/beans.xml
@@ -7,6 +7,8 @@
     <context:annotation-config/>
     <bean class="org.springframework.context.support.PropertySourcesPlaceholderConfigurer"/>
     <bean class="org.springframework.beans.factory.config.PreferencesPlaceholderConfigurer"/>
+    <!-- For Identity Server, the jaxrs:server configuration is maintained in beans.xml of wso2/identity-rest-dispatcher
+         These configuration is maintained here as other products packing this webapp as .war -->
     <jaxrs:server id="services" address="/">
         <jaxrs:serviceBeans>
             <bean class="org.wso2.carbon.identity.oauth.scope.endpoint.ScopesApi"/>

--- a/features/org.wso2.carbon.identity.oauth.dcr.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.oauth.dcr.server.feature/pom.xml
@@ -119,6 +119,14 @@
                                     <outputDirectory>${basedir}/src/main/resources/</outputDirectory>
                                     <destFileName>api#identity#oauth2#dcr#v1.1.war</destFileName>
                                 </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.wso2.carbon.identity.inbound.auth.oauth2</groupId>
+                                    <artifactId>org.wso2.carbon.identity.oauth2.dcr.endpoint</artifactId>
+                                    <version>${project.version}</version>
+                                    <type>jar</type>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>${basedir}/src/main/resources/api_resources</outputDirectory>
+                                </artifactItem>
                             </artifactItems>
                         </configuration>
                     </execution>

--- a/features/org.wso2.carbon.identity.oauth.dcr.server.feature/resources/p2.inf
+++ b/features/org.wso2.carbon.identity.oauth.dcr.server.feature/resources/p2.inf
@@ -3,3 +3,4 @@ org.eclipse.equinox.p2.touchpoint.natives.mkdir(path:${installFolder}/../../depl
 org.eclipse.equinox.p2.touchpoint.natives.mkdir(path:${installFolder}/../../deployment/server/);\
 org.eclipse.equinox.p2.touchpoint.natives.mkdir(path:${installFolder}/../../deployment/server/webapps/);\
 org.eclipse.equinox.p2.touchpoint.natives.copy(source:${installFolder}/../features/org.wso2.carbon.identity.oauth.dcr.server_${feature.version}/api#identity#oauth2#dcr#v1.1.war,target:${installFolder}/../../deployment/server/webapps/api#identity#oauth2#dcr#v1.1.war,overwrite:true);\
+org.eclipse.equinox.p2.touchpoint.natives.copy(source:${installFolder}/../features/org.wso2.carbon.identity.oauth.dcr.server_${feature.version}/api_resources/,target:${installFolder}/../../deployment/server/webapps/api_resources/,overwrite:true);\

--- a/features/org.wso2.carbon.identity.oauth.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.oauth.server.feature/pom.xml
@@ -152,6 +152,14 @@
                                 </artifactItem>
                                 <artifactItem>
                                     <groupId>org.wso2.carbon.identity.inbound.auth.oauth2</groupId>
+                                    <artifactId>org.wso2.carbon.identity.oauth.scope.endpoint</artifactId>
+                                    <version>${project.version}</version>
+                                    <type>jar</type>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>${basedir}/src/main/resources/api_resources</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.wso2.carbon.identity.inbound.auth.oauth2</groupId>
                                     <artifactId>org.wso2.carbon.identity.oauth.client.authn.filter</artifactId>
                                     <version>${project.version}</version>
                                     <type>jar</type>

--- a/features/org.wso2.carbon.identity.oauth.server.feature/resources/p2.inf
+++ b/features/org.wso2.carbon.identity.oauth.server.feature/resources/p2.inf
@@ -14,6 +14,7 @@ org.eclipse.equinox.p2.touchpoint.natives.mkdir(path:${installFolder}/../../depl
 org.eclipse.equinox.p2.touchpoint.natives.mkdir(path:${installFolder}/../../deployment/server/webapps/);\
 org.eclipse.equinox.p2.touchpoint.natives.copy(source:${installFolder}/../features/org.wso2.carbon.identity.oauth.server_${feature.version}/oauth2.war,target:${installFolder}/../../deployment/server/webapps/oauth2.war,overwrite:true);\
 org.eclipse.equinox.p2.touchpoint.natives.copy(source:${installFolder}/../features/org.wso2.carbon.identity.oauth.server_${feature.version}/api#identity#oauth2#v1.0.war,target:${installFolder}/../../deployment/server/webapps/api#identity#oauth2#v1.0.war,overwrite:true);\
+org.eclipse.equinox.p2.touchpoint.natives.copy(source:${installFolder}/../features/org.wso2.carbon.identity.oauth.server_${feature.version}/api_resources/,target:${installFolder}/../../deployment/server/webapps/api_resources/,overwrite:true);\
 org.eclipse.equinox.p2.touchpoint.natives.mkdir(path:${installFolder}/../../../lib/); \
 org.eclipse.equinox.p2.touchpoint.natives.mkdir(path:${installFolder}/../../../lib/runtimes/); \
 org.eclipse.equinox.p2.touchpoint.natives.mkdir(path:${installFolder}/../../../lib/runtimes/cxf3/); \


### PR DESCRIPTION
Add dcr and oauth scope as jars and deploy them as jars inside API rest dispatcher 
Related to https://github.com/wso2/product-is/issues/11425



As `api#identity#oauth2#dcr#v1.1.war` and `api#identity#oauth2#v1.0.war` are packed by other products, those wars will be kept as it is in the features and new jars will be copied inside `api_resources` then moved to api-dispatcher and wars will be removed in the product-is. Other products can remove `api_resources` folder and keep the wars.