### PR TITLE
Improve JWTTokenIssuer according to the specification

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuer.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuer.java
@@ -361,7 +361,7 @@ public class JWTTokenIssuer extends OauthTokenIssuerImpl {
     }
 
     /**
-     * This method map signature algorithm define in identity.xml to nimbus signature algorithm format, Strings are.
+     * This method map signature algorithm define in identity.xml to nimbus signature algorithm format, Strings are
      * defined inline hence there are not being used anywhere
      *
      * @param signatureAlgorithm Signature algorithm.

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuer.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuer.java
@@ -524,8 +524,7 @@ public class JWTTokenIssuer extends OauthTokenIssuerImpl {
      */
     private String getAuthenticatedSubjectIdentifier
     (OAuthAuthzReqMessageContext authAuthzReqMessageContext,
-     OAuthTokenReqMessageContext tokenReqMessageContext)
-            throws IdentityOAuth2Exception {
+     OAuthTokenReqMessageContext tokenReqMessageContext) throws IdentityOAuth2Exception {
 
         AuthenticatedUser authenticatedUser = getAuthenticatedUser(authAuthzReqMessageContext, tokenReqMessageContext);
         return authenticatedUser.getAuthenticatedSubjectIdentifier();

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuer.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuer.java
@@ -522,8 +522,7 @@ public class JWTTokenIssuer extends OauthTokenIssuerImpl {
      * @param tokenReqMessageContext     Token request message context.
      * @return authenticated subject identifier.
      */
-    private String getAuthenticatedSubjectIdentifier
-    (OAuthAuthzReqMessageContext authAuthzReqMessageContext,
+    private String getAuthenticatedSubjectIdentifier(OAuthAuthzReqMessageContext authAuthzReqMessageContext,
      OAuthTokenReqMessageContext tokenReqMessageContext) throws IdentityOAuth2Exception {
 
         AuthenticatedUser authenticatedUser = getAuthenticatedUser(authAuthzReqMessageContext, tokenReqMessageContext);

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuer.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuer.java
@@ -79,6 +79,7 @@ public class JWTTokenIssuer extends OauthTokenIssuerImpl {
     private static final String SHA512_WITH_EC = "SHA512withEC";
 
     private static final String AUTHORIZATION_PARTY = "azp";
+    private static final String CLIENT_ID = "client_id";
     private static final String AUDIENCE = "aud";
     private static final String SCOPE = "scope";
     private static final String TOKEN_BINDING_REF = "binding_ref";
@@ -360,8 +361,8 @@ public class JWTTokenIssuer extends OauthTokenIssuerImpl {
     }
 
     /**
-     * This method map signature algorithm define in identity.xml to nimbus signature algorithm format, Strings are
-     * defined inline hence there are not being used any where
+     * This method map signature algorithm define in identity.xml to nimbus signature algorithm format, Strings are.
+     * defined inline hence there are not being used anywhere
      *
      * @param signatureAlgorithm Signature algorithm.
      * @return JWS algorithm.
@@ -446,6 +447,7 @@ public class JWTTokenIssuer extends OauthTokenIssuerImpl {
         jwtClaimsSetBuilder.issueTime(new Date(curTimeInMillis));
         jwtClaimsSetBuilder.jwtID(UUID.randomUUID().toString());
         jwtClaimsSetBuilder.notBeforeTime(new Date(curTimeInMillis));
+        jwtClaimsSetBuilder.claim(CLIENT_ID, consumerKey);
 
         String scope = getScope(authAuthzReqMessageContext, tokenReqMessageContext);
         if (StringUtils.isNotEmpty(scope)) {
@@ -490,7 +492,7 @@ public class JWTTokenIssuer extends OauthTokenIssuerImpl {
     private Date calculateAccessTokenExpiryTime(Long accessTokenLifeTimeInMillis, Long curTimeInMillis) {
 
         Date expirationTime;
-        // When accessTokenLifeTimeInMillis is equal to Long.MAX_VALUE the curTimeInMillis + 
+        // When accessTokenLifeTimeInMillis is equal to Long.MAX_VALUE the curTimeInMillis +
         // accessTokenLifeTimeInMillis can be a negative value
         if (curTimeInMillis + accessTokenLifeTimeInMillis < curTimeInMillis) {
             expirationTime = new Date(Long.MAX_VALUE);
@@ -520,8 +522,10 @@ public class JWTTokenIssuer extends OauthTokenIssuerImpl {
      * @param tokenReqMessageContext     Token request message context.
      * @return authenticated subject identifier.
      */
-    private String getAuthenticatedSubjectIdentifier(OAuthAuthzReqMessageContext authAuthzReqMessageContext,
-            OAuthTokenReqMessageContext tokenReqMessageContext) throws IdentityOAuth2Exception {
+    private String getAuthenticatedSubjectIdentifier
+    (OAuthAuthzReqMessageContext authAuthzReqMessageContext,
+     OAuthTokenReqMessageContext tokenReqMessageContext)
+            throws IdentityOAuth2Exception {
 
         AuthenticatedUser authenticatedUser = getAuthenticatedUser(authAuthzReqMessageContext, tokenReqMessageContext);
         return authenticatedUser.getAuthenticatedSubjectIdentifier();
@@ -541,7 +545,7 @@ public class JWTTokenIssuer extends OauthTokenIssuerImpl {
     }
 
     /**
-     * Get authentication request object from message context
+     * Get authentication request object from message context.
      *
      * @param authAuthzReqMessageContext
      * @param tokenReqMessageContext
@@ -572,7 +576,7 @@ public class JWTTokenIssuer extends OauthTokenIssuerImpl {
      * @return scope of token.
      */
     private String getScope(OAuthAuthzReqMessageContext authAuthzReqMessageContext,
-            OAuthTokenReqMessageContext tokenReqMessageContext) throws IdentityOAuth2Exception {
+                            OAuthTokenReqMessageContext tokenReqMessageContext) throws IdentityOAuth2Exception {
 
         String[] scope;
         String scopeString = null;
@@ -673,7 +677,7 @@ public class JWTTokenIssuer extends OauthTokenIssuerImpl {
     }
 
     /**
-     * Populate custom claims (For implicit grant)
+     * Populate custom claims (For implicit grant).
      *
      * @param jwtClaimsSetBuilder
      * @param tokenReqMessageContext
@@ -689,7 +693,7 @@ public class JWTTokenIssuer extends OauthTokenIssuerImpl {
     }
 
     /**
-     * Populate custom claims
+     * Populate custom claims.
      *
      * @param jwtClaimsSetBuilder
      * @param authzReqMessageContext

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuerTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuerTest.java
@@ -1,5 +1,5 @@
 /*
- *Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -114,7 +114,6 @@ public class JWTTokenIssuerTest extends PowerMockIdentityBaseTest {
     private static final String CLAIM_CLIENT_ID = "client_id";
     private static final String DEFAULT_TYP_HEADER_VALUE = "at+jwt";
     private static final String THUMB_PRINT = "Certificate";
-
 
     @Mock
     private OAuthServerConfiguration oAuthServerConfiguration;
@@ -313,7 +312,6 @@ public class JWTTokenIssuerTest extends PowerMockIdentityBaseTest {
                                    String sub,
                                    long expectedExpiry) throws Exception {
 
-        try {
             OAuthAppDO appDO = spy(new OAuthAppDO());
             mockGrantHandlers();
             mockCustomClaimsCallbackHandler();
@@ -351,11 +349,6 @@ public class JWTTokenIssuerTest extends PowerMockIdentityBaseTest {
             assertNotNull(signedJWT.getHeader());
             assertNotNull(signedJWT.getHeader().getType());
             assertEquals(signedJWT.getHeader().getType().toString(), DEFAULT_TYP_HEADER_VALUE);
-
-        } catch (Exception ex) {
-            assertTrue(ex.getMessage() != null && ex.getMessage().contains("is not supported"),
-                    "Looks like someone has implemented this method. Need to modify this testcase");
-        }
     }
 
     @Test

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuerTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuerTest.java
@@ -113,7 +113,7 @@ public class JWTTokenIssuerTest extends PowerMockIdentityBaseTest {
 
     private static final String CLAIM_CLIENT_ID = "client_id";
     private static final String DEFAULT_TYP_HEADER_VALUE = "at+jwt";
-    private static final String THUMB_PRINT = "Certificate";
+    private static final String THUMBPRINT = "Certificate";
 
     @Mock
     private OAuthServerConfiguration oAuthServerConfiguration;
@@ -317,7 +317,7 @@ public class JWTTokenIssuerTest extends PowerMockIdentityBaseTest {
             mockCustomClaimsCallbackHandler();
             mockStatic(OAuth2Util.class);
             when(OAuth2Util.getAppInformationByClientId(anyString())).thenReturn(appDO);
-            when(OAuth2Util.getThumbPrint(anyString(), anyInt())).thenReturn(THUMB_PRINT);
+            when(OAuth2Util.getThumbPrint(anyString(), anyInt())).thenReturn(THUMBPRINT);
 
             System.setProperty(CarbonBaseConstants.CARBON_HOME,
                     Paths.get(System.getProperty("user.dir"), "src", "test", "resources").toString());


### PR DESCRIPTION
### Proposed changes in this pull request

- Set client_id claim as a payload value in the JWTTokenIssuer class 
- Update JWTTokenIssuerTest class.
1. testCreateJWTClaimSet method - Test client_id claim
2. testSignJWTWithRSA method - Test header "typ" value 

**specification** - https://datatracker.ietf.org/doc/html/rfc9068

