### PR TITLE
Get consumer key from OAuthAppDO to avoid DB calls

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuthApplicationMgtListener.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuthApplicationMgtListener.java
@@ -377,10 +377,9 @@ public class OAuthApplicationMgtListener extends AbstractApplicationMgtListener 
             } else {
                 //nothing to do
             }
-        } catch (IdentityOAuthAdminException e) {
+        } catch (IdentityOAuth2Exception | InvalidOAuthClientException e) {
             throw new IdentityApplicationManagementException("Injecting client secret failed.", e);
         }
-
 
         return;
     }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuthApplicationMgtListener.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuthApplicationMgtListener.java
@@ -53,7 +53,6 @@ import org.wso2.carbon.identity.oauth.common.exception.InvalidOAuthClientExcepti
 import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
 import org.wso2.carbon.identity.oauth.dao.OAuthAppDAO;
 import org.wso2.carbon.identity.oauth.dao.OAuthAppDO;
-import org.wso2.carbon.identity.oauth.dao.OAuthConsumerDAO;
 import org.wso2.carbon.identity.oauth.dto.OAuthConsumerAppDTO;
 import org.wso2.carbon.identity.oauth.internal.OAuthComponentServiceHolder;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
@@ -364,7 +363,7 @@ public class OAuthApplicationMgtListener extends AbstractApplicationMgtListener 
                             Property[] props = inboundRequestConfig.getProperties();
                             Property property = new Property();
                             property.setName(OAUTH2_CONSUMER_SECRET);
-                            property.setValue(getClientSecret(inboundRequestConfig.getInboundAuthKey()));
+                            property.setValue(OAuth2Util.getClientSecret(inboundRequestConfig.getInboundAuthKey()));
                             props = (Property[]) ArrayUtils.add(props, property);
                             inboundRequestConfig.setProperties(props);
                             continue; // we are interested only on oauth2 config. Only one will be present.
@@ -384,11 +383,6 @@ public class OAuthApplicationMgtListener extends AbstractApplicationMgtListener 
 
 
         return;
-    }
-
-    private String getClientSecret(String inboundAuthKey) throws IdentityOAuthAdminException {
-        OAuthConsumerDAO dao = new OAuthConsumerDAO();
-        return dao.getOAuthConsumerSecret(inboundAuthKey);
     }
 
     /**

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -2075,21 +2075,14 @@ public class OAuth2Util {
      * @return Consumer Secret.
      * @throws IdentityOAuthAdminException Error when reading the consumer secret from the persistence store.
      */
-    public static String getClientSecret(String consumerKey) throws IdentityOAuthAdminException {
+    public static String getClientSecret(String consumerKey) throws IdentityOAuth2Exception,
+            InvalidOAuthClientException {
 
         OAuthAppDO oAuthAppDO;
-        try {
-            oAuthAppDO = OAuth2Util.getAppInformationByClientId(consumerKey);
-        } catch (IdentityOAuth2Exception | InvalidOAuthClientException e) {
-            throw new IdentityOAuthAdminException("Error while retrieving the OAuth application for " +
-                    "consumer key: " + consumerKey, e);
-        }
-
+        oAuthAppDO = OAuth2Util.getAppInformationByClientId(consumerKey);
         if (oAuthAppDO == null) {
-            throw new IdentityOAuthAdminException("Unable to retrieve app information for consumer key: " +
-                    consumerKey);
+            throw new IdentityOAuth2Exception("Unable to retrieve app information for consumer key: " + consumerKey);
         }
-
         return oAuthAppDO.getOauthConsumerSecret();
     }
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -2069,6 +2069,31 @@ public class OAuth2Util {
     }
 
     /**
+     * Get the client secret of the application.
+     *
+     * @param consumerKey Consumer Key provided by the user.
+     * @return Consumer Secret.
+     * @throws IdentityOAuthAdminException Error when reading the consumer secret from the persistence store.
+     */
+    public static String getClientSecret(String consumerKey) throws IdentityOAuthAdminException {
+
+        OAuthAppDO oAuthAppDO;
+        try {
+            oAuthAppDO = OAuth2Util.getAppInformationByClientId(consumerKey);
+        } catch (IdentityOAuth2Exception | InvalidOAuthClientException e) {
+            throw new IdentityOAuthAdminException("Error while retrieving the OAuth application for " +
+                    "consumer key: " + consumerKey, e);
+        }
+
+        if (oAuthAppDO == null) {
+            throw new IdentityOAuthAdminException("Unable to retrieve app information for consumer key: " +
+                    consumerKey);
+        }
+
+        return oAuthAppDO.getOauthConsumerSecret();
+    }
+
+    /**
      * This method map signature algorithm define in identity.xml to nimbus
      * signature algorithm
      *


### PR DESCRIPTION
### Proposed changes in this pull request

This PR contains the changes to read the consumer key from OAuthAppDO without making DB calls to get the value all the times. 

This will remove the multiple executions of the below query in the authorization code flow,
`SELECT CONSUMER_SECRET FROM IDN_OAUTH_CONSUMER_APPS WHERE CONSUMER_KEY=?`

Fixes https://github.com/wso2/product-is/issues/11664
