### PR TITLE
Add WWW-Authenticate header to 401 response when invalid_client error occurs due to unknown client_id

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/expmapper/InvalidRequestExceptionMapper.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/expmapper/InvalidRequestExceptionMapper.java
@@ -190,7 +190,8 @@ public class InvalidRequestExceptionMapper implements ExceptionMapper<InvalidReq
                         oAuthResponse.getBody());
             }
 
-            if (exception instanceof TokenEndpointAccessDeniedException) {
+            if (exception instanceof TokenEndpointAccessDeniedException ||
+                    exception instanceof InvalidApplicationClientException) {
                 return Response.status(oAuthResponse.getResponseStatus())
                         .header(OAuthConstants.HTTP_RESP_HEADER_AUTHENTICATE, EndpointUtil.getRealmInfo())
                         .entity(oAuthResponse.getBody()).build();


### PR DESCRIPTION
Fix for [wso2/product-is #12258](https://github.com/wso2/product-is/issues/12258)

According to the OAuth2 specification: [https://datatracker.ietf.org/doc/html/rfc6749#section-5.2](https://datatracker.ietf.org/doc/html/rfc6749#section-5.2) _WWW-Authenticate_ header should be present in the 401 HTTP error response when password grant type OAuth authentication request failed due to unknown OAuth client id. Currently _WWW-Authenticate_ header is not added to the 401 response in this scenario. This PR address that issue by adding the _WWW-Authenticate_ header to the error response.