### PR TITLE
Clear cache when deleting claim attribute mappings

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/OIDCClaimMetaDataOperationHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/OIDCClaimMetaDataOperationHandler.java
@@ -53,7 +53,7 @@ public class OIDCClaimMetaDataOperationHandler extends AbstractEventHandler {
         if (MapUtils.isEmpty(eventProperties)) {
             return;
         }
-        if (eventProperties.get(IdentityEventConstants.EventProperty.TENANT_ID) != null) {
+        if (eventProperties.get(IdentityEventConstants.EventProperty.TENANT_ID) == null) {
             return;
         }
         int tenantId = (int) eventProperties.get(IdentityEventConstants.EventProperty.TENANT_ID);

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/OIDCClaimMetaDataOperationHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/OIDCClaimMetaDataOperationHandler.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.com).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.openidconnect;
+
+import org.apache.commons.collections.MapUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.event.IdentityEventConstants;
+import org.wso2.carbon.identity.event.IdentityEventException;
+import org.wso2.carbon.identity.event.event.Event;
+import org.wso2.carbon.identity.event.handler.AbstractEventHandler;
+import org.wso2.carbon.identity.openidconnect.cache.OIDCScopeClaimCache;
+
+import java.util.Map;
+
+/**
+ * This handles the claim metadata operation related events and it will clear the OIDCScopeClaimCache
+ * cache when the event is triggered. When these relevant events are fired the cache will be
+ * cleared based on the tenant and the cache will be rebuilt with the next request.
+ */
+public class OIDCClaimMetaDataOperationHandler extends AbstractEventHandler {
+
+    private static final Log log = LogFactory.getLog(OIDCClaimMetaDataOperationHandler.class);
+    private final OIDCScopeClaimCache oidcScopeClaimCache = OIDCScopeClaimCache.getInstance();
+    private static final String HANDLER_NAME = "OIDCClaimMetaDataOperationHandler";
+
+    @Override
+    public void handleEvent(Event event) throws IdentityEventException {
+
+        String eventName = event.getEventName();
+        if (IdentityEventConstants.Event.POST_DELETE_EXTERNAL_CLAIM.equals(eventName)) {
+            if (log.isDebugEnabled()) {
+                log.debug("OIDCClaimMetaDataOperationHandler will not be executed for event: " + eventName);
+            }
+        }
+        Map<String, Object> eventProperties = event.getEventProperties();
+        if (MapUtils.isEmpty(eventProperties)) {
+            return;
+        }
+        if (eventProperties.get(IdentityEventConstants.EventProperty.TENANT_ID) != null) {
+            return;
+        }
+        int tenantId = (int) eventProperties.get(IdentityEventConstants.EventProperty.TENANT_ID);
+        oidcScopeClaimCache.clearScopeClaimMap(tenantId);
+    }
+
+    @Override
+    public String getName() {
+
+        return HANDLER_NAME;
+    }
+}

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/internal/OpenIDConnectServiceComponent.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/internal/OpenIDConnectServiceComponent.java
@@ -30,6 +30,7 @@ import org.wso2.carbon.identity.core.util.IdentityCoreInitializedEvent;
 import org.wso2.carbon.identity.event.handler.AbstractEventHandler;
 import org.wso2.carbon.identity.event.services.IdentityEventService;
 import org.wso2.carbon.identity.openidconnect.ClaimProvider;
+import org.wso2.carbon.identity.openidconnect.OIDCClaimMetaDataOperationHandler;
 import org.wso2.carbon.identity.openidconnect.OpenIDConnectClaimFilter;
 import org.wso2.carbon.identity.openidconnect.OpenIDConnectSystemClaimImpl;
 import org.wso2.carbon.identity.openidconnect.RequestObjectService;
@@ -58,6 +59,8 @@ public class OpenIDConnectServiceComponent {
                     new RequestObjectHandler(), null);
             bundleContext.registerService(RequestObjectService.class.getName(),
                     new RequestObjectService(), null);
+            bundleContext.registerService(AbstractEventHandler.class.getName(),
+                    new OIDCClaimMetaDataOperationHandler(), null);
         } catch (Throwable e) {
             String errMsg = "Error while activating OpenIDConnectServiceComponent.";
             log.error(errMsg, e);

--- a/pom.xml
+++ b/pom.xml
@@ -816,7 +816,7 @@
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!-- Carbon Identity Framework version -->
-        <carbon.identity.framework.version>5.20.202</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.20.207</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.17.5, 6.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 


### PR DESCRIPTION
### Proposed changes in this pull request
Introduce a handler subscribed to `POST_DELETE_EXTERNAL_CLAIM` and cleared cache.

### Before merging
- [x] Merge: https://github.com/wso2/carbon-identity-framework/pull/3760
- [x] Bump framework version is product-is
- [ ] Bump framework verion in `identity-inbound-auth-oauth`