### PR TITLE
Remove adding SessionDataCache after authentication completed.

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
@@ -694,9 +694,26 @@ public class EndpointUtil {
      * @param params
      * @param loggedInUser
      * @return
+     * @deprecated use {{@link #getUserConsentURL(OAuth2Parameters, String, String, boolean, OAuthMessage)}}
      */
+    @Deprecated
     public static String getUserConsentURL(OAuth2Parameters params, String loggedInUser, String sessionDataKey,
                                            boolean isOIDC) throws OAuthSystemException {
+
+        return getUserConsentURL(params, loggedInUser, sessionDataKey, isOIDC, null);
+    }
+
+    /**
+     * Returns the consent page URL.
+     *
+     * @param params            OAuth2 Parameters.
+     * @param loggedInUser      The logged in user
+     * @param isOIDC            Whether the flow is an OIDC or not.
+     * @param oAuthMessage      oAuth Message.
+     * @return                  The consent url.
+     */
+    public static String getUserConsentURL(OAuth2Parameters params, String loggedInUser, String sessionDataKey,
+                                           boolean isOIDC, OAuthMessage oAuthMessage) throws OAuthSystemException {
 
         String queryString = "";
         if (log.isDebugEnabled()) {
@@ -706,7 +723,13 @@ public class EndpointUtil {
             }
         }
         SessionDataCache sessionDataCache = SessionDataCache.getInstance();
-        SessionDataCacheEntry entry = sessionDataCache.getValueFromCache(new SessionDataCacheKey(sessionDataKey));
+        SessionDataCacheEntry entry;
+        if (oAuthMessage != null) {
+            entry = oAuthMessage.getResultFromLogin();
+        } else {
+            entry = sessionDataCache.getValueFromCache(new SessionDataCacheKey(sessionDataKey));
+        }
+
         AuthenticatedUser user = null;
         String consentPage = null;
         String sessionDataKeyConsent = UUID.randomUUID().toString();

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpointTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpointTest.java
@@ -1806,7 +1806,7 @@ public class OAuth2AuthzEndpointTest extends TestOAuthEndpointBase {
 
         doReturn(oAuthServerConfiguration).when(EndpointUtil.class, "getOAuthServerConfiguration");
         doReturn(USER_CONSENT_URL).when(EndpointUtil.class, "getUserConsentURL", any(OAuth2Parameters.class),
-                anyString(), anyString(), anyBoolean());
+                anyString(), anyString(), anyBoolean(), any(OAuthMessage.class));
         doReturn(LOGIN_PAGE_URL).when(EndpointUtil.class, "getLoginPageURL", anyString(), anyString(), anyBoolean(),
                 anyBoolean(), anySet(), anyMap(), any());
         doReturn(requestObjectService).when(EndpointUtil.class, "getRequestObjectService");


### PR DESCRIPTION
### Proposed changes in this pull request

A new SessionDataCache is added after framework authentication completed to pass authenticated user and authenticated IDP details to other downstream codes. Other than adding these as a new Cache entry, these details can be passed through oAuthMessage.


fix https://github.com/wso2/product-is/issues/12049