### PR TITLE
Removed mandatory client_id param from token request in Device Flow Grant

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
@@ -212,17 +212,17 @@ public class OAuth2AuthzEndpoint {
 
     private static final String OIDC_DIALECT = "http://wso2.org/oidc/claim";
 
-    private OpenIDConnectClaimFilterImpl openIDConnectClaimFilter;
+    private static OpenIDConnectClaimFilterImpl openIDConnectClaimFilter;
     private static final Log diagnosticLog = LogFactory.getLog("diagnostics");
 
-    public OpenIDConnectClaimFilterImpl getOpenIDConnectClaimFilter() {
+    public static OpenIDConnectClaimFilterImpl getOpenIDConnectClaimFilter() {
 
         return openIDConnectClaimFilter;
     }
 
-    public void setOpenIDConnectClaimFilter(OpenIDConnectClaimFilterImpl openIDConnectClaimFilter) {
+    public static void setOpenIDConnectClaimFilter(OpenIDConnectClaimFilterImpl openIDConnectClaimFilter) {
 
-        this.openIDConnectClaimFilter = openIDConnectClaimFilter;
+        OAuth2AuthzEndpoint.openIDConnectClaimFilter = openIDConnectClaimFilter;
     }
 
     @GET

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/device/UserAuthenticationEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/device/UserAuthenticationEndpoint.java
@@ -77,7 +77,7 @@ public class UserAuthenticationEndpoint {
     @Consumes("application/x-www-form-urlencoded")
     @Produces("text/html")
     public Response deviceAuthorize(@Context HttpServletRequest request, @Context HttpServletResponse response)
-            throws OAuthSystemException, InvalidRequestParentException {
+            throws URISyntaxException, InvalidRequestParentException, OAuthSystemException {
 
         try {
             String userCode = request.getParameter(Constants.USER_CODE);
@@ -115,8 +115,6 @@ public class UserAuthenticationEndpoint {
                         .addParameter("error", "invalid_request").build().getAbsolutePublicURL());
                 return null;
             }
-        } catch (URISyntaxException e) {
-            return handleURISyntaxException(e);
         } catch (IdentityOAuth2Exception e) {
             return handleIdentityOAuth2Exception(e);
         } catch (IOException e) {
@@ -124,16 +122,6 @@ public class UserAuthenticationEndpoint {
         } catch (URLBuilderException e) {
             return handleURLBuilderException(e);
         }
-    }
-
-    private Response handleURISyntaxException(URISyntaxException e) throws OAuthSystemException {
-
-        log.error("Error while parsing string as an URI reference.", e);
-        OAuthResponse response = OAuthASResponse.errorResponse(HttpServletResponse.SC_INTERNAL_SERVER_ERROR).
-                setError(OAuth2ErrorCodes.SERVER_ERROR).setErrorDescription("Internal Server Error")
-                .buildJSONMessage();
-        return Response.status(response.getResponseStatus()).header(OAuthConstants.HTTP_RESP_HEADER_AUTHENTICATE,
-                EndpointUtil.getRealmInfo()).entity(response.getBody()).build();
     }
 
     private Response handleIdentityOAuth2Exception(IdentityOAuth2Exception e) throws OAuthSystemException {

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/device/UserAuthenticationEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/device/UserAuthenticationEndpoint.java
@@ -87,7 +87,7 @@ public class UserAuthenticationEndpoint {
                     log.debug("user_code is missing in the request.");
                 }
                 response.sendRedirect(ServiceURLBuilder.create().addPath(Constants.DEVICE_ENDPOINT_PATH)
-                        .addParameter("error", "invalid_request").build().getAbsolutePublicURL());
+                        .addParameter("error", OAuth2ErrorCodes.INVALID_REQUEST).build().getAbsolutePublicURL());
                 return null;
             }
             String clientId = deviceAuthService.getClientId(userCode);
@@ -112,7 +112,7 @@ public class UserAuthenticationEndpoint {
                     log.debug("Incorrect user_code.");
                 }
                 response.sendRedirect(ServiceURLBuilder.create().addPath(Constants.DEVICE_ENDPOINT_PATH)
-                        .addParameter("error", "invalid_request").build().getAbsolutePublicURL());
+                        .addParameter("error", OAuth2ErrorCodes.INVALID_REQUEST).build().getAbsolutePublicURL());
                 return null;
             }
         } catch (IdentityOAuth2Exception e) {

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/device/UserAuthenticationEndpointTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/device/UserAuthenticationEndpointTest.java
@@ -47,12 +47,15 @@ import org.wso2.carbon.identity.oauth.tokenprocessor.TokenPersistenceProcessor;
 import org.wso2.carbon.identity.oauth2.device.api.DeviceAuthServiceImpl;
 import org.wso2.carbon.identity.oauth2.device.dao.DeviceFlowDAO;
 import org.wso2.carbon.identity.oauth2.device.dao.DeviceFlowPersistenceFactory;
+import org.wso2.carbon.identity.oauth2.device.model.DeviceFlowDO;
 import org.wso2.carbon.identity.oauth2.model.CarbonOAuthAuthzRequest;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 import org.wso2.carbon.identity.oidc.session.util.OIDCSessionManagementUtil;
 import org.wso2.carbon.utils.CarbonUtils;
 
 import java.nio.file.Paths;
+import java.sql.Timestamp;
+import java.util.Date;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -111,8 +114,16 @@ public class UserAuthenticationEndpointTest extends TestOAuthEndpointBase {
     private static final String USED = "USED";
     private static final String CLIENT_ID_VALUE = "ca19a540f544777860e44e75f605d927";
 
+    private static final Date date = new Date();
+    private static DeviceFlowDO deviceFlowDO = new DeviceFlowDO();
+    private static final String[] scopes = {"openid"};
+
     @BeforeTest
     public void setUp() {
+
+        deviceFlowDO.setStatus(PENDING);
+        deviceFlowDO.setExpiryTime(new Timestamp(date.getTime() + 400000));
+        deviceFlowDO.setDeviceCode("testDeviceCode");
 
         System.setProperty(
                 CarbonBaseConstants.CARBON_HOME,
@@ -154,7 +165,8 @@ public class UserAuthenticationEndpointTest extends TestOAuthEndpointBase {
         when(DeviceFlowPersistenceFactory.getInstance()).thenReturn(deviceFlowPersistenceFactory);
         when(deviceFlowPersistenceFactory.getDeviceFlowDAO()).thenReturn(deviceFlowDAO);
         when(deviceFlowDAO.getClientIdByUserCode(anyString())).thenReturn(clientId);
-        when(deviceFlowDAO.getStatusForUserCode(anyString())).thenReturn(status);
+        when(deviceFlowDAO.getDetailsForUserCode(anyString())).thenReturn(deviceFlowDO);
+        when(deviceFlowDAO.getScopesForUserCode(anyString())).thenReturn(scopes);
         when(httpServletRequest.getParameter(anyString())).thenReturn(userCode);
         mockStatic(OAuth2Util.class);
         when(OAuth2Util.getAppInformationByClientId(anyString())).thenReturn(oAuthAppDO);

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/device/UserAuthenticationEndpointTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/device/UserAuthenticationEndpointTest.java
@@ -21,6 +21,7 @@ package org.wso2.carbon.identity.oauth.endpoint.device;
 import com.nimbusds.jwt.SignedJWT;
 import org.apache.oltu.oauth2.common.message.OAuthResponse;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.powermock.core.classloader.annotations.PrepareForTest;
@@ -33,9 +34,11 @@ import org.wso2.carbon.base.CarbonBaseConstants;
 import org.wso2.carbon.base.MultitenantConstants;
 import org.wso2.carbon.identity.application.authentication.framework.model.CommonAuthRequestWrapper;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
+import org.wso2.carbon.identity.core.ServiceURL;
+import org.wso2.carbon.identity.core.ServiceURLBuilder;
+import org.wso2.carbon.identity.core.URLBuilderException;
 import org.wso2.carbon.identity.core.util.IdentityDatabaseUtil;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
-import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.oauth.cache.SessionDataCache;
 import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
 import org.wso2.carbon.identity.oauth.dao.OAuthAppDO;
@@ -53,6 +56,8 @@ import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 import org.wso2.carbon.identity.oidc.session.util.OIDCSessionManagementUtil;
 import org.wso2.carbon.utils.CarbonUtils;
 
+import java.io.IOException;
+import java.net.URISyntaxException;
 import java.nio.file.Paths;
 import java.sql.Timestamp;
 import java.util.Date;
@@ -62,7 +67,6 @@ import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.core.Response;
 
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyString;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
@@ -74,8 +78,8 @@ import static org.powermock.api.mockito.PowerMockito.when;
 @PrepareForTest({OAuth2Util.class, SessionDataCache.class, OAuthServerConfiguration.class, IdentityDatabaseUtil.class,
         EndpointUtil.class, FrameworkUtils.class, EndpointUtil.class, OpenIDConnectUserRPStore.class,
         CarbonOAuthAuthzRequest.class, IdentityTenantUtil.class, OAuthResponse.class, SignedJWT.class,
-        OIDCSessionManagementUtil.class, CarbonUtils.class, SessionDataCache.class, IdentityUtil.class,
-        DeviceFlowPersistenceFactory.class, OAuth2AuthzEndpoint.class})
+        OIDCSessionManagementUtil.class, CarbonUtils.class, SessionDataCache.class, ServiceURLBuilder.class,
+        ServiceURL.class, DeviceFlowPersistenceFactory.class, OAuth2AuthzEndpoint.class})
 public class UserAuthenticationEndpointTest extends TestOAuthEndpointBase {
 
     @Mock
@@ -107,6 +111,12 @@ public class UserAuthenticationEndpointTest extends TestOAuthEndpointBase {
 
     @Mock
     UserAuthenticationEndpoint userAuthenticationEndpoint;
+
+    @Mock
+    ServiceURLBuilder serviceURLBuilder;
+
+    @Mock
+    ServiceURL serviceURL;
 
     private static final String TEST_USER_CODE = "testUserCode";
     private static final String TEST_URL = "testURL";
@@ -178,12 +188,17 @@ public class UserAuthenticationEndpointTest extends TestOAuthEndpointBase {
         when(OAuth2Util.getAppInformationByClientId(anyString())).thenReturn(oAuthAppDO);
         when(oAuthAppDO.getCallbackUrl()).thenReturn(uri);
         Response response1;
-        mockStatic(IdentityUtil.class);
         mockStatic(IdentityTenantUtil.class);
         when(IdentityTenantUtil.getTenantDomain(anyInt())).thenReturn(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         when(IdentityTenantUtil.getTenantId(anyString())).thenReturn(MultitenantConstants.SUPER_TENANT_ID);
 
-        when(IdentityUtil.getServerURL(anyString(), anyBoolean(), anyBoolean())).thenReturn(TEST_URL);
+        mockStatic(ServiceURLBuilder.class);
+        when(ServiceURLBuilder.create()).thenReturn(serviceURLBuilder);
+        when(serviceURLBuilder.addPath(any())).thenReturn(serviceURLBuilder);
+        when(serviceURLBuilder.addParameter(any(), any())).thenReturn(serviceURLBuilder);
+        when(serviceURLBuilder.build()).thenReturn(serviceURL);
+        when(serviceURL.getAbsolutePublicURL()).thenReturn(TEST_URL);
+
         when(oAuth2AuthzEndpoint.authorize(any(CommonAuthRequestWrapper.class), any(HttpServletResponse.class)))
                 .thenReturn(response);
         DeviceAuthServiceImpl deviceAuthService = new DeviceAuthServiceImpl();
@@ -218,30 +233,92 @@ public class UserAuthenticationEndpointTest extends TestOAuthEndpointBase {
         });
     }
 
-    @DataProvider(name = "providePostParamsForExpiredUserCodePath")
-    public Object[][] providePostParamsForExpiredUserCodePath() {
+    @DataProvider(name = "providePostParamsForURLBuilderExceptionPath")
+    public Object[][] providePostParamsForURLBuilderExceptionPath() {
 
         return new Object[][]{
-                {TEST_USER_CODE, null, 0, USED, TEST_URL},
-                {null, null, 0, USED, null},
-                {TEST_USER_CODE, CLIENT_ID_VALUE, 0, PENDING, TEST_URL},
-                {TEST_USER_CODE, CLIENT_ID_VALUE, 0, PENDING, null}
+                {TEST_USER_CODE, null, HttpServletResponse.SC_ACCEPTED, PENDING, TEST_URL},
+                {TEST_USER_CODE, CLIENT_ID_VALUE, HttpServletResponse.SC_ACCEPTED, PENDING, null}
         };
     }
 
     /**
-     * Test device endpoint with expired user_code.
+     * Test device endpoint throwing URLBuilderException.
      *
      * @param userCode      User code of the user.
      * @param clientId      Consumer key of the application.
      * @param expectedValue Expected http status.
      * @param status        Status of user code.
      * @param uri           Redirection uri.
-     * @throws Exception Error while testing device endpoint.
+     * @throws Exception Error while testing device endpoint throwing URLBuilderException.
      */
-    @Test(dataProvider = "providePostParamsForExpiredUserCodePath")
-    public void testDeviceAuthorizeForExpiredUserCodePath(String userCode, String clientId, int expectedValue,
-        String status, String uri) throws Exception {
+    @Test(dataProvider = "providePostParamsForURLBuilderExceptionPath")
+    public void testDeviceAuthorizeForURLBuilderExceptionPath(String userCode, String clientId, int expectedValue,
+                                                              String status, String uri) throws Exception {
+
+        mockOAuthServerConfiguration();
+
+        WhiteboxImpl.setInternalState(userAuthenticationEndpoint, "oAuth2AuthzEndpoint", oAuth2AuthzEndpoint);
+        mockStatic(IdentityDatabaseUtil.class);
+        when(IdentityDatabaseUtil.getDBConnection()).thenReturn(connection);
+        mockStatic(DeviceFlowPersistenceFactory.class);
+        when(DeviceFlowPersistenceFactory.getInstance()).thenReturn(deviceFlowPersistenceFactory);
+        when(deviceFlowPersistenceFactory.getDeviceFlowDAO()).thenReturn(deviceFlowDAO);
+        when(deviceFlowDAO.getClientIdByUserCode(anyString())).thenReturn(clientId);
+        when(deviceFlowDAO.getDetailsForUserCode(anyString())).thenReturn(deviceFlowDOAsNotExpired);
+        when(deviceFlowDAO.getScopesForUserCode(anyString())).thenReturn(scopes);
+        when(httpServletRequest.getParameter(anyString())).thenReturn(userCode);
+        mockStatic(OAuth2Util.class);
+        when(OAuth2Util.getAppInformationByClientId(anyString())).thenReturn(oAuthAppDO);
+        when(oAuthAppDO.getCallbackUrl()).thenReturn(uri);
+        Response response1;
+        mockStatic(IdentityTenantUtil.class);
+        when(IdentityTenantUtil.getTenantDomain(anyInt())).thenReturn(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+        when(IdentityTenantUtil.getTenantId(anyString())).thenReturn(MultitenantConstants.SUPER_TENANT_ID);
+
+        mockStatic(ServiceURLBuilder.class);
+        when(ServiceURLBuilder.create()).thenReturn(serviceURLBuilder);
+        when(serviceURLBuilder.addPath(any())).thenReturn(serviceURLBuilder);
+        when(serviceURLBuilder.addParameter(any(), any())).thenReturn(serviceURLBuilder);
+        when(serviceURLBuilder.build()).thenThrow(new URLBuilderException("Throwing URLBuilderException."));
+        when(serviceURL.getAbsolutePublicURL()).thenReturn(TEST_URL);
+
+        when(oAuth2AuthzEndpoint.authorize(any(CommonAuthRequestWrapper.class), any(HttpServletResponse.class))).
+                thenReturn(response);
+        DeviceAuthServiceImpl deviceAuthService = new DeviceAuthServiceImpl();
+        userAuthenticationEndpoint = new UserAuthenticationEndpoint();
+        userAuthenticationEndpoint.setDeviceAuthService(deviceAuthService);
+        WhiteboxImpl.setInternalState(userAuthenticationEndpoint, OAuth2AuthzEndpoint.class, oAuth2AuthzEndpoint);
+        response1 = userAuthenticationEndpoint.deviceAuthorize(httpServletRequest, httpServletResponse);
+        if (expectedValue == HttpServletResponse.SC_ACCEPTED) {
+            Assert.assertNotNull(response1);
+        } else {
+            Assert.assertNull(response1);
+        }
+    }
+
+    @DataProvider(name = "providePostParamsForIOExceptionPath")
+    public Object[][] providePostParamsForIOExceptionPath() {
+
+        return new Object[][]{
+                {TEST_USER_CODE, null, HttpServletResponse.SC_ACCEPTED, PENDING, TEST_URL},
+                {TEST_USER_CODE, CLIENT_ID_VALUE, HttpServletResponse.SC_ACCEPTED, PENDING, null}
+        };
+    }
+
+    /**
+     * Test device endpoint throwing IOException.
+     *
+     * @param userCode      User code of the user.
+     * @param clientId      Consumer key of the application.
+     * @param expectedValue Expected http status.
+     * @param status        Status of user code.
+     * @param uri           Redirection uri.
+     * @throws Exception Error while testing device endpoint throwing IOException.
+     */
+    @Test(dataProvider = "providePostParamsForIOExceptionPath")
+    public void testDeviceAuthorizeForIOExceptionPath(String userCode, String clientId, int expectedValue,
+                                                      String status, String uri) throws Exception {
 
         mockOAuthServerConfiguration();
 
@@ -259,14 +336,84 @@ public class UserAuthenticationEndpointTest extends TestOAuthEndpointBase {
         when(OAuth2Util.getAppInformationByClientId(anyString())).thenReturn(oAuthAppDO);
         when(oAuthAppDO.getCallbackUrl()).thenReturn(uri);
         Response response1;
-        mockStatic(IdentityUtil.class);
         mockStatic(IdentityTenantUtil.class);
         when(IdentityTenantUtil.getTenantDomain(anyInt())).thenReturn(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         when(IdentityTenantUtil.getTenantId(anyString())).thenReturn(MultitenantConstants.SUPER_TENANT_ID);
 
-        when(IdentityUtil.getServerURL(anyString(), anyBoolean(), anyBoolean())).thenReturn(TEST_URL);
+        mockStatic(ServiceURLBuilder.class);
+        when(ServiceURLBuilder.create()).thenReturn(serviceURLBuilder);
+        when(serviceURLBuilder.addPath(any())).thenReturn(serviceURLBuilder);
+        when(serviceURLBuilder.addParameter(any(), any())).thenReturn(serviceURLBuilder);
+        when(serviceURLBuilder.build()).thenReturn(serviceURL);
+        when(serviceURL.getAbsolutePublicURL()).thenReturn(TEST_URL);
+        Mockito.doThrow(new IOException("Throwing IOException.")).when(httpServletResponse).sendRedirect(TEST_URL);
+
         when(oAuth2AuthzEndpoint.authorize(any(CommonAuthRequestWrapper.class), any(HttpServletResponse.class)))
                 .thenReturn(response);
+        DeviceAuthServiceImpl deviceAuthService = new DeviceAuthServiceImpl();
+        userAuthenticationEndpoint = new UserAuthenticationEndpoint();
+        userAuthenticationEndpoint.setDeviceAuthService(deviceAuthService);
+        WhiteboxImpl.setInternalState(userAuthenticationEndpoint, OAuth2AuthzEndpoint.class, oAuth2AuthzEndpoint);
+        response1 = userAuthenticationEndpoint.deviceAuthorize(httpServletRequest, httpServletResponse);
+        if (expectedValue == HttpServletResponse.SC_ACCEPTED) {
+            Assert.assertNotNull(response1);
+        } else {
+            Assert.assertNull(response1);
+        }
+    }
+
+    @DataProvider(name = "providePostParamsForURISyntaxExceptionPath")
+    public Object[][] providePostParamsForURISyntaxExceptionPath() {
+
+        return new Object[][]{
+                {TEST_USER_CODE, CLIENT_ID_VALUE, HttpServletResponse.SC_ACCEPTED, PENDING, TEST_URL},
+                {TEST_USER_CODE, CLIENT_ID_VALUE, HttpServletResponse.SC_ACCEPTED, PENDING, null}
+        };
+    }
+
+    /**
+     * Test device endpoint throwing URISyntaxException.
+     *
+     * @param userCode      User code of the user.
+     * @param clientId      Consumer key of the application.
+     * @param expectedValue Expected http status.
+     * @param status        Status of user code.
+     * @param uri           Redirection uri.
+     * @throws Exception Error while testing device endpoint throwing URISyntaxException.
+     */
+    @Test(dataProvider = "providePostParamsForURISyntaxExceptionPath")
+    public void testDeviceAuthorizeForURISyntaxExceptionPath(String userCode, String clientId, int expectedValue,
+                                                             String status, String uri) throws Exception {
+
+        mockOAuthServerConfiguration();
+
+        WhiteboxImpl.setInternalState(userAuthenticationEndpoint, "oAuth2AuthzEndpoint", oAuth2AuthzEndpoint);
+        mockStatic(IdentityDatabaseUtil.class);
+        when(IdentityDatabaseUtil.getDBConnection()).thenReturn(connection);
+        mockStatic(DeviceFlowPersistenceFactory.class);
+        when(DeviceFlowPersistenceFactory.getInstance()).thenReturn(deviceFlowPersistenceFactory);
+        when(deviceFlowPersistenceFactory.getDeviceFlowDAO()).thenReturn(deviceFlowDAO);
+        when(deviceFlowDAO.getClientIdByUserCode(anyString())).thenReturn(clientId);
+        when(deviceFlowDAO.getDetailsForUserCode(anyString())).thenReturn(deviceFlowDOAsNotExpired);
+        when(deviceFlowDAO.getScopesForUserCode(anyString())).thenReturn(scopes);
+        when(httpServletRequest.getParameter(anyString())).thenReturn(userCode);
+        mockStatic(OAuth2Util.class);
+        when(OAuth2Util.getAppInformationByClientId(anyString())).thenReturn(oAuthAppDO);
+        when(oAuthAppDO.getCallbackUrl()).thenReturn(uri);
+        Response response1;
+        mockStatic(IdentityTenantUtil.class);
+        when(IdentityTenantUtil.getTenantDomain(anyInt())).thenReturn(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+        when(IdentityTenantUtil.getTenantId(anyString())).thenReturn(MultitenantConstants.SUPER_TENANT_ID);
+
+        mockStatic(ServiceURLBuilder.class);
+        when(ServiceURLBuilder.create()).thenReturn(serviceURLBuilder);
+        when(serviceURLBuilder.addPath(any())).thenReturn(serviceURLBuilder);
+        when(serviceURLBuilder.addParameter(any(), any())).thenReturn(serviceURLBuilder);
+        when(serviceURLBuilder.build()).thenReturn(serviceURL);
+        when(serviceURL.getAbsolutePublicURL()).thenReturn(TEST_URL);
+
+        when(oAuth2AuthzEndpoint.authorize(any(CommonAuthRequestWrapper.class), any(HttpServletResponse.class)))
+                .thenThrow(new URISyntaxException("Creating URISyntaxException.", "Throwing URISyntaxException."));
         DeviceAuthServiceImpl deviceAuthService = new DeviceAuthServiceImpl();
         userAuthenticationEndpoint = new UserAuthenticationEndpoint();
         userAuthenticationEndpoint.setDeviceAuthService(deviceAuthService);

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/device/UserAuthenticationEndpointTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/device/UserAuthenticationEndpointTest.java
@@ -57,7 +57,6 @@ import org.wso2.carbon.identity.oidc.session.util.OIDCSessionManagementUtil;
 import org.wso2.carbon.utils.CarbonUtils;
 
 import java.io.IOException;
-import java.net.URISyntaxException;
 import java.nio.file.Paths;
 import java.sql.Timestamp;
 import java.util.Date;
@@ -350,70 +349,6 @@ public class UserAuthenticationEndpointTest extends TestOAuthEndpointBase {
 
         when(oAuth2AuthzEndpoint.authorize(any(CommonAuthRequestWrapper.class), any(HttpServletResponse.class)))
                 .thenReturn(response);
-        DeviceAuthServiceImpl deviceAuthService = new DeviceAuthServiceImpl();
-        userAuthenticationEndpoint = new UserAuthenticationEndpoint();
-        userAuthenticationEndpoint.setDeviceAuthService(deviceAuthService);
-        WhiteboxImpl.setInternalState(userAuthenticationEndpoint, OAuth2AuthzEndpoint.class, oAuth2AuthzEndpoint);
-        response1 = userAuthenticationEndpoint.deviceAuthorize(httpServletRequest, httpServletResponse);
-        if (expectedValue == HttpServletResponse.SC_ACCEPTED) {
-            Assert.assertNotNull(response1);
-        } else {
-            Assert.assertNull(response1);
-        }
-    }
-
-    @DataProvider(name = "providePostParamsForURISyntaxExceptionPath")
-    public Object[][] providePostParamsForURISyntaxExceptionPath() {
-
-        return new Object[][]{
-                {TEST_USER_CODE, CLIENT_ID_VALUE, HttpServletResponse.SC_ACCEPTED, PENDING, TEST_URL},
-                {TEST_USER_CODE, CLIENT_ID_VALUE, HttpServletResponse.SC_ACCEPTED, PENDING, null}
-        };
-    }
-
-    /**
-     * Test device endpoint throwing URISyntaxException.
-     *
-     * @param userCode      User code of the user.
-     * @param clientId      Consumer key of the application.
-     * @param expectedValue Expected http status.
-     * @param status        Status of user code.
-     * @param uri           Redirection uri.
-     * @throws Exception Error while testing device endpoint throwing URISyntaxException.
-     */
-    @Test(dataProvider = "providePostParamsForURISyntaxExceptionPath")
-    public void testDeviceAuthorizeForURISyntaxExceptionPath(String userCode, String clientId, int expectedValue,
-                                                             String status, String uri) throws Exception {
-
-        mockOAuthServerConfiguration();
-
-        WhiteboxImpl.setInternalState(userAuthenticationEndpoint, "oAuth2AuthzEndpoint", oAuth2AuthzEndpoint);
-        mockStatic(IdentityDatabaseUtil.class);
-        when(IdentityDatabaseUtil.getDBConnection()).thenReturn(connection);
-        mockStatic(DeviceFlowPersistenceFactory.class);
-        when(DeviceFlowPersistenceFactory.getInstance()).thenReturn(deviceFlowPersistenceFactory);
-        when(deviceFlowPersistenceFactory.getDeviceFlowDAO()).thenReturn(deviceFlowDAO);
-        when(deviceFlowDAO.getClientIdByUserCode(anyString())).thenReturn(clientId);
-        when(deviceFlowDAO.getDetailsForUserCode(anyString())).thenReturn(deviceFlowDOAsNotExpired);
-        when(deviceFlowDAO.getScopesForUserCode(anyString())).thenReturn(scopes);
-        when(httpServletRequest.getParameter(anyString())).thenReturn(userCode);
-        mockStatic(OAuth2Util.class);
-        when(OAuth2Util.getAppInformationByClientId(anyString())).thenReturn(oAuthAppDO);
-        when(oAuthAppDO.getCallbackUrl()).thenReturn(uri);
-        Response response1;
-        mockStatic(IdentityTenantUtil.class);
-        when(IdentityTenantUtil.getTenantDomain(anyInt())).thenReturn(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
-        when(IdentityTenantUtil.getTenantId(anyString())).thenReturn(MultitenantConstants.SUPER_TENANT_ID);
-
-        mockStatic(ServiceURLBuilder.class);
-        when(ServiceURLBuilder.create()).thenReturn(serviceURLBuilder);
-        when(serviceURLBuilder.addPath(any())).thenReturn(serviceURLBuilder);
-        when(serviceURLBuilder.addParameter(any(), any())).thenReturn(serviceURLBuilder);
-        when(serviceURLBuilder.build()).thenReturn(serviceURL);
-        when(serviceURL.getAbsolutePublicURL()).thenReturn(TEST_URL);
-
-        when(oAuth2AuthzEndpoint.authorize(any(CommonAuthRequestWrapper.class), any(HttpServletResponse.class)))
-                .thenThrow(new URISyntaxException("Creating URISyntaxException.", "Throwing URISyntaxException."));
         DeviceAuthServiceImpl deviceAuthService = new DeviceAuthServiceImpl();
         userAuthenticationEndpoint = new UserAuthenticationEndpoint();
         userAuthenticationEndpoint.setDeviceAuthService(deviceAuthService);

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/client/authentication/BasicAuthClientAuthenticator.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/client/authentication/BasicAuthClientAuthenticator.java
@@ -90,14 +90,13 @@ public class BasicAuthClientAuthenticator extends AbstractOAuthClientAuthenticat
                     (String) oAuthClientAuthnContext.getParameter(OAuth.OAUTH_CLIENT_SECRET));
         } catch (IdentityOAuthAdminException e) {
             diagnosticLog.error("Error while authenticating client. Error message: " + e.getMessage());
-            throw new OAuthClientAuthnException(OAuth2ErrorCodes.INVALID_CLIENT, "Error while authenticating " +
-                    "client", e);
+            throw new OAuthClientAuthnException("Error while authenticating client",
+                    OAuth2ErrorCodes.INVALID_CLIENT, e);
         } catch (InvalidOAuthClientException | IdentityOAuth2Exception e) {
             diagnosticLog.error("Invalid client. Error message: " + e.getMessage());
-            throw new OAuthClientAuthnException(OAuth2ErrorCodes.INVALID_CLIENT,
-                    "Invalid Client : " + oAuthClientAuthnContext.getClientId(), e);
+            throw new OAuthClientAuthnException("Invalid Client : " + oAuthClientAuthnContext.getClientId(),
+                    OAuth2ErrorCodes.INVALID_CLIENT, e);
         }
-
     }
 
     private void validateAuthenticationInfo(HttpServletRequest request, Map<String, List> contentMap)
@@ -268,5 +267,4 @@ public class BasicAuthClientAuthenticator extends AbstractOAuthClientAuthenticat
         context.setClientId(stringContent.get(OAuth.OAUTH_CLIENT_ID));
         context.addParameter(OAuth.OAUTH_CLIENT_SECRET, stringContent.get(OAuth.OAUTH_CLIENT_SECRET));
     }
-
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/client/authentication/BasicAuthClientAuthenticator.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/client/authentication/BasicAuthClientAuthenticator.java
@@ -97,6 +97,7 @@ public class BasicAuthClientAuthenticator extends AbstractOAuthClientAuthenticat
             throw new OAuthClientAuthnException(OAuth2ErrorCodes.INVALID_CLIENT,
                     "Invalid Client : " + oAuthClientAuthnContext.getClientId(), e);
         }
+
     }
 
     private void validateAuthenticationInfo(HttpServletRequest request, Map<String, List> contentMap)

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/client/authentication/BasicAuthClientAuthenticator.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/client/authentication/BasicAuthClientAuthenticator.java
@@ -90,12 +90,12 @@ public class BasicAuthClientAuthenticator extends AbstractOAuthClientAuthenticat
                     (String) oAuthClientAuthnContext.getParameter(OAuth.OAUTH_CLIENT_SECRET));
         } catch (IdentityOAuthAdminException e) {
             diagnosticLog.error("Error while authenticating client. Error message: " + e.getMessage());
-            throw new OAuthClientAuthnException("Error while authenticating client",
-                    OAuth2ErrorCodes.INVALID_CLIENT, e);
+            throw new OAuthClientAuthnException(OAuth2ErrorCodes.INVALID_CLIENT, "Error while authenticating " +
+                    "client", e);
         } catch (InvalidOAuthClientException | IdentityOAuth2Exception e) {
             diagnosticLog.error("Invalid client. Error message: " + e.getMessage());
-            throw new OAuthClientAuthnException("Invalid Client : " + oAuthClientAuthnContext.getClientId(),
-                    OAuth2ErrorCodes.INVALID_CLIENT, e);
+            throw new OAuthClientAuthnException(OAuth2ErrorCodes.INVALID_CLIENT,
+                    "Invalid Client : " + oAuthClientAuthnContext.getClientId(), e);
         }
     }
 
@@ -267,4 +267,5 @@ public class BasicAuthClientAuthenticator extends AbstractOAuthClientAuthenticat
         context.setClientId(stringContent.get(OAuth.OAUTH_CLIENT_ID));
         context.addParameter(OAuth.OAUTH_CLIENT_SECRET, stringContent.get(OAuth.OAUTH_CLIENT_SECRET));
     }
+
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/device/grant/DeviceFlowGrantValidator.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/device/grant/DeviceFlowGrantValidator.java
@@ -32,7 +32,6 @@ public class DeviceFlowGrantValidator extends AbstractValidator<HttpServletReque
     public DeviceFlowGrantValidator() {
 
         requiredParams.add(OAuth.OAUTH_GRANT_TYPE);
-        requiredParams.add(Constants.CLIENT_ID);
         requiredParams.add(Constants.DEVICE_CODE);
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuer.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuer.java
@@ -280,7 +280,7 @@ public class AccessTokenIssuer {
                 log.debug("Invalid Grant provided by the client Id: " + tokenReqDTO.getClientId());
             }
             diagnosticLog.info("Invalid Grant provided by the client Id: " + tokenReqDTO.getClientId());
-            tokenRespDTO = handleError(OAuthError.TokenResponse.INVALID_GRANT, error, tokenReqDTO);
+            tokenRespDTO = handleError(errorCode, error, tokenReqDTO);
             setResponseHeaders(tokReqMsgCtx, tokenRespDTO);
             triggerPostListeners(tokenReqDTO, tokenRespDTO, tokReqMsgCtx, isRefreshRequest);
             return tokenRespDTO;

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuer.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuer.java
@@ -255,11 +255,15 @@ public class AccessTokenIssuer {
         }
         boolean isValidGrant = false;
         error = "Provided Authorization Grant is invalid";
+        String errorCode = OAuthError.TokenResponse.INVALID_GRANT;
         try {
             isValidGrant = authzGrantHandler.validateGrant(tokReqMsgCtx);
         } catch (IdentityOAuth2Exception e) {
             if (log.isDebugEnabled()) {
                 log.debug("Error occurred while validating grant", e);
+            }
+            if (e.getErrorCode() != null) {
+                errorCode = e.getErrorCode();
             }
             error = e.getMessage();
             diagnosticLog.error("Error occurred while validating grant. Error message: " + error);


### PR DESCRIPTION
**Related PR**: https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/1569

**Resolves**: https://github.com/wso2/product-is/issues/9063

**Purpose**
To prevent making client_id a mandatory body param for the token request even when the Authorization header is used.           Gives “Invalid_request” error when sending device access token request with basic authorization header instead of client_id as a body param in Device Flow Grant.

**Describe the improvement**
Removed Client Id as a requiredParam in device access token request in Device Flow Grant.

**Product Version**
Wso2 IS 5.10.0

**How to reproduce**
Get a wum updated pack and check with appropriate requests.