### PR TITLE
Using OAuth2Util.getServiceProvider inside ClaimUtil.java

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/ClaimUtil.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/ClaimUtil.java
@@ -25,10 +25,8 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.oltu.oauth2.common.error.OAuthError;
 import org.wso2.carbon.identity.application.authentication.framework.exception.FrameworkException;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
-import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
 import org.wso2.carbon.identity.application.common.model.ClaimMapping;
 import org.wso2.carbon.identity.application.common.model.ServiceProvider;
-import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.base.IdentityConstants;
 import org.wso2.carbon.identity.base.IdentityException;
 import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataHandler;
@@ -46,7 +44,6 @@ import org.wso2.carbon.identity.oauth.user.UserInfoClaimRetriever;
 import org.wso2.carbon.identity.oauth.user.UserInfoEndpointException;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2TokenValidationResponseDTO;
-import org.wso2.carbon.identity.oauth2.internal.OAuth2ServiceComponentHolder;
 import org.wso2.carbon.identity.oauth2.model.AccessTokenDO;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 import org.wso2.carbon.identity.openidconnect.OIDCClaimUtil;
@@ -74,7 +71,6 @@ import static org.wso2.carbon.identity.core.util.IdentityUtil.isTokenLoggable;
 public class ClaimUtil {
 
     private static final String SP_DIALECT = "http://wso2.org/oidc/claim";
-    private static final String INBOUND_AUTH2_TYPE = "oauth2";
     private static final Log log = LogFactory.getLog(ClaimUtil.class);
 
     private ClaimUtil() {
@@ -137,7 +133,7 @@ public class ClaimUtil {
                 OAuthAppDO oAuthAppDO = OAuth2Util.getAppInformationByClientId(clientId);
                 String spTenantDomain = OAuth2Util.getTenantDomainOfOauthApp(oAuthAppDO);
 
-                ServiceProvider serviceProvider = getServiceProvider(clientId, spTenantDomain);
+                ServiceProvider serviceProvider = OAuth2Util.getServiceProvider(clientId, spTenantDomain);
                 ClaimMapping[] requestedLocalClaimMappings = serviceProvider.getClaimConfig().getClaimMappings();
                 String subjectClaimURI = getSubjectClaimUri(serviceProvider, requestedLocalClaimMappings);
 
@@ -317,21 +313,6 @@ public class ClaimUtil {
             }
         }
         return subjectClaimURI;
-    }
-
-    private static ServiceProvider getServiceProvider(String clientId, String spTenantDomain)
-            throws IdentityApplicationManagementException, UserInfoEndpointException {
-
-        ApplicationManagementService applicationMgtService = OAuth2ServiceComponentHolder.getApplicationMgtService();
-        String spName = applicationMgtService.getServiceProviderNameByClientId(clientId, INBOUND_AUTH2_TYPE,
-                spTenantDomain);
-        ServiceProvider serviceProvider = applicationMgtService.getApplicationExcludingFileBasedSPs(spName,
-                spTenantDomain);
-        if (serviceProvider == null) {
-            throw new UserInfoEndpointException("Cannot retrieve service provider: " + spName + " in " +
-                    "tenantDomain: " + spTenantDomain);
-        }
-        return serviceProvider;
     }
 
     private static String getClientID(AccessTokenDO accessTokenDO) throws UserInfoEndpointException {

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/util/ClaimUtilTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/util/ClaimUtilTest.java
@@ -280,8 +280,8 @@ public class ClaimUtilTest extends PowerMockIdentityBaseTest {
                 anyString(), anyString(), anyString())).thenReturn("SP1");
 
         if (mockServiceProvider) {
-            when(mockedApplicationManagementService.getApplicationExcludingFileBasedSPs(anyString(), anyString())).
-                    thenReturn(mockedServiceProvider);
+            when(mockedApplicationManagementService.getServiceProviderByClientId(anyString(), anyString(),
+                    anyString())).thenReturn(mockedServiceProvider);
         }
 
         when(mockedValidationTokenResponseDTO.getAuthorizedUser()).thenReturn(AUTHORIZED_USER);
@@ -336,6 +336,7 @@ public class ClaimUtilTest extends PowerMockIdentityBaseTest {
         when(OAuth2Util.isFederatedUser(any(AuthenticatedUser.class))).thenCallRealMethod();
         when(OAuth2Util.getAppInformationByClientId(anyString())).thenReturn(mockedOAuthAppDO);
         when(OAuth2Util.getTenantDomainOfOauthApp(any(OAuthAppDO.class))).thenReturn("carbon.super");
+        when(OAuth2Util.getServiceProvider(anyString(), anyString())).thenCallRealMethod();
     }
 
     private AccessTokenDO getAccessTokenDO(String clientId, AuthenticatedUser authenticatedUser) {


### PR DESCRIPTION
### Proposed changes in this pull request
Fixes: https://github.com/wso2/product-apim/issues/12829

### Approach
The ClaimUtil.java class resides in org.wso2.carbon.identity.oauth.endpoint. The used getServiceProvider() inside that class uses OAuth2ServiceComponentHolder which is in the package org.wso2.carbon.identity.oauth2.internal. 
This PR removes this dependency between these two packages by using an existing method that resides in the org.wso2.carbon.identity.oauth OAuth2Util.java.

### Tests
Modified existing unit test (ClaimUtilTest.java)