### PR TITLE
added token_endpoint_auth_method support

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.dcr/src/gen/java/org/wso2/carbon/identity/oauth2/dcr/endpoint/dto/ApplicationDTO.java
+++ b/components/org.wso2.carbon.identity.api.server.dcr/src/gen/java/org/wso2/carbon/identity/oauth2/dcr/endpoint/dto/ApplicationDTO.java
@@ -34,7 +34,11 @@ public class ApplicationDTO  {
   
   private String clientName = null;
 
-  
+
+  private String tokenEndpointAuthMethod = null;
+
+
+
   /**
    **/
   @ApiModelProperty(value = "")
@@ -106,6 +110,16 @@ public class ApplicationDTO  {
     this.clientName = clientName;
   }
 
+
+  /**
+   **/
+  @ApiModelProperty(value = "")
+  @JsonProperty("token_endpoint_auth_method")
+  public String getTokenEndpointAuthMethod() { return tokenEndpointAuthMethod; }
+  public void setTokenEndpointAuthMethod(String tokenEndpointAuthMethod) {
+    this.tokenEndpointAuthMethod = tokenEndpointAuthMethod;
+  }
+
   
 
   @Override
@@ -119,6 +133,7 @@ public class ApplicationDTO  {
     sb.append("  redirect_uris: ").append(redirectUris).append("\n");
     sb.append("  grant_types: ").append(grantTypes).append("\n");
     sb.append("  client_name: ").append(clientName).append("\n");
+    sb.append(" token_endpoint_auth_method: ").append(tokenEndpointAuthMethod).append("\n");
     sb.append("}\n");
     return sb.toString();
   }

--- a/components/org.wso2.carbon.identity.api.server.dcr/src/gen/java/org/wso2/carbon/identity/oauth2/dcr/endpoint/dto/RegistrationRequestDTO.java
+++ b/components/org.wso2.carbon.identity.api.server.dcr/src/gen/java/org/wso2/carbon/identity/oauth2/dcr/endpoint/dto/RegistrationRequestDTO.java
@@ -1,201 +1,283 @@
 package org.wso2.carbon.identity.oauth2.dcr.endpoint.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
-
 import java.util.ArrayList;
 import java.util.List;
+
+import io.swagger.annotations.*;
+import com.fasterxml.jackson.annotation.*;
+
 import javax.validation.constraints.NotNull;
 
 
-@ApiModel
+
+
+
+@ApiModel(description = "")
 public class RegistrationRequestDTO  {
 
+
   @NotNull
-  private List<String> redirectUris = new ArrayList<>();
+  private List<String> redirectUris = new ArrayList<String>();
+
   @NotNull
   private String clientName = null;
-  private List<String> grantTypes = new ArrayList<>();
-  private String applicationType = null;
-  private String jwksUri = null;
-  private String url = null;
-  private String clientId = null;
-  private String clientSecret = null;
-  private List<String> contacts = new ArrayList<>();
-  private List<String> postLogoutRedirectUris = new ArrayList<>();
-  private List<String> requestUris = new ArrayList<>();
-  private List<String> responseTypes = new ArrayList<>();
-  private String tokenType = null;
-  private String spTemplateName = null;
-  private String backchannelLogoutUri = null;
-  private boolean backchannelLogoutSessionRequired;
 
-  @ApiModelProperty(required = true)
+
+  private List<String> grantTypes = new ArrayList<String>();
+
+
+  private String applicationType = null;
+
+
+  private String jwksUri = null;
+
+
+  private String url = null;
+
+
+  private String clientId = null;
+
+
+  private String clientSecret = null;
+
+
+  private List<String> contacts = new ArrayList<String>();
+
+
+  private List<String> postLogoutRedirectUris = new ArrayList<String>();
+
+
+  private List<String> requestUris = new ArrayList<String>();
+
+
+  private List<String> responseTypes = new ArrayList<String>();
+
+
+  private String spTemplateName = null;
+
+
+  private String backchannelLogoutUri = null;
+
+
+  private Boolean backchannelLogoutSessionRequired = null;
+
+
+  private String tokenEndpointAuthMethod = null;
+
+
+  private String tokenType = null;
+
+
+  /**
+   **/
+  @ApiModelProperty(required = true, value = "")
   @JsonProperty("redirect_uris")
   public List<String> getRedirectUris() {
     return redirectUris;
   }
-
   public void setRedirectUris(List<String> redirectUris) {
     this.redirectUris = redirectUris;
   }
 
-  @ApiModelProperty(required = true)
+
+  /**
+   **/
+  @ApiModelProperty(required = true, value = "")
   @JsonProperty("client_name")
   public String getClientName() {
     return clientName;
   }
-
   public void setClientName(String clientName) {
     this.clientName = clientName;
   }
 
-  @ApiModelProperty
+
+  /**
+   **/
+  @ApiModelProperty(value = "")
   @JsonProperty("grant_types")
   public List<String> getGrantTypes() {
     return grantTypes;
   }
-
   public void setGrantTypes(List<String> grantTypes) {
     this.grantTypes = grantTypes;
   }
 
-  @ApiModelProperty
+
+  /**
+   **/
+  @ApiModelProperty(value = "")
   @JsonProperty("application_type")
   public String getApplicationType() {
     return applicationType;
   }
-
   public void setApplicationType(String applicationType) {
     this.applicationType = applicationType;
   }
 
-  @ApiModelProperty
+
+  /**
+   **/
+  @ApiModelProperty(value = "")
   @JsonProperty("jwks_uri")
   public String getJwksUri() {
     return jwksUri;
   }
-
   public void setJwksUri(String jwksUri) {
     this.jwksUri = jwksUri;
   }
 
-  @ApiModelProperty
+
+  /**
+   **/
+  @ApiModelProperty(value = "")
   @JsonProperty("url")
   public String getUrl() {
     return url;
   }
-
   public void setUrl(String url) {
     this.url = url;
   }
 
-  @ApiModelProperty
+
+  /**
+   **/
+  @ApiModelProperty(value = "")
   @JsonProperty("ext_param_client_id")
   public String getClientId() {
     return clientId;
   }
-
   public void setClientId(String clientId) {
     this.clientId = clientId;
   }
 
-  @ApiModelProperty
+
+  /**
+   **/
+  @ApiModelProperty(value = "")
   @JsonProperty("ext_param_client_secret")
   public String getClientSecret() {
     return clientSecret;
   }
-
   public void setClientSecret(String clientSecret) {
     this.clientSecret = clientSecret;
   }
 
-  @ApiModelProperty
+
+  /**
+   **/
+  @ApiModelProperty(value = "")
   @JsonProperty("contacts")
   public List<String> getContacts() {
     return contacts;
   }
-
   public void setContacts(List<String> contacts) {
     this.contacts = contacts;
   }
 
-  @ApiModelProperty
+
+  /**
+   **/
+  @ApiModelProperty(value = "")
   @JsonProperty("post_logout_redirect_uris")
   public List<String> getPostLogoutRedirectUris() {
     return postLogoutRedirectUris;
   }
-
   public void setPostLogoutRedirectUris(List<String> postLogoutRedirectUris) {
     this.postLogoutRedirectUris = postLogoutRedirectUris;
   }
 
-  @ApiModelProperty
+
+  /**
+   **/
+  @ApiModelProperty(value = "")
   @JsonProperty("request_uris")
   public List<String> getRequestUris() {
     return requestUris;
   }
-
   public void setRequestUris(List<String> requestUris) {
     this.requestUris = requestUris;
   }
 
-  @ApiModelProperty
+
+  /**
+   **/
+  @ApiModelProperty(value = "")
   @JsonProperty("response_types")
   public List<String> getResponseTypes() {
     return responseTypes;
   }
-
   public void setResponseTypes(List<String> responseTypes) {
     this.responseTypes = responseTypes;
   }
 
-  @ApiModelProperty
-  @JsonProperty("token_type_extension")
-  public String getTokenType() {
-    return tokenType;
-  }
 
-  public void setTokenType(String tokenType) {
-    this.tokenType = tokenType;
-  }
-
-  @ApiModelProperty
-  @JsonProperty("backchannel_logout_uri")
-  public String getBackchannelLogoutUri() {
-    return backchannelLogoutUri;
-  }
-
-  public void setBackchannelLogoutUri(String backchannelLogoutUri) {
-    this.backchannelLogoutUri = backchannelLogoutUri;
-  }
-
-  @ApiModelProperty
-  @JsonProperty("backchannel_logout_session_required")
-  public boolean getBackchannelLogoutSessionRequired() {
-    return backchannelLogoutSessionRequired;
-  }
-
-  public void setBackchannelLogoutSessionRequired(boolean backchannelLogoutSessionRequired) {
-    this.backchannelLogoutSessionRequired = backchannelLogoutSessionRequired;
-  }
-
-  @ApiModelProperty
+  /**
+   **/
+  @ApiModelProperty(value = "")
   @JsonProperty("ext_param_sp_template")
   public String getSpTemplateName() {
     return spTemplateName;
   }
-
   public void setSpTemplateName(String spTemplateName) {
     this.spTemplateName = spTemplateName;
   }
+
+
+  /**
+   **/
+  @ApiModelProperty(value = "")
+  @JsonProperty("backchannel_logout_uri")
+  public String getBackchannelLogoutUri() {
+    return backchannelLogoutUri;
+  }
+  public void setBackchannelLogoutUri(String backchannelLogoutUri) {
+    this.backchannelLogoutUri = backchannelLogoutUri;
+  }
+
+
+  /**
+   **/
+  @ApiModelProperty(value = "")
+  @JsonProperty("backchannel_logout_session_required")
+  public Boolean getBackchannelLogoutSessionRequired() {
+    return backchannelLogoutSessionRequired;
+  }
+  public void setBackchannelLogoutSessionRequired(Boolean backchannelLogoutSessionRequired) {
+    this.backchannelLogoutSessionRequired = backchannelLogoutSessionRequired;
+  }
+
+
+  /**
+   **/
+  @ApiModelProperty(value = "")
+  @JsonProperty("token_endpoint_auth_method")
+  public String getTokenEndpointAuthMethod() {
+    return tokenEndpointAuthMethod;
+  }
+  public void setTokenEndpointAuthMethod(String tokenEndpointAuthMethod) {
+    this.tokenEndpointAuthMethod = tokenEndpointAuthMethod;
+  }
+
+
+  /**
+   **/
+  @ApiModelProperty(value = "")
+  @JsonProperty("token_type_extension")
+  public String getTokenType() {
+    return tokenType;
+  }
+  public void setTokenType(String tokenType) {
+    this.tokenType = tokenType;
+  }
+
+
 
   @Override
   public String toString()  {
     StringBuilder sb = new StringBuilder();
     sb.append("class RegistrationRequestDTO {\n");
-    
+
     sb.append("  redirect_uris: ").append(redirectUris).append("\n");
     sb.append("  client_name: ").append(clientName).append("\n");
     sb.append("  grant_types: ").append(grantTypes).append("\n");
@@ -212,6 +294,7 @@ public class RegistrationRequestDTO  {
     sb.append("  ext_param_sp_template: ").append(spTemplateName).append("\n");
     sb.append("  backchannel_logout_uri: ").append(backchannelLogoutUri).append("\n");
     sb.append("  backchannel_logout_session_required: ").append(backchannelLogoutSessionRequired).append("\n");
+    sb.append("  token_endpoint_auth_method: ").append(tokenEndpointAuthMethod).append("\n");
     sb.append("}\n");
     return sb.toString();
   }

--- a/components/org.wso2.carbon.identity.api.server.dcr/src/gen/java/org/wso2/carbon/identity/oauth2/dcr/endpoint/dto/UpdateRequestDTO.java
+++ b/components/org.wso2.carbon.identity.api.server.dcr/src/gen/java/org/wso2/carbon/identity/oauth2/dcr/endpoint/dto/UpdateRequestDTO.java
@@ -19,6 +19,8 @@ public class UpdateRequestDTO {
     private String clientSecret = null;
     private String backchannelLogoutUri = null;
     private boolean backchannelLogoutSessionRequired;
+    private String tokenEndpointAuthMethod = null;
+
 
     @ApiModelProperty
     @JsonProperty("redirect_uris")
@@ -99,6 +101,15 @@ public class UpdateRequestDTO {
         this.backchannelLogoutSessionRequired = backchannelLogoutSessionRequired;
     }
 
+    /**
+     **/
+    @ApiModelProperty(value = "")
+    @JsonProperty("token_endpoint_auth_method")
+    public String getTokenEndpointAuthMethod() { return tokenEndpointAuthMethod; }
+    public void setTokenEndpointAuthMethod(String tokenEndpointAuthMethod) {
+        this.tokenEndpointAuthMethod = tokenEndpointAuthMethod;
+    }
+
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
@@ -112,6 +123,7 @@ public class UpdateRequestDTO {
         sb.append("  client_secret: ").append(clientSecret).append("\n");
         sb.append("  backchannel_logout_uri: ").append(backchannelLogoutUri).append("\n");
         sb.append("  backchannel_logout_session_required: ").append(backchannelLogoutSessionRequired).append("\n");
+        sb.append("  token_endpoint_auth_method: ").append(tokenEndpointAuthMethod).append("\n");
         sb.append("}\n");
         return sb.toString();
     }

--- a/components/org.wso2.carbon.identity.api.server.dcr/src/main/java/org/wso2/carbon/identity/oauth2/dcr/endpoint/util/DCRMUtils.java
+++ b/components/org.wso2.carbon.identity.api.server.dcr/src/main/java/org/wso2/carbon/identity/oauth2/dcr/endpoint/util/DCRMUtils.java
@@ -67,6 +67,7 @@ public class DCRMUtils {
         appRegistrationRequest.setConsumerSecret(registrationRequestDTO.getClientSecret());
         appRegistrationRequest.setSpTemplateName(registrationRequestDTO.getSpTemplateName());
         appRegistrationRequest.setBackchannelLogoutUri(registrationRequestDTO.getBackchannelLogoutUri());
+        appRegistrationRequest.setTokenEndpointAuthMethod(registrationRequestDTO.getTokenEndpointAuthMethod());
         return appRegistrationRequest;
 
     }
@@ -79,6 +80,7 @@ public class DCRMUtils {
         applicationUpdateRequest.setGrantTypes(updateRequestDTO.getGrantTypes());
         applicationUpdateRequest.setTokenType(updateRequestDTO.getTokenType());
         applicationUpdateRequest.setBackchannelLogoutUri(updateRequestDTO.getBackchannelLogoutUri());
+        applicationUpdateRequest.setTokenEndpointAuthMethod(updateRequestDTO.getTokenEndpointAuthMethod());
         return applicationUpdateRequest;
 
     }
@@ -150,6 +152,8 @@ public class DCRMUtils {
         applicationDTO.setClientSecret(application.getClientSecret());
         applicationDTO.setRedirectUris(application.getRedirectUris());
         applicationDTO.setGrantTypes(application.getGrantTypes());
+        applicationDTO.setTokenEndpointAuthMethod(application.getTokenEndpointAuthMethod());
+
 
         return applicationDTO;
     }

--- a/components/org.wso2.carbon.identity.api.server.dcr/src/main/java/org/wso2/carbon/identity/oauth2/dcr/endpoint/util/DCRMUtils.java
+++ b/components/org.wso2.carbon.identity.api.server.dcr/src/main/java/org/wso2/carbon/identity/oauth2/dcr/endpoint/util/DCRMUtils.java
@@ -154,7 +154,6 @@ public class DCRMUtils {
         applicationDTO.setGrantTypes(application.getGrantTypes());
         applicationDTO.setTokenEndpointAuthMethod(application.getTokenEndpointAuthMethod());
 
-
         return applicationDTO;
     }
 

--- a/components/org.wso2.carbon.identity.api.server.dcr/src/main/resources/api.identity.oauth.dcr.endpoint.yaml
+++ b/components/org.wso2.carbon.identity.api.server.dcr/src/main/resources/api.identity.oauth.dcr.endpoint.yaml
@@ -308,6 +308,8 @@ definitions:
         type: string
       backchannel_logout_session_required:
         type: boolean
+      token_endpoint_auth_method:
+        type: string
 #-----------------------------------------------------
 # The Application Update Request Object
 #-----------------------------------------------------
@@ -332,6 +334,8 @@ definitions:
         type: string
       backchannel_logout_session_required:
         type: boolean
+      token_endpoint_auth_method:
+        type: string
 #-----------------------------------------------------
 # The OAuth2 Application Object
 #-----------------------------------------------------
@@ -353,6 +357,8 @@ definitions:
         items:
           type: string
       client_name:
+        type: string
+      token_endpoint_auth_method:
         type: string
 #-----------------------------------------------------
 # The Error Response object

--- a/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
+++ b/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
@@ -457,6 +457,7 @@ public final class OAuthConstants {
                 "tokenRevocationWithIDPSessionTermination";
         public static final String TOKEN_BINDING_VALIDATION = "tokenBindingValidation";
         public static final String TOKEN_BINDING_TYPE_NONE = "None";
+        public static final String TOKEN_ENDPOINT_AUTH_METHOD = "tokenEndpointAuthMethod";
 
         private OIDCConfigProperties() {
 

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/DCRMConstants.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/DCRMConstants.java
@@ -42,6 +42,7 @@ public class DCRMConstants {
         BAD_REQUEST_INVALID_SP_NAME("Client Name is not adhering to the regex: %s"),
         BAD_REQUEST_INVALID_SP_TEMPLATE_NAME("Invalid service provider template name: %s"),
         BAD_REQUEST_INVALID_INPUT("%s"),
+        BAD_REQUEST_INVALID_TOKEN_ENDPOINT_AUTH_METHOD("Invalid token endpoint auth method: %s"),
         BAD_REQUEST_INSUFFICIENT_DATA("Insufficient data in the request"),
         NOT_FOUND_APPLICATION_WITH_ID("Application not available for given client key: %s"),
         NOT_FOUND_APPLICATION_WITH_NAME("Application not available for given client name: %s"),

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/bean/Application.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/bean/Application.java
@@ -33,6 +33,7 @@ public class Application implements Serializable {
     private String clientSecret = null;
     private List<String> redirectUris = null;
     private List<String> grantTypes = null;
+    private String tokenEndpointAuthMethod = null;
 
     public String getClientName() {
 
@@ -84,6 +85,16 @@ public class Application implements Serializable {
         this.grantTypes = grantTypes;
     }
 
+    public String getTokenEndpointAuthMethod() {
+
+        return tokenEndpointAuthMethod;
+    }
+
+    public void setTokenEndpointAuthMethod(String tokenEndpointAuthMethod) {
+
+        this.tokenEndpointAuthMethod = tokenEndpointAuthMethod;
+    }
+
     @Override
     public String toString() {
 
@@ -93,6 +104,7 @@ public class Application implements Serializable {
                 "  clientSecret: " + this.clientSecret + "\n" +
                 "  redirectUris: " + this.redirectUris + "\n" +
                 "  grantTypes: " + this.grantTypes + "\n" +
+                "  tokenEndpointAuthMethod: " + this.tokenEndpointAuthMethod + "\n" +
                 "}\n";
     }
 }

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/bean/ApplicationRegistrationRequest.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/bean/ApplicationRegistrationRequest.java
@@ -37,6 +37,8 @@ public class ApplicationRegistrationRequest implements Serializable {
     private String consumerSecret = null;
     private String spTemplateName = null;
     private String backchannelLogoutUri = null;
+    private String tokenEndpointAuthMethod = null;
+
 
     public List<String> getRedirectUris() {
 
@@ -106,6 +108,16 @@ public class ApplicationRegistrationRequest implements Serializable {
     public void setBackchannelLogoutUri(String backchannelLogoutUri) {
 
         this.backchannelLogoutUri = backchannelLogoutUri;
+    }
+
+    public String getTokenEndpointAuthMethod() {
+
+        return tokenEndpointAuthMethod;
+    }
+
+    public void setTokenEndpointAuthMethod(String tokenEndpointAuthMethod) {
+
+        this.tokenEndpointAuthMethod = tokenEndpointAuthMethod;
     }
 
     /**

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/bean/ApplicationUpdateRequest.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/bean/ApplicationUpdateRequest.java
@@ -34,6 +34,8 @@ public class ApplicationUpdateRequest implements Serializable {
     private List<String> grantTypes = new ArrayList<>();
     private String tokenType = null;
     private String backchannelLogoutUri = null;
+    private String tokenEndpointAuthMethod = null;
+
 
     public List<String> getRedirectUris() {
 
@@ -83,5 +85,15 @@ public class ApplicationUpdateRequest implements Serializable {
     public void setBackchannelLogoutUri(String backchannelLogoutUri) {
 
         this.backchannelLogoutUri = backchannelLogoutUri;
+    }
+
+    public String getTokenEndpointAuthMethod() {
+
+        return tokenEndpointAuthMethod;
+    }
+
+    public void setTokenEndpointAuthMethod(String tokenEndpointAuthMethod) {
+
+        this.tokenEndpointAuthMethod = tokenEndpointAuthMethod;
     }
 }

--- a/components/org.wso2.carbon.identity.oauth.stub/src/main/resources/OAuthAdminService.wsdl
+++ b/components/org.wso2.carbon.identity.oauth.stub/src/main/resources/OAuthAdminService.wsdl
@@ -418,6 +418,7 @@
                     <xs:element minOccurs="0" name="tokenBindingType" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="tokenBindingValidationEnabled" type="xs:boolean"/>
                     <xs:element minOccurs="0" name="tokenRevocationWithIDPSessionTerminationEnabled" type="xs:boolean"/>
+                    <xs:element minOccurs="0" name="tokenEndpointAuthMethod" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="tokenType" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="userAccessTokenExpiryTime" type="xs:long"/>
                     <xs:element minOccurs="0" name="username" nillable="true" type="xs:string"/>

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImpl.java
@@ -304,6 +304,8 @@ public class OAuthAdminServiceImpl {
                     app.setTokenBindingValidationEnabled(application.isTokenBindingValidationEnabled());
                     app.setTokenRevocationWithIDPSessionTerminationEnabled(
                             application.isTokenRevocationWithIDPSessionTerminationEnabled());
+                    app.setTokenEndpointAuthMethod(application.getTokenEndpointAuthMethod());
+
                 }
                 dao.addOAuthApplication(app);
                 AppInfoCache.getInstance().addToCache(app.getOauthConsumerKey(), app);
@@ -496,6 +498,7 @@ public class OAuthAdminServiceImpl {
             oauthappdo.setTokenRevocationWithIDPSessionTerminationEnabled(consumerAppDTO
                     .isTokenRevocationWithIDPSessionTerminationEnabled());
             oauthappdo.setTokenBindingValidationEnabled(consumerAppDTO.isTokenBindingValidationEnabled());
+            oauthappdo.setTokenEndpointAuthMethod(consumerAppDTO.getTokenEndpointAuthMethod());
         }
         dao.updateConsumerApplication(oauthappdo);
         AppInfoCache.getInstance().addToCache(oauthappdo.getOauthConsumerKey(), oauthappdo);

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthUtil.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthUtil.java
@@ -350,6 +350,7 @@ public final class OAuthUtil {
         dto.setTokenRevocationWithIDPSessionTerminationEnabled(appDO
                 .isTokenRevocationWithIDPSessionTerminationEnabled());
         dto.setTokenBindingValidationEnabled(appDO.isTokenBindingValidationEnabled());
+        dto.setTokenEndpointAuthMethod(appDO.getTokenEndpointAuthMethod());
         return dto;
     }
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dao/OAuthAppDAO.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dao/OAuthAppDAO.java
@@ -75,6 +75,7 @@ import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCConfigPro
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCConfigProperties.TOKEN_BINDING_TYPE;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCConfigProperties.TOKEN_BINDING_TYPE_NONE;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCConfigProperties.TOKEN_BINDING_VALIDATION;
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCConfigProperties.TOKEN_ENDPOINT_AUTH_METHOD;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCConfigProperties
         .TOKEN_REVOCATION_WITH_IDP_SESSION_TERMINATION;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCConfigProperties.TOKEN_TYPE;
@@ -630,6 +631,10 @@ public class OAuthAppDAO {
                 oauthAppDO.getRenewRefreshTokenEnabled(), prepStatementForPropertyAdd,
                 preparedStatementForPropertyUpdate);
 
+        addOrUpdateOIDCSpProperty(preprocessedClientId, spTenantId, spOIDCProperties,
+                TOKEN_ENDPOINT_AUTH_METHOD, oauthAppDO.getTokenEndpointAuthMethod(),
+                prepStatementForPropertyAdd, preparedStatementForPropertyUpdate);
+
         if (TOKEN_BINDING_TYPE_NONE.equalsIgnoreCase(oauthAppDO.getTokenBindingType())) {
             oauthAppDO.setTokenType(null);
         }
@@ -1175,6 +1180,9 @@ public class OAuthAppDAO {
             addToBatchForOIDCPropertyAdd(processedClientId, spTenantId, prepStmtAddOIDCProperty,
                     RENEW_REFRESH_TOKEN, consumerAppDO.getRenewRefreshTokenEnabled());
 
+            addToBatchForOIDCPropertyAdd(processedClientId, spTenantId, prepStmtAddOIDCProperty,
+                    TOKEN_ENDPOINT_AUTH_METHOD, consumerAppDO.getTokenEndpointAuthMethod());
+
             if (TOKEN_BINDING_TYPE_NONE.equalsIgnoreCase(consumerAppDO.getTokenBindingType())) {
                 consumerAppDO.setTokenType(null);
             }
@@ -1271,6 +1279,9 @@ public class OAuthAppDAO {
 
         String tokenType = getFirstPropertyValue(spOIDCProperties, TOKEN_TYPE);
         oauthApp.setTokenType(tokenType);
+
+        String tokenEndpointAuthMethod = getFirstPropertyValue(spOIDCProperties, TOKEN_ENDPOINT_AUTH_METHOD);
+        oauthApp.setTokenEndpointAuthMethod(tokenEndpointAuthMethod);
 
         boolean bypassClientCreds = Boolean.parseBoolean(
                 getFirstPropertyValue(spOIDCProperties, BYPASS_CLIENT_CREDENTIALS));

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dao/OAuthAppDO.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dao/OAuthAppDO.java
@@ -67,6 +67,7 @@ public class OAuthAppDO implements Serializable {
     private String idTokenEncryptionMethod;
     private String backChannelLogoutUrl;
     private String frontchannelLogoutUrl;
+    private String tokenEndpointAuthMethod;
     @XmlTransient
     private AuthenticatedUser appOwner;
     private String tokenType;
@@ -267,6 +268,16 @@ public class OAuthAppDO implements Serializable {
 
     public void setFrontchannelLogoutUrl(String frontchannelLogoutUrl) {
         this.frontchannelLogoutUrl = frontchannelLogoutUrl;
+    }
+
+    public String getTokenEndpointAuthMethod() {
+
+        return tokenEndpointAuthMethod;
+    }
+
+    public void setTokenEndpointAuthMethod(String tokenEndpointAuthMethod) {
+
+        this.tokenEndpointAuthMethod = tokenEndpointAuthMethod;
     }
 
     public long getIdTokenExpiryTime() {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dto/OAuthConsumerAppDTO.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dto/OAuthConsumerAppDTO.java
@@ -52,6 +52,8 @@ public class OAuthConsumerAppDTO {
     private String tokenBindingType;
     private boolean tokenRevocationWithIDPSessionTerminationEnabled;
     private boolean tokenBindingValidationEnabled;
+    private String tokenEndpointAuthMethod;
+
 
     public long getUserAccessTokenExpiryTime() {
         return userAccessTokenExpiryTime;
@@ -299,6 +301,16 @@ public class OAuthConsumerAppDTO {
     public void setTokenBindingValidationEnabled(boolean tokenBindingValidationEnabled) {
 
         this.tokenBindingValidationEnabled = tokenBindingValidationEnabled;
+    }
+
+    public String getTokenEndpointAuthMethod() {
+
+        return tokenEndpointAuthMethod;
+    }
+
+    public void setTokenEndpointAuthMethod(String tokenEndpointAuthMethod) {
+
+        this.tokenEndpointAuthMethod = tokenEndpointAuthMethod;
     }
 }
 


### PR DESCRIPTION
Added support for `token_endpoint_auth_method` attribute through DCR API. Following functionalities are added

- Take `token_endpoint_auth_method` value from registration request, validate and save in the database
- Send `token_endpoint_auth_method` in registration response
- Send `token_endpoint_auth_method` in application information response

Part of fix for https://github.com/wso2/product-is/issues/10652
