### PR TITLE
Remove packed slf4j bundles

### DIFF
--- a/features/org.wso2.carbon.identity.oauth.common.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.oauth.common.feature/pom.xml
@@ -81,8 +81,6 @@
                                 <bundleDef>org.wso2.carbon.identity.inbound.auth.oauth2:org.wso2.carbon.identity.oauth.common</bundleDef>
                                 <bundleDef>org.wso2.orbit.org.apache.oltu.oauth2:oltu</bundleDef>
                                 <bundleDef>org.json.wso2:json</bundleDef>
-                                <bundleDef>org.slf4j:slf4j-log4j12</bundleDef>
-                                <bundleDef>org.slf4j:slf4j-api</bundleDef>
                             </bundles>
                             <importFeatures>
                                 <importFeatureDef>org.wso2.carbon.identity.core.server:compatible:${carbon.identity.framework.version}</importFeatureDef>


### PR DESCRIPTION
### Proposed changes in this pull request

The slf4j-api and slf4j-log4j12 bundles had packed here and that bundles expect slf4j implementation of 1.6 version and log4j1 respectively but the updated pax-logging does not provide them. Therefore the slf4j-api and slf4j-log4j12 bundles were removed. 

ref : https://github.com/wso2/carbon-metrics/pull/104