### PR TITLE
Add missing AUD and ISS values from the Introspect response

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/TokenValidationHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/TokenValidationHandler.java
@@ -457,6 +457,10 @@ public class TokenValidationHandler {
             introResp.setUsername(getAuthzUser(accessTokenDO));
             // add client id
             introResp.setClientId(accessTokenDO.getConsumerKey());
+            // add issuer
+            introResp.setIss(OAuth2Util.OAuthURL.getOAuth2TokenEPUrl());
+            // add audience
+            introResp.setAud(accessTokenDO.getConsumerKey());
             // Set token binding info.
             if (accessTokenDO.getTokenBinding() != null) {
                 introResp.setBindingType(accessTokenDO.getTokenBinding().getBindingType());


### PR DESCRIPTION
### Purpose
To add AUD and ISS values that are missing from the Introspect response of the APIM 3.2.0 where the same values are present in the Introspect response of the APIM 2.6.0.

### Goal
Fixes: https://github.com/wso2/product-apim/issues/11894

### Approach
- This PR sets the ISS and AUD values to introspection response.
- Furthermore configuration changes will be added to the identity.xml.j2 file and default.json files with the changes in deployment.toml