### PR TITLE
Adding Unit tests for Oauth DCR 

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/context/DCRMessageContextTest.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/context/DCRMessageContextTest.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.wso2.carbon.identity.oauth.dcr.context;
 
 import org.testng.annotations.Test;

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/context/DCRMessageContextTest.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/context/DCRMessageContextTest.java
@@ -24,12 +24,17 @@ import org.wso2.carbon.identity.application.authentication.framework.inbound.Ide
 import static org.powermock.api.mockito.PowerMockito.mock;
 import static org.testng.Assert.assertNotNull;
 
+/**
+ * Unit test covering DCRMessageContext
+ */
 public class DCRMessageContextTest {
 
     private DCRMessageContext dcrMessageContext;
     private IdentityRequest mockIdentityRequet;
+
     @Test
     public void testGetIdentityRequest() throws Exception {
+
         mockIdentityRequet = mock(IdentityRequest.class);
         dcrMessageContext = new DCRMessageContext(mockIdentityRequet);
         assertNotNull(dcrMessageContext.getIdentityRequest());

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/context/DCRMessageContextTest.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/context/DCRMessageContextTest.java
@@ -1,0 +1,19 @@
+package org.wso2.carbon.identity.oauth.dcr.context;
+
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.application.authentication.framework.inbound.IdentityRequest;
+
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.testng.Assert.assertNotNull;
+
+public class DCRMessageContextTest {
+
+    private DCRMessageContext dcrMessageContext;
+    private IdentityRequest mockIdentityRequet;
+    @Test
+    public void testGetIdentityRequest() throws Exception {
+        mockIdentityRequet = mock(IdentityRequest.class);
+        dcrMessageContext = new DCRMessageContext(mockIdentityRequet);
+        assertNotNull(dcrMessageContext.getIdentityRequest());
+    }
+}

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/context/DCRMessageContextTest.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/context/DCRMessageContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/factory/HttpRegistrationResponseFactoryTest.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/factory/HttpRegistrationResponseFactoryTest.java
@@ -148,11 +148,28 @@ public class HttpRegistrationResponseFactoryTest extends PowerMockTestCase {
     @Test
     public void testCreate() throws Exception {
 
+        create();
+        httpRegistrationResponseFactory.create(mockHttpIdentityResponseBuilder, mockRegistrationResponse);
+        assertEquals((int) statusCode[0], HttpServletResponse.SC_CREATED);
+        assertEquals(header[0], MediaType.APPLICATION_JSON);
+    }
+
+    @Test
+    public void createTest() throws Exception {
+        create();
+        httpRegistrationResponseFactory.create(mockRegistrationResponse);
+        assertEquals((int) statusCode[0], HttpServletResponse.SC_CREATED);
+        assertEquals(header[0], MediaType.APPLICATION_JSON);
+    }
+
+    private void create() throws Exception {
         RegistrationResponseProfile registrationRequestProfile = mock(RegistrationResponseProfile.class);
         mockHttpIdentityResponseBuilder = mock(HttpIdentityResponse.HttpIdentityResponseBuilder.class);
+        whenNew(HttpIdentityResponse.HttpIdentityResponseBuilder.class).withNoArguments().thenReturn
+                (mockHttpIdentityResponseBuilder);
         when(mockRegistrationResponse.getRegistrationResponseProfile()).thenReturn(registrationRequestProfile);
 
-        final Integer[] statusCode = new Integer[1];
+        statusCode = new Integer[1];
         doAnswer(new Answer<Object>() {
             @Override
             public Object answer(InvocationOnMock invocation) throws Throwable {
@@ -162,7 +179,7 @@ public class HttpRegistrationResponseFactoryTest extends PowerMockTestCase {
             }
         }).when(mockHttpIdentityResponseBuilder).setStatusCode(anyInt());
 
-        final String[] header = new String[1];
+        header = new String[1];
         doAnswer(new Answer<Object>() {
             @Override
             public Object answer(InvocationOnMock invocation) throws Throwable {
@@ -171,10 +188,6 @@ public class HttpRegistrationResponseFactoryTest extends PowerMockTestCase {
                 return null;
             }
         }).when(mockHttpIdentityResponseBuilder).addHeader(anyString(), anyString());
-
-        httpRegistrationResponseFactory.create(mockHttpIdentityResponseBuilder, mockRegistrationResponse);
-        assertEquals((int) statusCode[0], HttpServletResponse.SC_CREATED);
-        assertEquals(header[0], MediaType.APPLICATION_JSON);
     }
 
     @Test
@@ -196,6 +209,7 @@ public class HttpRegistrationResponseFactoryTest extends PowerMockTestCase {
         assertEquals(header[0], MediaType.APPLICATION_JSON);
         assertEquals((int) statusCode[0], HttpServletResponse.SC_BAD_REQUEST);
     }
+
     private FrameworkException handleException() throws Exception {
 
         mockHttpIdentityResponseBuilder = mock(HttpIdentityResponse.HttpIdentityResponseBuilder.class);

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/factory/HttpRegistrationResponseFactoryTest.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/factory/HttpRegistrationResponseFactoryTest.java
@@ -194,7 +194,6 @@ public class HttpRegistrationResponseFactoryTest extends PowerMockTestCase {
     public void testGenerateErrorResponse() throws Exception {
 
         String dummyError = "dummyError";
-
         JSONObject jsonObject = httpRegistrationResponseFactory.generateErrorResponse(dummyError, dummyDescription);
         assertEquals(jsonObject.get("error"), dummyError);
         assertEquals(jsonObject.get("error_description"), dummyDescription);

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/factory/HttpRegistrationResponseFactoryTest.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/factory/HttpRegistrationResponseFactoryTest.java
@@ -70,25 +70,17 @@ public class HttpRegistrationResponseFactoryTest extends PowerMockTestCase {
         httpRegistrationResponseFactory = new HttpRegistrationResponseFactory();
     }
 
-    @DataProvider(name = "instanceProvider")
-    public Object[][] getInstanceType() {
+    @Test
+    public void testCanHandle() throws Exception {
 
-        mockRegistrationResponse = mock(RegistrationResponse.class);
         IdentityResponse identityResponse = mock(IdentityResponse.class);
-        return new Object[][]{
-                {mockRegistrationResponse, true},
-                {identityResponse, false}
-        };
+        assertFalse(httpRegistrationResponseFactory.canHandle(identityResponse));
     }
 
-    @Test(dataProvider = "instanceProvider")
-    public void testCanHandle(Object identityResponse, boolean expected) throws Exception {
+    @Test
+    public void testCanHandleFailed() {
 
-        if (expected) {
-            assertTrue(httpRegistrationResponseFactory.canHandle((RegistrationResponse) identityResponse));
-        } else {
-            assertFalse(httpRegistrationResponseFactory.canHandle((IdentityResponse) identityResponse));
-        }
+        assertTrue(httpRegistrationResponseFactory.canHandle(mockRegistrationResponse));
     }
 
     @DataProvider(name = "exceptionInstanceProvider")
@@ -149,13 +141,13 @@ public class HttpRegistrationResponseFactoryTest extends PowerMockTestCase {
         mockHttpIdentityResponseBuilder = mock(HttpIdentityResponse.HttpIdentityResponseBuilder.class);
         mockRegistrationResponse = mock(RegistrationResponse.class);
         return new Object[][]{
-                {mockHttpIdentityResponseBuilder, mockRegistrationResponse},
-                {null, mockRegistrationResponse}
+                {mockHttpIdentityResponseBuilder},
+                {null}
         };
     }
 
     @Test(dataProvider = "instanceDataProvider")
-    public void testCreate(Object builder, Object registrationResponse) throws Exception {
+    public void testCreate(Object builder) throws Exception {
 
         if (builder == null) {
             mockHttpIdentityResponseBuilder = mock(HttpIdentityResponse.HttpIdentityResponseBuilder.class);
@@ -166,7 +158,7 @@ public class HttpRegistrationResponseFactoryTest extends PowerMockTestCase {
 
         whenNew(HttpIdentityResponse.HttpIdentityResponseBuilder.class).withNoArguments().thenReturn
                 (mockHttpIdentityResponseBuilder);
-        when(((RegistrationResponse) registrationResponse).getRegistrationResponseProfile()).
+        when((mockRegistrationResponse).getRegistrationResponseProfile()).
                 thenReturn(registrationRequestProfile);
 
         final Integer[] statusCode = new Integer[1];
@@ -190,10 +182,10 @@ public class HttpRegistrationResponseFactoryTest extends PowerMockTestCase {
         }).when(mockHttpIdentityResponseBuilder).addHeader(anyString(), anyString());
 
         if (builder == null) {
-            httpRegistrationResponseFactory.create((IdentityResponse) registrationResponse);
+            httpRegistrationResponseFactory.create(mockRegistrationResponse);
         } else {
             httpRegistrationResponseFactory.create((HttpIdentityResponse.HttpIdentityResponseBuilder) builder,
-                    (IdentityResponse) registrationResponse);
+                    (mockRegistrationResponse));
         }
         assertEquals((int) statusCode[0], HttpServletResponse.SC_CREATED);
         assertEquals(header[0], MediaType.APPLICATION_JSON);

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/factory/HttpRegistrationResponseFactoryTest.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/factory/HttpRegistrationResponseFactoryTest.java
@@ -157,8 +157,7 @@ public class HttpRegistrationResponseFactoryTest extends PowerMockTestCase {
     }
 
     @Test(dataProvider = "instanceDataProvider")
-    public void testCreate(Object builder,
-                           Object registrationResponse) throws Exception {
+    public void testCreate(Object builder, Object registrationResponse) throws Exception {
 
         if (builder == null) {
             mockHttpIdentityResponseBuilder = mock(HttpIdentityResponse.HttpIdentityResponseBuilder.class);

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/factory/HttpRegistrationResponseFactoryTest.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/factory/HttpRegistrationResponseFactoryTest.java
@@ -107,6 +107,7 @@ public class HttpRegistrationResponseFactoryTest extends PowerMockTestCase {
 
     @Test(dataProvider = "exceptionInstanceProvider")
     public void testCanHandleException(Object exception, boolean expected) throws Exception {
+
         if (expected) {
             assertTrue(httpRegistrationResponseFactory.canHandle((RegistrationException) exception));
         } else {
@@ -121,7 +122,6 @@ public class HttpRegistrationResponseFactoryTest extends PowerMockTestCase {
         redirectUrl.add("dummyRedirectUrl");
 
         RegistrationResponseProfile registrationRequestProfile = mock(RegistrationResponseProfile.class);
-
         when(mockRegistrationResponse.getRegistrationResponseProfile()).thenReturn(registrationRequestProfile);
         String dummyClientId = "dummyClientId";
         when(registrationRequestProfile.getClientId()).thenReturn(dummyClientId);
@@ -197,6 +197,7 @@ public class HttpRegistrationResponseFactoryTest extends PowerMockTestCase {
         assertEquals((int) statusCode[0], HttpServletResponse.SC_BAD_REQUEST);
     }
     private FrameworkException handleException() throws Exception {
+
         mockHttpIdentityResponseBuilder = mock(HttpIdentityResponse.HttpIdentityResponseBuilder.class);
         whenNew(HttpIdentityResponse.HttpIdentityResponseBuilder.class).withNoArguments().thenReturn
                 (mockHttpIdentityResponseBuilder);
@@ -225,17 +226,18 @@ public class HttpRegistrationResponseFactoryTest extends PowerMockTestCase {
         when(exception.getMessage()).thenReturn(dummyDescription);
         return exception;
     }
+
     @Test
     public void testHandleExceptionValidationError() throws Exception {
 
         FrameworkException exception = handleException();
-
         when(exception.getErrorCode()).thenReturn(ErrorCodes.META_DATA_VALIDATION_FAILED.toString());
         httpRegistrationResponseFactory.handleException(exception);
 
         assertEquals(header[0], MediaType.APPLICATION_JSON);
         assertEquals((int) statusCode[0], HttpServletResponse.SC_BAD_REQUEST);
     }
+
     @Test
     public void testHandleExceptionForbiddenError() throws Exception {
 
@@ -244,16 +246,16 @@ public class HttpRegistrationResponseFactoryTest extends PowerMockTestCase {
         httpRegistrationResponseFactory.handleException(exception);
         assertEquals((int) statusCode[0], HttpServletResponse.SC_FORBIDDEN);
     }
+
     @Test
     public void testHandleExceptionGoneError() throws Exception {
 
         FrameworkException exception = handleException();
         when(exception.getErrorCode()).thenReturn(ErrorCodes.GONE.toString());
         httpRegistrationResponseFactory.handleException(exception);
-
-
         assertEquals((int) statusCode[0], HttpServletResponse.SC_GONE);
     }
+
     @Test
     public void testHandleExceptionBadRequestError() throws Exception {
 

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/factory/HttpRegistrationResponseFactoryTest.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/factory/HttpRegistrationResponseFactoryTest.java
@@ -94,26 +94,23 @@ public class HttpRegistrationResponseFactoryTest extends PowerMockTestCase {
     @DataProvider(name = "exceptionInstanceProvider")
     public Object[][] getExceptionInstanceType() {
 
-        FrameworkException exception1 = new RegistrationException("");
-        FrameworkException exception2 = new RegistrationException("", "dummyMessage");
-        FrameworkException exception3 = new RegistrationException("", new Throwable());
-        FrameworkException exception4 = new FrameworkException("");
         return new Object[][]{
-                {exception1, true},
-                {exception2, true},
-                {exception3, true},
-                {exception4, false}
+                {new RegistrationException("")},
+                {new RegistrationException("", "dummyMessage")},
+                {new RegistrationException("", new Throwable())}
         };
     }
 
     @Test(dataProvider = "exceptionInstanceProvider")
-    public void testCanHandleException(Object exception, boolean expected) throws Exception {
+    public void testCanHandleException(Object exception) throws Exception {
 
-        if (expected) {
-            assertTrue(httpRegistrationResponseFactory.canHandle((RegistrationException) exception));
-        } else {
-            assertFalse(httpRegistrationResponseFactory.canHandle((FrameworkException) exception));
-        }
+        assertTrue(httpRegistrationResponseFactory.canHandle((RegistrationException) exception));
+    }
+
+    @Test
+    public void testCanHandleExceptionFailed() {
+
+        assertFalse(httpRegistrationResponseFactory.canHandle(new FrameworkException("")));
     }
 
     @Test
@@ -148,6 +145,7 @@ public class HttpRegistrationResponseFactoryTest extends PowerMockTestCase {
 
     @DataProvider(name = "instanceDataProvider")
     public Object[][] getInstanceData() {
+
         mockHttpIdentityResponseBuilder = mock(HttpIdentityResponse.HttpIdentityResponseBuilder.class);
         mockRegistrationResponse = mock(RegistrationResponse.class);
         return new Object[][]{
@@ -212,6 +210,7 @@ public class HttpRegistrationResponseFactoryTest extends PowerMockTestCase {
 
     @DataProvider(name = "exceptionDataProvider")
     public Object[][] getExceptionData() {
+
         return new Object[][]{
                 {ErrorCodes.FORBIDDEN.toString(), HttpServletResponse.SC_FORBIDDEN},
                 {ErrorCodes.META_DATA_VALIDATION_FAILED.toString(), HttpServletResponse.SC_BAD_REQUEST},

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/factory/HttpUnRegistrationResponseFactoryTest.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/factory/HttpUnRegistrationResponseFactoryTest.java
@@ -87,10 +87,16 @@ public class HttpUnRegistrationResponseFactoryTest extends PowerMockTestCase {
     public Object[][] getExceptionInstanceType() {
 
         FrameworkException exception1 = new UnRegistrationException("");
-        FrameworkException exception2 = new FrameworkException("");
+        FrameworkException exception2 = new UnRegistrationException("", "dummyMessage");
+        FrameworkException exception3 = new UnRegistrationException("", new Throwable());
+        FrameworkException exception4 = new UnRegistrationException("", "dummyMessage", new Throwable());
+        FrameworkException exception5 = new FrameworkException("");
         return new Object[][]{
                 {exception1, true},
-                {exception2, false}
+                {exception2, true},
+                {exception3, true},
+                {exception4, true},
+                {exception5, false}
         };
     }
 

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/factory/HttpUnRegistrationResponseFactoryTest.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/factory/HttpUnRegistrationResponseFactoryTest.java
@@ -47,6 +47,9 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
+/**
+ * Unit test covering HttpUnregistrationResponseFactory
+ */
 @PrepareForTest({HttpUnregistrationResponseFactory.class, HttpIdentityResponse.HttpIdentityResponseBuilder.class})
 public class HttpUnRegistrationResponseFactoryTest extends PowerMockTestCase {
 
@@ -59,61 +62,47 @@ public class HttpUnRegistrationResponseFactoryTest extends PowerMockTestCase {
 
         mockUnregistrationResponse = mock(UnregistrationResponse.class);
         httpUnregistrationResponseFactory = new HttpUnregistrationResponseFactory();
-
     }
 
-    @DataProvider(name = "instanceProvider")
-    public Object[][] getInstanceType() {
+    @Test
+    public void testCanHandle() throws Exception {
 
-        mockUnregistrationResponse = mock(UnregistrationResponse.class);
         IdentityResponse identityResponse = mock(IdentityResponse.class);
-        return new Object[][]{
-                {mockUnregistrationResponse, true},
-                {identityResponse, false}
-        };
+        assertFalse(httpUnregistrationResponseFactory.canHandle(identityResponse));
     }
 
-    @Test(dataProvider = "instanceProvider")
-    public void testCanHandle(Object identityResponse, Boolean expected) throws Exception {
+    @Test
+    public void testCanHandleFailed() {
 
-        if (expected) {
-            assertTrue(httpUnregistrationResponseFactory.canHandle((UnregistrationResponse) identityResponse));
-        } else {
-            assertFalse(httpUnregistrationResponseFactory.canHandle((IdentityResponse) identityResponse));
-        }
+        assertTrue(httpUnregistrationResponseFactory.canHandle(mockUnregistrationResponse));
     }
 
     @DataProvider(name = "exceptionInstanceProvider")
     public Object[][] getExceptionInstanceType() {
 
-        FrameworkException exception1 = new UnRegistrationException("");
-        FrameworkException exception2 = new UnRegistrationException("", "dummyMessage");
-        FrameworkException exception3 = new UnRegistrationException("", new Throwable());
-        FrameworkException exception4 = new UnRegistrationException("", "dummyMessage", new Throwable());
-        FrameworkException exception5 = new FrameworkException("");
         return new Object[][]{
-                {exception1, true},
-                {exception2, true},
-                {exception3, true},
-                {exception4, true},
-                {exception5, false}
+                {new UnRegistrationException("")},
+                {new UnRegistrationException("", "dummyMessage")},
+                {new UnRegistrationException("", new Throwable())},
+                {new UnRegistrationException("", "dummyMessage", new Throwable())}
         };
     }
 
     @Test(dataProvider = "exceptionInstanceProvider")
-    public void testCanHandleException(Object exception, boolean expected) throws Exception {
+    public void testCanHandleException(Object exception) {
 
-        if (expected) {
-            Assert.assertTrue(httpUnregistrationResponseFactory.canHandle((UnRegistrationException) exception));
-        } else {
-            Assert.assertFalse(httpUnregistrationResponseFactory.canHandle((FrameworkException) exception));
-        }
+        Assert.assertTrue(httpUnregistrationResponseFactory.canHandle((UnRegistrationException) exception));
+    }
+
+    @Test
+    public void testCanHandleExceptionFailed() {
+
+        Assert.assertFalse(httpUnregistrationResponseFactory.canHandle(new FrameworkException("")));
     }
 
     @DataProvider(name = "instanceDataProvider")
     public Object[][] getInstanceData() {
-        mockHttpIdentityResponseBuilder = mock(HttpIdentityResponse.HttpIdentityResponseBuilder.class);
-        mockUnregistrationResponse = mock(UnregistrationResponse.class);
+
         return new Object[][]{
                 {mockHttpIdentityResponseBuilder, mockUnregistrationResponse},
                 {null, mockUnregistrationResponse}
@@ -121,8 +110,7 @@ public class HttpUnRegistrationResponseFactoryTest extends PowerMockTestCase {
     }
 
     @Test(dataProvider = "instanceDataProvider")
-    public void testCreate(Object builder,
-                           Object unregistrationResponse) throws Exception {
+    public void testCreate(Object builder, Object unregistrationResponse) throws Exception {
 
         if (builder == null) {
             mockHttpIdentityResponseBuilder = mock(HttpIdentityResponse.HttpIdentityResponseBuilder.class);

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/factory/HttpUnRegistrationResponseFactoryTest.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/factory/HttpUnRegistrationResponseFactoryTest.java
@@ -104,13 +104,13 @@ public class HttpUnRegistrationResponseFactoryTest extends PowerMockTestCase {
     public Object[][] getInstanceData() {
 
         return new Object[][]{
-                {mockHttpIdentityResponseBuilder, mockUnregistrationResponse},
-                {null, mockUnregistrationResponse}
+                {mockHttpIdentityResponseBuilder},
+                {null}
         };
     }
 
     @Test(dataProvider = "instanceDataProvider")
-    public void testCreate(Object builder, Object unregistrationResponse) throws Exception {
+    public void testCreate(Object builder) throws Exception {
 
         if (builder == null) {
             mockHttpIdentityResponseBuilder = mock(HttpIdentityResponse.HttpIdentityResponseBuilder.class);
@@ -141,10 +141,9 @@ public class HttpUnRegistrationResponseFactoryTest extends PowerMockTestCase {
         }).when(mockHttpIdentityResponseBuilder).addHeader(anyString(), anyString());
 
         if (builder == null) {
-            httpUnregistrationResponseFactory.create((IdentityResponse) unregistrationResponse);
+            httpUnregistrationResponseFactory.create(mockUnregistrationResponse);
         } else {
-            httpUnregistrationResponseFactory.create(mockHttpIdentityResponseBuilder,
-                    (IdentityResponse) unregistrationResponse);
+            httpUnregistrationResponseFactory.create(mockHttpIdentityResponseBuilder, mockUnregistrationResponse);
         }
         assertEquals((int) statusCode[0], HttpServletResponse.SC_NO_CONTENT);
     }

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/factory/HttpUnRegistrationResponseFactoryTest.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/factory/HttpUnRegistrationResponseFactoryTest.java
@@ -54,9 +54,6 @@ public class HttpUnRegistrationResponseFactoryTest extends PowerMockTestCase {
     private HttpUnregistrationResponseFactory httpUnregistrationResponseFactory;
     private HttpIdentityResponse.HttpIdentityResponseBuilder mockHttpIdentityResponseBuilder;
 
-    private Integer[] statusCode;
-    private String[] header;
-
     @BeforeMethod
     private void setUp() {
 
@@ -107,28 +104,29 @@ public class HttpUnRegistrationResponseFactoryTest extends PowerMockTestCase {
         }
     }
 
-    @Test
-    public void testCreate() throws Exception {
-
-        create();
-        httpUnregistrationResponseFactory.create(mockHttpIdentityResponseBuilder, mockUnregistrationResponse);
-        assertEquals((int) statusCode[0], HttpServletResponse.SC_NO_CONTENT);
+    @DataProvider(name = "instanceDataProvider")
+    public Object[][] getInstanceData() {
+        mockHttpIdentityResponseBuilder = mock(HttpIdentityResponse.HttpIdentityResponseBuilder.class);
+        mockUnregistrationResponse = mock(UnregistrationResponse.class);
+        return new Object[][]{
+                {mockHttpIdentityResponseBuilder, mockUnregistrationResponse},
+                {null, mockUnregistrationResponse}
+        };
     }
 
-     @Test
-     public void createTest() throws Exception {
+    @Test(dataProvider = "instanceDataProvider")
+    public void testCreate(Object builder,
+                           Object unregistrationResponse) throws Exception {
 
-        create();
-        httpUnregistrationResponseFactory.create(mockUnregistrationResponse);
-        assertEquals((int) statusCode[0], HttpServletResponse.SC_NO_CONTENT);
-     }
-
-    private void create() throws Exception {
-
-        mockHttpIdentityResponseBuilder = mock(HttpIdentityResponse.HttpIdentityResponseBuilder.class);
+        if (builder == null) {
+            mockHttpIdentityResponseBuilder = mock(HttpIdentityResponse.HttpIdentityResponseBuilder.class);
+        } else {
+            mockHttpIdentityResponseBuilder = (HttpIdentityResponse.HttpIdentityResponseBuilder) builder;
+        }
         whenNew(HttpIdentityResponse.HttpIdentityResponseBuilder.class).withNoArguments().thenReturn
                 (mockHttpIdentityResponseBuilder);
-        statusCode = new Integer[1];
+
+        final Integer[] statusCode = new Integer[1];
         doAnswer(new Answer<Object>() {
             @Override
             public Object answer(InvocationOnMock invocation) throws Throwable {
@@ -138,7 +136,7 @@ public class HttpUnRegistrationResponseFactoryTest extends PowerMockTestCase {
             }
         }).when(mockHttpIdentityResponseBuilder).setStatusCode(anyInt());
 
-        header = new String[1];
+        final String[] header = new String[1];
         doAnswer(new Answer<Object>() {
             @Override
             public Object answer(InvocationOnMock invocation) throws Throwable {
@@ -148,6 +146,13 @@ public class HttpUnRegistrationResponseFactoryTest extends PowerMockTestCase {
             }
         }).when(mockHttpIdentityResponseBuilder).addHeader(anyString(), anyString());
 
+        if (builder == null) {
+            httpUnregistrationResponseFactory.create((IdentityResponse) unregistrationResponse);
+        } else {
+            httpUnregistrationResponseFactory.create(mockHttpIdentityResponseBuilder,
+                    (IdentityResponse) unregistrationResponse);
+        }
+        assertEquals((int) statusCode[0], HttpServletResponse.SC_NO_CONTENT);
     }
 
     @Test

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/factory/HttpUnregistrationResponseFactoryTest.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/factory/HttpUnregistrationResponseFactoryTest.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.wso2.carbon.identity.oauth.dcr.factory;
 
 import org.mockito.invocation.InvocationOnMock;
@@ -25,10 +43,10 @@ import static org.testng.Assert.assertTrue;
 
 
 public class HttpUnregistrationResponseFactoryTest extends PowerMockTestCase {
+
     private UnregistrationResponse mockUnregistrationResponse;
     private HttpUnregistrationResponseFactory httpUnregistrationResponseFactory;
     private HttpIdentityResponse.HttpIdentityResponseBuilder mockHttpIdentityResponseBuilder;
-
 
     @BeforeMethod
     private void setUp() {
@@ -36,7 +54,9 @@ public class HttpUnregistrationResponseFactoryTest extends PowerMockTestCase {
         mockUnregistrationResponse = mock(UnregistrationResponse.class);
         httpUnregistrationResponseFactory = new HttpUnregistrationResponseFactory();
 
-    }@DataProvider(name = "instanceProvider")
+    }
+
+    @DataProvider(name = "instanceProvider")
     public Object[][] getInstanceType() {
 
         mockUnregistrationResponse = mock(UnregistrationResponse.class);
@@ -69,6 +89,7 @@ public class HttpUnregistrationResponseFactoryTest extends PowerMockTestCase {
 
     @Test(dataProvider = "exceptionInstanceProvider")
     public void testCanHandleException(Object exception, boolean expected) throws Exception {
+
         if (expected) {
             Assert.assertTrue(httpUnregistrationResponseFactory.canHandle((UnRegistrationException) exception));
         } else {

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/factory/HttpUnregistrationResponseFactoryTest.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/factory/HttpUnregistrationResponseFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/factory/HttpUnregistrationResponseFactoryTest.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/factory/HttpUnregistrationResponseFactoryTest.java
@@ -1,0 +1,107 @@
+package org.wso2.carbon.identity.oauth.dcr.factory;
+
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.powermock.modules.testng.PowerMockTestCase;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.application.authentication.framework.exception.FrameworkException;
+import org.wso2.carbon.identity.application.authentication.framework.inbound.HttpIdentityResponse;
+import org.wso2.carbon.identity.application.authentication.framework.inbound.IdentityResponse;
+import org.wso2.carbon.identity.oauth.dcr.exception.UnRegistrationException;
+import org.wso2.carbon.identity.oauth.dcr.model.UnregistrationResponse;
+
+import javax.servlet.http.HttpServletResponse;
+
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyString;
+import static org.powermock.api.mockito.PowerMockito.doAnswer;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+
+public class HttpUnregistrationResponseFactoryTest extends PowerMockTestCase {
+    private UnregistrationResponse mockUnregistrationResponse;
+    private HttpUnregistrationResponseFactory httpUnregistrationResponseFactory;
+    private HttpIdentityResponse.HttpIdentityResponseBuilder mockHttpIdentityResponseBuilder;
+
+
+    @BeforeMethod
+    private void setUp() {
+
+        mockUnregistrationResponse = mock(UnregistrationResponse.class);
+        httpUnregistrationResponseFactory = new HttpUnregistrationResponseFactory();
+
+    }@DataProvider(name = "instanceProvider")
+    public Object[][] getInstanceType() {
+
+        mockUnregistrationResponse = mock(UnregistrationResponse.class);
+        IdentityResponse identityResponse = mock(IdentityResponse.class);
+        return new Object[][]{
+                {mockUnregistrationResponse, true},
+                {identityResponse, false}
+        };
+    }
+
+    @Test(dataProvider = "instanceProvider")
+    public void testCanHandle(Object identityResponse, Boolean expected) throws Exception {
+        if (expected) {
+            assertTrue(httpUnregistrationResponseFactory.canHandle((UnregistrationResponse) identityResponse));
+        } else {
+            assertFalse(httpUnregistrationResponseFactory.canHandle((IdentityResponse) identityResponse));
+        }
+    }
+
+    @DataProvider(name = "exceptionInstanceProvider")
+    public Object[][] getExceptionInstanceType() {
+
+        FrameworkException exception1 = new UnRegistrationException("");
+        FrameworkException exception2 = new FrameworkException("");
+        return new Object[][]{
+                {exception1, true},
+                {exception2, false}
+        };
+    }
+
+    @Test(dataProvider = "exceptionInstanceProvider")
+    public void testCanHandleException(Object exception, boolean expected) throws Exception {
+        if (expected) {
+            Assert.assertTrue(httpUnregistrationResponseFactory.canHandle((UnRegistrationException) exception));
+        } else {
+            Assert.assertFalse(httpUnregistrationResponseFactory.canHandle((FrameworkException) exception));
+        }
+    }
+
+    @Test
+    public void testCreate()  {
+
+        mockHttpIdentityResponseBuilder = mock(HttpIdentityResponse.HttpIdentityResponseBuilder.class);
+        final Integer[] statusCode = new Integer[1];
+        doAnswer(new Answer<Object>() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+
+                statusCode[0] = (Integer) invocation.getArguments()[0];
+                return null;
+            }
+        }).when(mockHttpIdentityResponseBuilder).setStatusCode(anyInt());
+
+        final String[] header = new String[1];
+        doAnswer(new Answer<Object>() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+
+                header[0] = (String) invocation.getArguments()[1];
+                return null;
+            }
+        }).when(mockHttpIdentityResponseBuilder).addHeader(anyString(), anyString());
+
+        httpUnregistrationResponseFactory.create(mockHttpIdentityResponseBuilder, mockUnregistrationResponse);
+        assertEquals((int) statusCode[0], HttpServletResponse.SC_NO_CONTENT);
+    }
+
+}

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/factory/RegistrationRequestFactoryTest.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/factory/RegistrationRequestFactoryTest.java
@@ -310,7 +310,7 @@ public class RegistrationRequestFactoryTest extends PowerMockTestCase {
     }
 
     @Test(dataProvider = "invalidApplicationDataProvider")
-    public void testCreateWithInvalidApplicationOwner(Object userName, Boolean isThrowExceptiion,
+    public void testCreateWithInvalidApplicationOwner(String userName, Boolean isThrowException,
                                                       String expected) throws Exception {
 
         JSONObject jsonObject = getTestCreateData();
@@ -323,11 +323,11 @@ public class RegistrationRequestFactoryTest extends PowerMockTestCase {
 
         try {
             startTenantFlow();
-            PrivilegedCarbonContext.getThreadLocalCarbonContext().setUsername((String) userName);
+            PrivilegedCarbonContext.getThreadLocalCarbonContext().setUsername(userName);
 
             PrivilegedCarbonContext.getThreadLocalCarbonContext().setUserRealm(mockedUserRealm);
             when(mockedUserRealm.getUserStoreManager()).thenReturn(mockedUserStoreManager);
-            if (isThrowExceptiion) {
+            if (isThrowException) {
                 when(mockedUserStoreManager.isExistingUser(anyString())).thenThrow(UserStoreException.class);
             } else {
                 when(mockedUserStoreManager.isExistingUser("dummyParam")).thenReturn(false);
@@ -369,8 +369,8 @@ public class RegistrationRequestFactoryTest extends PowerMockTestCase {
             PrivilegedCarbonContext.getThreadLocalCarbonContext().setUsername(ownerName);
             registrationRequestFactory.create(mockRegistrationRequestBuilder, mockHttpRequest, mockHttpResponse);
         } catch (IdentityException ex) {
-        assertEquals(ex.getMessage(), "Error occurred while reading servlet request body, ");
-        return;
+            assertEquals(ex.getMessage(), "Error occurred while reading servlet request body, ");
+            return;
         } finally {
             PrivilegedCarbonContext.endTenantFlow();
         }

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/factory/RegistrationRequestFactoryTest.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/factory/RegistrationRequestFactoryTest.java
@@ -25,6 +25,7 @@ import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.testng.PowerMockTestCase;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -37,7 +38,6 @@ import org.wso2.carbon.identity.base.IdentityException;
 import org.wso2.carbon.identity.oauth.common.OAuthConstants;
 import org.wso2.carbon.identity.oauth.dcr.model.RegistrationRequest;
 import org.wso2.carbon.identity.oauth.dcr.model.RegistrationRequestProfile;
-import org.wso2.carbon.identity.testutil.powermock.PowerMockIdentityBaseTest;
 
 import java.io.BufferedReader;
 import java.nio.file.Paths;
@@ -63,7 +63,7 @@ import static org.testng.Assert.assertEquals;
  * Unit test covering RegistrationRequestFactory
  */
 @PrepareForTest(RegistrationRequestFactory.class)
-public class RegistrationRequestFactoryTest extends PowerMockIdentityBaseTest {
+public class RegistrationRequestFactoryTest extends PowerMockTestCase {
 
     private RegistrationRequestFactory registrationRequestFactory;
     private String dummyDescription = "dummyDescription";

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/factory/RegistrationRequestFactoryTest.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/factory/RegistrationRequestFactoryTest.java
@@ -303,14 +303,14 @@ public class RegistrationRequestFactoryTest extends PowerMockTestCase {
     public Object[][] getInvalidApplicationData() {
 
         return new Object[][]{
-                {null, "false", "Invalid application owner."},
-                {"", "userStoreException", "Invalid application owner, null"},
-                {"", "false", "Invalid application owner."}
+                {null, false, "Invalid application owner."},
+                {"", true, "Invalid application owner, null"},
+                {"", false, "Invalid application owner."}
         };
     }
 
     @Test(dataProvider = "invalidApplicationDataProvider")
-    public void testCreateWithInvalidApplicationOwner(Object userName, Object isExistingUser,
+    public void testCreateWithInvalidApplicationOwner(Object userName, Boolean isThrowExceptiion,
                                                       String expected) throws Exception {
 
         JSONObject jsonObject = getTestCreateData();
@@ -327,7 +327,7 @@ public class RegistrationRequestFactoryTest extends PowerMockTestCase {
 
             PrivilegedCarbonContext.getThreadLocalCarbonContext().setUserRealm(mockedUserRealm);
             when(mockedUserRealm.getUserStoreManager()).thenReturn(mockedUserStoreManager);
-            if (isExistingUser == "userStoreException") {
+            if (isThrowExceptiion) {
                 when(mockedUserStoreManager.isExistingUser(anyString())).thenThrow(UserStoreException.class);
             } else {
                 when(mockedUserStoreManager.isExistingUser("dummyParam")).thenReturn(false);
@@ -342,6 +342,7 @@ public class RegistrationRequestFactoryTest extends PowerMockTestCase {
     }
 
     private JSONObject getTestCreateData() throws Exception {
+
         String grantType = "implicit";
         JSONArray redirectUrls = new JSONArray();
         redirectUrls.add("redirectUrl");
@@ -351,16 +352,13 @@ public class RegistrationRequestFactoryTest extends PowerMockTestCase {
         jsonObject.put(RegistrationRequest.RegisterRequestConstant.REDIRECT_URIS, redirectUrls);
 
         RegistrationRequestProfile registrationRequestProfile = new RegistrationRequestProfile();
-
         whenNew(RegistrationRequestProfile.class).withNoArguments().thenReturn(registrationRequestProfile);
-
         suppress(methodsDeclaredIn(HttpIdentityRequestFactory.class));
         return jsonObject;
     }
 
     @Test
     public void testCreateWithServerRequestReadingError() throws Exception {
-
 
         JSONObject jsonObject = getTestCreateData();
         when(mockHttpRequest.getReader()).thenThrow(IOException.class);
@@ -373,7 +371,7 @@ public class RegistrationRequestFactoryTest extends PowerMockTestCase {
         } catch (IdentityException ex) {
         assertEquals(ex.getMessage(), "Error occurred while reading servlet request body, ");
         return;
-    } finally {
+        } finally {
             PrivilegedCarbonContext.endTenantFlow();
         }
     }

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/factory/RegistrationRequestFactoryTest.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/factory/RegistrationRequestFactoryTest.java
@@ -46,6 +46,7 @@ import org.wso2.carbon.user.core.UserStoreManager;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.nio.file.Paths;
+import java.util.Objects;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -314,7 +315,7 @@ public class RegistrationRequestFactoryTest extends PowerMockTestCase {
                                                       String expected) throws Exception {
 
         JSONObject jsonObject = getTestCreateData();
-        if (userName == "") {
+        if (!Objects.isNull(userName)) {
             jsonObject.put(RegistrationRequest.RegisterRequestConstant.EXT_PARAM_OWNER, "dummyParam");
         }
         when(mockHttpRequest.getReader()).thenReturn(mockReader);

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/factory/UnregistrationRequestFactoryTest.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/factory/UnregistrationRequestFactoryTest.java
@@ -22,12 +22,12 @@ import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.testng.PowerMockTestCase;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.wso2.carbon.identity.application.authentication.framework.inbound.HttpIdentityRequestFactory;
 import org.wso2.carbon.identity.oauth.dcr.model.UnregistrationRequest;
-import org.wso2.carbon.identity.testutil.powermock.PowerMockIdentityBaseTest;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -44,7 +44,7 @@ import static org.testng.Assert.assertEquals;
  * Unit test covering UnregistrationRequestFactory
  */
 @PrepareForTest(UnregistrationRequestFactory.class)
-public class UnregistrationRequestFactoryTest extends PowerMockIdentityBaseTest {
+public class UnregistrationRequestFactoryTest extends PowerMockTestCase {
 
     @Mock
     private UnregistrationRequest.DCRUnregisterRequestBuilder unregisterRequestBuilder;

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/factory/UnregistrationRequestFactoryTest.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/factory/UnregistrationRequestFactoryTest.java
@@ -88,6 +88,7 @@ public class UnregistrationRequestFactoryTest extends PowerMockTestCase {
 
     @DataProvider(name = "instanceDataProvider")
     public Object[][] getInstanceData() {
+
         unregisterRequestBuilder = mock(UnregistrationRequest.DCRUnregisterRequestBuilder.class);
         mockHttpResponse = mock(HttpServletResponse.class);
         mockHttpRequest = mock(HttpServletRequest.class);

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/factory/UnregistrationRequestFactoryTest.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/factory/UnregistrationRequestFactoryTest.java
@@ -90,19 +90,18 @@ public class UnregistrationRequestFactoryTest extends PowerMockTestCase {
     public Object[][] getInstanceData() {
 
         unregisterRequestBuilder = mock(UnregistrationRequest.DCRUnregisterRequestBuilder.class);
-        mockHttpResponse = mock(HttpServletResponse.class);
-        mockHttpRequest = mock(HttpServletRequest.class);
         return new Object[][]{
-                {null, mockHttpRequest, mockHttpResponse},
-                {unregisterRequestBuilder, mockHttpRequest, mockHttpResponse}
+                {null},
+                {unregisterRequestBuilder}
 
         };
     }
 
     @Test(dataProvider = "instanceDataProvider")
-    public void testCreate(Object builder, Object request, Object response) throws Exception {
+    public void testCreate(Object builder) throws Exception {
 
-        mockHttpRequest = (HttpServletRequest) request;
+        mockHttpResponse = mock(HttpServletResponse.class);
+        mockHttpRequest = mock(HttpServletRequest.class);
         suppress(methodsDeclaredIn(HttpIdentityRequestFactory.class));
         String dummyConsumerKey = "dummyConsumerKey";
         when(mockHttpRequest.getRequestURI()).thenReturn("dummyVal/identity/register/" + dummyConsumerKey);
@@ -149,10 +148,10 @@ public class UnregistrationRequestFactoryTest extends PowerMockTestCase {
         }).when(unregisterRequestBuilder).setConsumerKey(anyString());
 
         if (builder == null) {
-            registrationRequestFactory.create(mockHttpRequest, (HttpServletResponse) response);
+            registrationRequestFactory.create(mockHttpRequest, mockHttpResponse);
         } else {
             registrationRequestFactory.create(unregisterRequestBuilder,
-                    mockHttpRequest, (HttpServletResponse) response);
+                    mockHttpRequest, mockHttpResponse);
         }
         assertEquals(header[0], dummyApplicationName, "Application name doesn't match with the given " +
                 "application name");

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/handler/RegistrationHandlerTest.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/handler/RegistrationHandlerTest.java
@@ -19,6 +19,7 @@ package org.wso2.carbon.identity.oauth.dcr.handler;
 
 import org.mockito.Mock;
 import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.testng.PowerMockTestCase;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import org.wso2.carbon.identity.oauth.dcr.context.DCRMessageContext;
@@ -27,7 +28,6 @@ import org.wso2.carbon.identity.oauth.dcr.model.RegistrationRequestProfile;
 import org.wso2.carbon.identity.oauth.dcr.model.RegistrationResponse;
 import org.wso2.carbon.identity.oauth.dcr.model.RegistrationResponseProfile;
 import org.wso2.carbon.identity.oauth.dcr.service.DCRManagementService;
-import org.wso2.carbon.identity.testutil.powermock.PowerMockIdentityBaseTest;
 
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.when;
@@ -38,7 +38,7 @@ import static org.testng.Assert.assertEquals;
  * Unit test covering RegistrationHandler
  */
 @PrepareForTest({DCRManagementService.class, RegistrationHandler.class})
-public class RegistrationHandlerTest extends PowerMockIdentityBaseTest {
+public class RegistrationHandlerTest extends PowerMockTestCase {
 
     private RegistrationHandler registrationHandler;
 

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/handler/UnRegistrationHandlerTest.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/handler/UnRegistrationHandlerTest.java
@@ -21,13 +21,13 @@ import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.testng.PowerMockTestCase;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import org.wso2.carbon.identity.oauth.dcr.context.DCRMessageContext;
 import org.wso2.carbon.identity.oauth.dcr.model.UnregistrationRequest;
 import org.wso2.carbon.identity.oauth.dcr.model.UnregistrationResponse;
 import org.wso2.carbon.identity.oauth.dcr.service.DCRManagementService;
-import org.wso2.carbon.identity.testutil.powermock.PowerMockIdentityBaseTest;
 
 import static org.mockito.Matchers.anyString;
 import static org.powermock.api.mockito.PowerMockito.doAnswer;
@@ -40,7 +40,7 @@ import static org.testng.Assert.assertEquals;
  * Unit test covering UnRegistrationHandler
  */
 @PrepareForTest({UnRegistrationHandler.class, DCRManagementService.class})
-public class UnRegistrationHandlerTest extends PowerMockIdentityBaseTest {
+public class UnRegistrationHandlerTest extends PowerMockTestCase {
 
     private UnRegistrationHandler unRegistrationHandler;
 

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/processor/DCRProcessorTest.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/processor/DCRProcessorTest.java
@@ -19,6 +19,7 @@
 package org.wso2.carbon.identity.oauth.dcr.processor;
 
 import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.testng.PowerMockTestCase;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -35,7 +36,6 @@ import org.wso2.carbon.identity.oauth.dcr.model.RegistrationRequest;
 import org.wso2.carbon.identity.oauth.dcr.model.UnregistrationRequest;
 import org.wso2.carbon.identity.oauth.dcr.util.ErrorCodes;
 import org.wso2.carbon.identity.oauth.dcr.util.HandlerManager;
-import org.wso2.carbon.identity.testutil.powermock.PowerMockIdentityBaseTest;
 
 import static org.powermock.api.mockito.PowerMockito.doThrow;
 import static org.powermock.api.mockito.PowerMockito.mock;
@@ -51,7 +51,7 @@ import static org.testng.Assert.fail;
  * Unit test covering DCRProcessor
  */
 @PrepareForTest({HandlerManager.class, DCRProcessor.class})
-public class DCRProcessorTest extends PowerMockIdentityBaseTest {
+public class DCRProcessorTest extends PowerMockTestCase {
 
     private DCRProcessor dcrProcessor;
     private IdentityMessageContext mockIdentityMessageContext;

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/service/DCRMServiceTest.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/service/DCRMServiceTest.java
@@ -484,15 +484,14 @@ public class DCRMServiceTest extends PowerMockTestCase {
     @DataProvider(name = "RedirectAndGrantTypeProvider")
     public Object[][] getListSizeAndGrantType() {
 
-        List<String> redirectUri1 = new ArrayList<>();
         return new Object[][]{
-                {DCRConstants.GrantTypes.IMPLICIT, redirectUri1},
-                {DCRConstants.GrantTypes.AUTHORIZATION_CODE, redirectUri1},
+                {DCRConstants.GrantTypes.IMPLICIT},
+                {DCRConstants.GrantTypes.AUTHORIZATION_CODE},
         };
     }
 
     @Test(dataProvider = "RedirectAndGrantTypeProvider")
-    public void registerApplicationTestWithSPWithFailCallback(String grantTypeVal, List<String> redirectUri)
+    public void registerApplicationTestWithSPWithFailCallback(String grantTypeVal)
             throws Exception {
 
         mockApplicationManagementService = mock(ApplicationManagementService.class);
@@ -512,8 +511,6 @@ public class DCRMServiceTest extends PowerMockTestCase {
         dcrDataHolder.setApplicationManagementService(mockApplicationManagementService);
         when(mockApplicationManagementService.getServiceProvider(dummyClientName, dummyTenantDomain)).thenReturn
                 (null, serviceProvider);
-
-        applicationRegistrationRequest.setRedirectUris(redirectUri);
 
         OAuthConsumerAppDTO oAuthConsumerApp = new OAuthConsumerAppDTO();
         oAuthConsumerApp.setApplicationName(dummyClientName);

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/service/DCRMServiceTest.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/service/DCRMServiceTest.java
@@ -57,7 +57,11 @@ import java.util.List;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
-import static org.powermock.api.mockito.PowerMockito.*;
+import static org.powermock.api.mockito.PowerMockito.doThrow;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.when;
+import static org.powermock.api.mockito.PowerMockito.whenNew;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.fail;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OAuth10AParams.OAUTH_VERSION;

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/service/DCRMServiceTest.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/service/DCRMServiceTest.java
@@ -780,8 +780,6 @@ public class DCRMServiceTest extends PowerMockTestCase {
 
         doThrow(new IdentityApplicationManagementException("ehweh")).when(mockApplicationManagementService)
                 .updateApplication(serviceProvider, dummyTenantDomain, dummyUserName);
-
-
         when(mockApplicationManagementService.
                 getServiceProviderNameByClientId(oAuthConsumerApp.getOauthConsumerKey(),
                         DCRMConstants.OAUTH2, dummyTenantDomain))

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/service/DCRMServiceTest.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/service/DCRMServiceTest.java
@@ -82,8 +82,10 @@ public class DCRMServiceTest extends PowerMockTestCase {
     private final String dummyTokenType = "dummyTokenType";
     private String dummyConsumerSecret = "dummyConsumerSecret";
     private String dummyCallbackUrl = "dummyCallbackUrl";
+
     @Mock
     private OAuthConsumerAppDTO dto;
+
     private DCRMService dcrmService;
     private OAuthAdminService mockOAuthAdminService;
     private ApplicationRegistrationRequest applicationRegistrationRequest;
@@ -151,6 +153,7 @@ public class DCRMServiceTest extends PowerMockTestCase {
             when(mockOAuthAdminService.getAllOAuthApplicationData()).thenReturn(new OAuthConsumerAppDTO[]{dto});
         }
         Whitebox.setInternalState(dcrmService, "oAuthAdminService", mockOAuthAdminService);
+
         try {
             dcrmService.getApplication(dummyConsumerKey);
         } catch (IdentityException ex) {
@@ -165,10 +168,9 @@ public class DCRMServiceTest extends PowerMockTestCase {
 
         doThrow(new IdentityOAuthAdminException("")).when(mockOAuthAdminService)
                 .getOAuthApplicationData(dummyConsumerKey);
-
         when(mockOAuthAdminService.getAllOAuthApplicationData()).thenReturn(new OAuthConsumerAppDTO[0]);
-
         Whitebox.setInternalState(dcrmService, "oAuthAdminService", mockOAuthAdminService);
+
         try {
             dcrmService.getApplication(dummyConsumerKey);
         } catch (IdentityException ex) {
@@ -184,8 +186,8 @@ public class DCRMServiceTest extends PowerMockTestCase {
         doThrow(new IdentityOAuthAdminException("", new InvalidOAuthClientException(""))).when(mockOAuthAdminService)
                 .getOAuthApplicationData(dummyConsumerKey);
         when(mockOAuthAdminService.getAllOAuthApplicationData()).thenReturn(new OAuthConsumerAppDTO[0]);
-
         Whitebox.setInternalState(dcrmService, "oAuthAdminService", mockOAuthAdminService);
+
         try {
             dcrmService.getApplication(dummyConsumerKey);
         } catch (IdentityException ex) {
@@ -197,11 +199,13 @@ public class DCRMServiceTest extends PowerMockTestCase {
 
     @Test
     public void getApplicationDTOTestUserUnauthorized() throws Exception {
+
         startTenantFlow();
         Whitebox.setInternalState(dcrmService, "oAuthAdminService", mockOAuthAdminService);
         when(ApplicationMgtUtil.isUserAuthorized(anyString(), anyString())).thenReturn(false);
         when(mockOAuthAdminService.getOAuthApplicationData(dummyConsumerKey)).thenReturn(dto);
         when(dto.getApplicationName()).thenReturn(dummyClientName);
+
         try {
             dcrmService.getApplication(dummyConsumerKey);
         } catch (IdentityException ex) {
@@ -210,7 +214,6 @@ public class DCRMServiceTest extends PowerMockTestCase {
         }
         fail("Expected exception IdentityException not thrown by getApplication method");
     }
-
 
     @Test
     public void getApplicationDTOTest() throws Exception {
@@ -275,6 +278,7 @@ public class DCRMServiceTest extends PowerMockTestCase {
 
     @Test
     public void getApplicationNullNameTest() throws Exception {
+
         startTenantFlow();
         try {
             dcrmService.getApplicationByName(dummyClientName);
@@ -287,6 +291,7 @@ public class DCRMServiceTest extends PowerMockTestCase {
 
     @Test
     public void getApplicationNameTestWithIOCExceptionTest() throws Exception {
+
         startTenantFlow();
         doThrow(new IdentityOAuthAdminException("", new InvalidOAuthClientException(""))).when(mockOAuthAdminService)
                 .getOAuthApplicationDataByAppName(dummyClientName);
@@ -305,6 +310,7 @@ public class DCRMServiceTest extends PowerMockTestCase {
 
     @Test
     public void getApplicationByNameUserUnauthorizedTest() throws Exception {
+
         startTenantFlow();
         Whitebox.setInternalState(dcrmService, "oAuthAdminService", mockOAuthAdminService);
 
@@ -377,7 +383,6 @@ public class DCRMServiceTest extends PowerMockTestCase {
 
         dummyGrantTypes.add("dummy1");
         dummyGrantTypes.add("dummy2");
-
         applicationRegistrationRequest.setGrantTypes(dummyGrantTypes);
 
         startTenantFlow();
@@ -397,6 +402,7 @@ public class DCRMServiceTest extends PowerMockTestCase {
 
     @Test
     public void registerApplicationTestWithExistClientId() throws Exception {
+
         dummyGrantTypes.add("dummy1");
         dummyGrantTypes.add("dummy2");
 
@@ -417,7 +423,6 @@ public class DCRMServiceTest extends PowerMockTestCase {
         }
         fail("Expected exception IdentityException not thrown by registerApplication method");
     }
-
 
     @DataProvider(name = "RedirectAndGrantTypeProvider")
     public Object[][] getListSizeAndGrantType() {
@@ -527,9 +532,7 @@ public class DCRMServiceTest extends PowerMockTestCase {
     public void testRegisterApplicationWithInvalidSPName() throws Exception {
 
         mockApplicationManagementService = mock(ApplicationManagementService.class);
-
         Whitebox.setInternalState(dcrmService, "oAuthAdminService", mockOAuthAdminService);
-
         startTenantFlow();
 
         dummyGrantTypes.add("implicit");
@@ -594,9 +597,7 @@ public class DCRMServiceTest extends PowerMockTestCase {
     public void registerApplicationTestWithFailedToDeleteCreatedSP(List<String> redirectUri) throws Exception {
 
         mockStatic(IdentityProviderManager.class);
-
         mockApplicationManagementService = mock(ApplicationManagementService.class);
-
         Whitebox.setInternalState(dcrmService, "oAuthAdminService", mockOAuthAdminService);
 
         startTenantFlow();
@@ -637,7 +638,6 @@ public class DCRMServiceTest extends PowerMockTestCase {
         fail("Expected exception IdentityException not thrown by registerApplication method");
     }
 
-
     @Test(dataProvider = "redirectUriProvider")
     public void registerApplicationTestWithFailedToUpdateSPTest(List<String> redirectUri) throws Exception {
 
@@ -670,22 +670,17 @@ public class DCRMServiceTest extends PowerMockTestCase {
         fail("Expected exception IdentityException not thrown by registerApplication method");
     }
 
-
     private OAuthConsumerAppDTO registerApplicationTestWithFailedToUpdateSP() throws Exception {
+
         mockApplicationManagementService = mock(ApplicationManagementService.class);
-
         Whitebox.setInternalState(dcrmService, "oAuthAdminService", mockOAuthAdminService);
-
         startTenantFlow();
 
         dummyGrantTypes.add("implicit");
         applicationRegistrationRequest.setGrantTypes(dummyGrantTypes);
-
         String grantType = StringUtils.join(applicationRegistrationRequest.getGrantTypes(), " ");
 
         ServiceProvider serviceProvider = new ServiceProvider();
-        //serviceProvider.setApplicationName(dummyClientName);
-
         DCRDataHolder dcrDataHolder = DCRDataHolder.getInstance();
         dcrDataHolder.setApplicationManagementService(mockApplicationManagementService);
         when(mockApplicationManagementService.getServiceProvider(dummyClientName, dummyTenantDomain)).thenReturn
@@ -721,6 +716,7 @@ public class DCRMServiceTest extends PowerMockTestCase {
 
     @Test(dataProvider = "redirectUriProvider")
     public void updateApplicationTest(List<String> redirectUri1) throws Exception {
+
         updateApplication();
         applicationUpdateRequest.setRedirectUris(redirectUri1);
         Application application = dcrmService.updateApplication(applicationUpdateRequest, dummyConsumerKey);
@@ -733,10 +729,11 @@ public class DCRMServiceTest extends PowerMockTestCase {
 
     @Test
     public void updateApplicationTestWithFailedToGetSP() throws Exception {
-        updateApplication();
 
+        updateApplication();
         when(mockApplicationManagementService.getServiceProvider(dummyClientName, dummyTenantDomain))
                 .thenReturn(null);
+
         try {
             dcrmService.updateApplication(applicationUpdateRequest, dummyConsumerKey);
         } catch (IdentityException ex) {
@@ -749,6 +746,7 @@ public class DCRMServiceTest extends PowerMockTestCase {
 
     @Test
     public void updateApplicationTestWithInvalidSPName() throws Exception {
+
         updateApplication();
         applicationUpdateRequest.setClientName(dummyInvalidClientName);
 
@@ -763,6 +761,7 @@ public class DCRMServiceTest extends PowerMockTestCase {
 
     @Test
     public void updateApplicationTestWithSPAlreadyExist() throws Exception {
+
         startTenantFlow();
         updateApplication();
         applicationUpdateRequest.setClientName("dummynewClientName");
@@ -784,9 +783,9 @@ public class DCRMServiceTest extends PowerMockTestCase {
         fail("Expected exception IdentityException not thrown by registerApplication method");
     }
 
-
     @Test
     public void updateApplicationTestWithIOAException() throws Exception {
+
         dto = updateApplication();
         doThrow(new IdentityOAuthAdminException("")).when(mockOAuthAdminService)
                 .updateConsumerApplication(dto);
@@ -799,9 +798,9 @@ public class DCRMServiceTest extends PowerMockTestCase {
         fail("Expected exception IdentityException not thrown by getApplication method");
     }
 
-
     private OAuthConsumerAppDTO updateApplication()
             throws IdentityOAuthAdminException, IdentityApplicationManagementException {
+
         startTenantFlow();
         dummyGrantTypes.add("dummy1");
         dummyGrantTypes.add("dummy2");

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/service/DCRMServiceTest.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/service/DCRMServiceTest.java
@@ -528,9 +528,6 @@ public class DCRMServiceTest extends PowerMockTestCase {
         oAuthConsumerApp.setOauthConsumerKey(dummyConsumerKey);
         oAuthConsumerApp.setOauthConsumerSecret(dummyConsumerSecret);
         oAuthConsumerApp.setCallbackUrl(redirectUri.get(0));
-
-
-
         oAuthConsumerApp.setGrantTypes(grantType);
         oAuthConsumerApp.setOAuthVersion(OAUTH_VERSION);
 

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/service/DCRMServiceTest.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/service/DCRMServiceTest.java
@@ -144,7 +144,7 @@ public class DCRMServiceTest extends PowerMockTestCase {
             assertEquals(ex.getMessage(), "Invalid client_id");
             return;
         }
-        fail("Expected exception IdentityException not thrown by getApplication method");
+        fail("Expected IdentityException was not thrown by getApplication method");
     }
 
     @Test(dataProvider = "DTOProvider")
@@ -167,7 +167,7 @@ public class DCRMServiceTest extends PowerMockTestCase {
             assertEquals(ex.getErrorCode(), DCRMConstants.ErrorMessages.NOT_FOUND_APPLICATION_WITH_ID.toString());
             return;
         }
-        fail("Expected exception IdentityException not thrown by getApplication method");
+        fail("Expected IdentityException was not thrown by getApplication method");
     }
 
     @Test
@@ -184,7 +184,7 @@ public class DCRMServiceTest extends PowerMockTestCase {
             assertEquals(ex.getErrorCode(), DCRMConstants.ErrorMessages.FAILED_TO_GET_APPLICATION_BY_ID.toString());
             return;
         }
-        fail("Expected exception IdentityException not thrown by getApplication method");
+        fail("Expected IdentityException was not thrown by getApplication method");
     }
 
     @Test
@@ -201,7 +201,7 @@ public class DCRMServiceTest extends PowerMockTestCase {
             assertEquals(ex.getErrorCode(), DCRMConstants.ErrorMessages.NOT_FOUND_APPLICATION_WITH_ID.toString());
             return;
         }
-        fail("Expected exception IdentityException not thrown by getApplication method");
+        fail("Expected IdentityException was not thrown by getApplication method");
     }
 
     @Test
@@ -219,7 +219,7 @@ public class DCRMServiceTest extends PowerMockTestCase {
             assertEquals(ex.getErrorCode(), DCRMConstants.ErrorMessages.FORBIDDEN_UNAUTHORIZED_USER.toString());
             return;
         }
-        fail("Expected exception IdentityException not thrown by getApplication method");
+        fail("Expected IdentityException was not thrown by getApplication method");
     }
 
     @Test
@@ -239,7 +239,7 @@ public class DCRMServiceTest extends PowerMockTestCase {
             assertEquals(ex.getErrorCode(), DCRMConstants.ErrorMessages.FAILED_TO_GET_APPLICATION_BY_ID.toString());
             return;
         }
-        fail("Expected exception IdentityException not thrown by getApplication method");
+        fail("Expected IdentityException was not thrown by getApplication method");
     }
 
     @Test
@@ -277,8 +277,7 @@ public class DCRMServiceTest extends PowerMockTestCase {
                     TENANT_DOMAIN_MISMATCH.getMessage(), dummyConsumerKey));
             return;
         }
-        fail("Expected exception IdentityException not thrown by getApplication method");
-
+        fail("Expected IdentityException was not thrown by getApplication method");
     }
 
     @Test
@@ -293,8 +292,7 @@ public class DCRMServiceTest extends PowerMockTestCase {
                     FAILED_TO_VALIDATE_TENANT_DOMAIN.getMessage(), dummyConsumerKey));
             return;
         }
-        fail("Expected exception IdentityException not thrown by getApplication method");
-
+        fail("Expected DCRMException was not thrown by getApplication method");
     }
 
     @Test
@@ -332,7 +330,7 @@ public class DCRMServiceTest extends PowerMockTestCase {
             assertEquals(ex.getErrorCode(), DCRMConstants.ErrorMessages.BAD_REQUEST_INSUFFICIENT_DATA.toString());
             return;
         }
-        fail("Expected exception IdentityException not thrown by getApplication method");
+        fail("Expected IdentityException was not thrown by getApplicationByName method");
     }
 
     @Test
@@ -345,7 +343,7 @@ public class DCRMServiceTest extends PowerMockTestCase {
             assertEquals(ex.getErrorCode(), DCRMConstants.ErrorMessages.NOT_FOUND_APPLICATION_WITH_NAME.toString());
             return;
         }
-        fail("Expected exception IdentityException not thrown by getApplication method");
+        fail("Expected IdentityException was not thrown by getApplicationByName method");
     }
 
     @Test
@@ -364,7 +362,7 @@ public class DCRMServiceTest extends PowerMockTestCase {
             assertEquals(ex.getErrorCode(), DCRMConstants.ErrorMessages.FAILED_TO_GET_APPLICATION.toString());
             return;
         }
-        fail("Expected exception IdentityException not thrown by getApplication method");
+        fail("Expected IdentityException was not thrown by getApplicationByName method");
     }
 
     @Test
@@ -384,7 +382,7 @@ public class DCRMServiceTest extends PowerMockTestCase {
             assertEquals(ex.getErrorCode(), DCRMConstants.ErrorMessages.FORBIDDEN_UNAUTHORIZED_USER.toString());
             return;
         }
-        fail("Expected exception IdentityException not thrown by getApplication method");
+        fail("Expected IdentityException was not thrown by getApplicationByName method");
     }
 
     @Test
@@ -407,7 +405,7 @@ public class DCRMServiceTest extends PowerMockTestCase {
             assertEquals(ex.getErrorCode(), DCRMConstants.ErrorMessages.CONFLICT_EXISTING_APPLICATION.toString());
             return;
         }
-        fail("Expected exception IdentityException not thrown by registerApplication method");
+        fail("Expected IdentityException was not thrown by registerApplication method");
     }
 
     @Test
@@ -434,7 +432,7 @@ public class DCRMServiceTest extends PowerMockTestCase {
             assertEquals(ex.getErrorCode(), DCRMConstants.ErrorMessages.FAILED_TO_GET_SP.toString());
             return;
         }
-        fail("Expected exception IdentityException not thrown by registerApplication method");
+        fail("Expected IdentityException was not thrown by registerApplication method");
     }
 
     @Test
@@ -456,7 +454,7 @@ public class DCRMServiceTest extends PowerMockTestCase {
             assertEquals(ex.getErrorCode(), DCRMConstants.ErrorMessages.FAILED_TO_REGISTER_SP.toString());
             return;
         }
-        fail("Expected exception IdentityException not thrown by registerApplication method");
+        fail("Expected IdentityException was not thrown by registerApplication method");
     }
 
     @Test
@@ -480,7 +478,7 @@ public class DCRMServiceTest extends PowerMockTestCase {
             assertEquals(ex.getErrorCode(), DCRMConstants.ErrorMessages.CONFLICT_EXISTING_CLIENT_ID.toString());
             return;
         }
-        fail("Expected exception IdentityException not thrown by registerApplication method");
+        fail("Expected IdentityException was not thrown by registerApplication method");
     }
 
     @DataProvider(name = "RedirectAndGrantTypeProvider")
@@ -532,7 +530,7 @@ public class DCRMServiceTest extends PowerMockTestCase {
             assertEquals(ex.getErrorCode(), DCRMConstants.ErrorMessages.BAD_REQUEST_INVALID_INPUT.toString());
             return;
         }
-        fail("Expected exception IdentityException not thrown by registerApplication method");
+        fail("Expected IdentityException was not thrown by registerApplication method");
     }
 
     @DataProvider(name = "redirectUriProvider")
@@ -603,7 +601,6 @@ public class DCRMServiceTest extends PowerMockTestCase {
         assertEquals(application.getClientName(), dummyClientName);
         assertEquals(application.getGrantTypes(), dummyGrantTypes);
         assertEquals(application.toString(), toString);
-
     }
 
     @Test
@@ -635,8 +632,7 @@ public class DCRMServiceTest extends PowerMockTestCase {
             assertEquals(ex.getErrorCode(), DCRMConstants.ErrorMessages.FAILED_TO_REGISTER_APPLICATION.toString());
             return;
         }
-        Assert.fail("Expected exception IdentityException not thrown by registerApplication method");
-
+        Assert.fail("Expected IdentityException was not thrown by registerApplication method");
     }
 
     @Test
@@ -656,7 +652,7 @@ public class DCRMServiceTest extends PowerMockTestCase {
             assertEquals(ex.getErrorCode(), DCRMConstants.ErrorMessages.BAD_REQUEST_INVALID_SP_NAME.toString());
             return;
         }
-        fail("Expected exception IdentityException not thrown by registerApplication method");
+        fail("Expected IdentityException was not thrown by registerApplication method");
     }
 
     @Test(dataProvider = "redirectUriProvider")
@@ -701,7 +697,7 @@ public class DCRMServiceTest extends PowerMockTestCase {
             assertEquals(ex.getErrorCode(), DCRMConstants.ErrorMessages.FAILED_TO_REGISTER_APPLICATION.toString());
             return;
         }
-        fail("Expected exception IdentityException not thrown by registerApplication method");
+        fail("Expected IdentityException was not thrown by registerApplication method");
     }
 
     @Test(dataProvider = "redirectUriProvider")
@@ -746,7 +742,7 @@ public class DCRMServiceTest extends PowerMockTestCase {
             assertEquals(ex.getErrorCode(), DCRMConstants.ErrorMessages.FAILED_TO_DELETE_SP.toString());
             return;
         }
-        fail("Expected exception IdentityException not thrown by registerApplication method");
+        fail("Expected IdentityException was not thrown by registerApplication method");
     }
 
     @Test(dataProvider = "redirectUriProvider")
@@ -761,7 +757,7 @@ public class DCRMServiceTest extends PowerMockTestCase {
             assertEquals(ex.getErrorCode(), DCRMConstants.ErrorMessages.FAILED_TO_UPDATE_SP.toString());
             return;
         }
-        fail("Expected exception IdentityException not thrown by registerApplication method");
+        fail("Expected IdentityException was not thrown by registerApplication method");
     }
 
     @Test(dataProvider = "redirectUriProvider")
@@ -779,7 +775,7 @@ public class DCRMServiceTest extends PowerMockTestCase {
                     DCRMConstants.ErrorMessages.BAD_REQUEST_INVALID_SP_TEMPLATE_NAME.toString());
             return;
         }
-        fail("Expected exception IdentityException not thrown by registerApplication method");
+        fail("Expected IdentityException was not thrown by registerApplication method");
     }
 
     @Test(dataProvider = "redirectUriProvider")
@@ -812,7 +808,7 @@ public class DCRMServiceTest extends PowerMockTestCase {
             assertEquals(ex.getErrorCode(), ErrorCodes.BAD_REQUEST.toString());
             return;
         }
-        fail("Expected exception IdentityException not thrown by registerApplication method");
+        fail("Expected IdentityException was not thrown by registerApplication method");
     }
 
     @Test
@@ -837,7 +833,7 @@ public class DCRMServiceTest extends PowerMockTestCase {
                     DCRMConstants.ErrorMessages.FAILED_TO_GET_APPLICATION_BY_ID.toString());
             return;
         }
-        fail("Expected exception IdentityException not thrown by registerApplication method");
+        fail("Expected IdentityException was not thrown by registerApplication method");
     }
 
     @Test(dataProvider = "redirectUriProvider")
@@ -854,7 +850,7 @@ public class DCRMServiceTest extends PowerMockTestCase {
                     oAuthConsumerApp.getOauthConsumerKey());
             return;
         }
-        fail("Expected exception IdentityException not thrown by registerApplication method");
+        fail("Expected IdentityException was not thrown by registerApplication method");
     }
 
     private OAuthConsumerAppDTO registerApplicationTestWithFailedToUpdateSP() throws Exception {
@@ -909,7 +905,6 @@ public class DCRMServiceTest extends PowerMockTestCase {
         assertEquals(application.getClientId(), dummyConsumerKey);
         assertEquals(application.getClientName(), dummyClientName);
         assertEquals(application.getClientSecret(), dummyConsumerSecret);
-
     }
 
     @Test
@@ -925,7 +920,7 @@ public class DCRMServiceTest extends PowerMockTestCase {
             assertEquals(ex.getErrorCode(), DCRMConstants.ErrorMessages.FAILED_TO_GET_SP.toString());
             return;
         }
-        fail("Expected exception IdentityException not thrown by registerApplication method");
+        fail("Expected IdentityException not thrown by updateApplication method");
     }
 
 
@@ -941,7 +936,7 @@ public class DCRMServiceTest extends PowerMockTestCase {
             assertEquals(ex.getErrorCode(), DCRMConstants.ErrorMessages.BAD_REQUEST_INVALID_SP_NAME.toString());
             return;
         }
-        fail("Expected exception IdentityException not thrown by registerApplication method");
+        fail("Expected IdentityException was not thrown by updateApplication method");
     }
 
     @Test
@@ -965,7 +960,7 @@ public class DCRMServiceTest extends PowerMockTestCase {
             assertEquals(ex.getErrorCode(), DCRMConstants.ErrorMessages.CONFLICT_EXISTING_APPLICATION.toString());
             return;
         }
-        fail("Expected exception IdentityException not thrown by registerApplication method");
+        fail("Expected IdentityException was not thrown by updateApplication method");
     }
 
     @Test
@@ -980,7 +975,7 @@ public class DCRMServiceTest extends PowerMockTestCase {
             assertEquals(ex.getErrorCode(), DCRMConstants.ErrorMessages.FAILED_TO_UPDATE_APPLICATION.toString());
             return;
         }
-        fail("Expected exception IdentityException not thrown by getApplication method");
+        fail("Expected IdentityException was not thrown by updateApplication method");
     }
 
     private OAuthConsumerAppDTO updateApplication()

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/service/DCRManagementServiceTest.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/service/DCRManagementServiceTest.java
@@ -104,7 +104,7 @@ public class DCRManagementServiceTest extends PowerMockTestCase {
             assertEquals(ex.getMessage(), "Couldn't create Service Provider Application " + applicationName);
             return;
         }
-        fail("Expected exception IdentityException not thrown by registerOAuthApplication");
+        fail("Expected IdentityException was not thrown by registerOAuthApplication method");
     }
 
     @Test
@@ -125,7 +125,7 @@ public class DCRManagementServiceTest extends PowerMockTestCase {
             assertEquals(ex.getMessage(), "Error occurred while reading service provider, " + applicationName);
             return;
         }
-        fail("Expected exception IdentityException not thrown by registerOAuthApplication");
+        fail("Expected IdentityException was not thrown by registerOAuthApplication method");
     }
 
     @Test
@@ -149,7 +149,7 @@ public class DCRManagementServiceTest extends PowerMockTestCase {
                     " already registered");
             return;
         }
-        fail("Expected exception IdentityException not thrown by registerOAuthApplication");
+        fail("Expected IdentityException was not thrown by registerOAuthApplication method");
     }
 
     @Test
@@ -173,7 +173,7 @@ public class DCRManagementServiceTest extends PowerMockTestCase {
                     " the regex: " + DCRMUtils.getSPValidatorRegex());
             return;
         }
-        fail("Expected exception IdentityException not thrown by registerOAuthApplication");
+        fail("Expected IdentityException was not thrown by registerOAuthApplication method");
     }
 
     @Test
@@ -193,11 +193,11 @@ public class DCRManagementServiceTest extends PowerMockTestCase {
             assertEquals(ex.getMessage(), "RedirectUris property must have at least one URI value.");
             return;
         }
-        fail("Expected exception IdentityException not thrown by registerOAuthApplication");
+        fail("Expected IdentityException was not thrown by registerOAuthApplication method");
     }
 
     @DataProvider(name = "invalidRedirectUriProvider")
-    public Object[][] getReDirecturi() {
+    public Object[][] getRedirecturi() {
 
         return new Object[][]{
                 {new ArrayList<>(Arrays.asList("redirect#Uri1"))},
@@ -226,7 +226,7 @@ public class DCRManagementServiceTest extends PowerMockTestCase {
             assertEquals(ex.getMessage(), "Redirect URI: " + redirectUri.get(0) + ", is invalid");
             return;
         }
-        fail("Expected exception IdentityException not thrown by registerOAuthApplication");
+        fail("Expected IdentityException was not thrown by registerOAuthApplication");
     }
 
     @DataProvider(name = "serviceProviderData")
@@ -321,7 +321,7 @@ public class DCRManagementServiceTest extends PowerMockTestCase {
             assertEquals(ex.getErrorCode(), ErrorCodes.META_DATA_VALIDATION_FAILED.toString());
             return;
         }
-        fail("Expected exception IdentityException not thrown by registerApplication method");
+        fail("Expected IdentityException was not thrown by registerOAuthApplication method");
 
     }
 
@@ -339,7 +339,7 @@ public class DCRManagementServiceTest extends PowerMockTestCase {
                     + applicationName + "'");
             return;
         }
-        fail("Expected exception IdentityException not thrown by registerApplication method");
+        fail("Expected IdentityException was not thrown by unregisterOAuthApplication method");
     }
 
     @Test
@@ -353,7 +353,7 @@ public class DCRManagementServiceTest extends PowerMockTestCase {
             assertEquals(ex.getMessage(), "Username, Application Name and Consumer Key cannot be null or empty");
             return;
         }
-        fail("Expected exception IdentityException not thrown by registerApplication method");
+        fail("Expected IdentityException was not thrown by unregisterOAuthApplication method");
     }
 
     @Test
@@ -368,7 +368,7 @@ public class DCRManagementServiceTest extends PowerMockTestCase {
             assertEquals(ex.getMessage(), "Couldn't retrieve Service Provider Application " + applicationName);
             return;
         }
-        fail("Expected exception IdentityException not thrown by registerApplication method");
+        fail("Expected IdentityException was not thrown by unregisterOAuthApplication method");
     }
 
     private void unRegister() throws Exception {
@@ -449,7 +449,7 @@ public class DCRManagementServiceTest extends PowerMockTestCase {
             assertEquals(ex.getMessage(), "Error occurred while retrieving information of OAuthApp " + applicationName);
             return;
         }
-        fail("Expected exception IdentityException not thrown by registerApplication method");
+        fail("Expected IdentityException was not thrown by isOAuthApplicationAvailable method");
     }
 
     @Test

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/service/DCRManagementServiceTest.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/service/DCRManagementServiceTest.java
@@ -311,9 +311,9 @@ public class DCRManagementServiceTest extends PowerMockTestCase {
         assertEquals(registrationRqstProfile.getClientName(), applicationName);
     }
 
-
     @Test
     public void unregisterOAuthApplicationIAMExceptionTest() throws Exception {
+
         unRegister();
         doThrow(new IdentityApplicationManagementException("")).when(mockApplicationManagementService)
                 .deleteApplication(applicationName, tenantDomain, userName);
@@ -330,6 +330,7 @@ public class DCRManagementServiceTest extends PowerMockTestCase {
 
     @Test
     public void unregisterOAuthApplicationEmptyApplicationNameTest() throws Exception {
+
         unRegister();
         applicationName = "";
         try {
@@ -343,6 +344,7 @@ public class DCRManagementServiceTest extends PowerMockTestCase {
 
     @Test
     public void unregisterOAuthApplicationWithNullSPTest() throws Exception {
+
         unRegister();
         when(mockApplicationManagementService.getServiceProvider(applicationName, tenantDomain)).thenReturn(
                 null);
@@ -355,8 +357,8 @@ public class DCRManagementServiceTest extends PowerMockTestCase {
         fail("Expected exception IdentityException not thrown by registerApplication method");
     }
 
-
     private void unRegister() throws Exception {
+
         startTenantFlow();
         mockApplicationManagementService = mock(ApplicationManagementService.class);
         ServiceProvider serviceProvider = new ServiceProvider();
@@ -375,7 +377,6 @@ public class DCRManagementServiceTest extends PowerMockTestCase {
         OAuthConsumerAppDTO dto = new OAuthConsumerAppDTO();
         dto.setApplicationName(applicationName);
         when(mockOAuthAdminService.getOAuthApplicationData(consumerkey)).thenReturn(dto);
-
     }
 
     private void registerOAuthApplication() {

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/service/DCRManagementServiceTest.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/service/DCRManagementServiceTest.java
@@ -44,8 +44,14 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.powermock.api.mockito.PowerMockito.*;
-import static org.testng.Assert.*;
+import static org.powermock.api.mockito.PowerMockito.doThrow;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.when;
+import static org.powermock.api.mockito.PowerMockito.whenNew;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.fail;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OAuth10AParams.OAUTH_VERSION;
 
 /**

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/service/DCRManagementServiceTest.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/service/DCRManagementServiceTest.java
@@ -45,6 +45,7 @@ import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 import java.nio.file.Paths;
 import java.rmi.registry.Registry;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.powermock.api.mockito.PowerMockito.doThrow;
@@ -107,8 +108,7 @@ public class DCRManagementServiceTest extends PowerMockTestCase {
     }
 
     @Test
-    public void registerOAuthApplicationWithIAMException() throws
-            IdentityApplicationManagementException {
+    public void registerOAuthApplicationWithIAMException() throws IdentityApplicationManagementException {
 
         registerOAuthApplication();
         mockApplicationManagementService = mock(ApplicationManagementService.class);
@@ -129,8 +129,7 @@ public class DCRManagementServiceTest extends PowerMockTestCase {
     }
 
     @Test
-    public void registerOAuthApplicationWithExistingSP() throws
-            IdentityApplicationManagementException {
+    public void registerOAuthApplicationWithExistingSP() throws IdentityApplicationManagementException {
 
         registerOAuthApplication();
         mockApplicationManagementService = mock(ApplicationManagementService.class);
@@ -178,8 +177,7 @@ public class DCRManagementServiceTest extends PowerMockTestCase {
     }
 
     @Test
-    public void registerOAuthApplicationWithNewSPNoRedirectUri() throws
-            Exception {
+    public void registerOAuthApplicationWithNewSPNoRedirectUri() throws Exception {
 
         registerOAuthApplication();
         registrationRequestProfile.setRedirectUris(new ArrayList<>());
@@ -201,14 +199,9 @@ public class DCRManagementServiceTest extends PowerMockTestCase {
     @DataProvider(name = "invalidRedirectUriProvider")
     public Object[][] getReDirecturi() {
 
-        List<String> redirectUri1 = new ArrayList<>();
-        redirectUri1.add("redirect#Uri1");
-        List<String> redirectUri2 = new ArrayList<>();
-        redirectUri2.add("redirect#Uri1");
-        redirectUri2.add("redirect#Uri2");
         return new Object[][]{
-                {redirectUri1},
-                {redirectUri2}
+                {new ArrayList<>(Arrays.asList("redirect#Uri1"))},
+                {new ArrayList<>(Arrays.asList("redirect#Uri1", "redirect#Uri2"))}
         };
     }
 
@@ -414,9 +407,8 @@ public class DCRManagementServiceTest extends PowerMockTestCase {
         startTenantFlow();
     }
 
-    @DataProvider(name = "outhApplicationDataProvider")
+    @DataProvider(name = "oauthApplicationDataProvider")
     public Object[][] getExceptionInstanceType() {
-
 
         ServiceProvider serviceProvider = new ServiceProvider();
         return new Object[][]{
@@ -425,7 +417,7 @@ public class DCRManagementServiceTest extends PowerMockTestCase {
         };
     }
 
-    @Test(dataProvider = "outhApplicationDataProvider")
+    @Test(dataProvider = "oauthApplicationDataProvider")
     public void oAuthApplicationAvailableTest(Object serviceProvider, boolean expected) throws Exception {
 
         startTenantFlow();

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/util/DCRMUtilsTest.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/util/DCRMUtilsTest.java
@@ -25,6 +25,8 @@ import org.wso2.carbon.identity.oauth.dcr.DCRMConstants;
 import org.wso2.carbon.identity.oauth.dcr.exception.DCRMClientException;
 import org.wso2.carbon.identity.oauth.dcr.exception.DCRMServerException;
 
+import static org.wso2.carbon.identity.oauth.dcr.util.DCRConstants.APP_NAME_VALIDATING_REGEX;
+
 public class DCRMUtilsTest extends PowerMockTestCase {
 
     @DataProvider(name = "BuildRedirectUrl")
@@ -32,6 +34,7 @@ public class DCRMUtilsTest extends PowerMockTestCase {
 
         return new Object[][]{
                 {"http://example.com/", true},
+                {"http:\\example.com/", false},
                 {null, false},
                 {"", false},
         };
@@ -76,5 +79,40 @@ public class DCRMUtilsTest extends PowerMockTestCase {
     public void testGenerateClientException(DCRMConstants.ErrorMessages error, String data) throws Exception {
 
         throw DCRMUtils.generateClientException(error, data);
+    }
+
+    @DataProvider(name = "BuildRBackchannelLogoutUri")
+    public Object[][] buildBackchannelLogoutUri() {
+
+        return new Object[][]{
+                {"http://example.com/", true},
+                {"", true},
+                {"http://examp#le.com/", false},
+                {"http:\\example.com", false},
+                {"example", false},
+        };
+    }
+
+    @Test(dataProvider = "BuildRBackchannelLogoutUri")
+    public void backChannelURIValidTest(String url, boolean response) {
+
+        Assert.assertEquals(DCRMUtils.isBackchannelLogoutUriValid(url), response);
+
+    }
+
+    @DataProvider(name = "applicationName")
+    public Object[][] buildApplicationName() {
+
+        return new Object[][]{
+                {"dummyApplicationName", true},
+                {"dummy@ApllicationName", false},
+
+        };
+    }
+
+    @Test(dataProvider = "applicationName")
+    public void regrexTest(String input, boolean expected) {
+
+        Assert.assertEquals(DCRMUtils.isRegexValidated(input, APP_NAME_VALIDATING_REGEX), expected);
     }
 }

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/util/DCRMUtilsTest.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/util/DCRMUtilsTest.java
@@ -105,6 +105,7 @@ public class DCRMUtilsTest extends PowerMockTestCase {
 
         return new Object[][]{
                 {"dummyApplicationName", true},
+                {"", true},
                 {"dummy@ApllicationName", false},
 
         };

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/util/DCRMUtilsTest.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/util/DCRMUtilsTest.java
@@ -81,7 +81,7 @@ public class DCRMUtilsTest extends PowerMockTestCase {
         throw DCRMUtils.generateClientException(error, data);
     }
 
-    @DataProvider(name = "BuildRBackchannelLogoutUri")
+    @DataProvider(name = "BuildBackchannelLogoutUri")
     public Object[][] buildBackchannelLogoutUri() {
 
         return new Object[][]{
@@ -93,11 +93,10 @@ public class DCRMUtilsTest extends PowerMockTestCase {
         };
     }
 
-    @Test(dataProvider = "BuildRBackchannelLogoutUri")
+    @Test(dataProvider = "BuildBackchannelLogoutUri")
     public void backChannelURIValidTest(String url, boolean response) {
 
         Assert.assertEquals(DCRMUtils.isBackchannelLogoutUriValid(url), response);
-
     }
 
     @DataProvider(name = "applicationName")
@@ -106,8 +105,7 @@ public class DCRMUtilsTest extends PowerMockTestCase {
         return new Object[][]{
                 {"dummyApplicationName", true},
                 {"", true},
-                {"dummy@ApllicationName", false},
-
+                {"dummy@ApllicationName", false}
         };
     }
 

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/util/DCRMUtilsTest.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/util/DCRMUtilsTest.java
@@ -17,15 +17,15 @@
  */
 package org.wso2.carbon.identity.oauth.dcr.util;
 
+import org.powermock.modules.testng.PowerMockTestCase;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.wso2.carbon.identity.oauth.dcr.DCRMConstants;
 import org.wso2.carbon.identity.oauth.dcr.exception.DCRMClientException;
 import org.wso2.carbon.identity.oauth.dcr.exception.DCRMServerException;
-import org.wso2.carbon.identity.testutil.IdentityBaseTest;
 
-public class DCRMUtilsTest extends IdentityBaseTest {
+public class DCRMUtilsTest extends PowerMockTestCase {
 
     @DataProvider(name = "BuildRedirectUrl")
     public Object[][] buildRedirectUrl() {

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/test/resources/testng.xml
@@ -24,6 +24,7 @@
     <test name="basic-authenticator-tests-with-debug-logs" preserve-order="true" parallel="false">
         <parameter name="log-level" value="debug"/>
         <classes>
+            <class name="org.wso2.carbon.identity.oauth.dcr.context.DCRMessageContextTest"/>
             <class name="org.wso2.carbon.identity.oauth.dcr.service.DCRManagementServiceTest"/>
             <class name="org.wso2.carbon.identity.oauth.dcr.service.DCRMServiceTest"/>
             <class name="org.wso2.carbon.identity.oauth.dcr.processor.DCRProcessorTest"/>
@@ -32,20 +33,21 @@
             <class name="org.wso2.carbon.identity.oauth.dcr.util.DCRMUtilsTest"/>
             <class name="org.wso2.carbon.identity.oauth.dcr.handler.RegistrationHandlerTest"/>
             <class name="org.wso2.carbon.identity.oauth.dcr.handler.UnRegistrationHandlerTest"/>
-            <class name="org.wso2.carbon.identity.oauth.dcr.factory.HttpUnregistrationResponseFactory"></class>
+            <class name="org.wso2.carbon.identity.oauth.dcr.factory.HttpUnRegistrationResponseFactoryTest"/>
         </classes>
     </test>
 
     <test name="basic-authenticator-tests-with-info-logs" preserve-order="true" parallel="false">
     <parameter name="log-level" value="info"/>
     <classes>
+        <class name="org.wso2.carbon.identity.oauth.dcr.context.DCRMessageContextTest"/>
         <class name="org.wso2.carbon.identity.oauth.dcr.service.DCRManagementServiceTest"/>
         <class name="org.wso2.carbon.identity.oauth.dcr.service.DCRMServiceTest"/>
         <class name="org.wso2.carbon.identity.oauth.dcr.processor.DCRProcessorTest"/>
         <class name="org.wso2.carbon.identity.oauth.dcr.factory.HttpRegistrationResponseFactoryTest"/>
         <class name="org.wso2.carbon.identity.oauth.dcr.factory.RegistrationRequestFactoryTest"/>
         <class name="org.wso2.carbon.identity.oauth.dcr.factory.UnregistrationRequestFactoryTest"/>
-        <class name="org.wso2.carbon.identity.oauth.dcr.factory.HttpUnregistrationResponseFactory"></class>
+        <class name="org.wso2.carbon.identity.oauth.dcr.factory.HttpUnRegistrationResponseFactoryTest"/>
         <class name="org.wso2.carbon.identity.oauth.dcr.util.DCRMUtilsTest"/>
         <class name="org.wso2.carbon.identity.oauth.dcr.util.HandlerManagerTest"/>
         <class name="org.wso2.carbon.identity.oauth.dcr.handler.RegistrationHandlerTest"/>

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/test/resources/testng.xml
@@ -32,6 +32,7 @@
             <class name="org.wso2.carbon.identity.oauth.dcr.util.DCRMUtilsTest"/>
             <class name="org.wso2.carbon.identity.oauth.dcr.handler.RegistrationHandlerTest"/>
             <class name="org.wso2.carbon.identity.oauth.dcr.handler.UnRegistrationHandlerTest"/>
+            <class name="org.wso2.carbon.identity.oauth.dcr.factory.HttpUnregistrationResponseFactory"></class>
         </classes>
     </test>
 
@@ -44,10 +45,11 @@
         <class name="org.wso2.carbon.identity.oauth.dcr.factory.HttpRegistrationResponseFactoryTest"/>
         <class name="org.wso2.carbon.identity.oauth.dcr.factory.RegistrationRequestFactoryTest"/>
         <class name="org.wso2.carbon.identity.oauth.dcr.factory.UnregistrationRequestFactoryTest"/>
+        <class name="org.wso2.carbon.identity.oauth.dcr.factory.HttpUnregistrationResponseFactory"></class>
         <class name="org.wso2.carbon.identity.oauth.dcr.util.DCRMUtilsTest"/>
         <class name="org.wso2.carbon.identity.oauth.dcr.util.HandlerManagerTest"/>
         <class name="org.wso2.carbon.identity.oauth.dcr.handler.RegistrationHandlerTest"/>
         <class name="org.wso2.carbon.identity.oauth.dcr.handler.UnRegistrationHandlerTest"/>
-    </classes>
+       </classes>
     </test>
 </suite>

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/test/resources/testng.xml
@@ -52,6 +52,6 @@
         <class name="org.wso2.carbon.identity.oauth.dcr.util.HandlerManagerTest"/>
         <class name="org.wso2.carbon.identity.oauth.dcr.handler.RegistrationHandlerTest"/>
         <class name="org.wso2.carbon.identity.oauth.dcr.handler.UnRegistrationHandlerTest"/>
-       </classes>
+    </classes>
     </test>
 </suite>


### PR DESCRIPTION
Adding new unit tests for the following classes :

- DCRMServiceTest
- DCRManagementServiceTest
- HttpRegistrationResponseFactoryTest
- HttpUnregistrationResponseFactoryTest
- DCRMessageContextTest

Changed the extended classes of some test classes; powerMockIdentityBaseTest -> PowerMockTestCase , as it was shown **no tests were found** error.

