### PR TITLE
Token introspection restricted to tenant specific admins.

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
+++ b/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
@@ -156,6 +156,9 @@ public final class OAuthConstants {
     //JWT claim for authorized user type
     public static final String AUTHORIZED_USER_TYPE = "aut";
 
+    // Identity config properties related to OAuth.
+    public static final String ALLOW_CROSS_TENANT_TOKEN_INTROSPECTION = "AllowCrossTenantTokenIntrospection";
+
     private OAuthConstants() {
 
     }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -4417,4 +4417,14 @@ public class OAuth2Util {
                 = (AbstractUserStoreManager) realmService.getTenantUserRealm(tenantId).getUserStoreManager();
         return userStoreManager.getUserNameFromUserID(userId);
     }
+
+    /**
+     * Check whether introspecting tokens from different tenants is allowed.
+     *
+     * @return true/false Allow or block cross tenant token inspection.
+     */
+    public static boolean isCrossTenantTokenInspectionAllowed() {
+
+        return Boolean.parseBoolean(IdentityUtil.getProperty(OAuthConstants.ALLOW_CROSS_TENANT_TOKEN_INTROSPECTION));
+    }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/TokenValidationHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/TokenValidationHandler.java
@@ -22,6 +22,7 @@ import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
 import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
 import org.wso2.carbon.identity.application.common.model.ServiceProvider;
@@ -39,6 +40,7 @@ import org.wso2.carbon.identity.oauth2.dto.OAuth2TokenValidationResponseDTO;
 import org.wso2.carbon.identity.oauth2.internal.OAuth2ServiceComponentHolder;
 import org.wso2.carbon.identity.oauth2.model.AccessTokenDO;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
+import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -300,6 +302,19 @@ public class TokenValidationHandler {
         }
 
         if (introResp.getUsername() != null) {
+            if (!OAuth2Util.isCrossTenantTokenInspectionAllowed()) {
+                // Check whether introspection is being done from the same tenant the token belongs to.
+                String tenantDomainFromContext =
+                        PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
+                String tenantDomainOfToken = MultitenantUtils.getTenantDomain(introResp.getUsername());
+                if (!StringUtils.equalsIgnoreCase(tenantDomainFromContext, tenantDomainOfToken)) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Unauthorized cross tenant token introspection.");
+                    }
+                    return buildIntrospectionErrorResponse("Unauthorized cross tenant token introspection.");
+                }
+            }
+
             responseDTO.setAuthorizedUser(introResp.getUsername());
         }
 


### PR DESCRIPTION
### Proposed changes in this pull request
Admins from different tenants are blocked by default from introspecting token of other tenants. This can be disabled by applying the following config.

```
[oauth]
allow_cross_tenant_token_introspection=true
```