### PR TITLE
Remove introspection data providers enable check during introspection

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/introspection/OAuth2IntrospectionEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/introspection/OAuth2IntrospectionEndpoint.java
@@ -23,7 +23,6 @@ import org.apache.commons.logging.LogFactory;
 import org.json.JSONException;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.core.handler.AbstractIdentityHandler;
-import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.IntrospectionDataProvider;
 import org.wso2.carbon.identity.oauth2.OAuth2TokenValidationService;
@@ -156,7 +155,8 @@ public class OAuth2IntrospectionEndpoint {
         for (Object dataProvider : introspectionDataProviders) {
             if (dataProvider instanceof IntrospectionDataProvider) {
 
-                if (!((AbstractIdentityHandler) dataProvider).isEnabled()) {
+                if (dataProvider instanceof AbstractIdentityHandler &&
+                        !((AbstractIdentityHandler) dataProvider).isEnabled()) {
                     if (log.isDebugEnabled()) {
                         log.debug(String.format("%s data provider is not enabled.",
                                 ((AbstractIdentityHandler) dataProvider).getName()));

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/introspection/OAuth2IntrospectionEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/introspection/OAuth2IntrospectionEndpoint.java
@@ -22,6 +22,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.json.JSONException;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.identity.core.handler.AbstractIdentityHandler;
 import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.IntrospectionDataProvider;
@@ -148,31 +149,34 @@ public class OAuth2IntrospectionEndpoint {
             respBuilder.setBindingReference(introspectionResponse.getBindingReference());
         }
 
-        // Check data providers are enabled for token introspection.
-        if (OAuthServerConfiguration.getInstance().isEnableIntrospectionDataProviders()) {
+        // Retrieve list of registered IntrospectionDataProviders.
+        List<Object> introspectionDataProviders = PrivilegedCarbonContext
+                .getThreadLocalCarbonContext().getOSGiServices(IntrospectionDataProvider.class, null);
 
-            // Retrieve list of registered IntrospectionDataProviders.
-            List<Object> introspectionDataProviders = PrivilegedCarbonContext
-                    .getThreadLocalCarbonContext().getOSGiServices(IntrospectionDataProvider.class, null);
+        for (Object dataProvider : introspectionDataProviders) {
+            if (dataProvider instanceof IntrospectionDataProvider) {
 
-            for (Object dataProvider : introspectionDataProviders) {
-                if (dataProvider instanceof IntrospectionDataProvider) {
-
+                if (!((AbstractIdentityHandler) dataProvider).isEnabled()) {
                     if (log.isDebugEnabled()) {
-                        log.debug("Executing introspection data provider: " + dataProvider.getClass().getName());
+                        log.debug(String.format("%s data provider is not enabled.",
+                                ((AbstractIdentityHandler) dataProvider).getName()));
                     }
-                    try {
-                        respBuilder.setAdditionalData(
-                                (((IntrospectionDataProvider) dataProvider).getIntrospectionData(
-                                        introspectionRequest, introspectionResponse)));
-                    } catch (IdentityOAuth2Exception e) {
-                        log.error("Error occurred while processing additional token introspection data.", e);
+                    continue;
+                }
+                if (log.isDebugEnabled()) {
+                    log.debug("Executing introspection data provider: " + dataProvider.getClass().getName());
+                }
+                try {
+                    respBuilder.setAdditionalData(
+                            (((IntrospectionDataProvider) dataProvider).getIntrospectionData(
+                                    introspectionRequest, introspectionResponse)));
+                } catch (IdentityOAuth2Exception e) {
+                    log.error("Error occurred while processing additional token introspection data.", e);
 
-                        return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
-                                .entity("{\"error\": \"Error occurred while building the introspection " +
-                                        "response.\"}")
-                                .build();
-                    }
+                    return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+                            .entity("{\"error\": \"Error occurred while building the introspection " +
+                                    "response.\"}")
+                            .build();
                 }
             }
         }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
@@ -1336,7 +1336,10 @@ public class OAuthServerConfiguration {
      * Returns whether introspection data providers should be enabled.
      *
      * @return true if introspection data providers should be enabled.
+     * @deprecated This configuration is deprecated from IS 5.12.0 onwards. Use EventListener configurations for data providers
+     * instead.
      */
+    @Deprecated
     public boolean isEnableIntrospectionDataProviders() {
 
         return enableIntrospectionDataProviders;

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
@@ -1336,8 +1336,8 @@ public class OAuthServerConfiguration {
      * Returns whether introspection data providers should be enabled.
      *
      * @return true if introspection data providers should be enabled.
-     * @deprecated This configuration is deprecated from IS 5.12.0 onwards. Use EventListener configurations for data providers
-     * instead.
+     * @deprecated This configuration is deprecated from IS 5.12.0 onwards. Use EventListener configurations for
+     * data providers instead.
      */
     @Deprecated
     public boolean isEnableIntrospectionDataProviders() {


### PR DESCRIPTION
### Proposed changes in this pull request
> This PR removes the `EnableDataProviders` configuration in identity.xml check during token introspection.
> Fixes https://github.com/wso2/product-is/issues/11351