### PR TITLE
Update json-smart version

### DIFF
--- a/features/org.wso2.carbon.identity.oauth.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.oauth.server.feature/pom.xml
@@ -220,6 +220,7 @@
                                 <bundleDef>net.minidev:json-smart</bundleDef>
                                 <bundleDef>net.minidev:accessors-smart:${net.minidev.accessors-smart.version}</bundleDef>
                                 <bundleDef>org.ow2.asm:asm-all:${org.ow2.asm.asm.version}</bundleDef>
+                                <bundleDef>org.ow2.asm:asm:${org.ow2.asm.version}</bundleDef>
                                 <bundleDef>org.wso2.orbit.com.github.dblock.waffle:waffle-jna</bundleDef>
                                 <bundleDef>org.wso2.orbit.org.opensaml:opensaml</bundleDef>
                                 <bundleDef>org.wso2.orbit.joda-time:joda-time</bundleDef>

--- a/pom.xml
+++ b/pom.xml
@@ -276,6 +276,11 @@
                 <version>${org.ow2.asm.asm.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.ow2.asm</groupId>
+                <artifactId>asm</artifactId>
+                <version>${org.ow2.asm.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-core</artifactId>
                 <version>${org.apache.cxf.version}</version>
@@ -885,11 +890,12 @@
         <org.slf4j.verison>1.7.21</org.slf4j.verison>
         <com.google.code.gson.version>2.8.5</com.google.code.gson.version>
         <com.google.code.gson.osgi.version.range>[2.6.2,3.0.0)</com.google.code.gson.osgi.version.range>
-        <json-smart.version>2.3</json-smart.version>
+        <json-smart.version>2.4.7</json-smart.version>
         <version.org.wso2.orbit.javax.xml.bind>2.3.1.wso2v1</version.org.wso2.orbit.javax.xml.bind>
         <version.org.wso2.orbit.javax.activation>1.1.1.wso2v1</version.org.wso2.orbit.javax.activation>
-        <net.minidev.accessors-smart.version>1.2</net.minidev.accessors-smart.version>
+        <net.minidev.accessors-smart.version>2.4.7</net.minidev.accessors-smart.version>
         <org.ow2.asm.asm.version>5.2</org.ow2.asm.asm.version>
+        <org.ow2.asm.version>9.2</org.ow2.asm.version>
 
         <!--Maven Plugin Version-->
         <carbon.p2.plugin.version>5.1.2</carbon.p2.plugin.version>


### PR DESCRIPTION
Related issues https://github.com/wso2/product-is/issues/12485
### Proposed changes in this pull request

Dependency version update
- json-smart 2.3 -> 2.4.7
- accessors-smart 1.2 -> 2.4.7

Add new Dependency
- asm - 9.2

asm - 9.2 is required for json-smart