### PR TITLE
[DCR] Add correlation ID for DCR

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.dcr/src/gen/java/org/wso2/carbon/identity/oauth2/dcr/endpoint/dto/ErrorDTO.java
+++ b/components/org.wso2.carbon.identity.api.server.dcr/src/gen/java/org/wso2/carbon/identity/oauth2/dcr/endpoint/dto/ErrorDTO.java
@@ -20,6 +20,8 @@ public class ErrorDTO  {
   
   private String errorDescription = null;
 
+  private String ref = null;
+
   
   /**
    **/
@@ -44,7 +46,18 @@ public class ErrorDTO  {
     this.errorDescription = errorDescription;
   }
 
-  
+  /**
+   **/
+  @ApiModelProperty(value = "")
+  @JsonProperty("traceId")
+  public String getRef() {
+    return ref;
+  }
+
+  public void setRef(String ref) {
+    this.ref = ref;
+  }
+
 
   @Override
   public String toString()  {
@@ -53,6 +66,9 @@ public class ErrorDTO  {
     
     sb.append("  error: ").append(error).append("\n");
     sb.append("  error_description: ").append(errorDescription).append("\n");
+    if (!ref.isEmpty()) {
+      sb.append("  traceId: ").append(ref).append("\n");
+    }
     sb.append("}\n");
     return sb.toString();
   }

--- a/components/org.wso2.carbon.identity.api.server.dcr/src/main/java/org/wso2/carbon/identity/oauth2/dcr/endpoint/util/DCRMUtils.java
+++ b/components/org.wso2.carbon.identity.api.server.dcr/src/main/java/org/wso2/carbon/identity/oauth2/dcr/endpoint/util/DCRMUtils.java
@@ -172,12 +172,9 @@ public class DCRMUtils {
      * @return correlation-id
      */
     public static String getCorrelation() {
-        String ref;
+        String ref = null;
         if (isCorrelationIDPresent()) {
             ref = MDC.get(DCRMConstants.CORRELATION_ID_MDC).toString();
-        } else {
-            ref = UUID.randomUUID().toString();
-            MDC.put(DCRMConstants.CORRELATION_ID_MDC, ref);
         }
         return ref;
     }

--- a/components/org.wso2.carbon.identity.api.server.dcr/src/main/java/org/wso2/carbon/identity/oauth2/dcr/endpoint/util/DCRMUtils.java
+++ b/components/org.wso2.carbon.identity.api.server.dcr/src/main/java/org/wso2/carbon/identity/oauth2/dcr/endpoint/util/DCRMUtils.java
@@ -33,6 +33,7 @@ import org.wso2.carbon.identity.oauth2.dcr.endpoint.dto.UpdateRequestDTO;
 import org.wso2.carbon.identity.oauth2.dcr.endpoint.exceptions.DCRMEndpointException;
 
 import java.util.UUID;
+
 import javax.ws.rs.core.Response;
 
 /**

--- a/components/org.wso2.carbon.identity.api.server.dcr/src/main/java/org/wso2/carbon/identity/oauth2/dcr/endpoint/util/DCRMUtils.java
+++ b/components/org.wso2.carbon.identity.api.server.dcr/src/main/java/org/wso2/carbon/identity/oauth2/dcr/endpoint/util/DCRMUtils.java
@@ -177,7 +177,7 @@ public class DCRMUtils {
             ref = MDC.get(DCRMConstants.CORRELATION_ID_MDC).toString();
         } else {
             ref = UUID.randomUUID().toString();
-
+            MDC.put(DCRMConstants.CORRELATION_ID_MDC, ref);
         }
         return ref;
     }

--- a/components/org.wso2.carbon.identity.api.server.dcr/src/main/java/org/wso2/carbon/identity/oauth2/dcr/endpoint/util/DCRMUtils.java
+++ b/components/org.wso2.carbon.identity.api.server.dcr/src/main/java/org/wso2/carbon/identity/oauth2/dcr/endpoint/util/DCRMUtils.java
@@ -19,6 +19,7 @@
 package org.wso2.carbon.identity.oauth2.dcr.endpoint.util;
 
 import org.apache.commons.logging.Log;
+import org.apache.log4j.MDC;
 import org.wso2.carbon.identity.oauth.dcr.DCRMConstants;
 import org.wso2.carbon.identity.oauth.dcr.bean.Application;
 import org.wso2.carbon.identity.oauth.dcr.bean.ApplicationRegistrationRequest;
@@ -31,6 +32,7 @@ import org.wso2.carbon.identity.oauth2.dcr.endpoint.dto.RegistrationRequestDTO;
 import org.wso2.carbon.identity.oauth2.dcr.endpoint.dto.UpdateRequestDTO;
 import org.wso2.carbon.identity.oauth2.dcr.endpoint.exceptions.DCRMEndpointException;
 
+import java.util.UUID;
 import javax.ws.rs.core.Response;
 
 /**
@@ -154,6 +156,31 @@ public class DCRMUtils {
         return applicationDTO;
     }
 
+    /**
+     * Check whether correlation id present in the log MDC.
+     *
+     * @return whether the correlation id is present
+     */
+    public static boolean isCorrelationIDPresent() {
+        return MDC.get(DCRMConstants.CORRELATION_ID_MDC) != null;
+    }
+
+    /**
+     * Get correlation id of current thread.
+     *
+     * @return correlation-id
+     */
+    public static String getCorrelation() {
+        String ref;
+        if (isCorrelationIDPresent()) {
+            ref = MDC.get(DCRMConstants.CORRELATION_ID_MDC).toString();
+        } else {
+            ref = UUID.randomUUID().toString();
+
+        }
+        return ref;
+    }
+
     private static DCRMEndpointException buildDCRMEndpointException(Response.Status status,
                                                                     String code, String description,
                                                                     boolean isStatusOnly) {
@@ -169,6 +196,7 @@ public class DCRMUtils {
             ErrorDTO errorDTO = new ErrorDTO();
             errorDTO.setError(error);
             errorDTO.setErrorDescription(description);
+            errorDTO.setRef(getCorrelation());
             return new DCRMEndpointException(status, errorDTO);
         }
     }

--- a/components/org.wso2.carbon.identity.api.server.dcr/src/main/java/org/wso2/carbon/identity/oauth2/dcr/endpoint/util/DCRMUtils.java
+++ b/components/org.wso2.carbon.identity.api.server.dcr/src/main/java/org/wso2/carbon/identity/oauth2/dcr/endpoint/util/DCRMUtils.java
@@ -32,8 +32,6 @@ import org.wso2.carbon.identity.oauth2.dcr.endpoint.dto.RegistrationRequestDTO;
 import org.wso2.carbon.identity.oauth2.dcr.endpoint.dto.UpdateRequestDTO;
 import org.wso2.carbon.identity.oauth2.dcr.endpoint.exceptions.DCRMEndpointException;
 
-import java.util.UUID;
-
 import javax.ws.rs.core.Response;
 
 /**

--- a/components/org.wso2.carbon.identity.api.server.dcr/src/main/resources/api.identity.oauth.dcr.endpoint.yaml
+++ b/components/org.wso2.carbon.identity.api.server.dcr/src/main/resources/api.identity.oauth.dcr.endpoint.yaml
@@ -364,3 +364,5 @@ definitions:
         type: string
       error_description:
         type: string
+      traceId:
+        type: string

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/DCRMConstants.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/DCRMConstants.java
@@ -23,6 +23,8 @@ package org.wso2.carbon.identity.oauth.dcr;
  */
 public class DCRMConstants {
 
+    public static final String CORRELATION_ID_MDC = "Correlation-ID";
+
     /**
      * Enum for OAuth DCR service related error messages.
      */


### PR DESCRIPTION
### Purpose
> This PR add correlationID support for DCR Endpoint. Here, since spec allows to send additional parameter, **traceId** is sent in the body of error responses. 

### Goals
> This correlationID (returned as `traceId`) will help in tracking issues and to follow up on the errors. 

### Approach
> Since the correlationID is set in MDC, first we check for any available ID and if not send a random UUID for tracking purposes.
