### PR TITLE
Fix the issue of not having the newly added associate tenant in ID token

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuer.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuer.java
@@ -364,6 +364,11 @@ public class AccessTokenIssuer {
                     tokReqMsgCtx.getAuthorizedUser() + " and scopes: " + tokenRespDTO.getAuthorizedScopes());
         }
 
+        if (GrantType.AUTHORIZATION_CODE.toString().equals(grantType)) {
+            // Should add user attributes to the cache before building the ID token.
+            addUserAttributesAgainstAccessToken(tokenReqDTO, tokenRespDTO);
+        }
+
         if (tokReqMsgCtx.getScope() != null && OAuth2Util.isOIDCAuthzRequest(tokReqMsgCtx.getScope())) {
             if (log.isDebugEnabled()) {
                 log.debug("Issuing ID token for client: " + tokenReqDTO.getClientId());
@@ -380,7 +385,6 @@ public class AccessTokenIssuer {
         }
 
         if (GrantType.AUTHORIZATION_CODE.toString().equals(grantType)) {
-            addUserAttributesAgainstAccessToken(tokenReqDTO, tokenRespDTO);
             // Cache entry against the authorization code has no value beyond the token request.
             clearCacheEntryAgainstAuthorizationCode(getAuthorizationCode(tokenReqDTO));
         }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/DefaultOIDCClaimsCallbackHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/DefaultOIDCClaimsCallbackHandler.java
@@ -241,22 +241,18 @@ public class DefaultOIDCClaimsCallbackHandler implements CustomClaimsCallbackHan
     }
 
     private Map<ClaimMapping, String> getCachedUserAttributes(OAuthTokenReqMessageContext requestMsgCtx) {
-
-        Map<ClaimMapping, String> userAttributes =
-                getUserAttributesCachedAgainstAuthorizationCode(getAuthorizationCode(requestMsgCtx));
+        Map<ClaimMapping, String> userAttributes = getUserAttributesCachedAgainstToken(getAccessToken(requestMsgCtx));
         if (log.isDebugEnabled()) {
-            log.debug("Retrieving claims cached against authorization_code for user: " +
-                    requestMsgCtx.getAuthorizedUser());
+            log.debug("Retrieving claims cached against access_token for user: " + requestMsgCtx.getAuthorizedUser());
         }
         if (isEmpty(userAttributes)) {
             if (log.isDebugEnabled()) {
-                log.debug("No claims cached against the authorization_code for user: " +
-                        requestMsgCtx.getAuthorizedUser() +
-                        ". Retrieving claims cached against the access_token code.");
+                log.debug("No claims cached against the access_token for user: " + requestMsgCtx.getAuthorizedUser() +
+                        ". Retrieving claims cached against the authorization code.");
             }
-            userAttributes = getUserAttributesCachedAgainstToken(getAccessToken(requestMsgCtx));
+            userAttributes = getUserAttributesCachedAgainstAuthorizationCode(getAuthorizationCode(requestMsgCtx));
             if (log.isDebugEnabled()) {
-                log.debug("Retrieving claims cached against access_token for user: " +
+                log.debug("Retrieving claims cached against authorization_code for user: " +
                         requestMsgCtx.getAuthorizedUser());
             }
         }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/DefaultOIDCClaimsCallbackHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/DefaultOIDCClaimsCallbackHandler.java
@@ -241,18 +241,22 @@ public class DefaultOIDCClaimsCallbackHandler implements CustomClaimsCallbackHan
     }
 
     private Map<ClaimMapping, String> getCachedUserAttributes(OAuthTokenReqMessageContext requestMsgCtx) {
-        Map<ClaimMapping, String> userAttributes = getUserAttributesCachedAgainstToken(getAccessToken(requestMsgCtx));
+
+        Map<ClaimMapping, String> userAttributes =
+                getUserAttributesCachedAgainstAuthorizationCode(getAuthorizationCode(requestMsgCtx));
         if (log.isDebugEnabled()) {
-            log.debug("Retrieving claims cached against access_token for user: " + requestMsgCtx.getAuthorizedUser());
+            log.debug("Retrieving claims cached against authorization_code for user: " +
+                    requestMsgCtx.getAuthorizedUser());
         }
         if (isEmpty(userAttributes)) {
             if (log.isDebugEnabled()) {
-                log.debug("No claims cached against the access_token for user: " + requestMsgCtx.getAuthorizedUser() +
-                        ". Retrieving claims cached against the authorization code.");
+                log.debug("No claims cached against the authorization_code for user: " +
+                        requestMsgCtx.getAuthorizedUser() +
+                        ". Retrieving claims cached against the access_token code.");
             }
-            userAttributes = getUserAttributesCachedAgainstAuthorizationCode(getAuthorizationCode(requestMsgCtx));
+            userAttributes = getUserAttributesCachedAgainstToken(getAccessToken(requestMsgCtx));
             if (log.isDebugEnabled()) {
-                log.debug("Retrieving claims cached against authorization_code for user: " +
+                log.debug("Retrieving claims cached against access_token for user: " +
                         requestMsgCtx.getAuthorizedUser());
             }
         }


### PR DESCRIPTION
### Description
The associate tenants were added as requested claims in the console and that associated tenant list is expected in the ID token. But the issue was, when a new tenant is created, the new ID token obtained after the immediate refresh does not have the updated list of tenants.

The issue was due to not correctly updating the user attribute cache against the access token. With this fix, it will copy the attributes cached against code to token in the authorization code flow before building the ID token. 

Resolves: https://github.com/wso2-enterprise/asgardeo-product/issues/3368