### PR TITLE
Fixed issues in OAuth and introspection endpoints

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
@@ -1754,7 +1754,13 @@ public class OAuth2AuthzEndpoint {
             replaceIfPresent(requestObject, LOGIN_HINT, params::setLoginHint);
             replaceIfPresent(requestObject, ID_TOKEN_HINT, params::setIDTokenHint);
             replaceIfPresent(requestObject, PROMPT, params::setPrompt);
-            replaceIfPresent(requestObject, CLAIMS, params::setEssentialClaims);
+
+            if (requestObject.getClaim(CLAIMS) != null) {
+                if (requestObject.getClaim(CLAIMS) instanceof net.minidev.json.JSONObject) {
+                    net.minidev.json.JSONObject claims = (net.minidev.json.JSONObject) requestObject.getClaim(CLAIMS);
+                    params.setEssentialClaims(claims.toJSONString());
+                }
+            }
 
             if (isPkceSupportEnabled()) {
                 // If code_challenge and code_challenge_method is sent inside the request object then add them to

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/introspection/IntrospectionResponseBuilder.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/introspection/IntrospectionResponseBuilder.java
@@ -20,8 +20,10 @@ package org.wso2.carbon.identity.oauth.endpoint.introspection;
 import org.apache.commons.lang.StringUtils;
 import org.apache.oltu.oauth2.common.utils.JSONUtils;
 import org.json.JSONException;
+import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -40,6 +42,12 @@ public class IntrospectionResponseBuilder {
      */
     public String build() throws JSONException {
 
+        List<String> unsupportedClaims = OAuthServerConfiguration.getInstance().getUnsupportedIntrospectionClaims();
+        for (String parameter : parameters.keySet()) {
+            if (unsupportedClaims.contains(parameter)) {
+                parameters.remove(parameter);
+            }
+        }
         return JSONUtils.buildJSON(parameters);
     }
 

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/introspection/IntrospectionResponseBuilderTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/introspection/IntrospectionResponseBuilderTest.java
@@ -19,11 +19,18 @@ package org.wso2.carbon.identity.oauth.endpoint.introspection;
 
 import org.json.JSONArray;
 import org.json.JSONObject;
+import org.mockito.Mock;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+import org.wso2.carbon.base.CarbonBaseConstants;
 import org.wso2.carbon.identity.oauth.common.OAuthConstants;
+import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
+import org.wso2.carbon.identity.testutil.powermock.PowerMockIdentityBaseTest;
 
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -36,17 +43,27 @@ import static org.testng.Assert.assertTrue;
 /**
  * This class does unit test coverage for RecoveryConfigImpl class
  */
-public class IntrospectionResponseBuilderTest {
+@PrepareForTest({OAuthServerConfiguration.class})
+public class IntrospectionResponseBuilderTest extends PowerMockIdentityBaseTest {
 
     private IntrospectionResponseBuilder introspectionResponseBuilder1;
 
     private IntrospectionResponseBuilder introspectionResponseBuilder2;
+
+    @Mock
+    OAuthServerConfiguration oAuthServerConfiguration;
+    List<String> unsupportedIntrospectionClaims = new ArrayList<>();
 
     @BeforeTest
     public void setUp() {
 
         introspectionResponseBuilder1 = new IntrospectionResponseBuilder();
         introspectionResponseBuilder2 = new IntrospectionResponseBuilder();
+
+        System.setProperty(
+                CarbonBaseConstants.CARBON_HOME,
+                Paths.get(System.getProperty("user.dir"), "src", "test", "resources").toString()
+        );
     }
 
     @DataProvider(name = "provideBuilderData")
@@ -74,6 +91,8 @@ public class IntrospectionResponseBuilderTest {
                 "ImlzcyI6Imh0dHBzOlwvXC9sb2NhbGhvc3Q6OTQ0M1wvb2F1dGgyXC90b2tlbiIsImlhdCI6MTQ1MjE3MDE3Nn0.RqAgm0ybe7tQ" +
                 "YvQYi7uqEtzWf6wgDv5sJq2UIQRC4OJGjn_fTqftIWerZc7rIMRYXi7jzuHxX_GabUhuj7m1iRzi1wgxbI9yQn825lDVF4Lt9" +
                 "DMUTBfKLk81KIy6uB_ECtyxumoX3372yRgC7R56_L_hAElflgBsclEUwEH9psE";
+
+        mockOAuthServerConfiguration();
 
         introspectionResponseBuilder1.setActive(isActive);
         introspectionResponseBuilder1.setIssuedAt(1452170176);
@@ -125,6 +144,8 @@ public class IntrospectionResponseBuilderTest {
     @Test
     public void testResposeBuilderWithoutVal() {
 
+        mockOAuthServerConfiguration();
+
         introspectionResponseBuilder2.setActive(false);
         introspectionResponseBuilder2.setIssuedAt(0);
         introspectionResponseBuilder2.setJwtId("");
@@ -167,6 +188,8 @@ public class IntrospectionResponseBuilderTest {
         Map<String, Object> additionalData = new HashMap<>();
         List<Map<String, Object>> permissions = new ArrayList<>();
 
+        mockOAuthServerConfiguration();
+
         Map<String, Object> resource1 = new HashMap<>();
         String resourceIdKey = "resource_id";
         String resourceScopesKey = "resource_scopes";
@@ -201,5 +224,13 @@ public class IntrospectionResponseBuilderTest {
         assertTrue(resourceEntry.has(resourceIdKey), resourceIdKey + " key not found in introspection response.");
         assertTrue(resourceEntry.has(resourceScopesKey), resourceScopesKey + " key not found in introspection " +
                 "response.");
+    }
+
+    private void mockOAuthServerConfiguration() {
+
+        PowerMockito.mockStatic(OAuthServerConfiguration.class);
+        PowerMockito.when(OAuthServerConfiguration.getInstance()).thenReturn(oAuthServerConfiguration);
+        PowerMockito.when(oAuthServerConfiguration.getUnsupportedIntrospectionClaims())
+                .thenReturn(unsupportedIntrospectionClaims);
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
@@ -267,6 +267,9 @@ public class OAuthServerConfiguration {
     // Property to define the allowed scopes.
     private List<String> allowedScopes = new ArrayList<>();
 
+    // Property to define the allowed scopes.
+    private List<String> unsupportedIntrospectionClaims = new ArrayList<>();
+
     // Property to check whether to drop unregistered scopes.
     private boolean dropUnregisteredScopes = false;
 
@@ -436,6 +439,9 @@ public class OAuthServerConfiguration {
         // Read config for allowed scopes.
         parseAllowedScopesConfiguration(oauthElem);
 
+        // Read config for unsupported claims for introspection response.
+        parseUnsupportedClaimsForIntrospectionResponseConfiguration(oauthElem);
+
         // Read config for dropping unregistered scopes.
         parseDropUnregisteredScopes(oauthElem);
     }
@@ -455,6 +461,25 @@ public class OAuthServerConfiguration {
             while (scopeIterator.hasNext()) {
                 OMElement scopeElement = (OMElement) scopeIterator.next();
                 allowedScopes.add(scopeElement.getText());
+            }
+        }
+    }
+
+    /**
+     * Parse unsupported claims for introspection response configuration.
+     *
+     * @param oauthConfigElem oauthConfigElem.
+     */
+    private void parseUnsupportedClaimsForIntrospectionResponseConfiguration(OMElement oauthConfigElem) {
+
+        OMElement introspectionClaimsElem = oauthConfigElem.getFirstChildWithName(
+                getQNameWithIdentityNS(ConfigElements.INTROSPECTION_RESPONSE));
+        if (introspectionClaimsElem != null) {
+            Iterator claimIterator =   introspectionClaimsElem.getChildrenWithName(getQNameWithIdentityNS(
+                    ConfigElements.UNSUPPORTED_CLAIM));
+            while (claimIterator.hasNext()) {
+                OMElement claimElement = (OMElement) claimIterator.next();
+                unsupportedIntrospectionClaims.add(claimElement.getText());
             }
         }
     }
@@ -522,6 +547,11 @@ public class OAuthServerConfiguration {
     public List<String> getAllowedScopes() {
 
         return allowedScopes;
+    }
+
+    public List<String> getUnsupportedIntrospectionClaims() {
+
+        return unsupportedIntrospectionClaims;
     }
 
     public String getOAuth1RequestTokenUrl() {
@@ -3271,6 +3301,9 @@ public class OAuthServerConfiguration {
         // Allowed Scopes Config.
         private static final String ALLOWED_SCOPES_ELEMENT = "AllowedScopes";
         private static final String SCOPES_ELEMENT = "Scope";
+        // Unsupported Claims For Introspection Response Config.
+        private static final String INTROSPECTION_RESPONSE = "IntrospectionResponse";
+        private static final String UNSUPPORTED_CLAIM = "UnsupportedClaim";
 
         private static final String DROP_UNREGISTERED_SCOPES = "DropUnregisteredScopes";
 


### PR DESCRIPTION
## Purpose
1. When auth_time is specified as an essential claim in the request object in the authorizations request, id_token returned with in the token response should include the auth_time claim. But there was an issue in that, since claims in the request object was retrieved as a string. This PR contains the fix for that.

2. Some claims returned to the introspection response are optional, but there was no way to remove them from the response if not required. Change the implementation to take the unsupported claims and set the values accordingly.

Related PR - https://github.com/wso2/carbon-identity-framework/pull/3782

Related Issues - https://github.com/wso2/product-is/issues/12631, https://github.com/wso2/product-is/issues/12632