### PR TITLE
Fix returning 500 error if the CON_APP_KEY constraint violation happened with SQL Server DB

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/OAuth2Service.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/OAuth2Service.java
@@ -58,6 +58,7 @@ import org.wso2.carbon.user.api.Claim;
 import org.wso2.carbon.user.core.UserStoreManager;
 import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
+import java.sql.SQLException;
 import java.sql.SQLIntegrityConstraintViolationException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -274,8 +275,9 @@ public class OAuth2Service extends AbstractAdmin {
                     tokenReqDTO.getGrantType(), e);
             OAuth2AccessTokenRespDTO tokenRespDTO = new OAuth2AccessTokenRespDTO();
             tokenRespDTO.setError(true);
-            if (e.getCause() != null && e.getCause().getCause() != null &&
-                    e.getCause().getCause() instanceof SQLIntegrityConstraintViolationException) {
+            if (e.getCause() != null && e.getCause().getCause() != null && (
+                    e.getCause().getCause() instanceof SQLIntegrityConstraintViolationException || e.getCause()
+                            .getCause() instanceof SQLException)) {
                 tokenRespDTO.setErrorCode("sql_error");
             } else {
                 tokenRespDTO.setErrorCode(OAuth2ErrorCodes.SERVER_ERROR);


### PR DESCRIPTION
### Purpose
To fix returning 500 error if the CON_APP_KEY constraint violation happened with SQL Server DB.

### Goal
Fixes: https://github.com/wso2/product-apim/issues/11450

### Approach
Check if the cause of the error is an instance of SQLException then assign error code defined for "sql_error"
Wire logs after fix:
```
[2021-08-09 18:43:48,858] DEBUG - wire HTTPS-Listener I/O dispatcher-8 >> "POST /token HTTP/1.1[\r][\n]"
[2021-08-09 18:43:48,858] DEBUG - wire HTTPS-Listener I/O dispatcher-8 >> "Connection: keep-alive[\r][\n]"
[2021-08-09 18:43:48,858] DEBUG - wire HTTPS-Listener I/O dispatcher-8 >> "Authorization: Basic MmpQT19TYTgyeGZOdWVtem9yTkxMaU1qUjBJYTpNUWc1RzJDV2lmV2lqWXdMODBWTjdDN0w4NU1h[\r][\n]"
[2021-08-09 18:43:48,858] DEBUG - wire HTTPS-Listener I/O dispatcher-8 >> "Content-Type: application/x-www-form-urlencoded[\r][\n]"
[2021-08-09 18:43:48,858] DEBUG - wire HTTPS-Listener I/O dispatcher-8 >> "Content-Length: 64[\r][\n]"
[2021-08-09 18:43:48,858] DEBUG - wire HTTPS-Listener I/O dispatcher-8 >> "Host: localhost:8243[\r][\n]"
[2021-08-09 18:43:48,858] DEBUG - wire HTTPS-Listener I/O dispatcher-8 >> "User-Agent: Apache-HttpClient/4.5.12 (Java/1.8.0_292)[\r][\n]"
[2021-08-09 18:43:48,858] DEBUG - wire HTTPS-Listener I/O dispatcher-8 >> "[\r][\n]"
[2021-08-09 18:43:48,858] DEBUG - wire HTTPS-Listener I/O dispatcher-8 >> "grant_type=client_credentials&scope=am_application_scope default"
[2021-08-09 18:43:48,863] DEBUG - wire HTTPS-Sender I/O dispatcher-3 << "POST /oauth2/token HTTP/1.1[\r][\n]"
[2021-08-09 18:43:48,863] DEBUG - wire HTTPS-Sender I/O dispatcher-3 << "Authorization: Basic MmpQT19TYTgyeGZOdWVtem9yTkxMaU1qUjBJYTpNUWc1RzJDV2lmV2lqWXdMODBWTjdDN0w4NU1h[\r][\n]"
[2021-08-09 18:43:48,863] DEBUG - wire HTTPS-Sender I/O dispatcher-3 << "activityid: 5f0ebf3f-6446-4e5e-a1d0-142c52969647[\r][\n]"
[2021-08-09 18:43:48,863] DEBUG - wire HTTPS-Sender I/O dispatcher-3 << "Content-Type: application/x-www-form-urlencoded[\r][\n]"
[2021-08-09 18:43:48,863] DEBUG - wire HTTPS-Sender I/O dispatcher-3 << "Transfer-Encoding: chunked[\r][\n]"
[2021-08-09 18:43:48,864] DEBUG - wire HTTPS-Sender I/O dispatcher-3 << "Host: localhost:9443[\r][\n]"
[2021-08-09 18:43:48,864] DEBUG - wire HTTPS-Sender I/O dispatcher-3 << "Connection: Keep-Alive[\r][\n]"
[2021-08-09 18:43:48,864] DEBUG - wire HTTPS-Sender I/O dispatcher-3 << "User-Agent: Synapse-PT-HttpComponents-NIO[\r][\n]"
[2021-08-09 18:43:48,864] DEBUG - wire HTTPS-Sender I/O dispatcher-3 << "[\r][\n]"
[2021-08-09 18:43:48,864] DEBUG - wire HTTPS-Sender I/O dispatcher-3 << "40[\r][\n]"
[2021-08-09 18:43:48,864] DEBUG - wire HTTPS-Sender I/O dispatcher-3 << "grant_type=client_credentials&scope=am_application_scope default[\r][\n]"
[2021-08-09 18:43:48,864] DEBUG - wire HTTPS-Sender I/O dispatcher-3 << "0[\r][\n]"
[2021-08-09 18:43:48,864] DEBUG - wire HTTPS-Sender I/O dispatcher-3 << "[\r][\n]"
[2021-08-09 18:43:48,969]  WARN - AccessTokenDAOImpl Retry attempt to recover 'CON_APP_KEY' constraint violation : 4
[2021-08-09 18:43:50,158]  WARN - AccessTokenDAOImpl Retry attempt to recover 'CON_APP_KEY' constraint violation : 5
[2021-08-09 18:43:50,784] ERROR - AccessTokenDAOImpl 'CON_APP_KEY' constrain violation retry count exceeds above the maximum count - 5
[2021-08-09 18:43:50,785] ERROR - OAuth2Service Error occurred while issuing the access token for Client ID : 2jPO_Sa82xfNuemzorNLLiMjR0Ia, User ID null, Scope : [default, am_application_scope] and Grant Type : client_credentials
org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception: Error occurred while storing new access token : eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik5UQXhabU14TkRNeVpEZzNNVFUxWkdNME16RXpPREpoWldJNE5ETmxaRFUxT0dGa05qRmlNUSIsImtpZCI6Ik5UQXhabU14TkRNeVpEZzNNVFUxWkdNME16RXpPREpoWldJNE5ETmxaRFUxT0dGa05qRmlNUV9SUzI1NiJ9.eyJhdWQiOiJodHRwOlwvXC9vcmcud3NvMi5hcGltZ3RcL2dhdGV3YXkiLCJzdWIiOiJhZG1pbiIsImFwcGxpY2F0aW9uIjp7ImlkIjoxLCJuYW1lIjoiRGVmYXVsdEFwcGxpY2F0aW9uIiwidGllciI6IlVubGltaXRlZCIsIm93bmVyIjoiYWRtaW4ifSwic2NvcGUiOiJhbV9hcHBsaWNhdGlvbl9zY29wZSBkZWZhdWx0IiwiaXNzIjoiaHR0cHM6XC9cL2xvY2FsaG9zdDo5NDQzXC9vYXV0aDJcL3Rva2VuIiwia2V5dHlwZSI6IlBST0RVQ1RJT04iLCJzdWJzY3JpYmVkQVBJcyI6W3sibmFtZSI6IlBpenphU2hhY2tBUEkiLCJjb250ZXh0IjoiXC9waXp6YXNoYWNrXC8xLjAuMCIsInZlcnNpb24iOiIxLjAuMCIsInB1Ymxpc2hlciI6ImFkbWluIiwic3Vic2NyaXB0aW9uVGllciI6IlVubGltaXRlZCIsInN1YnNjcmliZXJUZW5hbnREb21haW4iOiJjYXJib24uc3VwZXIifV0sImNvbnN1bWVyS2V5IjoiMmpQT19TYTgyeGZOdWVtem9yTkxMaU1qUjBJYSIsImV4cCI6MTYyODUxODQyNiwiaWF0IjoxNjI4NTE0ODI2LCJqdGkiOiIyYzNhNjk0MC0yMDM0LTQxM2YtOGJhMy05MmE2NzIwMjE5MTYifQ==.VOhX11aEITIxAfF0BmEt3ucDvocBoYq5coAEhkW7PdW4RVwUlqbwgMt6Sha9xwDIUFT511E_t5djqgdQ1hVp4bwIXQoot7uMphsPW0xFUglvPlnHpjMHlBKNzBssn7H5bbkmd_4k3YpBwVdlrxAs-2lhHLo6OzBF0TjqlD9LCuCVLjtIxRhUZbE3qZN_fCDxPNsRY97KqnO9WKxAfpjYTE2N2YivmX-MQUymOnOfYDBsw4h0D1PkNYKK1tiJvO6K1VXPpmFyGgoq3JlsEQQ6RgdTlzm0DGvQReuV5FXRzDDQiz-GdR6sh5jciM1Zx1HZUwiKtyt-8FGxVxpQA_ZEEw==
	at org.wso2.carbon.identity.oauth2.token.handlers.grant.AbstractAuthorizationGrantHandler.storeAccessToken(AbstractAuthorizationGrantHandler.java:285)
	at org.wso2.carbon.identity.oauth2.token.handlers.grant.AbstractAuthorizationGrantHandler.persistAccessTokenInDB(AbstractAuthorizationGrantHandler.java:416)
	at org.wso2.carbon.identity.oauth2.token.handlers.grant.AbstractAuthorizationGrantHandler.generateNewAccessToken(AbstractAuthorizationGrantHandler.java:344)
	at org.wso2.carbon.identity.oauth2.token.handlers.grant.AbstractAuthorizationGrantHandler.renewAccessToken(AbstractAuthorizationGrantHandler.java:312)
	at org.wso2.carbon.identity.oauth2.token.handlers.grant.AbstractAuthorizationGrantHandler.issue(AbstractAuthorizationGrantHandler.java:141)
	at org.wso2.carbon.identity.oauth2.token.AccessTokenIssuer.issue(AccessTokenIssuer.java:276)
	at org.wso2.carbon.identity.oauth2.OAuth2Service.issueAccessToken(OAuth2Service.java:222)
	at org.wso2.carbon.identity.oauth.endpoint.token.OAuth2TokenEndpoint.issueAccessToken(OAuth2TokenEndpoint.java:305)
	at org.wso2.carbon.identity.oauth.endpoint.token.OAuth2TokenEndpoint.issueAccessToken(OAuth2TokenEndpoint.java:91)
	at sun.reflect.GeneratedMethodAccessor93.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.apache.cxf.service.invoker.AbstractInvoker.performInvocation(AbstractInvoker.java:179)
	at org.apache.cxf.service.invoker.AbstractInvoker.invoke(AbstractInvoker.java:96)
	at org.apache.cxf.jaxrs.JAXRSInvoker.invoke(JAXRSInvoker.java:193)
	at org.apache.cxf.jaxrs.JAXRSInvoker.invoke(JAXRSInvoker.java:103)
	at org.apache.cxf.interceptor.ServiceInvokerInterceptor$1.run(ServiceInvokerInterceptor.java:59)
	at org.apache.cxf.interceptor.ServiceInvokerInterceptor.handleMessage(ServiceInvokerInterceptor.java:96)
	at org.apache.cxf.phase.PhaseInterceptorChain.doIntercept(PhaseInterceptorChain.java:308)
	at org.apache.cxf.transport.ChainInitiationObserver.onMessage(ChainInitiationObserver.java:121)
	at org.apache.cxf.transport.http.AbstractHTTPDestination.invoke(AbstractHTTPDestination.java:267)
	at org.apache.cxf.transport.servlet.ServletController.invokeDestination(ServletController.java:234)
	at org.apache.cxf.transport.servlet.ServletController.invoke(ServletController.java:208)
	at org.apache.cxf.transport.servlet.ServletController.invoke(ServletController.java:160)
	at org.apache.cxf.transport.servlet.CXFNonSpringServlet.invoke(CXFNonSpringServlet.java:216)
	at org.apache.cxf.transport.servlet.AbstractHTTPServlet.handleRequest(AbstractHTTPServlet.java:301)
	at org.apache.cxf.transport.servlet.AbstractHTTPServlet.doPost(AbstractHTTPServlet.java:220)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:647)
	at org.apache.cxf.transport.servlet.AbstractHTTPServlet.service(AbstractHTTPServlet.java:276)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:303)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:208)
	at org.apache.tomcat.websocket.server.WsFilter.doFilter(WsFilter.java:52)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:241)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:208)
	at org.wso2.carbon.webapp.mgt.filter.AuthorizationHeaderFilter.doFilter(AuthorizationHeaderFilter.java:128)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:241)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:208)
	at org.wso2.carbon.ui.filters.cache.ContentTypeBasedCachePreventionFilter.doFilter(ContentTypeBasedCachePreventionFilter.java:53)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:241)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:208)
	at org.apache.catalina.filters.HttpHeaderSecurityFilter.doFilter(HttpHeaderSecurityFilter.java:126)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:241)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:208)
	at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:219)
	at org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:110)
	at org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:492)
	at org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:165)
	at org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:104)
	at org.wso2.carbon.identity.context.rewrite.valve.TenantContextRewriteValve.invoke(TenantContextRewriteValve.java:80)
	at org.wso2.carbon.identity.authz.valve.AuthorizationValve.invoke(AuthorizationValve.java:100)
	at org.wso2.carbon.identity.auth.valve.AuthenticationValve.invoke(AuthenticationValve.java:65)
	at org.wso2.carbon.tomcat.ext.valves.CompositeValve.continueInvocation(CompositeValve.java:99)
	at org.wso2.carbon.tomcat.ext.valves.CarbonTomcatValve$1.invoke(CarbonTomcatValve.java:47)
	at org.wso2.carbon.webapp.mgt.TenantLazyLoaderValve.invoke(TenantLazyLoaderValve.java:57)
	at org.wso2.carbon.event.receiver.core.internal.tenantmgt.TenantLazyLoaderValve.invoke(TenantLazyLoaderValve.java:48)
	at org.wso2.carbon.tomcat.ext.valves.TomcatValveContainer.invokeValves(TomcatValveContainer.java:47)
	at org.wso2.carbon.tomcat.ext.valves.CompositeValve.invoke(CompositeValve.java:62)
	at org.wso2.carbon.tomcat.ext.valves.CarbonStuckThreadDetectionValve.invoke(CarbonStuckThreadDetectionValve.java:159)
	at org.apache.catalina.valves.AccessLogValve.invoke(AccessLogValve.java:1025)
	at org.wso2.carbon.tomcat.ext.valves.CarbonContextCreatorValve.invoke(CarbonContextCreatorValve.java:57)
	at org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:116)
	at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:452)
	at org.apache.coyote.http11.AbstractHttp11Processor.process(AbstractHttp11Processor.java:1201)
	at org.apache.coyote.AbstractProtocol$AbstractConnectionHandler.process(AbstractProtocol.java:654)
	at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1782)
	at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.run(NioEndpoint.java:1741)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61)
	at java.lang.Thread.run(Thread.java:748)
Caused by: org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception: Access Token for consumer key : 2jPO_Sa82xfNuemzorNLLiMjR0Ia, user : admin@carbon.super and scope : am_application_scope defaultalready exists
	at org.wso2.carbon.identity.oauth2.dao.AccessTokenDAOImpl.insertAccessToken(AccessTokenDAOImpl.java:254)
	at org.wso2.carbon.identity.oauth2.dao.AccessTokenDAOImpl.recoverFromConAppKeyConstraintViolation(AccessTokenDAOImpl.java:2011)
	at org.wso2.carbon.identity.oauth2.dao.AccessTokenDAOImpl.insertAccessToken(AccessTokenDAOImpl.java:257)
	at org.wso2.carbon.identity.oauth2.dao.AccessTokenDAOImpl.recoverFromConAppKeyConstraintViolation(AccessTokenDAOImpl.java:1968)
	at org.wso2.carbon.identity.oauth2.dao.AccessTokenDAOImpl.insertAccessToken(AccessTokenDAOImpl.java:257)
	at org.wso2.carbon.identity.oauth2.dao.AccessTokenDAOImpl.recoverFromConAppKeyConstraintViolation(AccessTokenDAOImpl.java:2011)
	at org.wso2.carbon.identity.oauth2.dao.AccessTokenDAOImpl.insertAccessToken(AccessTokenDAOImpl.java:257)
	at org.wso2.carbon.identity.oauth2.dao.AccessTokenDAOImpl.recoverFromConAppKeyConstraintViolation(AccessTokenDAOImpl.java:1968)
	at org.wso2.carbon.identity.oauth2.dao.AccessTokenDAOImpl.insertAccessToken(AccessTokenDAOImpl.java:257)
	at org.wso2.carbon.identity.oauth2.dao.AccessTokenDAOImpl.recoverFromConAppKeyConstraintViolation(AccessTokenDAOImpl.java:2011)
	at org.wso2.carbon.identity.oauth2.dao.AccessTokenDAOImpl.insertAccessToken(AccessTokenDAOImpl.java:257)
	at org.wso2.carbon.identity.oauth2.dao.AccessTokenDAOImpl.insertAccessToken(AccessTokenDAOImpl.java:98)
	at org.wso2.carbon.identity.oauth2.dao.AccessTokenDAOImpl.insertAccessToken(AccessTokenDAOImpl.java:300)
	at org.wso2.carbon.identity.oauth2.token.handlers.grant.AbstractAuthorizationGrantHandler.storeAccessToken(AbstractAuthorizationGrantHandler.java:282)
	... 69 more
Caused by: com.microsoft.sqlserver.jdbc.SQLServerException: Violation of UNIQUE KEY constraint 'CON_APP_KEY'. Cannot insert duplicate key in object 'dbo.IDN_OAUTH2_ACCESS_TOKEN'. The duplicate key value is (1, admin, -1234, PRIMARY, APPLICATION, 15703966c63ae7da301cd656ef647fa6, ACTIVE, NONE).
	at com.microsoft.sqlserver.jdbc.SQLServerException.makeFromDatabaseError(SQLServerException.java:262)
	at com.microsoft.sqlserver.jdbc.SQLServerStatement.getNextResult(SQLServerStatement.java:1632)
	at com.microsoft.sqlserver.jdbc.SQLServerPreparedStatement.doExecutePreparedStatement(SQLServerPreparedStatement.java:602)
	at com.microsoft.sqlserver.jdbc.SQLServerPreparedStatement$PrepStmtExecCmd.doExecute(SQLServerPreparedStatement.java:524)
	at com.microsoft.sqlserver.jdbc.TDSCommand.execute(IOBuffer.java:7418)
	at com.microsoft.sqlserver.jdbc.SQLServerConnection.executeCommand(SQLServerConnection.java:3272)
	at com.microsoft.sqlserver.jdbc.SQLServerStatement.executeCommand(SQLServerStatement.java:247)
	at com.microsoft.sqlserver.jdbc.SQLServerStatement.executeStatement(SQLServerStatement.java:222)
	at com.microsoft.sqlserver.jdbc.SQLServerPreparedStatement.execute(SQLServerPreparedStatement.java:505)
	at sun.reflect.GeneratedMethodAccessor92.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.apache.tomcat.jdbc.pool.StatementFacade$StatementProxy.invoke(StatementFacade.java:114)
	at com.sun.proxy.$Proxy19.execute(Unknown Source)
	at org.wso2.carbon.identity.oauth2.dao.AccessTokenDAOImpl.insertAccessToken(AccessTokenDAOImpl.java:210)
	... 82 more
[2021-08-09 18:43:50,791] DEBUG - wire HTTPS-Sender I/O dispatcher-1 >> "HTTP/1.1 502 Bad Gateway[\r][\n]"
[2021-08-09 18:43:50,791] DEBUG - wire HTTPS-Sender I/O dispatcher-1 >> "X-Frame-Options: DENY[\r][\n]"
[2021-08-09 18:43:50,791] DEBUG - wire HTTPS-Sender I/O dispatcher-1 >> "X-Content-Type-Options: nosniff[\r][\n]"
[2021-08-09 18:43:50,791] DEBUG - wire HTTPS-Sender I/O dispatcher-1 >> "X-XSS-Protection: 1; mode=block[\r][\n]"
[2021-08-09 18:43:50,791] DEBUG - wire HTTPS-Sender I/O dispatcher-1 >> "WWW-Authenticate: Basic realm=null[\r][\n]"
[2021-08-09 18:43:50,791] DEBUG - wire HTTPS-Sender I/O dispatcher-1 >> "Date: Mon, 09 Aug 2021 13:13:50 GMT[\r][\n]"
[2021-08-09 18:43:50,791] DEBUG - wire HTTPS-Sender I/O dispatcher-1 >> "Content-Type: application/json[\r][\n]"
[2021-08-09 18:43:50,791] DEBUG - wire HTTPS-Sender I/O dispatcher-1 >> "Content-Length: 73[\r][\n]"
[2021-08-09 18:43:50,791] DEBUG - wire HTTPS-Sender I/O dispatcher-1 >> "Server: WSO2 Carbon Server[\r][\n]"
[2021-08-09 18:43:50,791] DEBUG - wire HTTPS-Sender I/O dispatcher-1 >> "[\r][\n]"
[2021-08-09 18:43:50,791] DEBUG - wire HTTPS-Sender I/O dispatcher-1 >> "{"error_description":"Service Unavailable Error.","error":"server_error"}"
[2021-08-09 18:43:50,797] DEBUG - wire HTTPS-Listener I/O dispatcher-5 << "HTTP/1.1 502 Bad Gateway[\r][\n]"
[2021-08-09 18:43:50,797] DEBUG - wire HTTPS-Listener I/O dispatcher-5 << "X-Frame-Options: DENY[\r][\n]"
[2021-08-09 18:43:50,797] DEBUG - wire HTTPS-Listener I/O dispatcher-5 << "activityid: 3b270d4e-923f-4c21-9e08-30e36c8ebfc3[\r][\n]"
[2021-08-09 18:43:50,797] DEBUG - wire HTTPS-Listener I/O dispatcher-5 << "X-Content-Type-Options: nosniff[\r][\n]"
[2021-08-09 18:43:50,797] DEBUG - wire HTTPS-Listener I/O dispatcher-5 << "WWW-Authenticate: Basic realm=null[\r][\n]"
[2021-08-09 18:43:50,797] DEBUG - wire HTTPS-Listener I/O dispatcher-5 << "X-XSS-Protection: 1; mode=block[\r][\n]"
[2021-08-09 18:43:50,797] DEBUG - wire HTTPS-Listener I/O dispatcher-5 << "Content-Type: application/json[\r][\n]"
[2021-08-09 18:43:50,797] DEBUG - wire HTTPS-Listener I/O dispatcher-5 << "Date: Mon, 09 Aug 2021 13:13:50 GMT[\r][\n]"
[2021-08-09 18:43:50,797] DEBUG - wire HTTPS-Listener I/O dispatcher-5 << "Transfer-Encoding: chunked[\r][\n]"
[2021-08-09 18:43:50,797] DEBUG - wire HTTPS-Listener I/O dispatcher-5 << "Connection: keep-alive[\r][\n]"
[2021-08-09 18:43:50,797] DEBUG - wire HTTPS-Listener I/O dispatcher-5 << "[\r][\n]"
[2021-08-09 18:43:50,797] DEBUG - wire HTTPS-Listener I/O dispatcher-5 << "49[\r][\n]"
[2021-08-09 18:43:50,798] DEBUG - wire HTTPS-Listener I/O dispatcher-5 << "{"error_description":"Service Unavailable Error.","error":"server_error"}[\r][\n]"
[2021-08-09 18:43:50,798] DEBUG - wire HTTPS-Listener I/O dispatcher-5 << "0[\r][\n]"
[2021-08-09 18:43:50,798] DEBUG - wire HTTPS-Listener I/O dispatcher-5 << "[\r][\n]"
```