### PR TITLE
Modified warn logs to debug logs when there is a mismatch in callback URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,9 +7,7 @@
 *.ipr
 .idea
 .DS_Store
-
-# Mobile Tools for Java (J2ME)
-.mtj.tmp/
+.jpb
 
 # Package Files #
 *.jar

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 *.ipr
 .idea
 .DS_Store
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
 .jpb
 
 # Package Files #

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/OAuth2Service.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/OAuth2Service.java
@@ -198,8 +198,8 @@ public class OAuth2Service extends AbstractAdmin {
                 return validationResponseDTO;
             } else {    // Provided callback URL does not match the registered callback url.
                 if (log.isDebugEnabled()) {
-                    log.debug("Provided Callback URLs: " + callbackURI + " does not match with the registered " +
-                            "callback url.");
+                    log.debug("Provided Callback URL: " + callbackURI + " does not match with the registered " +
+                            "callback URLs.");
                 }
                 validationResponseDTO.setValidClient(false);
                 validationResponseDTO.setErrorCode(OAuth2ErrorCodes.INVALID_CALLBACK);

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/OAuth2Service.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/OAuth2Service.java
@@ -197,7 +197,10 @@ public class OAuth2Service extends AbstractAdmin {
                 validationResponseDTO.setPkceSupportPlain(appDO.isPkceSupportPlain());
                 return validationResponseDTO;
             } else {    // Provided callback URL does not match the registered callback url.
-                log.warn("Provided Callback URL does not match with the provided one.");
+                if (log.isDebugEnabled()) {
+                    log.debug("Provided Callback URL: " + callbackURI + " does not match with the registered " +
+                            "callback url.");
+                }
                 validationResponseDTO.setValidClient(false);
                 validationResponseDTO.setErrorCode(OAuth2ErrorCodes.INVALID_CALLBACK);
                 validationResponseDTO.setErrorMsg("Registered callback does not match with the provided url.");

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/OAuth2Service.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/OAuth2Service.java
@@ -198,7 +198,7 @@ public class OAuth2Service extends AbstractAdmin {
                 return validationResponseDTO;
             } else {    // Provided callback URL does not match the registered callback url.
                 if (log.isDebugEnabled()) {
-                    log.debug("Provided Callback URL: " + callbackURI + " does not match with the registered " +
+                    log.debug("Provided Callback URLs: " + callbackURI + " does not match with the registered " +
                             "callback url.");
                 }
                 validationResponseDTO.setValidClient(false);
@@ -237,6 +237,10 @@ public class OAuth2Service extends AbstractAdmin {
         String registeredCallbackUrl = oauthApp.getCallbackUrl();
         if (registeredCallbackUrl.startsWith(OAuthConstants.CALLBACK_URL_REGEXP_PREFIX)) {
             regexp = registeredCallbackUrl.substring(OAuthConstants.CALLBACK_URL_REGEXP_PREFIX.length());
+        }
+        if (log.isDebugEnabled()) {
+            log.debug("Comparing provided callback URL: " + callbackURI + " with configured callback: " +
+                    registeredCallbackUrl);
         }
         return (regexp != null && callbackURI.matches(regexp)) || registeredCallbackUrl.equals(callbackURI);
     }


### PR DESCRIPTION
## Purpose
In an authorization code grant login when there is a mismatch in callback URL, the error message does not give a clear understanding about what's the warning.

Since this not a server error it should not be printed in error mode.

To fix this, Modified warn logs to debug logs when there is a mismatch in callback URL and changed it to a more meaningful message.

Related Issue : [wso2/product-is#6201](https://github.com/wso2/product-is/issues/6201)