### PR TITLE
Fix tenant resolving issue

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/pom.xml
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/pom.xml
@@ -305,7 +305,7 @@
                                         <limit implementation="org.jacoco.report.check.Limit">
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.55</minimum>
+                                            <!-- <minimum>0.6</minimum> -->
                                         </limit>
                                     </limits>
                                 </rule>

--- a/components/org.wso2.carbon.identity.oauth.endpoint/pom.xml
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/pom.xml
@@ -305,7 +305,7 @@
                                         <limit implementation="org.jacoco.report.check.Limit">
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <!-- <minimum>0.6</minimum> -->
+                                            <minimum>0.55</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
@@ -249,13 +249,13 @@ public class OAuth2AuthzEndpoint {
             throw e;
         }
 
-        // Start tenant domain flow if the tenant configuration is not enabled.
-        if (!IdentityTenantUtil.isTenantedSessionsEnabled()) {
-            String tenantDomain = EndpointUtil.getSPTenantDomainFromClientId(oAuthMessage.getClientId());
-            FrameworkUtils.startTenantFlow(tenantDomain);
-        }
-
         try {
+            // Start tenant domain flow if the tenant configuration is not enabled.
+            if (!IdentityTenantUtil.isTenantedSessionsEnabled()) {
+                String tenantDomain = EndpointUtil.getSPTenantDomainFromClientId(oAuthMessage.getClientId());
+                FrameworkUtils.startTenantFlow(tenantDomain);
+            }
+
             if (isPassthroughToFramework(oAuthMessage)) {
                 return handleAuthFlowThroughFramework(oAuthMessage);
             } else if (isInitialRequestFromClient(oAuthMessage)) {

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
@@ -1922,13 +1922,13 @@ public class OAuth2AuthzEndpoint {
     private String getLoginTenantDomain(OAuthMessage oAuthMessage, String clientId) throws InvalidRequestException {
 
         if (!IdentityTenantUtil.isTenantedSessionsEnabled()) {
-            return getSpTenantDomain(clientId);
+            return EndpointUtil.getSPTenantDomainFromClientId(oAuthMessage.getClientId());
         }
 
         String loginTenantDomain =
                 oAuthMessage.getRequest().getParameter(FrameworkConstants.RequestParams.LOGIN_TENANT_DOMAIN);
         if (StringUtils.isBlank(loginTenantDomain)) {
-            return getSpTenantDomain(clientId);
+            return EndpointUtil.getSPTenantDomainFromClientId(oAuthMessage.getClientId());
         }
         return loginTenantDomain;
     }

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpointTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpointTest.java
@@ -450,6 +450,9 @@ public class OAuth2AuthzEndpointTest extends TestOAuthEndpointBase {
         mockStatic(OAuth2Util.OAuthURL.class);
         when(OAuth2Util.OAuthURL.getOAuth2ErrorPageUrl()).thenReturn(ERROR_PAGE_URL);
 
+        spy(FrameworkUtils.class);
+        doNothing().when(FrameworkUtils.class, "startTenantFlow", anyString());
+        doNothing().when(FrameworkUtils.class, "endTenantFlow");
         mockStatic(IdentityTenantUtil.class);
         mockStatic(LoggerUtils.class);
         when(LoggerUtils.isDiagnosticLogsEnabled()).thenReturn(true);
@@ -612,6 +615,8 @@ public class OAuth2AuthzEndpointTest extends TestOAuthEndpointBase {
 
         spy(FrameworkUtils.class);
         doReturn(requestCoordinator).when(FrameworkUtils.class, "getRequestCoordinator");
+        doNothing().when(FrameworkUtils.class, "startTenantFlow", anyString());
+        doNothing().when(FrameworkUtils.class, "endTenantFlow");
 
         spy(IdentityUtil.class);
         doReturn("https://localhost:9443/carbon").when(IdentityUtil.class, "getServerURL", anyString(), anyBoolean
@@ -631,6 +636,8 @@ public class OAuth2AuthzEndpointTest extends TestOAuthEndpointBase {
 
         spy(FrameworkUtils.class);
         doReturn("sample").when(FrameworkUtils.class, "resolveUserIdFromUsername", anyInt(), anyString(), anyString());
+        doNothing().when(FrameworkUtils.class, "startTenantFlow", anyString());
+        doNothing().when(FrameworkUtils.class, "endTenantFlow");
         try (Connection connection = getConnection()) {
             mockStatic(IdentityDatabaseUtil.class);
             when(IdentityDatabaseUtil.getDBConnection()).thenReturn(connection);
@@ -743,6 +750,8 @@ public class OAuth2AuthzEndpointTest extends TestOAuthEndpointBase {
         spy(FrameworkUtils.class);
         when(authCookie.getValue()).thenReturn("dummyValue");
         doReturn(authCookie).when(FrameworkUtils.class, "getAuthCookie", any());
+        doNothing().when(FrameworkUtils.class, "startTenantFlow", anyString());
+        doNothing().when(FrameworkUtils.class, "endTenantFlow");
         mockStatic(LoggerUtils.class);
         when(LoggerUtils.isDiagnosticLogsEnabled()).thenReturn(true);
         mockStatic(IdentityTenantUtil.class);
@@ -995,6 +1004,9 @@ public class OAuth2AuthzEndpointTest extends TestOAuthEndpointBase {
 
         when(oAuthServerConfiguration.getSupportedResponseTypeValidators()).thenReturn(responseTypeValidators);
 
+        spy(FrameworkUtils.class);
+        doNothing().when(FrameworkUtils.class, "startTenantFlow", anyString());
+        doNothing().when(FrameworkUtils.class, "endTenantFlow");
         mockStatic(IdentityTenantUtil.class);
         when(IdentityTenantUtil.getTenantDomain(anyInt())).thenReturn(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         when(IdentityTenantUtil.getTenantId(anyString())).thenReturn(MultitenantConstants.SUPER_TENANT_ID);
@@ -1179,6 +1191,9 @@ public class OAuth2AuthzEndpointTest extends TestOAuthEndpointBase {
         mockStatic(OAuth2Util.class);
         when(OAuth2Util.getServiceProvider(CLIENT_ID_VALUE)).thenReturn(new ServiceProvider());
         mockApplicationManagementService();
+        spy(FrameworkUtils.class);
+        doNothing().when(FrameworkUtils.class, "startTenantFlow", anyString());
+        doNothing().when(FrameworkUtils.class, "endTenantFlow");
         mockStatic(IdentityTenantUtil.class);
         when(IdentityTenantUtil.getTenantDomain(anyInt())).thenReturn(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         when(IdentityTenantUtil.getTenantId(anyString())).thenReturn(MultitenantConstants.SUPER_TENANT_ID);
@@ -1303,6 +1318,8 @@ public class OAuth2AuthzEndpointTest extends TestOAuthEndpointBase {
 
         spy(FrameworkUtils.class);
         doReturn("sample").when(FrameworkUtils.class, "resolveUserIdFromUsername", anyInt(), anyString(), anyString());
+        doNothing().when(FrameworkUtils.class, "startTenantFlow", anyString());
+        doNothing().when(FrameworkUtils.class, "endTenantFlow");
         spy(IdentityTenantUtil.class);
         doReturn(MultitenantConstants.SUPER_TENANT_ID).when(IdentityTenantUtil.class, "getTenantId", anyString());
         doReturn(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME).when(IdentityTenantUtil.class, "getTenantDomain",
@@ -1435,6 +1452,8 @@ public class OAuth2AuthzEndpointTest extends TestOAuthEndpointBase {
 
         spy(FrameworkUtils.class);
         doReturn("sample").when(FrameworkUtils.class, "resolveUserIdFromUsername", anyInt(), anyString(), anyString());
+        doNothing().when(FrameworkUtils.class, "startTenantFlow", anyString());
+        doNothing().when(FrameworkUtils.class, "endTenantFlow");
         spy(IdentityTenantUtil.class);
         doReturn(MultitenantConstants.SUPER_TENANT_ID).when(IdentityTenantUtil.class, "getTenantId", anyString());
         doReturn(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME).when(IdentityTenantUtil.class, "getTenantDomain",
@@ -1558,6 +1577,8 @@ public class OAuth2AuthzEndpointTest extends TestOAuthEndpointBase {
 
         spy(FrameworkUtils.class);
         doReturn(requestCoordinator).when(FrameworkUtils.class, "getRequestCoordinator");
+        doNothing().when(FrameworkUtils.class, "startTenantFlow", anyString());
+        doNothing().when(FrameworkUtils.class, "endTenantFlow");
 
         doAnswer(new Answer<Object>() {
             @Override
@@ -2127,6 +2148,9 @@ public class OAuth2AuthzEndpointTest extends TestOAuthEndpointBase {
 
         mockStatic(LoggerUtils.class);
         when(LoggerUtils.isDiagnosticLogsEnabled()).thenReturn(true);
+        spy(FrameworkUtils.class);
+        doNothing().when(FrameworkUtils.class, "startTenantFlow", anyString());
+        doNothing().when(FrameworkUtils.class, "endTenantFlow");
         mockStatic(IdentityTenantUtil.class);
         when(IdentityTenantUtil.getTenantDomain(anyInt())).thenReturn(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         when(IdentityTenantUtil.getTenantId(anyString())).thenReturn(MultitenantConstants.SUPER_TENANT_ID);

--- a/pom.xml
+++ b/pom.xml
@@ -926,7 +926,7 @@
         <!--Test Dependencies-->
         <junit.version>4.13.1</junit.version>
         <testng.version>6.9.10</testng.version>
-        <jacoco.version>0.7.9</jacoco.version>
+        <jacoco.version>0.8.7</jacoco.version>
         <powermock.version>1.7.4</powermock.version>
         <maven.surefire.plugin.version>2.18.1</maven.surefire.plugin.version>
         <javaee.web.api.version>7.0</javaee.web.api.version>


### PR DESCRIPTION
### Proposed changes in this pull request

- At the beginning of the OIDC scopes retrieving flow, a super tenant flow is initiated. And this results in picking the OIDC scopes related to the super tenant at one point. The changes are introduced to start tenant domain flow if the tenant configuration is not enabled.

### Related Issue

https://github.com/wso2-enterprise/asgardeo-product/issues/9165
