### PR TITLE
Set debug log instead of error log when trying with an invalid client id

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/OAuth2Service.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/OAuth2Service.java
@@ -647,10 +647,9 @@ public class OAuth2Service extends AbstractAdmin {
             OAuthAppDO appDO = OAuth2Util.getAppInformationByClientId(consumerKey);
             return appDO.getState();
         } catch (IdentityOAuth2Exception | InvalidOAuthClientException e) {
-            String msg = "Error while finding application state for application with client_id: " + consumerKey;
-            log.error(msg);
             if (log.isDebugEnabled()) {
-                log.debug(msg, e);
+                log.debug("Error while finding application state for application with client_id: " +
+                        consumerKey, e);
             }
             return null;
         }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/OAuth2Service.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/OAuth2Service.java
@@ -646,9 +646,12 @@ public class OAuth2Service extends AbstractAdmin {
         try {
             OAuthAppDO appDO = OAuth2Util.getAppInformationByClientId(consumerKey);
             return appDO.getState();
-        } catch (IdentityOAuth2Exception | InvalidOAuthClientException e) {
+        } catch (IdentityOAuth2Exception e) {
+            log.error("Error while finding application state for application with client_id: " + consumerKey, e);
+            return null;
+        } catch (InvalidOAuthClientException e) {
             if (log.isDebugEnabled()) {
-                log.debug("Error while finding application state for application with client_id: " +
+                log.debug("Error while finding an application associated with the given consumer key " +
                         consumerKey, e);
             }
             return null;

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/client/authentication/PublicClientAuthenticator.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/client/authentication/PublicClientAuthenticator.java
@@ -102,7 +102,9 @@ public class PublicClientAuthenticator extends AbstractOAuthClientAuthenticator 
                 }
             }
         } catch (InvalidOAuthClientException e) {
-            log.error("Error in retrieving an Application (Service Provider) with client ID : " + clientId, e);
+            if (log.isDebugEnabled()) {
+                log.debug("Error in retrieving an Application (Service Provider) with client ID : " + clientId, e);
+            }
         } catch (IdentityOAuth2Exception e) {
             log.error("Error in Application (Service Provider) with client ID : " + clientId, e);
         }


### PR DESCRIPTION
### Description

Set debug log instead of error log when trying to authenticate with an invalid client id as it is a client error.