### PR TITLE
Remove redirect_uri Validations for request_uri Authorization Flows

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/CodeTokenResponseValidator.java
+++ b/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/CodeTokenResponseValidator.java
@@ -66,7 +66,7 @@ public class CodeTokenResponseValidator extends TokenValidator {
 
         if (StringUtils.isNotBlank(request.getParameter(REQUEST_URI))) {
             // PAR spec mandates request_uri to have client_id, response_type in accordance to OAuth 2.0
-            // Also request is disallowed if request_uri is used.
+            // Also 'request' parameter is disallowed if 'request_uri' parameter is present in the authorization request.
             requiredParams = new ArrayList<>(Arrays.asList(CLIENT_ID, RESPONSE_TYPE, REQUEST_URI));
             notAllowedParams.add(REQUEST);
         }

--- a/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/CodeTokenResponseValidator.java
+++ b/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/CodeTokenResponseValidator.java
@@ -65,8 +65,8 @@ public class CodeTokenResponseValidator extends TokenValidator {
     public void validateRequiredParameters(HttpServletRequest request) throws OAuthProblemException {
 
         if (StringUtils.isNotBlank(request.getParameter(REQUEST_URI))) {
-            // PAR spec mandates request_uri to have client_id, response_type in accordance to OAuth 2.0
-            // Also 'request' parameter is disallowed if 'request_uri' parameter is present in the authorization request.
+            // PAR spec mandates request_uri to have client_id, response_type in accordance to OAuth 2.0. Also
+            // 'request' parameter is disallowed if 'request_uri' parameter is present in the authorization request.
             requiredParams = new ArrayList<>(Arrays.asList(CLIENT_ID, RESPONSE_TYPE, REQUEST_URI));
             notAllowedParams.add(REQUEST);
         }

--- a/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/CodeTokenResponseValidator.java
+++ b/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/CodeTokenResponseValidator.java
@@ -65,7 +65,7 @@ public class CodeTokenResponseValidator extends TokenValidator {
     public void validateRequiredParameters(HttpServletRequest request) throws OAuthProblemException {
 
         if (StringUtils.isNotBlank(request.getParameter(REQUEST_URI))) {
-            requiredParams = new ArrayList<>(Arrays.asList(CLIENT_ID, RESPONSE_TYPE, SCOPE, REQUEST_URI));
+            requiredParams = new ArrayList<>(Arrays.asList(CLIENT_ID, RESPONSE_TYPE, REQUEST_URI));
             notAllowedParams.add(REQUEST);
         }
         super.validateRequiredParameters(request);

--- a/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/CodeTokenResponseValidator.java
+++ b/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/CodeTokenResponseValidator.java
@@ -65,6 +65,8 @@ public class CodeTokenResponseValidator extends TokenValidator {
     public void validateRequiredParameters(HttpServletRequest request) throws OAuthProblemException {
 
         if (StringUtils.isNotBlank(request.getParameter(REQUEST_URI))) {
+            // PAR spec mandates request_uri to have client_id, response_type in accordance to OAuth 2.0
+            // Also request is disallowed if request_uri is used.
             requiredParams = new ArrayList<>(Arrays.asList(CLIENT_ID, RESPONSE_TYPE, REQUEST_URI));
             notAllowedParams.add(REQUEST);
         }

--- a/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/CodeTokenResponseValidator.java
+++ b/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/CodeTokenResponseValidator.java
@@ -64,7 +64,7 @@ public class CodeTokenResponseValidator extends TokenValidator {
     @Override
     public void validateRequiredParameters(HttpServletRequest request) throws OAuthProblemException {
 
-        if (!StringUtils.isBlank(request.getParameter(REQUEST_URI))) {
+        if (StringUtils.isNotBlank(request.getParameter(REQUEST_URI))) {
             requiredParams = new ArrayList<>(Arrays.asList(CLIENT_ID, RESPONSE_TYPE, SCOPE, REQUEST_URI));
             notAllowedParams.add(REQUEST);
         }

--- a/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/CodeTokenResponseValidator.java
+++ b/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/CodeTokenResponseValidator.java
@@ -24,9 +24,15 @@ import org.apache.oltu.oauth2.common.OAuth;
 import org.apache.oltu.oauth2.common.error.OAuthError;
 import org.apache.oltu.oauth2.common.exception.OAuthProblemException;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+
 import javax.servlet.http.HttpServletRequest;
 
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OAuth20Params.CLIENT_ID;
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OAuth20Params.REQUEST;
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OAuth20Params.REQUEST_URI;
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OAuth20Params.RESPONSE_TYPE;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OAuth20Params.SCOPE;
 
 /**
@@ -58,6 +64,10 @@ public class CodeTokenResponseValidator extends TokenValidator {
     @Override
     public void validateRequiredParameters(HttpServletRequest request) throws OAuthProblemException {
 
+        if (!StringUtils.isBlank(request.getParameter(REQUEST_URI))) {
+            requiredParams = new ArrayList<>(Arrays.asList(CLIENT_ID, RESPONSE_TYPE, SCOPE, REQUEST_URI));
+            notAllowedParams.add(REQUEST);
+        }
         super.validateRequiredParameters(request);
 
         // For code token response type, the scope parameter should contain 'openid' as one of the scopes.

--- a/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
+++ b/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
@@ -226,6 +226,7 @@ public final class OAuthConstants {
         public static final String USERINFO = "userinfo";
         public static final String CLIENT_ID = "client_id";
         public static final String REDIRECT_URI = "redirect_uri";
+        public static final String REQUEST_URI = "request_uri";
         public static final String STATE = "state";
         public static final String RESPONSE_TYPE = "response_type";
         public static final String REQUEST = "request";

--- a/components/org.wso2.carbon.identity.oauth.common/src/test/java/org/wso2/carbon/identity/oauth/common/CodeTokenResponseValidatorTest.java
+++ b/components/org.wso2.carbon.identity.oauth.common/src/test/java/org/wso2/carbon/identity/oauth/common/CodeTokenResponseValidatorTest.java
@@ -86,7 +86,7 @@ public class CodeTokenResponseValidatorTest {
         when(mockRequest.getParameter("redirect_uri")).thenReturn("www.oidc.test.com");
         if (shouldPass) {
             testedResponseValidator.validateRequiredParameters(mockRequest);
-            // Nothing to assert here. The above method will only throw an exception if not valid
+            // Nothing to assert here. The above method will only throw an exception if not valid.
         } else {
             try {
                 testedResponseValidator.validateRequiredParameters(mockRequest);

--- a/components/org.wso2.carbon.identity.oauth.common/src/test/java/org/wso2/carbon/identity/oauth/common/CodeTokenResponseValidatorTest.java
+++ b/components/org.wso2.carbon.identity.oauth.common/src/test/java/org/wso2/carbon/identity/oauth/common/CodeTokenResponseValidatorTest.java
@@ -95,6 +95,69 @@ public class CodeTokenResponseValidatorTest {
         }
     }
 
+    @DataProvider(name = "Request Provider Request Uri")
+    public Object[][] getRequestParamsForRequestUri() {
+
+        Map<String, String> validUriRequest = new HashMap<>();
+        validUriRequest.put(SCOPE, OAuthConstants.Scope.OPENID);
+        validUriRequest.put("response_type", getResponseTypeValue());
+        validUriRequest.put("request_uri", "company:domain:urn");
+        validUriRequest.put(CLIENT_ID, CLIENT_ID);
+
+        Map<String, String> requestUriLessValidRequest = new HashMap<>();
+        requestUriLessValidRequest.put(SCOPE, OAuthConstants.Scope.OPENID);
+        requestUriLessValidRequest.put("response_type", getResponseTypeValue());
+        requestUriLessValidRequest.put("redirect_uri", "www.oidc.test.com");
+        requestUriLessValidRequest.put(CLIENT_ID, CLIENT_ID);
+
+        Map<String, String> clientIDLessRequest = new HashMap<>();
+        clientIDLessRequest.put(SCOPE, OAuthConstants.Scope.OPENID);
+        clientIDLessRequest.put("response_type", getResponseTypeValue());
+        clientIDLessRequest.put("request_uri", "company:domain:urn");
+
+        Map<String, String> requestUriLessRequest = new HashMap<>();
+        requestUriLessRequest.put(SCOPE, OAuthConstants.Scope.OPENID);
+        requestUriLessRequest.put("response_type", getResponseTypeValue());
+        requestUriLessRequest.put(CLIENT_ID, CLIENT_ID);
+
+        Map<String, String> redirectUriWithRedirectUriRequest = new HashMap<>();
+        redirectUriWithRedirectUriRequest.put(SCOPE, OAuthConstants.Scope.OPENID);
+        redirectUriWithRedirectUriRequest.put("response_type", getResponseTypeValue());
+        redirectUriWithRedirectUriRequest.put("request_uri", "company:domain:urn");
+        redirectUriWithRedirectUriRequest.put(CLIENT_ID, CLIENT_ID);
+        redirectUriWithRedirectUriRequest.put("redirect_uri", "www.oidc.test.com");
+
+        return new Object[][]{
+                {validUriRequest, true},
+                {requestUriLessValidRequest, true},
+                {clientIDLessRequest, false},
+                {requestUriLessRequest, false},
+                {redirectUriWithRedirectUriRequest, true},
+        };
+    }
+
+    @Test(dataProvider = "Request Provider Request Uri")
+    public void testValidateRequiredParametersForRequestUri(Map<String, String> headerMap, boolean shouldPass)
+            throws Exception {
+
+        HttpServletRequest mockRequest = mock(HttpServletRequest.class);
+        for (Map.Entry<String, String> entry : headerMap.entrySet()) {
+            when(mockRequest.getParameter(entry.getKey())).thenReturn(entry.getValue());
+        }
+        if (shouldPass) {
+            testedResponseValidator.validateRequiredParameters(mockRequest);
+            // Nothing to assert here. The above method will only throw an exception if not valid
+        } else {
+            try {
+                testedResponseValidator.validateRequiredParameters(mockRequest);
+                fail("Request validation should have failed");
+            } catch (OAuthProblemException e) {
+                assertTrue(e.getMessage().startsWith(OAuthError.TokenResponse.INVALID_REQUEST),
+                        "Invalid error message received");
+            }
+        }
+    }
+
     @DataProvider(name = "Request Method Provider")
     public Object[][] getRequestMethod() {
 

--- a/components/org.wso2.carbon.identity.oauth.common/src/test/java/org/wso2/carbon/identity/oauth/common/CodeTokenResponseValidatorTest.java
+++ b/components/org.wso2.carbon.identity.oauth.common/src/test/java/org/wso2/carbon/identity/oauth/common/CodeTokenResponseValidatorTest.java
@@ -35,6 +35,9 @@ import static org.powermock.api.mockito.PowerMockito.when;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OAuth20Params.CLIENT_ID;
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OAuth20Params.REDIRECT_URI;
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OAuth20Params.REQUEST_URI;
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OAuth20Params.RESPONSE_TYPE;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OAuth20Params.SCOPE;
 
 /**
@@ -100,32 +103,32 @@ public class CodeTokenResponseValidatorTest {
 
         Map<String, String> validUriRequest = new HashMap<>();
         validUriRequest.put(SCOPE, OAuthConstants.Scope.OPENID);
-        validUriRequest.put("response_type", getResponseTypeValue());
-        validUriRequest.put("request_uri", "company:domain:urn");
+        validUriRequest.put(RESPONSE_TYPE, getResponseTypeValue());
+        validUriRequest.put(REQUEST_URI, "company:domain:urn");
         validUriRequest.put(CLIENT_ID, CLIENT_ID);
 
         Map<String, String> requestUriLessValidRequest = new HashMap<>();
         requestUriLessValidRequest.put(SCOPE, OAuthConstants.Scope.OPENID);
-        requestUriLessValidRequest.put("response_type", getResponseTypeValue());
-        requestUriLessValidRequest.put("redirect_uri", "www.oidc.test.com");
+        requestUriLessValidRequest.put(RESPONSE_TYPE, getResponseTypeValue());
+        requestUriLessValidRequest.put(REDIRECT_URI, "www.oidc.test.com");
         requestUriLessValidRequest.put(CLIENT_ID, CLIENT_ID);
 
         Map<String, String> clientIDLessRequest = new HashMap<>();
         clientIDLessRequest.put(SCOPE, OAuthConstants.Scope.OPENID);
-        clientIDLessRequest.put("response_type", getResponseTypeValue());
-        clientIDLessRequest.put("request_uri", "company:domain:urn");
+        clientIDLessRequest.put(RESPONSE_TYPE, getResponseTypeValue());
+        clientIDLessRequest.put(REQUEST_URI, "company:domain:urn");
 
         Map<String, String> requestUriLessRequest = new HashMap<>();
         requestUriLessRequest.put(SCOPE, OAuthConstants.Scope.OPENID);
-        requestUriLessRequest.put("response_type", getResponseTypeValue());
+        requestUriLessRequest.put(RESPONSE_TYPE, getResponseTypeValue());
         requestUriLessRequest.put(CLIENT_ID, CLIENT_ID);
 
         Map<String, String> redirectUriWithRedirectUriRequest = new HashMap<>();
         redirectUriWithRedirectUriRequest.put(SCOPE, OAuthConstants.Scope.OPENID);
-        redirectUriWithRedirectUriRequest.put("response_type", getResponseTypeValue());
-        redirectUriWithRedirectUriRequest.put("request_uri", "company:domain:urn");
+        redirectUriWithRedirectUriRequest.put(RESPONSE_TYPE, getResponseTypeValue());
+        redirectUriWithRedirectUriRequest.put(REQUEST_URI, "company:domain:urn");
         redirectUriWithRedirectUriRequest.put(CLIENT_ID, CLIENT_ID);
-        redirectUriWithRedirectUriRequest.put("redirect_uri", "www.oidc.test.com");
+        redirectUriWithRedirectUriRequest.put(REDIRECT_URI, "www.oidc.test.com");
 
         return new Object[][]{
                 {validUriRequest, true},

--- a/components/org.wso2.carbon.identity.oauth.common/src/test/java/org/wso2/carbon/identity/oauth/common/CodeTokenResponseValidatorTest.java
+++ b/components/org.wso2.carbon.identity.oauth.common/src/test/java/org/wso2/carbon/identity/oauth/common/CodeTokenResponseValidatorTest.java
@@ -86,7 +86,7 @@ public class CodeTokenResponseValidatorTest {
         when(mockRequest.getParameter("redirect_uri")).thenReturn("www.oidc.test.com");
         if (shouldPass) {
             testedResponseValidator.validateRequiredParameters(mockRequest);
-            // Nothing to assert here. The above method will only throw an exception if not valid.
+            // Nothing to assert here. The above method will only throw an exception if not valid
         } else {
             try {
                 testedResponseValidator.validateRequiredParameters(mockRequest);
@@ -149,7 +149,7 @@ public class CodeTokenResponseValidatorTest {
         }
         if (shouldPass) {
             testedResponseValidator.validateRequiredParameters(mockRequest);
-            // Nothing to assert here. The above method will only throw an exception if not valid
+            // Nothing to assert here. The above method will only throw an exception if not valid.
         } else {
             try {
                 testedResponseValidator.validateRequiredParameters(mockRequest);

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
@@ -1691,9 +1691,10 @@ public class OAuth2AuthzEndpoint {
         overrideAuthzParameters(oAuthMessage, parameters, oauthRequest.getParam(REQUEST),
                 oauthRequest.getParam(REQUEST_URI), requestObject);
 
-        // if the redirect uri was not given in auth request, validating if the registration redirect uri was added
+        // If the redirect uri was not given in auth request the registered redirect uri will be available here,
+        // so validating if the registered redirect uri is a single uri that can be properly redirected.
         if (parameters.getRedirectURI().startsWith(REGEX_PATTERN)) {
-            throw new InvalidRequestException("Redirect URI is not present in the authorization request",
+            throw new InvalidRequestException("Redirect URI is not present in the authorization request.",
                     OAuth2ErrorCodes.INVALID_REQUEST, OAuth2ErrorCodes.OAuth2SubErrorCodes.INVALID_REDIRECT_URI);
         }
         persistRequestObject(parameters, requestObject);

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
@@ -1693,7 +1693,7 @@ public class OAuth2AuthzEndpoint {
 
         // If the redirect uri was not given in auth request the registered redirect uri will be available here,
         // so validating if the registered redirect uri is a single uri that can be properly redirected.
-        if (StringUtils.startsWith(parameters.getRedirectURI(), REGEX_PATTERN)) {
+        if (StringUtils.isBlank(parameters.getRedirectURI()) || StringUtils.startsWith(parameters.getRedirectURI(), REGEX_PATTERN)) {
             throw new InvalidRequestException("Redirect URI is not present in the authorization request.",
                     OAuth2ErrorCodes.INVALID_REQUEST, OAuth2ErrorCodes.OAuth2SubErrorCodes.INVALID_REDIRECT_URI);
         }

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
@@ -1693,7 +1693,8 @@ public class OAuth2AuthzEndpoint {
 
         // If the redirect uri was not given in auth request the registered redirect uri will be available here,
         // so validating if the registered redirect uri is a single uri that can be properly redirected.
-        if (StringUtils.isBlank(parameters.getRedirectURI()) || StringUtils.startsWith(parameters.getRedirectURI(), REGEX_PATTERN)) {
+        if (StringUtils.isBlank(parameters.getRedirectURI()) ||
+                StringUtils.startsWith(parameters.getRedirectURI(), REGEX_PATTERN)) {
             throw new InvalidRequestException("Redirect URI is not present in the authorization request.",
                     OAuth2ErrorCodes.INVALID_REQUEST, OAuth2ErrorCodes.OAuth2SubErrorCodes.INVALID_REDIRECT_URI);
         }

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
@@ -1693,7 +1693,7 @@ public class OAuth2AuthzEndpoint {
 
         // If the redirect uri was not given in auth request the registered redirect uri will be available here,
         // so validating if the registered redirect uri is a single uri that can be properly redirected.
-        if (parameters.getRedirectURI().startsWith(REGEX_PATTERN)) {
+        if (StringUtils.startsWith(parameters.getRedirectURI(), REGEX_PATTERN)) {
             throw new InvalidRequestException("Redirect URI is not present in the authorization request.",
                     OAuth2ErrorCodes.INVALID_REQUEST, OAuth2ErrorCodes.OAuth2SubErrorCodes.INVALID_REDIRECT_URI);
         }

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
@@ -1643,7 +1643,8 @@ public class OAuth2AuthzEndpoint {
     }
 
     private void handleOIDCRequestObject(OAuthMessage oAuthMessage, OAuthAuthzRequest oauthRequest,
-                                         OAuth2Parameters parameters) throws RequestObjectException {
+                                         OAuth2Parameters parameters)
+            throws RequestObjectException, InvalidRequestException {
 
         validateRequestObjectParams(oauthRequest);
         String requestObjValue = null;
@@ -1673,7 +1674,8 @@ public class OAuth2AuthzEndpoint {
     }
 
     private void handleRequestObject(OAuthMessage oAuthMessage, OAuthAuthzRequest oauthRequest,
-                                     OAuth2Parameters parameters) throws RequestObjectException {
+                                     OAuth2Parameters parameters)
+            throws RequestObjectException, InvalidRequestException {
 
         RequestObject requestObject = OIDCRequestObjectUtil.buildRequestObject(oauthRequest, parameters);
         if (requestObject == null) {
@@ -1686,6 +1688,12 @@ public class OAuth2AuthzEndpoint {
              */
         overrideAuthzParameters(oAuthMessage, parameters, oauthRequest.getParam(REQUEST),
                 oauthRequest.getParam(REQUEST_URI), requestObject);
+
+        // if the redirect uri was not given in auth request, validating if the registration redirect uri was added
+        if (parameters.getRedirectURI().startsWith("regexp")) {
+            throw new InvalidRequestException("Redirect URI is not present in the authorization request",
+                    OAuth2ErrorCodes.INVALID_REQUEST, OAuth2ErrorCodes.OAuth2SubErrorCodes.INVALID_REDIRECT_URI);
+        }
         persistRequestObject(parameters, requestObject);
     }
 

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
@@ -209,6 +209,8 @@ public class OAuth2AuthzEndpoint {
     private static final String DEFAULT_ERROR_MSG_FOR_FAILURE = "Authentication required";
     private static final String COMMONAUTH_COOKIE = "commonAuthId";
     private static final String SET_COOKIE_HEADER = "Set-Cookie";
+    private static final String REGEX_PATTERN = "regexp";
+
 
     private static final String OIDC_DIALECT = "http://wso2.org/oidc/claim";
 
@@ -1690,7 +1692,7 @@ public class OAuth2AuthzEndpoint {
                 oauthRequest.getParam(REQUEST_URI), requestObject);
 
         // if the redirect uri was not given in auth request, validating if the registration redirect uri was added
-        if (parameters.getRedirectURI().startsWith("regexp")) {
+        if (parameters.getRedirectURI().startsWith(REGEX_PATTERN)) {
             throw new InvalidRequestException("Redirect URI is not present in the authorization request",
                     OAuth2ErrorCodes.INVALID_REQUEST, OAuth2ErrorCodes.OAuth2SubErrorCodes.INVALID_REDIRECT_URI);
         }

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/state/OAuthRequestStateValidator.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/state/OAuthRequestStateValidator.java
@@ -41,6 +41,7 @@ public class OAuthRequestStateValidator {
 
     private static final Log log = LogFactory.getLog(OAuthRequestStateValidator.class);
     private static final String REDIRECT_URI = "redirect_uri";
+    private static final String REQUEST_URI = "request_uri";
 
     public OAuthAuthorizeState validateAndGetState(OAuthMessage oAuthMessage) throws InvalidRequestParentException {
 
@@ -137,7 +138,8 @@ public class OAuthRequestStateValidator {
                     OAuth2ErrorCodes.INVALID_REQUEST, OAuth2ErrorCodes.OAuth2SubErrorCodes.INVALID_CLIENT);
         }
 
-        if (StringUtils.isBlank(oAuthMessage.getRequest().getParameter(REDIRECT_URI))) {
+        if (StringUtils.isBlank(oAuthMessage.getRequest().getParameter(REQUEST_URI)) &&
+                StringUtils.isBlank(oAuthMessage.getRequest().getParameter(REDIRECT_URI))) {
             if (log.isDebugEnabled()) {
                 log.debug("Redirect URI is not present in the authorization request");
             }

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
@@ -133,6 +133,7 @@ public class EndpointUtil {
     private static final String PROP_ERROR = "error";
     private static final String PROP_ERROR_DESCRIPTION = "error_description";
     private static final String PROP_REDIRECT_URI = "redirect_uri";
+    private static final String REQUEST_URI = "request_uri";
     private static final String NOT_AVAILABLE = "N/A";
     private static final String UNKNOWN_ERROR = "unknown_error";
     private static OAuth2Service oAuth2Service;
@@ -470,8 +471,9 @@ public class EndpointUtil {
         // redirected to a common OAuth Error page.
         if (!OAuthServerConfiguration.getInstance().isRedirectToRequestedRedirectUriEnabled()) {
             return getErrorPageURL(request, errorCode, errorMessage, appName);
-        } else if (subErrorCode.equals(OAuth2ErrorCodes.OAuth2SubErrorCodes.INVALID_REDIRECT_URI) || subErrorCode
-                .equals(OAuth2ErrorCodes.OAuth2SubErrorCodes.INVALID_CLIENT)) {
+        } else if (subErrorCode.equals(OAuth2ErrorCodes.OAuth2SubErrorCodes.INVALID_REDIRECT_URI) ||
+                subErrorCode.equals(OAuth2ErrorCodes.OAuth2SubErrorCodes.INVALID_CLIENT) ||
+                StringUtils.isBlank(request.getParameter(PROP_REDIRECT_URI))) {
             return getErrorPageURL(request, errorCode, errorMessage, appName);
         } else {
             String redirectUri = request.getParameter(OAuthConstants.OAuth20Params.REDIRECT_URI);
@@ -681,6 +683,11 @@ public class EndpointUtil {
         String sessionDataKeyConsent = UUID.randomUUID().toString();
         try {
             if (entry != null && entry.getQueryString() != null) {
+
+                if (entry.getQueryString().contains(REQUEST_URI) && params != null) {
+                    entry.setQueryString(entry.getQueryString() +
+                            "&" + PROP_REDIRECT_URI + "=" + params.getRedirectURI());
+                }
                 queryString = URLEncoder.encode(entry.getQueryString(), UTF_8);
             }
 

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
@@ -685,6 +685,8 @@ public class EndpointUtil {
             if (entry != null && entry.getQueryString() != null) {
 
                 if (entry.getQueryString().contains(REQUEST_URI) && params != null) {
+                    // When request_uri requests come without redirect_uri, we need to append it to the SPQueryParams
+                    // to be used in storing consent data
                     entry.setQueryString(entry.getQueryString() +
                             "&" + PROP_REDIRECT_URI + "=" + params.getRedirectURI());
                 }


### PR DESCRIPTION
Resolves https://github.com/wso2/product-is/issues/9401

Description

PAR spec request expects `redirect_uri` to be omitted from the authorization call [1] as it is already added to the request object through PAR endpoint. But currently any requests without `redirect_uri` fails in IAM. This PR removes the check for `redirect_uri` when authorization call comes with `request_uri`

[1] https://tools.ietf.org/html/draft-ietf-oauth-par-03#section-4