### PR TITLE
Enable tenanted paths for opbs cookie

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
@@ -61,6 +61,7 @@ import org.wso2.carbon.identity.claim.metadata.mgt.exception.ClaimMetadataExcept
 import org.wso2.carbon.identity.claim.metadata.mgt.model.ExternalClaim;
 import org.wso2.carbon.identity.core.ServiceURLBuilder;
 import org.wso2.carbon.identity.core.URLBuilderException;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.oauth.IdentityOAuthAdminException;
 import org.wso2.carbon.identity.oauth.cache.AuthorizationGrantCache;
@@ -1645,6 +1646,10 @@ public class OAuth2AuthzEndpoint {
         // Set the service provider tenant domain.
         params.setTenantDomain(getSpTenantDomain(clientId));
 
+        // Set the login tenant domain.
+        String loginTenantDomain = getLoginTenantDomain(oAuthMessage, clientId);
+        params.setLoginTenantDomain(loginTenantDomain);
+
         if (StringUtils.isNotBlank(oauthRequest.getParam(ACR_VALUES)) && !"null".equals(oauthRequest.getParam
                 (ACR_VALUES))) {
             List acrValuesList = Arrays.asList(oauthRequest.getParam(ACR_VALUES).split(" "));
@@ -1704,6 +1709,21 @@ public class OAuth2AuthzEndpoint {
             throw new InvalidRequestException("Error retrieving Service Provider tenantDomain for client_id: "
                     + clientId, OAuth2ErrorCodes.INVALID_REQUEST, OAuth2ErrorCodes.OAuth2SubErrorCodes
                     .UNEXPECTED_SERVER_ERROR);
+        }
+    }
+
+    private String getLoginTenantDomain(OAuthMessage oAuthMessage, String clientId) throws InvalidRequestException {
+
+        if (!IdentityTenantUtil.isTenantedSessionsEnabled()) {
+            return getSpTenantDomain(clientId);
+        }
+
+        String loginTenantDomain =
+                oAuthMessage.getRequest().getParameter(FrameworkConstants.RequestParams.LOGIN_TENANT_DOMAIN);
+        if (StringUtils.isBlank(loginTenantDomain)) {
+            return getSpTenantDomain(clientId);
+        } else {
+            return loginTenantDomain;
         }
     }
 
@@ -2647,7 +2667,8 @@ public class OAuth2AuthzEndpoint {
                 if (log.isDebugEnabled()) {
                     log.debug("User authenticated. Initiate OIDC browser session.");
                 }
-                opBrowserStateCookie = OIDCSessionManagementUtil.addOPBrowserStateCookie(response);
+                opBrowserStateCookie = OIDCSessionManagementUtil.
+                        addOPBrowserStateCookie(response, oAuth2Parameters.getLoginTenantDomain());
                 // Adding sid claim in the IDtoken to OIDCSessionState class.
                 storeSidClaim(redirectURL, sessionStateObj, oAuth2Parameters);
                 storeOpbsInSessionContext(sessionDataCacheEntry, opBrowserStateCookie.getValue());
@@ -2666,7 +2687,8 @@ public class OAuth2AuthzEndpoint {
                             log.debug("User is authenticated to a new client. Restore browser session state.");
                         }
                         String oldOPBrowserStateCookieId = opBrowserStateCookie.getValue();
-                        opBrowserStateCookie = OIDCSessionManagementUtil.addOPBrowserStateCookie(response);
+                        opBrowserStateCookie = OIDCSessionManagementUtil
+                                .addOPBrowserStateCookie(response, oAuth2Parameters.getLoginTenantDomain());
                         String newOPBrowserStateCookieId = opBrowserStateCookie.getValue();
                         previousSessionState.addSessionParticipant(oAuth2Parameters.getClientId());
                         storeOpbsInSessionContext(sessionDataCacheEntry, opBrowserStateCookie.getValue());
@@ -2679,7 +2701,8 @@ public class OAuth2AuthzEndpoint {
                     if (log.isDebugEnabled()) {
                         log.debug("Restore browser session state.");
                     }
-                    opBrowserStateCookie = OIDCSessionManagementUtil.addOPBrowserStateCookie(response);
+                    opBrowserStateCookie = OIDCSessionManagementUtil
+                            .addOPBrowserStateCookie(response, oAuth2Parameters.getLoginTenantDomain());
                     sessionStateObj.setAuthenticatedUser(authenticatedUser);
                     sessionStateObj.addSessionParticipant(oAuth2Parameters.getClientId());
                     storeOpbsInSessionContext(sessionDataCacheEntry, opBrowserStateCookie.getValue());

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
@@ -1725,9 +1725,8 @@ public class OAuth2AuthzEndpoint {
                 oAuthMessage.getRequest().getParameter(FrameworkConstants.RequestParams.LOGIN_TENANT_DOMAIN);
         if (StringUtils.isBlank(loginTenantDomain)) {
             return getSpTenantDomain(clientId);
-        } else {
-            return loginTenantDomain;
         }
+        return loginTenantDomain;
     }
 
     private void handleMaxAgeParameter(OAuthAuthzRequest oauthRequest,

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
@@ -2672,7 +2672,7 @@ public class OAuth2AuthzEndpoint {
                     log.debug("User authenticated. Initiate OIDC browser session.");
                 }
                 opBrowserStateCookie = OIDCSessionManagementUtil.
-                        addOPBrowserStateCookie(response, oAuth2Parameters.getLoginTenantDomain());
+                        addOPBrowserStateCookie(response, request, oAuth2Parameters.getLoginTenantDomain());
                 // Adding sid claim in the IDtoken to OIDCSessionState class.
                 storeSidClaim(oAuthMessage, sessionStateObj, redirectURL);
                 storeOpbsInSessionContext(sessionDataCacheEntry, opBrowserStateCookie.getValue());
@@ -2692,7 +2692,7 @@ public class OAuth2AuthzEndpoint {
                         }
                         String oldOPBrowserStateCookieId = opBrowserStateCookie.getValue();
                         opBrowserStateCookie = OIDCSessionManagementUtil
-                                .addOPBrowserStateCookie(response, oAuth2Parameters.getLoginTenantDomain());
+                                .addOPBrowserStateCookie(response, request, oAuth2Parameters.getLoginTenantDomain());
                         String newOPBrowserStateCookieId = opBrowserStateCookie.getValue();
                         previousSessionState.addSessionParticipant(oAuth2Parameters.getClientId());
                         storeOpbsInSessionContext(sessionDataCacheEntry, opBrowserStateCookie.getValue());
@@ -2707,7 +2707,7 @@ public class OAuth2AuthzEndpoint {
                         log.debug("Restore browser session state.");
                     }
                     opBrowserStateCookie = OIDCSessionManagementUtil
-                            .addOPBrowserStateCookie(response, oAuth2Parameters.getLoginTenantDomain());
+                            .addOPBrowserStateCookie(response, request, oAuth2Parameters.getLoginTenantDomain());
                     sessionStateObj.setAuthenticatedUser(authenticatedUser);
                     sessionStateObj.addSessionParticipant(oAuth2Parameters.getClientId());
                     storeOpbsInSessionContext(sessionDataCacheEntry, opBrowserStateCookie.getValue());

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpointTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpointTest.java
@@ -1316,8 +1316,8 @@ public class OAuth2AuthzEndpointTest extends TestOAuthEndpointBase {
                 .thenReturn(opBrowserStateCookie);
         when(OIDCSessionManagementUtil.addOPBrowserStateCookie(any(HttpServletResponse.class)))
                 .thenReturn(newOpBrowserStateCookie);
-        when(OIDCSessionManagementUtil.addOPBrowserStateCookie(any(HttpServletResponse.class), any(String.class)))
-                .thenReturn(newOpBrowserStateCookie);
+        when(OIDCSessionManagementUtil.addOPBrowserStateCookie(any(HttpServletResponse.class),
+                any(HttpServletRequest.class), any(String.class))).thenReturn(newOpBrowserStateCookie);
         when(OIDCSessionManagementUtil.getSessionManager()).thenReturn(oidcSessionManager);
         when(oidcSessionManager.getOIDCSessionState(anyString())).thenReturn(previousSessionState);
         when(OIDCSessionManagementUtil.getSessionStateParam(anyString(), anyString(), anyString()))

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpointTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpointTest.java
@@ -1316,6 +1316,8 @@ public class OAuth2AuthzEndpointTest extends TestOAuthEndpointBase {
                 .thenReturn(opBrowserStateCookie);
         when(OIDCSessionManagementUtil.addOPBrowserStateCookie(any(HttpServletResponse.class)))
                 .thenReturn(newOpBrowserStateCookie);
+        when(OIDCSessionManagementUtil.addOPBrowserStateCookie(any(HttpServletResponse.class), any(String.class)))
+                .thenReturn(newOpBrowserStateCookie);
         when(OIDCSessionManagementUtil.getSessionManager()).thenReturn(oidcSessionManager);
         when(oidcSessionManager.getOIDCSessionState(anyString())).thenReturn(previousSessionState);
         when(OIDCSessionManagementUtil.getSessionStateParam(anyString(), anyString(), anyString()))
@@ -1993,5 +1995,47 @@ public class OAuth2AuthzEndpointTest extends TestOAuthEndpointBase {
 
         mockStatic(ServiceURLBuilder.class);
         when(ServiceURLBuilder.create()).thenReturn(builder);
+    }
+
+    @DataProvider(name = "provideGetLoginTenantDomainData")
+    public Object[][] provideGetLoginTenantDomainData() {
+        return new Object[][]{
+                {true, "loginTenantDomain", "loginTenantDomain"},
+                {true, "", MultitenantConstants.SUPER_TENANT_DOMAIN_NAME},
+                {false, "domain", MultitenantConstants.SUPER_TENANT_DOMAIN_NAME},
+        };
+    }
+
+    @Test(dataProvider = "provideGetLoginTenantDomainData")
+    public void testGetLoginTenantDomain(boolean isTenantedSessionsEnabled, String loginDomain, String expectedDomain)
+            throws Exception {
+
+        mockOAuthServerConfiguration();
+
+        mockStatic(IdentityTenantUtil.class);
+        when(IdentityTenantUtil.getTenantDomain(anyInt())).thenReturn(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+        if (isTenantedSessionsEnabled) {
+            when(IdentityTenantUtil.isTenantedSessionsEnabled()).thenReturn(true);
+        } else {
+            when(IdentityTenantUtil.isTenantedSessionsEnabled()).thenReturn(false);
+        }
+
+        mockStatic(IdentityDatabaseUtil.class);
+        when(IdentityDatabaseUtil.getDBConnection()).thenReturn(connection);
+
+        Map<String, String[]> requestParams = new HashMap();
+        Map<String, Object> requestAttributes = new HashMap();
+
+        requestParams.put(FrameworkConstants.RequestParams.LOGIN_TENANT_DOMAIN, new String[]{loginDomain});
+        mockHttpRequest(requestParams, requestAttributes, HttpMethod.POST);
+
+        when(oAuthMessage.getRequest()).thenReturn(httpServletRequest);
+
+        Method getLoginTenantDomain = authzEndpointObject.getClass().getDeclaredMethod(
+                "getLoginTenantDomain", OAuthMessage.class, String.class);
+        getLoginTenantDomain.setAccessible(true);
+
+        String tenantDomain = (String) getLoginTenantDomain.invoke(authzEndpointObject, oAuthMessage, CLIENT_ID_VALUE);
+        assertEquals(tenantDomain, expectedDomain);
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/model/OAuth2Parameters.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/model/OAuth2Parameters.java
@@ -51,6 +51,7 @@ public class OAuth2Parameters implements Serializable {
     private String essentialClaims;
     private String displayName;
     private String sessionDataKey;
+    private String loginTenantDomain;
 
     public String getSessionDataKey() {
         return sessionDataKey;
@@ -258,5 +259,23 @@ public class OAuth2Parameters implements Serializable {
 
     public void setDisplayName(String displayName) {
         this.displayName = displayName;
+    }
+
+    /**
+     * @return the tenant domain the user's session should be created.
+     */
+    public String getLoginTenantDomain() {
+
+        return loginTenantDomain;
+    }
+
+    /**
+     * Sets the tenant domain where the user's session should be created.
+     *
+     * @param loginTenantDomain the tenant domain where the user's session is created.
+     */
+    public void setLoginTenantDomain(String loginTenantDomain) {
+
+        this.loginTenantDomain = loginTenantDomain;
     }
 }

--- a/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/DefaultOIDCSessionStateManager.java
+++ b/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/DefaultOIDCSessionStateManager.java
@@ -97,7 +97,7 @@ public class DefaultOIDCSessionStateManager implements OIDCSessionStateManager {
                                           String tenantDomain) {
 
         ServletCookie cookie;
-        if (IdentityTenantUtil.isTenantedSessionsEnabled()) {
+        if (IdentityTenantUtil.isTenantedSessionsEnabled() && tenantDomain != null) {
             // Invalidate the old opbs cookies which haven't tenanted paths.
             removeOPBrowserStateCookiesInRoot(request, response);
 

--- a/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/DefaultOIDCSessionStateManager.java
+++ b/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/DefaultOIDCSessionStateManager.java
@@ -21,6 +21,8 @@ package org.wso2.carbon.identity.oidc.session;
 import org.apache.commons.codec.binary.Base64;
 import org.wso2.carbon.core.SameSiteCookie;
 import org.wso2.carbon.core.ServletCookie;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
@@ -77,6 +79,28 @@ public class DefaultOIDCSessionStateManager implements OIDCSessionStateManager {
         cookie.setPath("/");
         cookie.setSameSite(SameSiteCookie.NONE);
 
+        response.addCookie(cookie);
+        return cookie;
+    }
+
+    /**
+     * Adds the browser state cookie with tenant qualified path to the response.
+     *
+     * @param response
+     * @param tenantDomain
+     * @return Cookie
+     */
+    @Override
+    public Cookie addOPBrowserStateCookie(HttpServletResponse response, String tenantDomain) {
+
+        ServletCookie cookie = new ServletCookie(OIDCSessionConstants.OPBS_COOKIE_ID, UUID.randomUUID().toString());
+        cookie.setSecure(true);
+        if (IdentityTenantUtil.isTenantedSessionsEnabled()) {
+            cookie.setPath(FrameworkConstants.TENANT_CONTEXT_PREFIX + tenantDomain + "/");
+        } else {
+            cookie.setPath("/");
+        }
+        cookie.setSameSite(SameSiteCookie.NONE);
         response.addCookie(cookie);
         return cookie;
     }

--- a/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/OIDCSessionConstants.java
+++ b/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/OIDCSessionConstants.java
@@ -24,6 +24,7 @@ package org.wso2.carbon.identity.oidc.session;
 public class OIDCSessionConstants {
 
     public static final String OPBS_COOKIE_ID = "opbs";
+    public static final String TENANT_QUALIFIED_OPBS_COOKIE_SUFFIX = "_v2";
 
     // Request Parameters
     public static final String OIDC_CLIENT_ID_PARAM = "client_id";

--- a/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/OIDCSessionConstants.java
+++ b/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/OIDCSessionConstants.java
@@ -24,7 +24,7 @@ package org.wso2.carbon.identity.oidc.session;
 public class OIDCSessionConstants {
 
     public static final String OPBS_COOKIE_ID = "opbs";
-    public static final String TENANT_QUALIFIED_OPBS_COOKIE_SUFFIX = "_v2";
+    public static final String TENANT_QUALIFIED_OPBS_COOKIE_SUFFIX = "-v2";
 
     // Request Parameters
     public static final String OIDC_CLIENT_ID_PARAM = "client_id";

--- a/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/OIDCSessionStateManager.java
+++ b/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/OIDCSessionStateManager.java
@@ -42,6 +42,19 @@ public interface OIDCSessionStateManager {
      * @param response
      * @return Cookie
      */
+    @Deprecated
     Cookie addOPBrowserStateCookie(HttpServletResponse response);
+
+    /**
+     * Adds the browser state cookie with tenant qualified path to the response.
+     *
+     * @param response
+     * @param tenantDomain
+     * @return Cookie
+     */
+    default Cookie addOPBrowserStateCookie(HttpServletResponse response, String tenantDomain) {
+
+        return addOPBrowserStateCookie(response);
+    }
 
 }

--- a/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/OIDCSessionStateManager.java
+++ b/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/OIDCSessionStateManager.java
@@ -41,6 +41,9 @@ public interface OIDCSessionStateManager {
      *
      * @param response
      * @return Cookie
+     *
+     * @deprecated This method was deprecated to enable tenanted paths for opbs cookie.
+     * Use {@link #addOPBrowserStateCookie(HttpServletResponse, String)} instead.
      */
     @Deprecated
     Cookie addOPBrowserStateCookie(HttpServletResponse response);

--- a/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/OIDCSessionStateManager.java
+++ b/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/OIDCSessionStateManager.java
@@ -19,6 +19,7 @@
 package org.wso2.carbon.identity.oidc.session;
 
 import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 /**
@@ -43,7 +44,7 @@ public interface OIDCSessionStateManager {
      * @return Cookie
      *
      * @deprecated This method was deprecated to enable tenanted paths for opbs cookie.
-     * Use {@link #addOPBrowserStateCookie(HttpServletResponse, String)} instead.
+     * Use {@link #addOPBrowserStateCookie(HttpServletResponse, HttpServletRequest, String)} instead.
      */
     @Deprecated
     Cookie addOPBrowserStateCookie(HttpServletResponse response);
@@ -52,10 +53,12 @@ public interface OIDCSessionStateManager {
      * Adds the browser state cookie with tenant qualified path to the response.
      *
      * @param response
+     * @param request
      * @param tenantDomain
      * @return Cookie
      */
-    default Cookie addOPBrowserStateCookie(HttpServletResponse response, String tenantDomain) {
+    default Cookie addOPBrowserStateCookie(HttpServletResponse response, HttpServletRequest request,
+                                           String tenantDomain) {
 
         return addOPBrowserStateCookie(response);
     }

--- a/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/util/OIDCSessionManagementUtil.java
+++ b/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/util/OIDCSessionManagementUtil.java
@@ -180,12 +180,14 @@ public class OIDCSessionManagementUtil {
      * Adds the browser state cookie with tenant qualified path to the response.
      *
      * @param response
+     * @param request
      * @param tenantDomain
      * @return Cookie
      */
-    public static Cookie addOPBrowserStateCookie(HttpServletResponse response, String tenantDomain) {
+    public static Cookie addOPBrowserStateCookie(HttpServletResponse response, HttpServletRequest request,
+                                                 String tenantDomain) {
 
-        return getOIDCessionStateManager().addOPBrowserStateCookie(response, tenantDomain);
+        return getOIDCessionStateManager().addOPBrowserStateCookie(response, request, tenantDomain);
     }
 
     /**
@@ -206,8 +208,13 @@ public class OIDCSessionManagementUtil {
                     servletCookie.setSecure(true);
 
                     if (IdentityTenantUtil.isTenantedSessionsEnabled()) {
-                        String tenantDomain = resolveTenantDomain(request);
-                        servletCookie.setPath(FrameworkConstants.TENANT_CONTEXT_PREFIX + tenantDomain + "/");
+                        // check weather the opbs cookie has a tenanted path.
+                        if (cookie.getValue().endsWith(OIDCSessionConstants.TENANT_QUALIFIED_OPBS_COOKIE_SUFFIX)) {
+                            String tenantDomain = resolveTenantDomain(request);
+                            servletCookie.setPath(FrameworkConstants.TENANT_CONTEXT_PREFIX + tenantDomain + "/");
+                        } else {
+                            servletCookie.setPath("/");
+                        }
                     } else {
                         servletCookie.setPath("/");
                     }

--- a/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/util/OIDCSessionManagementUtil.java
+++ b/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/util/OIDCSessionManagementUtil.java
@@ -228,12 +228,12 @@ public class OIDCSessionManagementUtil {
      * @return tenantDomain
      */
     private static String resolveTenantDomain(HttpServletRequest request) {
+
         String tenantDomain = request.getParameter(FrameworkConstants.RequestParams.LOGIN_TENANT_DOMAIN);
         if (StringUtils.isBlank(tenantDomain)) {
             return IdentityTenantUtil.getTenantDomainFromContext();
-        } else {
-            return tenantDomain;
         }
+        return tenantDomain;
     }
 
     /**

--- a/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/util/OIDCSessionManagementUtil.java
+++ b/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/util/OIDCSessionManagementUtil.java
@@ -208,7 +208,7 @@ public class OIDCSessionManagementUtil {
                     servletCookie.setSecure(true);
 
                     if (IdentityTenantUtil.isTenantedSessionsEnabled()) {
-                        // check weather the opbs cookie has a tenanted path.
+                        // check whether the opbs cookie has a tenanted path.
                         if (cookie.getValue().endsWith(OIDCSessionConstants.TENANT_QUALIFIED_OPBS_COOKIE_SUFFIX)) {
                             String tenantDomain = resolveTenantDomain(request);
                             servletCookie.setPath(FrameworkConstants.TENANT_CONTEXT_PREFIX + tenantDomain + "/");


### PR DESCRIPTION
### Proposed changes in this pull request

Enable tenanted paths for opbs cookie.

- Related Issue : https://github.com/wso2/product-is/issues/11381
- Related PRs : https://github.com/wso2/identity-apps/pull/2173

#### Approach
Enable tenanted paths for the opbs cookie if the Tenanted Sessions were enabled. Extract the tenant domain from the 't parameter' of the oauth request. (Same as in the common oauth cookie).

For avoid the conflicts that can be raised when migrating this fix, added a suffix to to the opbs cookie value, if the tenanted sessions enabled. So if a user has active sessions, at the time of migration happened, we can identified the old opbs cookies which has root path using this suffix of the cookie value. Then we invalidate those old opbs cookies to avoid the issues that can be raised due to two opbs cookies. 
