### PR TITLE
Update PR builder cache logic

### DIFF
--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -24,5 +24,16 @@ jobs:
         with:
           java-version: "8"
           distribution: "adopt"
+      - name: Set current week
+        run: |
+          echo "CURRENT_WEEK=$(date +%Y-%U)" >> ${GITHUB_ENV}
+      - name: Cache local Maven repository
+        id: cache-maven-m2
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-m2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ env.cache-name }}-${{ env.CURRENT_WEEK }}
       - name: Build with Maven
         run: mvn clean install -U -B


### PR DESCRIPTION
With this improvement, PR builder will use a weekly m2 cache during the build