### PR TITLE
Changing the logic in calculateAccessTokenExpiryTime

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuer.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuer.java
@@ -493,12 +493,9 @@ public class JWTTokenIssuer extends OauthTokenIssuerImpl {
     private Date calculateAccessTokenExpiryTime(Long accessTokenLifeTimeInMillis, Long curTimeInMillis) {
 
         Date expirationTime;
-        if (accessTokenLifeTimeInMillis < 0) {
-            if (log.isDebugEnabled()) {
-                log.debug("Infinite access token expiry detected. Setting the expiry value to MAX value: " +
-                        Long.MAX_VALUE + "ms.");
-            }
-            // Expiry time set to MAX value as (current + MAX) will lead to a negative value.
+        // When accessTokenLifeTimeInMillis is equal to Long.MAX_VALUE the curTimeInMillis + 
+        // accessTokenLifeTimeInMillis can be a negative value
+        if (curTimeInMillis + accessTokenLifeTimeInMillis < curTimeInMillis) {
             expirationTime = new Date(Long.MAX_VALUE);
         } else {
             expirationTime = new Date(curTimeInMillis + accessTokenLifeTimeInMillis);


### PR DESCRIPTION
### Proposed changes in this pull request
Fixes: https://github.com/wso2/product-apim/issues/9541

#### Functionality
Changed the logic of calculateAccessTokenExpiryTime in the JWTIssuer since there can be situations where accessTokenLifeTimeInMillis is equal to Long.MAX_VALUE


