### PR TITLE
Change opbs cookie removal execution order

### DIFF
--- a/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/servlet/OIDCLogoutServlet.java
+++ b/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/servlet/OIDCLogoutServlet.java
@@ -157,6 +157,7 @@ public class OIDCLogoutServlet extends HttpServlet {
             if (log.isDebugEnabled()) {
                 log.debug(msg);
             }
+            OIDCSessionManagementUtil.removeOPBrowserStateCookie(request, response);
             if (OIDCSessionManagementUtil.handleAlreadyLoggedOutSessionsGracefully()) {
                 handleMissingSessionStateGracefully(request, response);
             } else {
@@ -168,7 +169,6 @@ public class OIDCLogoutServlet extends HttpServlet {
                 redirectURL = getErrorPageURL(OAuth2ErrorCodes.ACCESS_DENIED, msg);
                 response.sendRedirect(getRedirectURL(redirectURL, request));
             }
-            OIDCSessionManagementUtil.removeOPBrowserStateCookie(request, response);
             return;
         }
 


### PR DESCRIPTION
### Proposed changes in this pull request
This PR fixes the issue due to opbs cookie removal logic execution order. Cookie removal should be done before the `response.sendRedirect()` call.