### PR TITLE
Fix diagnostic logs from OAuth Common Util getting appended to console

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.common/pom.xml
+++ b/components/org.wso2.carbon.identity.oauth.common/pom.xml
@@ -68,6 +68,24 @@
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>annotations</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>commons-lang.wso2</groupId>
+            <artifactId>commons-lang</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.ops4j.pax.logging</groupId>
+            <artifactId>pax-logging-api</artifactId>
+        </dependency>
     </dependencies>
 
     <build>
@@ -85,6 +103,7 @@
                             org.apache.oltu.oauth2.as.validator; version="${oltu.package.import.version.range}",
                             org.apache.oltu.oauth2.common.*; version="${oltu.package.import.version.range}",
                             org.apache.commons.lang.*; version="${commons-lang.version.range}",
+                            org.apache.commons.logging; version="${commons-logging.osgi.version.range}",
                             org.wso2.carbon.identity.base; version="${carbon.identity.framework.imp.pkg.version.range}",
                             javax.servlet.http; version="${imp.pkg.version.javax.servlet}"
                         </Import-Package>

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
@@ -505,7 +505,7 @@ public class OAuth2AuthzEndpoint {
         return !getSSOConsentService().isSSOConsentManagementEnabled(sp);
     }
 
-    private void handlePostConsent(OAuthMessage oAuthMessage) throws ConsentHandlingFailedException { // add diag logs
+    private void handlePostConsent(OAuthMessage oAuthMessage) throws ConsentHandlingFailedException {
 
         OAuth2Parameters oauth2Params = getOauth2Params(oAuthMessage);
         String tenantDomain = EndpointUtil.getSPTenantDomainFromClientId(oauth2Params.getClientId());


### PR DESCRIPTION
Following logs gets printed to console. Ideally they should get printed to a seperate log file.

```
[2021-05-15 16:47:08,363]  INFO {diagnostics} - Content type header: application/x-www-form-urlencoded
[2021-05-15 16:47:08,364]  INFO {diagnostics} - Allowed content types contains the requested content type: application/x-www-form-urlencoded
```