### PR TITLE
Fixing case sensitive scope validation issue..

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/JDBCScopeValidator.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/JDBCScopeValidator.java
@@ -396,7 +396,6 @@ public class JDBCScopeValidator extends OAuth2ScopeValidator {
             }
             return false;
         }
-
         boolean preservedCaseSensitive = Boolean.parseBoolean(System.getProperty("preservedCaseSensitive"));
 
         //Check if the user still has a valid role for this scope.
@@ -404,19 +403,16 @@ public class JDBCScopeValidator extends OAuth2ScopeValidator {
         if (!preservedCaseSensitive) {
             rolesOfScope.retainAll(Arrays.asList(userRoles));
         } else {
-
             for (String roleOfScope : rolesOfScope) {
                 rolesOfScope.remove(roleOfScope);
                 rolesOfScope.add(roleOfScope.toLowerCase());
             }
-
             ArrayList<String> userRolesLowercase = new ArrayList<>();
             for (String userRole : userRoles) {
                 userRolesLowercase.add(userRole.toLowerCase());
             }
             rolesOfScope.retainAll(userRolesLowercase);
         }
-
         rolesOfScope.retainAll(Arrays.asList(userRoles));
 
         if (rolesOfScope.isEmpty()) {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/JDBCScopeValidator.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/JDBCScopeValidator.java
@@ -397,8 +397,7 @@ public class JDBCScopeValidator extends OAuth2ScopeValidator {
             return false;
         }
 
-	
-	boolean preservedCaseSensitive = Boolean.parseBoolean(System.getProperty("preservedCaseSensitive"));
+        boolean preservedCaseSensitive = Boolean.parseBoolean(System.getProperty("preservedCaseSensitive"));
 
         //Check if the user still has a valid role for this scope.
         Set<String> scopeRoles = new HashSet<>(rolesOfScope);

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/JDBCScopeValidator.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/JDBCScopeValidator.java
@@ -397,8 +397,27 @@ public class JDBCScopeValidator extends OAuth2ScopeValidator {
             return false;
         }
 
+	
+	boolean preservedCaseSensitive = Boolean.parseBoolean(System.getProperty("preservedCaseSensitive"));
+
         //Check if the user still has a valid role for this scope.
         Set<String> scopeRoles = new HashSet<>(rolesOfScope);
+        if (!preservedCaseSensitive) {
+            rolesOfScope.retainAll(Arrays.asList(userRoles));
+        } else {
+
+            for (String roleOfScope : rolesOfScope) {
+                rolesOfScope.remove(roleOfScope);
+                rolesOfScope.add(roleOfScope.toLowerCase());
+            }
+
+            ArrayList<String> userRolesLowercase = new ArrayList<>();
+            for (String userRole : userRoles) {
+                userRolesLowercase.add(userRole.toLowerCase());
+            }
+            rolesOfScope.retainAll(userRolesLowercase);
+        }
+
         rolesOfScope.retainAll(Arrays.asList(userRoles));
 
         if (rolesOfScope.isEmpty()) {


### PR DESCRIPTION
FIx for - "APIs cannot be invoked using a token which is generated with a scope based on userstore role"

Steps to reproduce.

Get APIM 2.6 pack and update to the latest or level 72.
Get WSO2 IS to be used as the userstore.
Start both IS and APIM server, go to the APIM Management console and configure an userstore.
Them create a role for that userstore (Example:TestRole)
Create a user with that user role.
Go to the publisher and create a new API
Create two scopes as TestRole and testRole. (To identify case sensitive issues)
Then assign those scopes to two different resources.
Generate a token and try to invoke API. One with TestRole would work and the other one with testRole would fail.