### PR TITLE
Add support for admin users from secondary user stores

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/JDBCPermissionBasedInternalScopeValidator.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/JDBCPermissionBasedInternalScopeValidator.java
@@ -50,6 +50,7 @@ import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 import org.wso2.carbon.identity.oauth2.util.Oauth2ScopeUtils;
 import org.wso2.carbon.user.api.AuthorizationManager;
 import org.wso2.carbon.user.api.UserStoreException;
+import org.wso2.carbon.user.core.util.UserCoreUtil;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -334,6 +335,9 @@ public class JDBCPermissionBasedInternalScopeValidator {
         if (username == null) {
             username = OAuth2Util
                     .resolveUsernameFromUserId(authenticatedUser.getTenantDomain(), authenticatedUser.getUserId());
+        }
+        if (StringUtils.isNotEmpty(authenticatedUser.getUserStoreDomain())) {
+            username = UserCoreUtil.addDomainToName(username, authenticatedUser.getUserStoreDomain());
         }
         String[] allowedUIResourcesForUser =
                 authorizationManager.getAllowedUIResourcesForUser(username, "/");

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/RoleBasedInternalScopeValidator.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/RoleBasedInternalScopeValidator.java
@@ -155,7 +155,8 @@ public class RoleBasedInternalScopeValidator {
 
             String userName = userStoreManager.getUserNameFromUserID(authenticatedUser.getUserId());
 
-            return userStoreManager.getHybridRoleListOfUser(userName, authenticatedUser.getUserStoreDomain());
+            return userStoreManager.getHybridRoleListOfUser(UserCoreUtil.removeDomainFromName(userName),
+                    authenticatedUser.getUserStoreDomain());
 
         } catch (UserStoreException e) {
             String error =


### PR DESCRIPTION
### Proposed changes in this pull request

- Add `userstoreDomain` to username when checking in authorizationManager - scope validator
- Remove `userstoreDomain` from when getting getHybridRoleListOfUser in RolebasedInternal Validator 
