### PR TITLE
[Scopes EndPoints] Add correlation ID

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.oauth.scope/pom.xml
+++ b/components/org.wso2.carbon.identity.api.server.oauth.scope/pom.xml
@@ -109,6 +109,10 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/components/org.wso2.carbon.identity.api.server.oauth.scope/src/gen/java/org/wso2/carbon/identity/oauth/scope/endpoint/dto/ErrorDTO.java
+++ b/components/org.wso2.carbon.identity.api.server.oauth.scope/src/gen/java/org/wso2/carbon/identity/oauth/scope/endpoint/dto/ErrorDTO.java
@@ -23,7 +23,9 @@ public class ErrorDTO  {
   
   private String description = null;
 
-  
+  private String ref = null;
+
+
   /**
    **/
   @ApiModelProperty(value = "")
@@ -59,7 +61,17 @@ public class ErrorDTO  {
     this.description = description;
   }
 
-  
+  /**
+   **/
+  @ApiModelProperty(value = "")
+  @JsonProperty("traceId")
+  public String getRef() {
+    return ref;
+  }
+
+  public void setRef(String ref) {
+    this.ref = ref;
+  }
 
   @Override
   public String toString()  {
@@ -69,6 +81,9 @@ public class ErrorDTO  {
     sb.append("  code: ").append(code).append("\n");
     sb.append("  message: ").append(message).append("\n");
     sb.append("  description: ").append(description).append("\n");
+    if (!ref.isEmpty()) {
+      sb.append("  traceId: ").append(ref).append("\n");
+    }
     sb.append("}\n");
     return sb.toString();
   }

--- a/components/org.wso2.carbon.identity.api.server.oauth.scope/src/main/java/org/wso2/carbon/identity/oauth/scope/endpoint/exceptions/ScopeEndpointException.java
+++ b/components/org.wso2.carbon.identity.api.server.oauth.scope/src/main/java/org/wso2/carbon/identity/oauth/scope/endpoint/exceptions/ScopeEndpointException.java
@@ -17,6 +17,7 @@
 package org.wso2.carbon.identity.oauth.scope.endpoint.exceptions;
 
 import org.wso2.carbon.identity.oauth.scope.endpoint.dto.ErrorDTO;
+import org.wso2.carbon.identity.oauth.scope.endpoint.util.ScopeUtils;
 
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
@@ -36,6 +37,7 @@ public class ScopeEndpointException extends WebApplicationException {
     public ScopeEndpointException(Response.Status status) {
 
         super(Response.status(status)
+                .entity(ScopeUtils.getCorrelation())
                 .build());
     }
 }

--- a/components/org.wso2.carbon.identity.api.server.oauth.scope/src/main/java/org/wso2/carbon/identity/oauth/scope/endpoint/impl/ScopesApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.server.oauth.scope/src/main/java/org/wso2/carbon/identity/oauth/scope/endpoint/impl/ScopesApiServiceImpl.java
@@ -201,7 +201,7 @@ public class ScopesApiServiceImpl extends ScopesApiService {
         if (isScopeExists) {
             return Response.status(Response.Status.OK).build();
         }
-        return Response.status(Response.Status.NOT_FOUND).build();
+        return Response.status(Response.Status.NOT_FOUND).entity(ScopeUtils.getCorrelation()).build();
     }
 
     /**

--- a/components/org.wso2.carbon.identity.api.server.oauth.scope/src/main/java/org/wso2/carbon/identity/oauth/scope/endpoint/util/ScopeUtils.java
+++ b/components/org.wso2.carbon.identity.api.server.oauth.scope/src/main/java/org/wso2/carbon/identity/oauth/scope/endpoint/util/ScopeUtils.java
@@ -108,12 +108,9 @@ public class ScopeUtils {
      * @return correlation-id
      */
     public static String getCorrelation() {
-        String ref;
+        String ref = null;
         if (isCorrelationIDPresent()) {
             ref = MDC.get(Oauth2ScopeConstants.CORRELATION_ID_MDC).toString();
-        } else {
-            ref = UUID.randomUUID().toString();
-            MDC.put(Oauth2ScopeConstants.CORRELATION_ID_MDC, ref);
         }
         return ref;
     }

--- a/components/org.wso2.carbon.identity.api.server.oauth.scope/src/main/java/org/wso2/carbon/identity/oauth/scope/endpoint/util/ScopeUtils.java
+++ b/components/org.wso2.carbon.identity.api.server.oauth.scope/src/main/java/org/wso2/carbon/identity/oauth/scope/endpoint/util/ScopeUtils.java
@@ -130,6 +130,7 @@ public class ScopeUtils {
         errorDTO.setCode(code);
         errorDTO.setMessage(message);
         errorDTO.setDescription(description);
+        errorDTO.setRef(getCorrelation());
 
         return errorDTO;
     }

--- a/components/org.wso2.carbon.identity.api.server.oauth.scope/src/main/java/org/wso2/carbon/identity/oauth/scope/endpoint/util/ScopeUtils.java
+++ b/components/org.wso2.carbon.identity.api.server.oauth.scope/src/main/java/org/wso2/carbon/identity/oauth/scope/endpoint/util/ScopeUtils.java
@@ -17,6 +17,7 @@
 package org.wso2.carbon.identity.oauth.scope.endpoint.util;
 
 import org.apache.commons.logging.Log;
+import org.apache.log4j.MDC;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.oauth.scope.endpoint.dto.ErrorDTO;
 import org.wso2.carbon.identity.oauth.scope.endpoint.dto.ScopeBindingDTO;
@@ -33,6 +34,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 
 import javax.ws.rs.core.Response;
 
@@ -92,6 +94,31 @@ public class ScopeUtils {
     }
 
     /**
+     * Check whether correlation id present in the log MDC.
+     *
+     * @return whether the correlation id is present
+     */
+    public static boolean isCorrelationIDPresent() {
+        return MDC.get(Oauth2ScopeConstants.CORRELATION_ID_MDC) != null;
+    }
+
+    /**
+     * Get correlation id of current thread.
+     *
+     * @return correlation-id
+     */
+    public static String getCorrelation() {
+        String ref;
+        if (isCorrelationIDPresent()) {
+            ref = MDC.get(Oauth2ScopeConstants.CORRELATION_ID_MDC).toString();
+        } else {
+            ref = UUID.randomUUID().toString();
+
+        }
+        return ref;
+    }
+
+    /**
      * Returns a generic errorDTO.
      *
      * @param message specifies the error message.
@@ -103,6 +130,7 @@ public class ScopeUtils {
         errorDTO.setCode(code);
         errorDTO.setMessage(message);
         errorDTO.setDescription(description);
+
         return errorDTO;
     }
 

--- a/components/org.wso2.carbon.identity.api.server.oauth.scope/src/main/java/org/wso2/carbon/identity/oauth/scope/endpoint/util/ScopeUtils.java
+++ b/components/org.wso2.carbon.identity.api.server.oauth.scope/src/main/java/org/wso2/carbon/identity/oauth/scope/endpoint/util/ScopeUtils.java
@@ -34,7 +34,6 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.UUID;
 
 import javax.ws.rs.core.Response;
 

--- a/components/org.wso2.carbon.identity.api.server.oauth.scope/src/main/java/org/wso2/carbon/identity/oauth/scope/endpoint/util/ScopeUtils.java
+++ b/components/org.wso2.carbon.identity.api.server.oauth.scope/src/main/java/org/wso2/carbon/identity/oauth/scope/endpoint/util/ScopeUtils.java
@@ -113,7 +113,7 @@ public class ScopeUtils {
             ref = MDC.get(Oauth2ScopeConstants.CORRELATION_ID_MDC).toString();
         } else {
             ref = UUID.randomUUID().toString();
-
+            MDC.put(Oauth2ScopeConstants.CORRELATION_ID_MDC, ref);
         }
         return ref;
     }

--- a/components/org.wso2.carbon.identity.api.server.oauth.scope/src/main/resources/api.identity.oauth2.scope.endpoint.yaml
+++ b/components/org.wso2.carbon.identity.api.server.oauth.scope/src/main/resources/api.identity.oauth2.scope.endpoint.yaml
@@ -422,6 +422,8 @@ definitions:
         type: string
       description:
         type: string
+      traceId:
+        type: string
   #-----------------------------------------------------
   # The Scope Binding
   #-----------------------------------------------------

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/Oauth2ScopeConstants.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/Oauth2ScopeConstants.java
@@ -31,6 +31,7 @@ public class Oauth2ScopeConstants {
     public static final String SCOPE_TYPE_OIDC = "OIDC";
     public static final String CONSOLE_SCOPE_PREFIX = "console:";
     public static final String INTERNAL_SCOPE_PREFIX = "internal_";
+    public static final String CORRELATION_ID_MDC = "Correlation-ID";
 
     /**
      * Enums for error messages.

--- a/pom.xml
+++ b/pom.xml
@@ -343,6 +343,11 @@
                 <version>${org.slf4j.verison}</version>
             </dependency>
             <dependency>
+                <groupId>log4j</groupId>
+                <artifactId>log4j</artifactId>
+                <version>${log4j.verison}</version>
+            </dependency>
+            <dependency>
                 <groupId>javax.servlet</groupId>
                 <artifactId>servlet-api</artifactId>
                 <version>${servlet-api.version}</version>
@@ -934,6 +939,7 @@
         <!-- Log4j -->
         <log4j.api.version>2.12.0</log4j.api.version>
         <log4j.core.version>2.12.0</log4j.core.version>
+        <log4j.verison>1.2.17</log4j.verison>
 
         <maven.checkstyleplugin.version>3.1.0</maven.checkstyleplugin.version>
         <spotbugs-maven-plugin.version>3.1.12</spotbugs-maven-plugin.version>


### PR DESCRIPTION
### Purpose
> This PR add correlationID support for Oauth 2.0 scopes Endpoint. **traceId** is sent in the body of error responses. 

### Goals
> This correlationID (returned as `traceId`) will help in tracking issues and to follow up on the errors. 

### Approach
> Since the correlationID is set in MDC, first we check for any available ID and if not send a random UUID for tracking purposes.
