### PR TITLE
Fixing wso2/product-apim#11894

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/introspection/IntrospectionResponseBuilder.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/introspection/IntrospectionResponseBuilder.java
@@ -159,7 +159,13 @@ public class IntrospectionResponseBuilder {
     public IntrospectionResponseBuilder setAudience(String audience) {
 
         if (StringUtils.isNotBlank(audience)) {
-            parameters.put(IntrospectionResponse.AUD, audience);
+            String[] audienceArray = audience.split(",");
+            if (audienceArray.length == 1) {
+                parameters.put(IntrospectionResponse.AUD, audience);
+            } else {
+                parameters.put(IntrospectionResponse.AUD, audienceArray);
+            }
+
         }
         return this;
     }


### PR DESCRIPTION
### Proposed changes in this pull request

To add AUD and ISS values that are missing from the Introspect response  where the same values are present in the Introspect response of the APIM 2.6.0.

### Goal

Fixes: wso2/product-apim#11894

### Approach

This PR sets the ISS and AUD values to introspection response.
Further more configuration changes will be added to the identity.xml.j2 file and default.json files with the changes in deployment.toml
