### PR TITLE
Fix tenant resolving issue when retrieving the oidc scopes

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
@@ -816,12 +816,14 @@ public class EndpointUtil {
                     scopesToBeConsented.stream().collect(Collectors.joining(" ")) + " for client : " +
                     oAuth2Parameters.getClientId());
         }
-        // Remove OIDC scopes.
-        scopesToBeConsented.removeAll(getOIDCScopeNames());
         String userId = getUserIdOfAuthenticatedUser(user);
         String appId = getAppIdFromClientId(oAuth2Parameters.getClientId());
+        int tenantId = IdentityTenantUtil.getTenantId(user.getTenantDomain());
+
+        // Remove OIDC scopes.
+        scopesToBeConsented.removeAll(getTenantOIDCScopeNames(tenantId));
         return oAuth2ScopeService.hasUserProvidedConsentForAllRequestedScopes(userId, appId,
-                IdentityTenantUtil.getTenantId(user.getTenantDomain()), scopesToBeConsented);
+                tenantId, scopesToBeConsented);
     }
 
     /**
@@ -905,6 +907,11 @@ public class EndpointUtil {
     private static List<String> getOIDCScopeNames() throws IdentityOAuthAdminException {
 
         return Arrays.asList(ArrayUtils.nullToEmpty(oAuthAdminService.getScopeNames()));
+    }
+
+    private static List<String> getTenantOIDCScopeNames(int tenantId) throws IdentityOAuthAdminException {
+
+        return Arrays.asList(ArrayUtils.nullToEmpty(oAuthAdminService.getTenantScopeNames(tenantId)));
     }
 
     private static List<String> getAllowedOAuthScopes(OAuth2Parameters params) throws OAuthSystemException {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImpl.java
@@ -681,6 +681,31 @@ public class OAuthAdminServiceImpl {
     }
 
     /**
+     * To retrieve all persisted oidc scopes for a tenant.
+     *
+     * @param tenantId
+     * @return list of scopes persisted.
+     * @throws IdentityOAuthAdminException if an error occurs when loading oidc scopes.
+     */
+    public String[] getTenantScopeNames(int tenantId) throws IdentityOAuthAdminException {
+
+        try {
+            List<String> scopeDTOList = OAuthTokenPersistenceFactory.getInstance().getScopeClaimMappingDAO().
+                    getScopeNames(tenantId);
+            if (CollectionUtils.isNotEmpty(scopeDTOList)) {
+                return scopeDTOList.toArray(new String[scopeDTOList.size()]);
+            } else {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Could not load oidc scopes for tenant. Hence returning an empty array.");
+                }
+                return new String[0];
+            }
+        } catch (IdentityOAuth2Exception e) {
+            throw handleError("Error while loading OIDC scopes and claims for tenant: " + tenantId, e);
+        }
+    }
+
+    /**
      * To retrieve oidc claims mapped to an oidc scope.
      *
      * @param scope scope


### PR DESCRIPTION
### Proposed changes in this pull request

- At the beginning of the OIDC scopes retrieving flow, a super tenant flow is initiated. And this results in picking the OIDC scopes related to the super tenant at one point. The changes are introduced to pick the correct tenant when retrieving the OIDC scopes for the react app.

### Related Issue

https://github.com/wso2-enterprise/asgardeo-product/issues/9165


