### PR TITLE
Fix token revoking from cookie binding.

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/bindings/handlers/TokenBindingExpiryEventHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/bindings/handlers/TokenBindingExpiryEventHandler.java
@@ -257,8 +257,9 @@ public class TokenBindingExpiryEventHandler extends AbstractEventHandler {
                 .getAccessTokensByBindingRef(tokenBindingReference);
         for (AccessTokenDO accessTokenDO : boundTokens) {
             String consumerKey = accessTokenDO.getConsumerKey();
-            if (OAuth2Util.getAppInformationByClientId(consumerKey).
-                    isTokenRevocationWithIDPSessionTerminationEnabled()) {
+            if (OAuth2Util.getAppInformationByClientId(consumerKey)
+                    .isTokenRevocationWithIDPSessionTerminationEnabled() && accessTokenDO.getAuthzUser() != null &&
+                    user.toString().equals(accessTokenDO.getAuthzUser().toString())) {
                 revokeTokens(consumerKey, accessTokenDO, tokenBindingReference);
             }
         }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/bindings/impl/CookieBasedTokenBinder.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/bindings/impl/CookieBasedTokenBinder.java
@@ -138,19 +138,7 @@ public class CookieBasedTokenBinder extends AbstractTokenBinder {
 
     @Override
     public void clearTokenBindingElements(HttpServletRequest request, HttpServletResponse response) {
-
-        Cookie[] cookies = request.getCookies();
-        if (ArrayUtils.isNotEmpty(cookies)) {
-            Arrays.stream(cookies).filter(t -> COOKIE_NAME.equals(t.getName())).findAny().ifPresent(cookie -> {
-                ServletCookie servletCookie = new ServletCookie(cookie.getName(), cookie.getValue());
-                servletCookie.setMaxAge(0);
-                servletCookie.setSecure(true);
-                servletCookie.setHttpOnly(true);
-                servletCookie.setPath("/");
-                servletCookie.setSameSite(SameSiteCookie.NONE);
-                response.addCookie(servletCookie);
-            });
-        }
+        // Not required as we not clear the atbv cookie from the browser.
     }
 
     @Override


### PR DESCRIPTION
### Proposed changes in this pull request
- Not clearing the atbv cookie from the browser.
- Clearing the token based on cookie binding as well as based on the user to stop revoking all token with the same cookie binding.