### PR TITLE
Fix id_token from refresh token grant type does not contain auth_time claim

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/DefaultIDTokenBuilder.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/DefaultIDTokenBuilder.java
@@ -146,6 +146,16 @@ public class DefaultIDTokenBuilder implements org.wso2.carbon.identity.openidcon
             }
         } else {
             amrValues = tokenReqMsgCtxt.getOauth2AccessTokenReqDTO().getAuthenticationMethodReferences();
+            if (OAuthConstants.GrantTypes.REFRESH_TOKEN.equalsIgnoreCase(
+                    tokenReqMsgCtxt.getOauth2AccessTokenReqDTO().getGrantType())) {
+                AuthorizationGrantCacheEntry authorizationGrantCacheEntryFromToken =
+                        getAuthorizationGrantCacheEntryFromToken(tokenRespDTO.getAccessToken());
+                if (authorizationGrantCacheEntryFromToken != null) {
+                    if (isAuthTimeRequired(authorizationGrantCacheEntryFromToken)) {
+                        authTime = authorizationGrantCacheEntryFromToken.getAuthTime();
+                    }
+                }
+            }
             idpSessionKey = getIdpSessionKey(accessToken);
         }
 


### PR DESCRIPTION
### Description : id_token from refresh token grant type does not contain auth_time claim.

Fix for issue : https://github.com/wso2/product-is/issues/13271