### PR TITLE
Validate scopes before asking consent from the user

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
@@ -976,8 +976,12 @@ public class EndpointUtil {
                             new JDBCPermissionBasedInternalScopeValidator();
                     String[] validatedScope = scopeValidator.validateScope(requestedScopes, user, params.getClientId());
 
-                    // Add validated internal scopes to the allowedOAuthScopes list.
-                    allowedOAuthScopes.addAll(Arrays.asList(validatedScope));
+                    // Filter out requested scopes from the validated scope array.
+                    for (String scope : requestedScopes) {
+                        if (ArrayUtils.contains(validatedScope, scope)) {
+                            allowedOAuthScopes.add(scope);
+                        }
+                    }
                 }
                 params.setConsentRequiredScopes(new HashSet<>(allowedOAuthScopes));
                 consentRequiredScopes = String.join(" ", allowedOAuthScopes).trim();

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
@@ -965,18 +965,18 @@ public class EndpointUtil {
                 }
             }
             if (CollectionUtils.isNotEmpty(allowedOAuthScopes)) {
-                // filter out internal scopes to be validated
-                List<String> requestedScopes = Oauth2ScopeUtils.getRequestedScopes(allowedOAuthScopes);
-                if (CollectionUtils.isNotEmpty(requestedScopes)) {
-                    // remove the filtered internal scopes from the allowedOAuthScopes list
-                    allowedOAuthScopes.removeAll(requestedScopes);
+                // Filter out internal scopes to be validated.
+                String[] requestedScopes = Oauth2ScopeUtils.getRequestedScopes(
+                        allowedOAuthScopes.toArray(new String[0]));
+                if (ArrayUtils.isNotEmpty(requestedScopes)) {
+                    // Remove the filtered internal scopes from the allowedOAuthScopes list.
+                    allowedOAuthScopes.removeAll(Arrays.asList(requestedScopes));
 
                     JDBCPermissionBasedInternalScopeValidator scopeValidator =
                             new JDBCPermissionBasedInternalScopeValidator();
-                    String[] validatedScope = scopeValidator.validateScope(
-                            requestedScopes.toArray(new String[0]), user, params.getClientId());
+                    String[] validatedScope = scopeValidator.validateScope(requestedScopes, user, params.getClientId());
 
-                    // add validated internal scopes to the allowedOAuthScopes list
+                    // Add validated internal scopes to the allowedOAuthScopes list.
                     allowedOAuthScopes.addAll(Arrays.asList(validatedScope));
                 }
                 params.setConsentRequiredScopes(new HashSet<>(allowedOAuthScopes));

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtilTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtilTest.java
@@ -19,7 +19,10 @@ package org.wso2.carbon.identity.oauth.endpoint.util;
 
 import org.apache.axiom.util.base64.Base64Utils;
 import org.apache.commons.collections.map.HashedMap;
+import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.logging.Log;
+import org.apache.http.NameValuePair;
+import org.apache.http.client.utils.URLEncodedUtils;
 import org.apache.oltu.oauth2.as.response.OAuthASResponse;
 import org.apache.oltu.oauth2.common.exception.OAuthProblemException;
 import org.apache.oltu.oauth2.common.exception.OAuthSystemException;
@@ -61,6 +64,7 @@ import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
 import org.wso2.carbon.identity.oauth2.OAuth2ScopeService;
 import org.wso2.carbon.identity.oauth2.OAuth2Service;
 import org.wso2.carbon.identity.oauth2.OAuth2TokenValidationService;
+import org.wso2.carbon.identity.oauth2.bean.Scope;
 import org.wso2.carbon.identity.oauth2.model.OAuth2Parameters;
 import org.wso2.carbon.identity.oauth2.model.OAuth2ScopeConsentResponse;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
@@ -74,12 +78,14 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import javax.servlet.http.HttpServletRequest;
@@ -92,12 +98,14 @@ import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyMap;
 import static org.mockito.Matchers.anyString;
 import static org.powermock.api.mockito.PowerMockito.doAnswer;
+import static org.powermock.api.mockito.PowerMockito.doNothing;
 import static org.powermock.api.mockito.PowerMockito.doReturn;
 import static org.powermock.api.mockito.PowerMockito.mock;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.spy;
 import static org.powermock.api.mockito.PowerMockito.when;
 import static org.powermock.api.mockito.PowerMockito.whenNew;
+import static org.powermock.api.support.membermodification.MemberMatcher.method;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
@@ -105,7 +113,7 @@ import static org.testng.Assert.assertTrue;
 @PrepareForTest({SessionDataCache.class, OAuthServerConfiguration.class, OAuth2Util.class, IdentityUtil.class,
         FrameworkUtils.class, OAuthASResponse.class, OAuthResponse.class, PrivilegedCarbonContext.class,
         ServerConfiguration.class, ServiceURLBuilder.class, IdentityTenantUtil.class, EndpointUtil.class,
-        FileBasedConfigurationBuilder.class, LoggerUtils.class})
+        FileBasedConfigurationBuilder.class, LoggerUtils.class, JDBCPermissionBasedInternalScopeValidator.class})
 public class EndpointUtilTest extends PowerMockIdentityBaseTest {
 
     @Mock
@@ -297,11 +305,16 @@ public class EndpointUtilTest extends PowerMockIdentityBaseTest {
 
         EndpointUtil.setOAuthAdminService(mockedOAuthAdminService);
         when(mockedOAuthAdminService.getScopeNames()).thenReturn(new String[0]);
-        JDBCPermissionBasedInternalScopeValidator scopeValidator = mock(
-                JDBCPermissionBasedInternalScopeValidator.class);
-        when(scopeValidator.validateScope(any(), any(), anyString())).thenReturn(new String[] {"internal_login"});
+        JDBCPermissionBasedInternalScopeValidator scopeValidatorSpy = PowerMockito.spy(
+                new JDBCPermissionBasedInternalScopeValidator());
+        doNothing().when(scopeValidatorSpy, method(JDBCPermissionBasedInternalScopeValidator.class,
+                "endTenantFlow")).withNoArguments();
+        when(scopeValidatorSpy, method(JDBCPermissionBasedInternalScopeValidator.class,
+                "getUserAllowedScopes", AuthenticatedUser.class, String[].class, String.class))
+                .withArguments(any(AuthenticatedUser.class), any(), anyString())
+                .thenReturn(getScopeList());
         PowerMockito.whenNew(JDBCPermissionBasedInternalScopeValidator.class).withNoArguments()
-                .thenReturn(scopeValidator);
+                .thenReturn(scopeValidatorSpy);
 
         String consentUrl;
         try {
@@ -316,9 +329,18 @@ public class EndpointUtilTest extends PowerMockIdentityBaseTest {
                     "loggedInUser parameter value is not found in url");
             Assert.assertTrue(consentUrl.contains(URLEncoder.encode("TestApplication", "ISO-8859-1")),
                     "application parameter value is not found in url");
-            Assert.assertTrue(consentUrl.contains("scope2"), "scope parameter value is not found in url");
-            Assert.assertTrue(consentUrl.contains("internal_login"), "internal_login scope parameter " +
-                    "value is not found in url");
+            List<NameValuePair> nameValuePairList = URLEncodedUtils.parse(consentUrl, StandardCharsets.UTF_8);
+            Optional<NameValuePair> optionalScope = nameValuePairList.stream().filter(nameValuePair ->
+                    nameValuePair.getName().equals("scope")).findAny();
+            Assert.assertTrue(optionalScope.isPresent());
+            NameValuePair scopeNameValuePair = optionalScope.get();
+            String[] scopeArray = scopeNameValuePair.getValue().split(" ");
+            Assert.assertTrue(ArrayUtils.contains(scopeArray, "scope2"), "scope parameter value " +
+                    "is not found in url");
+            Assert.assertTrue(ArrayUtils.contains(scopeArray, "internal_login"), "internal_login " +
+                    "scope parameter value is not found in url");
+            Assert.assertFalse(ArrayUtils.contains(scopeArray, "SYSTEM"), "SYSTEM scope" +
+                    "parameter should not contain in the url.");
             if (queryString != null && cacheEntryExists) {
                 Assert.assertTrue(consentUrl.contains(queryString), "spQueryParams value is not found in url");
             }
@@ -732,5 +754,17 @@ public class EndpointUtilTest extends PowerMockIdentityBaseTest {
                 thenReturn(USER_INFO_CLAIM_RETRIEVER);
         when(mockedOAuthServerConfiguration.getOpenIDConnectUserInfoEndpointClaimDialect()).
                 thenReturn(USER_INFO_CLAIM_DIALECT);
+    }
+
+    private List<Scope> getScopeList() {
+        List<Scope> scopeList = new ArrayList<>();
+        // Add some sample scopes.
+        scopeList.add(new Scope("internal_login", "Login", "description1"));
+        scopeList.add(new Scope("internal_config_mgt_update", "Update Configs", "description2"));
+        scopeList.add(new Scope("internal_config_mgt_update", "Update Email Configs",
+                "description3"));
+        scopeList.add(new Scope("internal_user_mgt_update", "Update Users", "description4"));
+        scopeList.add(new Scope("internal_list_tenants", "List Tenant", "description5"));
+        return scopeList;
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/Oauth2ScopeUtils.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/Oauth2ScopeUtils.java
@@ -44,6 +44,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.wso2.carbon.identity.oauth2.Oauth2ScopeConstants.INTERNAL_SCOPE_PREFIX;
+import static org.wso2.carbon.identity.oauth2.Oauth2ScopeConstants.SYSTEM_SCOPE;
+
 /**
  * Utility functions related to OAuth 2 scopes.
  */
@@ -320,5 +323,45 @@ public class Oauth2ScopeUtils {
             return Boolean.parseBoolean(property);
         }
         return true;
+    }
+
+    /**
+     * Iterate through the scopes array to filter out the internal scopes.
+     * @param scopes String array of scopes.
+     * @return String array with internal scopes. Return an empty array if there's not any internal scopes in the
+     * given scopes array.
+     */
+    public static String[] getRequestedScopes(String[] scopes) {
+
+        List<String> requestedScopes = new ArrayList<>();
+        if (scopes == null) {
+            return null;
+        }
+        for (String scope : scopes) {
+            if (scope.startsWith(INTERNAL_SCOPE_PREFIX) || scope.equalsIgnoreCase(SYSTEM_SCOPE)) {
+                requestedScopes.add(scope);
+            }
+        }
+        return requestedScopes.toArray(new String[0]);
+    }
+
+    /**
+     * Iterate through the scopes list to filter out the internal scopes.
+     * @param scopes String list of scopes.
+     * @return String list with internal scopes. Return an empty list if there's not any internal scopes in the
+     * given scopes list.
+     */
+    public static List<String> getRequestedScopes(List<String> scopes) {
+
+        List<String> requestedScopes = new ArrayList<>();
+        if (scopes == null) {
+            return null;
+        }
+        for (String scope : scopes) {
+            if (scope.startsWith(INTERNAL_SCOPE_PREFIX) || scope.equalsIgnoreCase(SYSTEM_SCOPE)) {
+                requestedScopes.add(scope);
+            }
+        }
+        return requestedScopes;
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/Oauth2ScopeUtils.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/Oauth2ScopeUtils.java
@@ -334,8 +334,8 @@ public class Oauth2ScopeUtils {
     public static String[] getRequestedScopes(String[] scopes) {
 
         List<String> requestedScopes = new ArrayList<>();
-        if (scopes == null) {
-            return null;
+        if (ArrayUtils.isEmpty(scopes)) {
+            return ArrayUtils.EMPTY_STRING_ARRAY;
         }
         for (String scope : scopes) {
             if (scope.startsWith(INTERNAL_SCOPE_PREFIX) || scope.equalsIgnoreCase(SYSTEM_SCOPE)) {
@@ -343,25 +343,5 @@ public class Oauth2ScopeUtils {
             }
         }
         return requestedScopes.toArray(new String[0]);
-    }
-
-    /**
-     * Iterate through the scopes list to filter out the internal scopes.
-     * @param scopes String list of scopes.
-     * @return String list with internal scopes. Return an empty list if there's not any internal scopes in the
-     * given scopes list.
-     */
-    public static List<String> getRequestedScopes(List<String> scopes) {
-
-        List<String> requestedScopes = new ArrayList<>();
-        if (scopes == null) {
-            return null;
-        }
-        for (String scope : scopes) {
-            if (scope.startsWith(INTERNAL_SCOPE_PREFIX) || scope.equalsIgnoreCase(SYSTEM_SCOPE)) {
-                requestedScopes.add(scope);
-            }
-        }
-        return requestedScopes;
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/JDBCPermissionBasedInternalScopeValidator.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/JDBCPermissionBasedInternalScopeValidator.java
@@ -79,7 +79,7 @@ public class JDBCPermissionBasedInternalScopeValidator {
 
     /**
      * Execute Internal scope Validation.
-     * @param tokReqMsgCtx
+     * @param tokReqMsgCtx Oauth token request message.
      * @return array of validated scopes.
      */
     public String[] validateScope(OAuthTokenReqMessageContext tokReqMsgCtx) {
@@ -108,7 +108,7 @@ public class JDBCPermissionBasedInternalScopeValidator {
 
     /**
      * Execute Internal Scope Validation.
-     * @param authzReqMessageContext
+     * @param authzReqMessageContext OAuth authorization request message.
      * @return array of validated scopes.
      */
     public String[] validateScope(OAuthAuthzReqMessageContext authzReqMessageContext) {
@@ -141,8 +141,8 @@ public class JDBCPermissionBasedInternalScopeValidator {
     /**
      * Execute Internal Scope Validation.
      * @param requestedScopes Array of scopes that needs to be validated.
-     * @param authenticatedUser
-     * @param clientId
+     * @param authenticatedUser Authenticated user.
+     * @param clientId ID of the client.
      * @return Array of validated scopes.
      */
     public String[] validateScope(String[] requestedScopes, AuthenticatedUser authenticatedUser, String clientId) {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/JDBCPermissionBasedInternalScopeValidator.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/JDBCPermissionBasedInternalScopeValidator.java
@@ -120,22 +120,8 @@ public class JDBCPermissionBasedInternalScopeValidator {
         if (ArrayUtils.isEmpty(requestedScopes)) {
             return requestedScopes;
         }
-        List<Scope> userAllowedScopes =
-                getUserAllowedScopes(authzReqMessageContext.getAuthorizationReqDTO().getUser(), requestedScopes,
-                        authzReqMessageContext.getAuthorizationReqDTO().getConsumerKey());
-
-        String[] userAllowedScopesAsArray = getScopes(userAllowedScopes);
-        if (ArrayUtils.contains(requestedScopes, SYSTEM_SCOPE)) {
-            return userAllowedScopesAsArray;
-        }
-
-        List<String> scopesToRespond = new ArrayList<>();
-        for (String scope : requestedScopes) {
-            if (ArrayUtils.contains(userAllowedScopesAsArray, scope)) {
-                scopesToRespond.add(scope);
-            }
-        }
-        return scopesToRespond.toArray(new String[0]);
+        return validateScope(requestedScopes, authzReqMessageContext.getAuthorizationReqDTO().getUser(),
+                authzReqMessageContext.getAuthorizationReqDTO().getConsumerKey());
     }
 
     /**

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/JDBCPermissionBasedInternalScopeValidator.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/JDBCPermissionBasedInternalScopeValidator.java
@@ -77,6 +77,11 @@ public class JDBCPermissionBasedInternalScopeValidator {
     private static final String EVERYONE_PERMISSION = "everyone_permission";
     private static final String ATTRIBUTE_SEPARATOR = FrameworkUtils.getMultiAttributeSeparator();
 
+    /**
+     * Execute Internal scope Validation.
+     * @param tokReqMsgCtx
+     * @return array of validated scopes.
+     */
     public String[] validateScope(OAuthTokenReqMessageContext tokReqMsgCtx) {
 
         // filter internal scopes
@@ -101,6 +106,11 @@ public class JDBCPermissionBasedInternalScopeValidator {
         return scopesToRespond.toArray(new String[0]);
     }
 
+    /**
+     * Execute Internal Scope Validation.
+     * @param authzReqMessageContext
+     * @return array of validated scopes.
+     */
     public String[] validateScope(OAuthAuthzReqMessageContext authzReqMessageContext) {
 
         // Remove openid scope from the list if available
@@ -128,6 +138,13 @@ public class JDBCPermissionBasedInternalScopeValidator {
         return scopesToRespond.toArray(new String[0]);
     }
 
+    /**
+     * Execute Internal Scope Validation.
+     * @param requestedScopes Array of scopes that needs to be validated.
+     * @param authenticatedUser
+     * @param clientId
+     * @return Array of validated scopes.
+     */
     public String[] validateScope(String[] requestedScopes, AuthenticatedUser authenticatedUser, String clientId) {
 
         List<Scope> userAllowedScopes = getUserAllowedScopes(authenticatedUser, requestedScopes, clientId);


### PR DESCRIPTION
### Purpose

* Fix https://github.com/wso2/product-is/issues/12937
* With this improvement, all the internal scopes will be validated before asking consent from the user

Requested scopes: `internal_login` `openid` `email` `profile` `SYSTEM` `internal_application_mgt_update` `internal_email_mgt`, 

## Related PRs
https://github.com/wso2/product-is/pull/13023
** Note: Please merge the above PR and re-run the PR Builder to pass all test cases. Otherwise, some test cases are failing due to changes in this PR
**Then merge this PR:**
https://github.com/wso2/product-is/pull/13004

#### With Current Implementation
<img width="516" alt="Screenshot 2022-01-05 at 2 13 59 PM" src="https://user-images.githubusercontent.com/32576163/148190340-f19b485a-25b4-436d-8b9e-8812550f619f.png">

#### With Previous Implementation
<img width="509" alt="Screenshot 2022-01-05 at 2 44 53 PM" src="https://user-images.githubusercontent.com/32576163/148192148-d1536577-0acb-46be-8079-0ef002358433.png">

