### PR TITLE
Correcting the format of updated_at claim

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/OpenIDConnectClaimFilterImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/OpenIDConnectClaimFilterImpl.java
@@ -430,7 +430,8 @@ public class OpenIDConnectClaimFilterImpl implements OpenIDConnectClaimFilter {
             } else {
                 timeInMillis = Long.parseLong((String) (returnClaims.get(UPDATED_AT)));
             }
-            returnClaims.put(UPDATED_AT, timeInMillis);
+            long timeInSeconds = timeInMillis / 1000;
+            returnClaims.put(UPDATED_AT, timeInSeconds);
         }
     }
 


### PR DESCRIPTION
Related Issue: wso2/product-is#11317

Purpose: According to the OIDC specification, updated_at claim should be in seconds, not in milliseconds.