### PR TITLE
Check the requirement of having a configured public certificate or JWKS in SP to enable ID token encryption and request object signature validation

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImpl.java
@@ -264,7 +264,8 @@ public class OAuthAdminServiceImpl {
 
                 ///Check the requirement of having a configured public certificate or JWKS in SP
                 boolean isIdTokenEncryptionEnabled = application.isIdTokenEncryptionEnabled();
-                boolean isRequestObjectSignatureValidationEnabled = application.isRequestObjectSignatureValidationEnabled();
+                boolean isRequestObjectSignatureValidationEnabled =
+                        application.isRequestObjectSignatureValidationEnabled();
                 handlePublicCertificateConfig(app.getOauthConsumerKey(), tenantDomain, isIdTokenEncryptionEnabled,
                         isRequestObjectSignatureValidationEnabled);
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImpl.java
@@ -484,11 +484,11 @@ public class OAuthAdminServiceImpl {
         //Check the requirement of having a configured public certificate or JWKS in SP
         boolean isIdTokenEncryptionEnabled = !oauthappdo.isIdTokenEncryptionEnabled() &&
                 consumerAppDTO.isIdTokenEncryptionEnabled();
-        boolean isRequestObjectSignatureValidation = !oauthappdo.isRequestObjectSignatureValidationEnabled() &&
+        boolean isRequestObjectSignatureValidationEnabled = !oauthappdo.isRequestObjectSignatureValidationEnabled() &&
                 consumerAppDTO.isRequestObjectSignatureValidationEnabled();
-        if (isIdTokenEncryptionEnabled || isRequestObjectSignatureValidation) {
+        if (isIdTokenEncryptionEnabled || isRequestObjectSignatureValidationEnabled) {
             checkIfPublicCertConfigured(oauthConsumerKey, tenantDomain, isIdTokenEncryptionEnabled,
-                    isRequestObjectSignatureValidation);
+                    isRequestObjectSignatureValidationEnabled);
         }
 
         AuthenticatedUser defaultAppOwner = oauthappdo.getAppOwner();
@@ -1844,18 +1844,18 @@ public class OAuthAdminServiceImpl {
      * specific error message if the public certificate or JWKS in SP is not configured.
      *
      * @param isIdTokenEncryptionEnabled Is ID token encryption is enabled or not.
-     * @param isRequestObjectSignatureValidation Is request object signature validation is enabled or not.
+     * @param isRequestObjectSignatureValidationEnabled Is request object signature validation is enabled or not.
      * @param clientId Client ID of the service provider.
      * @param tenantDomain Tenant domain of the service provider.
      * @throws IdentityOAuthClientException
      */
     private void checkIfPublicCertConfigured(String clientId, String tenantDomain, boolean isIdTokenEncryptionEnabled,
-                                               boolean isRequestObjectSignatureValidation)
+                                               boolean isRequestObjectSignatureValidationEnabled)
             throws IdentityOAuthClientException {
 
         String blockedProperty = null;
         try {
-            if (isIdTokenEncryptionEnabled && isRequestObjectSignatureValidation) {
+            if (isIdTokenEncryptionEnabled && isRequestObjectSignatureValidationEnabled) {
                 blockedProperty = "ID token encryption and request object signature validation";
             } else if (isIdTokenEncryptionEnabled) {
                 blockedProperty = "ID token encryption";

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImpl.java
@@ -267,7 +267,7 @@ public class OAuthAdminServiceImpl {
                 boolean isRequestObjectSignatureValidationEnabled =
                         application.isRequestObjectSignatureValidationEnabled();
                 if (isIdTokenEncryptionEnabled || isRequestObjectSignatureValidationEnabled) {
-                    handlePublicCertificateConfig(app.getOauthConsumerKey(), tenantDomain, isIdTokenEncryptionEnabled,
+                    checkIfPublicCertConfigured(app.getOauthConsumerKey(), tenantDomain, isIdTokenEncryptionEnabled,
                             isRequestObjectSignatureValidationEnabled);
                 }
 
@@ -487,7 +487,7 @@ public class OAuthAdminServiceImpl {
         boolean isRequestObjectSignatureValidation = !oauthappdo.isRequestObjectSignatureValidationEnabled() &&
                 consumerAppDTO.isRequestObjectSignatureValidationEnabled();
         if (isIdTokenEncryptionEnabled || isRequestObjectSignatureValidation) {
-            handlePublicCertificateConfig(oauthConsumerKey, tenantDomain, isIdTokenEncryptionEnabled,
+            checkIfPublicCertConfigured(oauthConsumerKey, tenantDomain, isIdTokenEncryptionEnabled,
                     isRequestObjectSignatureValidation);
         }
 
@@ -1849,7 +1849,7 @@ public class OAuthAdminServiceImpl {
      * @param tenantDomain Tenant domain of the service provider.
      * @throws IdentityOAuthClientException
      */
-    private void handlePublicCertificateConfig(String clientId, String tenantDomain, boolean isIdTokenEncryptionEnabled,
+    private void checkIfPublicCertConfigured(String clientId, String tenantDomain, boolean isIdTokenEncryptionEnabled,
                                                boolean isRequestObjectSignatureValidation)
             throws IdentityOAuthClientException {
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImpl.java
@@ -266,8 +266,10 @@ public class OAuthAdminServiceImpl {
                 boolean isIdTokenEncryptionEnabled = application.isIdTokenEncryptionEnabled();
                 boolean isRequestObjectSignatureValidationEnabled =
                         application.isRequestObjectSignatureValidationEnabled();
-                handlePublicCertificateConfig(app.getOauthConsumerKey(), tenantDomain, isIdTokenEncryptionEnabled,
-                        isRequestObjectSignatureValidationEnabled);
+                if (isIdTokenEncryptionEnabled || isRequestObjectSignatureValidationEnabled) {
+                    handlePublicCertificateConfig(app.getOauthConsumerKey(), tenantDomain, isIdTokenEncryptionEnabled,
+                            isRequestObjectSignatureValidationEnabled);
+                }
 
                 AuthenticatedUser defaultAppOwner = buildAuthenticatedUser(tenantAwareLoggedInUser, tenantDomain);
                 AuthenticatedUser appOwner = getAppOwner(application, defaultAppOwner);
@@ -484,8 +486,10 @@ public class OAuthAdminServiceImpl {
                 consumerAppDTO.isIdTokenEncryptionEnabled();
         boolean isRequestObjectSignatureValidation = !oauthappdo.isRequestObjectSignatureValidationEnabled() &&
                 consumerAppDTO.isRequestObjectSignatureValidationEnabled();
-        handlePublicCertificateConfig(oauthConsumerKey, tenantDomain, isIdTokenEncryptionEnabled,
-                isRequestObjectSignatureValidation);
+        if (isIdTokenEncryptionEnabled || isRequestObjectSignatureValidation) {
+            handlePublicCertificateConfig(oauthConsumerKey, tenantDomain, isIdTokenEncryptionEnabled,
+                    isRequestObjectSignatureValidation);
+        }
 
         AuthenticatedUser defaultAppOwner = oauthappdo.getAppOwner();
         AuthenticatedUser appOwner = getAppOwner(consumerAppDTO, defaultAppOwner);
@@ -1855,10 +1859,8 @@ public class OAuthAdminServiceImpl {
                 blockedProperty = "ID token encryption and request object signature validation";
             } else if (isIdTokenEncryptionEnabled) {
                 blockedProperty = "ID token encryption";
-            } else if (isRequestObjectSignatureValidation) {
-                blockedProperty = "request object signature validation";
             } else {
-                return;
+                blockedProperty = "request object signature validation";
             }
             if (StringUtils.isBlank(OAuth2Util.getSPJwksUrl(clientId, tenantDomain))) {
                 if (LOG.isDebugEnabled()) {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImpl.java
@@ -1861,6 +1861,10 @@ public class OAuthAdminServiceImpl {
                 return;
             }
             if (StringUtils.isBlank(OAuth2Util.getSPJwksUrl(clientId, tenantDomain))) {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug(String.format("Jwks uri is not configured for the service provider associated with " +
+                            "client_id: %s , Checking for x509 certificate.", clientId));
+                }
                 OAuth2Util.getX509CertOfOAuthApp(clientId, tenantDomain);
             }
         } catch (IdentityOAuth2Exception e) {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -4161,7 +4161,7 @@ public class OAuth2Util {
      * @return Jwks Url
      * @throws IdentityOAuth2Exception
      */
-    private static String getSPJwksUrl(String clientId, String spTenantDomain) throws IdentityOAuth2Exception {
+    public static String getSPJwksUrl(String clientId, String spTenantDomain) throws IdentityOAuth2Exception {
 
         String jwksUri = null;
         ServiceProvider serviceProvider = OAuth2Util.getServiceProvider(clientId, spTenantDomain);

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -4173,8 +4173,8 @@ public class OAuth2Util {
                 break;
             }
         }
-        if (log.isDebugEnabled()) {
-            if (StringUtils.isNotBlank(jwksUri)) {
+        if (StringUtils.isNotBlank(jwksUri)) {
+            if (log.isDebugEnabled()) {
                 log.debug(String.format("Retrieved jwks uri: %s for the service provider associated with client_id: %s",
                         jwksUri, clientId));
             }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -4163,7 +4163,7 @@ public class OAuth2Util {
      */
     public static String getSPJwksUrl(String clientId, String spTenantDomain) throws IdentityOAuth2Exception {
 
-        String jwksUri = null;
+        String jwksUri = StringUtils.EMPTY;
         ServiceProvider serviceProvider = OAuth2Util.getServiceProvider(clientId, spTenantDomain);
         ServiceProviderProperty[] spPropertyArray = serviceProvider.getSpProperties();
         //get jwks uri from sp-properties
@@ -4174,8 +4174,10 @@ public class OAuth2Util {
             }
         }
         if (log.isDebugEnabled()) {
-            log.debug(String.format("Retrieved jwks uri: %s for the service provider associated with client_id: %s",
-                    jwksUri, clientId));
+            if (StringUtils.isNotBlank(jwksUri)) {
+                log.debug(String.format("Retrieved jwks uri: %s for the service provider associated with client_id: %s",
+                        jwksUri, clientId));
+            }
         }
         return jwksUri;
     }


### PR DESCRIPTION
Fix [wso2/product-is#11206](https://github.com/wso2/product-is/issues/11206)

Previously, if we enabled ID Token encryption without configuring the application certificate or the JWKS endpoint, it would give an internal server error when we attempt to generate an access token. 

As the solution, the certificate or JWKS configuration is mandatory if a user try to update or create an application. If the user try to enable ID token encryption or request object signature validation without configuring a public certificate or JWKS, we throw an exception with a specific error message.
