### PR TITLE
Validation for PKCE Parameters inside the JWT Request object

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
@@ -1627,26 +1627,9 @@ public class OAuth2AuthzEndpoint {
         }
 
         if (isPkceSupportEnabled()) {
-            String pkceChallengeCode;
-            String pkceChallengeMethod;
+            String pkceChallengeCode = getPkceCodeChallenge(oAuthMessage, params);
+            String pkceChallengeMethod = getPkceCodeChallengeMethod(oAuthMessage, params);
 
-            //If the code_challenge is in the request object, then it is added to Oauth2 params before this point
-            if (params.getPkceCodeChallenge() != null) {
-                //If Oauth2 params contains code_challenge get value from Oauth2 params
-                pkceChallengeCode = params.getPkceCodeChallenge();
-            } else {
-                //Else retrieve from request query params
-                pkceChallengeCode = oAuthMessage.getOauthPKCECodeChallenge();
-            }
-
-            //If the code_challenge_method is in the request object, then it is added to Oauth2 params before this point
-            if (params.getPkceCodeChallengeMethod() != null) {
-                //If Oauth2 params contains code_challenge_method get value from Oauth2 params
-                pkceChallengeMethod = params.getPkceCodeChallengeMethod();
-            } else {
-                //Else retrieve from request query params
-                pkceChallengeMethod = oAuthMessage.getOauthPKCECodeChallengeMethod();
-            }
             String redirectURI = validatePKCEParameters(oAuthMessage, validationResponse, pkceChallengeCode,
                     pkceChallengeMethod);
             if (redirectURI != null) {
@@ -1774,8 +1757,8 @@ public class OAuth2AuthzEndpoint {
             replaceIfPresent(requestObject, CLAIMS, params::setEssentialClaims);
 
             if (isPkceSupportEnabled()) {
-                //If code_challenge and code_challenge_method is sent inside the request object then add them to
-                // Oauth2 parameters
+                // If code_challenge and code_challenge_method is sent inside the request object then add them to
+                // Oauth2 parameters.
                 replaceIfPresent(requestObject, CODE_CHALLENGE, params::setPkceCodeChallenge);
                 replaceIfPresent(requestObject, CODE_CHALLENGE_METHOD, params::setPkceCodeChallengeMethod);
             }
@@ -2987,5 +2970,53 @@ public class OAuth2AuthzEndpoint {
             oAuth2Parameters = getOauth2Params(oAuthMessage);
         }
         return oAuth2Parameters;
+    }
+
+    /**
+     * Method to retrieve PkceCodeChallenge.
+     * First check whether PkceCodeChallenge available in OAuth2Parameters and retrieve. If not retrieve from
+     * request query parameters.
+     *
+     * @param oAuthMessage
+     * @param params
+     * @return
+     */
+    private String getPkceCodeChallenge(OAuthMessage oAuthMessage, OAuth2Parameters params) {
+
+        String pkceChallengeCode;
+        // If the code_challenge is in the request object, then it is added to Oauth2 params before this point.
+        if (params.getPkceCodeChallenge() != null) {
+            // If Oauth2 params contains code_challenge get value from Oauth2 params.
+            pkceChallengeCode = params.getPkceCodeChallenge();
+        } else {
+            // Else retrieve from request query params.
+            pkceChallengeCode = oAuthMessage.getOauthPKCECodeChallenge();
+        }
+
+        return pkceChallengeCode;
+    }
+
+    /**
+     * Method to retrieve PkceCodeChallengeMethod.
+     * First check whether PkceCodeChallengeMethod available in OAuth2Parameters and retrieve. If not retrieve from
+     * request query parameters.
+     *
+     * @param oAuthMessage
+     * @param params
+     * @return
+     */
+    private String getPkceCodeChallengeMethod(OAuthMessage oAuthMessage, OAuth2Parameters params) {
+
+        String pkceChallengeMethod;
+        // If the code_challenge_method is in the request object, then it is added to Oauth2 params before this point.
+        if (params.getPkceCodeChallengeMethod() != null) {
+            // If Oauth2 params contains code_challenge_method get value from Oauth2 params.
+            pkceChallengeMethod = params.getPkceCodeChallengeMethod();
+        } else {
+            // Else retrieve from request query params.
+            pkceChallengeMethod = oAuthMessage.getOauthPKCECodeChallengeMethod();
+        }
+
+        return pkceChallengeMethod;
     }
 }

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
@@ -196,6 +196,8 @@ public class OAuth2AuthzEndpoint {
     private static final String RESPONSE_MODE = "response_mode";
     private static final String REQUEST = "request";
     private static final String REQUEST_URI = "request_uri";
+    private static final String CODE_CHALLENGE = "code_challenge";
+    private static final String CODE_CHALLENGE_METHOD = "code_challenge_method";
 
     private static final String formPostRedirectPage = getFormPostRedirectPage();
     private static final String DISPLAY_NAME = "DisplayName";
@@ -1625,8 +1627,26 @@ public class OAuth2AuthzEndpoint {
         }
 
         if (isPkceSupportEnabled()) {
-            String pkceChallengeCode = oAuthMessage.getOauthPKCECodeChallenge();
-            String pkceChallengeMethod = oAuthMessage.getOauthPKCECodeChallengeMethod();
+            String pkceChallengeCode;
+            String pkceChallengeMethod;
+
+            //If the code_challenge is in the request object, then it is added to Oauth2 params before this point
+            if (params.getPkceCodeChallenge() != null) {
+                //If Oauth2 params contains code_challenge get value from Oauth2 params
+                pkceChallengeCode = params.getPkceCodeChallenge();
+            } else {
+                //Else retrieve from request query params
+                pkceChallengeCode = oAuthMessage.getOauthPKCECodeChallenge();
+            }
+
+            //If the code_challenge_method is in the request object, then it is added to Oauth2 params before this point
+            if (params.getPkceCodeChallengeMethod() != null) {
+                //If Oauth2 params contains code_challenge_method get value from Oauth2 params
+                pkceChallengeMethod = params.getPkceCodeChallengeMethod();
+            } else {
+                //Else retrieve from request query params
+                pkceChallengeMethod = oAuthMessage.getOauthPKCECodeChallengeMethod();
+            }
             String redirectURI = validatePKCEParameters(oAuthMessage, validationResponse, pkceChallengeCode,
                     pkceChallengeMethod);
             if (redirectURI != null) {
@@ -1752,6 +1772,13 @@ public class OAuth2AuthzEndpoint {
             replaceIfPresent(requestObject, ID_TOKEN_HINT, params::setIDTokenHint);
             replaceIfPresent(requestObject, PROMPT, params::setPrompt);
             replaceIfPresent(requestObject, CLAIMS, params::setEssentialClaims);
+
+            if (isPkceSupportEnabled()) {
+                //If code_challenge and code_challenge_method is sent inside the request object then add them to
+                // Oauth2 parameters
+                replaceIfPresent(requestObject, CODE_CHALLENGE, params::setPkceCodeChallenge);
+                replaceIfPresent(requestObject, CODE_CHALLENGE_METHOD, params::setPkceCodeChallengeMethod);
+            }
 
             if (StringUtils.isNotEmpty(requestObject.getClaimValue(SCOPE))) {
                 String scopeString = requestObject.getClaimValue(SCOPE);


### PR DESCRIPTION
# Purpose
According to the PKCE spec[1], an IAM Component supporting PKCE is supposed to accept several additional parameters in the authorization request (code_challenge, code_challenge_method) and token request (code_verifier). But the specification does not provide a clear-cut definition on where to send these parameters. Only in the Appendix B example indicates that these parameters could be sent as query params to the Authorization request. WSO2 Identity Server also supports the same parameters only as query params in Authorize request.

Since there is no clear indication on where to send the parameters, PKCE parameters for the authorization request (code_challenge, code_challenge_method) can be passed inside the JWT Request object. But current implementation does not support PKCE parameters inside the JWT Request object.
 
To fix the issue, 
- override relevant PKCE parameters from the request object to OAuth2Parameters (if PKCE parameters are present in request object) 
- PKCE parameters are set to the OAuth2Parameters (after PKCE parameter validation) before handling OIDC request object

[1] - https://datatracker.ietf.org/doc/html/rfc7636

**Issue** : https://github.com/wso2/product-is/issues/12371