### PR TITLE
API to revoke all the tokens issued for a given application

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImpl.java
@@ -53,6 +53,7 @@ import org.wso2.carbon.identity.oauth2.Oauth2ScopeConstants;
 import org.wso2.carbon.identity.oauth2.authz.handlers.ResponseTypeHandler;
 import org.wso2.carbon.identity.oauth2.dao.OAuthTokenPersistenceFactory;
 import org.wso2.carbon.identity.oauth2.model.AccessTokenDO;
+import org.wso2.carbon.identity.oauth2.token.bindings.TokenBinding;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 import org.wso2.carbon.identity.oauth2.validators.OAuth2ScopeValidator;
 import org.wso2.carbon.user.api.UserStoreException;
@@ -1119,6 +1120,68 @@ public class OAuthAdminServiceImpl {
     }
 
     /**
+     * Revoke issued tokens for the application.
+     *
+     * @param consumerKey Consumer key for the application.
+     * @throws IdentityOAuthAdminException Error while revoking the issued tokens.
+     */
+    public void revokeIssuedTokensByConsumerKey(String consumerKey) throws IdentityOAuthAdminException {
+
+        int countToken = 0;
+        List<AccessTokenDO> activeDetailedTokens;
+        try {
+            //Get active access tokens by application id
+            activeDetailedTokens = new ArrayList<>(OAuthTokenPersistenceFactory
+                    .getInstance().getAccessTokenDAO().getActiveAcessTokenDataByConsumerKey(consumerKey));
+        } catch (IdentityOAuth2Exception e) {
+            String errorMsg = "Error occurred while retrieving access tokens issued for Client ID : " + consumerKey;
+            throw handleError(errorMsg, e);
+        }
+        triggerBulkPreRevokeListeners(consumerKey, activeDetailedTokens);
+        String[] accessTokens = new String[activeDetailedTokens.size()];
+        AuthenticatedUser authzUser;
+        for (AccessTokenDO detailToken : activeDetailedTokens) {
+            String token = detailToken.getAccessToken();
+            accessTokens[countToken] = token;
+            countToken++;
+
+            OAuthCacheKey cacheKeyToken = new OAuthCacheKey(token);
+            String scope = buildScopeString(detailToken.getScope());
+            String accessToken = detailToken.getAccessToken();
+
+            //Clear cache with AccessTokenDO
+            authzUser = detailToken.getAuthzUser();
+            TokenBinding tokenBinding = detailToken.getTokenBinding();
+            String tokenBindingReference = (tokenBinding != null &&
+                    StringUtils.isNotBlank(tokenBinding.getBindingReference())) ?
+                    tokenBinding.getBindingReference() : NONE;
+
+            OAuthCache.getInstance().clearCacheEntry(cacheKeyToken);
+            OAuthUtil.clearOAuthCache(detailToken.getConsumerKey(), authzUser, scope, tokenBindingReference);
+            OAuthUtil.clearOAuthCache(detailToken.getConsumerKey(), authzUser, scope);
+            OAuthUtil.clearOAuthCache(detailToken.getConsumerKey(), authzUser);
+            OAuthUtil.clearOAuthCache(accessToken);
+        }
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Access tokens and token of users are removed from the cache for OAuth App with " +
+                    "consumerKey: " + consumerKey);
+        }
+
+        //Revoking token from database
+        if (accessTokens.length > 1) {
+            try {
+                OAuthTokenPersistenceFactory.getInstance().getAccessTokenDAO().revokeAccessTokens(accessTokens);
+            } catch (IdentityOAuth2Exception e) {
+                String errorMsg = "Error occurred while revoking access Tokens for OAuth App with consumerKey : "
+                        + consumerKey;
+                throw handleError(errorMsg, e);
+            }
+        }
+        triggerBulkPostRevokeListeners(new OAuthRevocationResponseDTO(), activeDetailedTokens);
+    }
+
+    /**
      * Revoke approve always of the consent for OAuth apps by resource owners
      *
      * @param appName name of the app
@@ -1158,6 +1221,36 @@ public class OAuthAdminServiceImpl {
                 oAuthEventInterceptorProxy.onPreTokenRevocationByResourceOwner(revokeRequestDTO, paramMap);
             } catch (IdentityOAuth2Exception e) {
                 throw handleError("Error occurred with Oauth pre-revoke listener ", e);
+            }
+        }
+    }
+
+    void triggerBulkPostRevokeListeners(OAuthRevocationResponseDTO revokeRespDTO, List<AccessTokenDO> accessTokenDOs) {
+
+        OAuthEventInterceptor oAuthEventInterceptorProxy = OAuthComponentServiceHolder.getInstance()
+                .getOAuthEventInterceptorProxy();
+        if (oAuthEventInterceptorProxy != null && oAuthEventInterceptorProxy.isEnabled()) {
+            try {
+                Map<String, Object> paramMap = new HashMap<>();
+                oAuthEventInterceptorProxy.onPostTokenRevocationByConsumer(revokeRespDTO, accessTokenDOs, paramMap);
+            } catch (IdentityOAuth2Exception e) {
+                LOG.error("Error occurred when triggering onPostTokenRevocationByConsumer() " +
+                        "of post revocation listener.", e);
+            }
+        }
+    }
+
+    void triggerBulkPreRevokeListeners(String consumerKey, List<AccessTokenDO> accessTokenDOs) {
+
+        OAuthEventInterceptor oAuthEventInterceptorProxy = OAuthComponentServiceHolder.getInstance()
+                .getOAuthEventInterceptorProxy();
+        if (oAuthEventInterceptorProxy != null && oAuthEventInterceptorProxy.isEnabled()) {
+            try {
+                Map<String, Object> paramMap = new HashMap<>();
+                oAuthEventInterceptorProxy.onPreTokenRevocationByConsumer(consumerKey, accessTokenDOs, paramMap);
+            } catch (IdentityOAuth2Exception e) {
+                LOG.error("Error occurred when triggering onPreTokenRevocationByConsumer() " +
+                        "of post revocation listener.", e);
             }
         }
     }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/event/OAuthEventInterceptor.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/event/OAuthEventInterceptor.java
@@ -33,6 +33,7 @@ import org.wso2.carbon.identity.oauth2.model.AccessTokenDO;
 import org.wso2.carbon.identity.oauth2.model.RefreshTokenValidationDataDO;
 import org.wso2.carbon.identity.oauth2.token.OAuthTokenReqMessageContext;
 
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -224,6 +225,30 @@ public interface OAuthEventInterceptor extends IdentityHandler {
      */
     default void onPostTokenRevocationBySystem(AccessTokenDO accessTokenDO, Map<String, Object> params)
             throws IdentityOAuth2Exception {
+
+    }
+
+    /**
+     * This will be called after when Tokens Revoked by consumer.
+     *
+     * @param accessTokenDOs
+     * @throws IdentityOAuth2Exception
+     */
+    default void onPostTokenRevocationByConsumer(
+            org.wso2.carbon.identity.oauth.dto.OAuthRevocationResponseDTO revokeRespDTO,
+            List<AccessTokenDO> accessTokenDOs, Map<String, Object> params) throws IdentityOAuth2Exception {
+
+    }
+
+    /**
+     * This will be called before when Tokens Revoked by consumer.
+     *
+     * @param consumerKey
+     * @param accessTokenDOs
+     * @throws IdentityOAuth2Exception
+     */
+    default void onPreTokenRevocationByConsumer(String consumerKey, List<AccessTokenDO> accessTokenDOs,
+                                                Map<String, Object> params) throws IdentityOAuth2Exception {
 
     }
 }


### PR DESCRIPTION
## Purpose
>Currently there is no API to revoke all the tokens issued for a given application via a single API call.
>OAuth2 Authorized Apps API V2[1] has APIs for the bellow combinations.
>- Per user per application
>- Per user all the applications

## Goals
>introduce a new delete API into the OAuth2 Authorized Apps API V2[1]

## GIT Issue
>https://github.com/wso2/product-is/issues/11993

## Related PRs
> wso2 : identity-api-user : https://github.com/wso2-support/identity-api-user/pull/5

[1]- https://is.docs.wso2.com/en/latest/develop/authorized-apps-v2-rest-api/#!
