### PR TITLE
Set authorized internal scopes to a property in context

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/Oauth2ScopeConstants.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/Oauth2ScopeConstants.java
@@ -30,7 +30,6 @@ public class Oauth2ScopeConstants {
     public static final String SCOPE_TYPE_OAUTH2 = "OAUTH2";
     public static final String SCOPE_TYPE_OIDC = "OIDC";
 
-
     /**
      * Enums for error messages.
      */

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/AuthorizationHandlerManager.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/AuthorizationHandlerManager.java
@@ -145,7 +145,7 @@ public class AuthorizationHandlerManager {
                     new String[0]));
         }
 
-        //Execute Internal SCOPE Validation.
+        // Execute Internal SCOPE Validation.
         JDBCPermissionBasedInternalScopeValidator scopeValidator = new JDBCPermissionBasedInternalScopeValidator();
         String[] authorizedInternalScopes = scopeValidator.validateScope(authzReqMsgCtx);
         // Clear the internal scopes. Internal scopes should only handle in JDBCPermissionBasedInternalScopeValidator.
@@ -153,6 +153,9 @@ public class AuthorizationHandlerManager {
         // Thus remove the scopes from the authzReqMsgCtx. Will be added to the response after executing
         // the other scope validators.
         removeInternalScopes(authzReqMsgCtx);
+
+        // Adding the authorized internal scopes to tokReqMsgCtx for any special validators to use.
+        authzReqMsgCtx.setAuthorizedInternalScopes(authorizedInternalScopes);
 
         boolean isDropUnregisteredScopes = OAuthServerConfiguration.getInstance().isDropUnregisteredScopes();
         if (isDropUnregisteredScopes) {
@@ -167,8 +170,8 @@ public class AuthorizationHandlerManager {
 
         boolean valid = validateScope(authzReqDTO, authorizeRespDTO, authzReqMsgCtx, authzHandler);
         if (valid) {
-            //Add authorized internal scopes to the request for sending in the response.
-            addAuthorizedInternalScopes(authzReqMsgCtx, authorizedInternalScopes);
+            // Add authorized internal scopes to the request for sending in the response.
+            addAuthorizedInternalScopes(authzReqMsgCtx, authzReqMsgCtx.getAuthorizedInternalScopes());
             addAllowedScopes(authzReqMsgCtx, requestedAllowedScopes.toArray(new String[0]));
         }
         return authorizeRespDTO;

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/OAuthAuthzReqMessageContext.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/OAuthAuthzReqMessageContext.java
@@ -45,6 +45,8 @@ public class OAuthAuthzReqMessageContext {
 
     private long codeIssuedTime;
 
+    private String[] authorizedInternalScopes;
+
     private Properties properties = new Properties();
 
     public OAuthAuthzReqMessageContext(OAuth2AuthorizeReqDTO authorizationReqDTO) {
@@ -158,5 +160,13 @@ public class OAuthAuthzReqMessageContext {
     public void setCodeIssuedTime(long codeIssuedTime) {
 
         this.codeIssuedTime = codeIssuedTime;
+    }
+
+    public String[] getAuthorizedInternalScopes() {
+        return authorizedInternalScopes;
+    }
+
+    public void setAuthorizedInternalScopes(String[] authorizedInternalScopes) {
+        this.authorizedInternalScopes = authorizedInternalScopes;
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuer.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuer.java
@@ -298,6 +298,9 @@ public class AccessTokenIssuer {
         // the other scope validators.
         removeInternalScopes(tokReqMsgCtx);
 
+        // Adding the authorized internal scopes to tokReqMsgCtx for any special validators to use.
+        tokReqMsgCtx.setAuthorizedInternalScopes(authorizedInternalScopes);
+
         boolean isDropUnregisteredScopes = OAuthServerConfiguration.getInstance().isDropUnregisteredScopes();
         if (isDropUnregisteredScopes) {
             if (log.isDebugEnabled()) {
@@ -311,8 +314,8 @@ public class AccessTokenIssuer {
 
         boolean isValidScope = authzGrantHandler.validateScope(tokReqMsgCtx);
         if (isValidScope) {
-            //Add authorized internal scopes to the request for sending in the response.
-            addAuthorizedInternalScopes(tokReqMsgCtx, authorizedInternalScopes);
+            // Add authorized internal scopes to the request for sending in the response.
+            addAuthorizedInternalScopes(tokReqMsgCtx, tokReqMsgCtx.getAuthorizedInternalScopes());
             addAllowedScopes(tokReqMsgCtx, requestedAllowedScopes.toArray(new String[0]));
         } else {
             if (log.isDebugEnabled()) {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/OAuthTokenReqMessageContext.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/OAuthTokenReqMessageContext.java
@@ -48,6 +48,8 @@ public class OAuthTokenReqMessageContext {
 
     private Properties properties = new Properties();
 
+    private String[] authorizedInternalScopes;
+
     private TokenBinding tokenBinding;
 
     public OAuthTokenReqMessageContext(OAuth2AccessTokenReqDTO oauth2AccessTokenReqDTO) {
@@ -148,5 +150,13 @@ public class OAuthTokenReqMessageContext {
     public void setTokenBinding(TokenBinding tokenBinding) {
 
         this.tokenBinding = tokenBinding;
+    }
+
+    public String[] getAuthorizedInternalScopes() {
+        return authorizedInternalScopes;
+    }
+
+    public void setAuthorizedInternalScopes(String[] authorizedInternalScopes) {
+        this.authorizedInternalScopes = authorizedInternalScopes;
     }
 }


### PR DESCRIPTION
### Proposed changes in this pull request
- Previously internal scopes (scopes with the prefix "internal_") were removed before invoking the scope validators. With this change, authorized internal scopes are set to a property in the context, so that they can be seen by the scope validators if needed.

Refers https://github.com/wso2-enterprise/asgardeo-product/issues/2631