### PR TITLE
Add support to remove opbs cookie during session termination logout

### DIFF
--- a/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/servlet/OIDCLogoutServlet.java
+++ b/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/servlet/OIDCLogoutServlet.java
@@ -159,7 +159,6 @@ public class OIDCLogoutServlet extends HttpServlet {
             }
             if (OIDCSessionManagementUtil.handleAlreadyLoggedOutSessionsGracefully()) {
                 handleMissingSessionStateGracefully(request, response);
-                return;
             } else {
                 if (log.isDebugEnabled()) {
                     msg = "HandleAlreadyLoggedOutSessionsGracefully configuration enabled. No valid session found is " +
@@ -168,8 +167,9 @@ public class OIDCLogoutServlet extends HttpServlet {
                 }
                 redirectURL = getErrorPageURL(OAuth2ErrorCodes.ACCESS_DENIED, msg);
                 response.sendRedirect(getRedirectURL(redirectURL, request));
-                return;
             }
+            OIDCSessionManagementUtil.removeOPBrowserStateCookie(request, response);
+            return;
         }
 
         String consent = request.getParameter(OIDCSessionConstants.OIDC_LOGOUT_CONSENT_PARAM);


### PR DESCRIPTION
### Proposed changes in this pull request
> This PR adds support to remove `opbs` cookie in the response of the logout request initiated after session termination.