### PR TITLE
Modify the logic of adding at_hash claim to the id_token

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/OpenIDConnectSystemClaimImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/OpenIDConnectSystemClaimImpl.java
@@ -18,6 +18,8 @@ package org.wso2.carbon.identity.openidconnect;
 import com.nimbusds.jose.JWSAlgorithm;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.io.Charsets;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.oltu.oauth2.common.message.types.ResponseType;
 import org.wso2.carbon.identity.oauth.common.OAuthConstants;
 import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
@@ -41,6 +43,8 @@ import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCClaims.C_
  * This class is used to inject system claims like c_hash, at_hash into the id_token.
  */
 public class OpenIDConnectSystemClaimImpl implements ClaimProvider {
+
+    public static final Log LOG = LogFactory.getLog(OpenIDConnectSystemClaimImpl.class);
     private static final String SHA384 = "SHA-384";
     private static final String SHA512 = "SHA-512";
     private JWSAlgorithm signatureAlgorithm = null;
@@ -145,8 +149,23 @@ public class OpenIDConnectSystemClaimImpl implements ClaimProvider {
 
     private boolean isAccessTokenHashApplicable(String responseType) {
         // At_hash is generated on an access token. Therefore check whether the response type returns an access_token.
-        // id_token and none response types don't return and access token
-        return !OAuthConstants.ID_TOKEN.equalsIgnoreCase(responseType) &&
-                !OAuthConstants.NONE.equalsIgnoreCase(responseType);
+        for (String respType : getResponseTypes(responseType)) {
+            if (OAuthConstants.TOKEN.equalsIgnoreCase(respType)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private String[] getResponseTypes(String responseType) {
+
+        if (isNotBlank(responseType)) {
+            return responseType.split(" ");
+        } else {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Response type not available.");
+            }
+            return new String[0];
+        }
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/openidconnect/OpenIDConnectSystemClaimImplTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/openidconnect/OpenIDConnectSystemClaimImplTest.java
@@ -74,8 +74,7 @@ public class OpenIDConnectSystemClaimImplTest extends PowerMockTestCase {
     public Object[][] getAuthzAdditionalClaims() throws Exception {
 
         return new Object[][] {
-                {"code", AUTHORIZATION_CODE, ACCESS_TOKEN, getHashValue(AUTHORIZATION_CODE),
-                        getHashValue(ACCESS_TOKEN)},
+                {"code", AUTHORIZATION_CODE, ACCESS_TOKEN, getHashValue(AUTHORIZATION_CODE), EMPTY_VALUE},
                 {"token", AUTHORIZATION_CODE, ACCESS_TOKEN, EMPTY_VALUE, getHashValue(ACCESS_TOKEN)},
                 {"id_token", AUTHORIZATION_CODE, ACCESS_TOKEN, EMPTY_VALUE, EMPTY_VALUE}
         };
@@ -115,7 +114,29 @@ public class OpenIDConnectSystemClaimImplTest extends PowerMockTestCase {
         Assert.assertEquals(claims.get(AT_HASH), hashAccessToken);
         Assert.assertEquals(claims.get(C_HASH), authorizationHashCode);
     }
-    
+
+    @DataProvider(name = "getAtHashClaim")
+    public Object[][] getAtHashClaim() throws Exception {
+
+        return new Object[][] {
+                {"id_token", EMPTY_VALUE, ACCESS_TOKEN, EMPTY_VALUE},
+                {"code id_token", AUTHORIZATION_CODE, ACCESS_TOKEN, EMPTY_VALUE},
+                {"code id_token token", AUTHORIZATION_CODE, ACCESS_TOKEN, getHashValue(ACCESS_TOKEN)},
+        };
+    }
+
+    @Test(dataProvider = "getAtHashClaim")
+    public void testSetAtHashClaim(String responseType, String authorizationCode,
+                                       String accessToken, String hashAccessToken) throws Exception {
+
+        oAuth2AuthorizeRespDTO.setAuthorizationCode(authorizationCode);
+        oAuth2AuthorizeReqDTO.setResponseType(responseType);
+        oAuth2AuthorizeRespDTO.setAccessToken(accessToken);
+        Map<String, Object> claims = openIDConnectSystemClaim.getAdditionalClaims(oAuthAuthzReqMessageContext,
+                oAuth2AuthorizeRespDTO);
+        Assert.assertEquals(claims.get(AT_HASH), hashAccessToken);
+    }
+
     private String getHashValue(String value) throws Exception {
 
         String signatureAlgorithm = "SHA256withRSA";


### PR DESCRIPTION
The logic of adding the at_hash claim to the id_token is changed to support all the hybrid flow response types. 
The at_hash claim is added only if the access token is returned.

