### PR TITLE
Add an extension point to OAuthAuthzRequest in OAuth2AuthzEndpoint

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
@@ -1557,7 +1557,7 @@ public class OAuth2AuthzEndpoint {
      *
      * @return boolean whether the default class name is configured.
      */
-    private boolean isDeafultOAuthAuthzRequestClassConfigured() {
+    private boolean isDefaultOAuthAuthzRequestClassConfigured() {
 
         String oauthAuthzRequestClassName = OAuthServerConfiguration.getInstance().getOAuthAuthzRequestClassName();
         return OAuthServerConfiguration.DEFAULT_OAUTH_AUTHZ_REQUEST_CLASSNAME.equals(oauthAuthzRequestClassName);
@@ -1596,7 +1596,7 @@ public class OAuth2AuthzEndpoint {
 
         OAuthAuthzRequest oAuthAuthzRequest;
 
-        if (isDeafultOAuthAuthzRequestClassConfigured()) {
+        if (isDefaultOAuthAuthzRequestClassConfigured()) {
             oAuthAuthzRequest = new CarbonOAuthAuthzRequest(request);
         } else {
             try {

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
@@ -93,7 +93,6 @@ import org.wso2.carbon.identity.oauth2.RequestObjectException;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2AuthorizeReqDTO;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2AuthorizeRespDTO;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2ClientValidationResponseDTO;
-import org.wso2.carbon.identity.oauth2.model.CarbonOAuthAuthzRequest;
 import org.wso2.carbon.identity.oauth2.model.HttpRequestHeaderHandler;
 import org.wso2.carbon.identity.oauth2.model.OAuth2Parameters;
 import org.wso2.carbon.identity.oauth2.token.bindings.TokenBinder;
@@ -1501,7 +1500,8 @@ public class OAuth2AuthzEndpoint {
             setSPAttributeToRequest(oAuthMessage.getRequest(), validationResponse.getApplicationName(), tenantDomain);
         }
 
-        OAuthAuthzRequest oauthRequest = new CarbonOAuthAuthzRequest(oAuthMessage.getRequest());
+        OAuthAuthzRequest oauthRequest = OAuthServerConfiguration.getInstance()
+                .getOAuthAuthzRequest(oAuthMessage.getRequest());
 
         OAuth2Parameters params = new OAuth2Parameters();
         String sessionDataKey = UUIDGenerator.generateUUID();

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
@@ -386,15 +386,16 @@ public class OAuth2AuthzEndpoint {
             log.debug(e.getError(), e);
         }
 
-        String errorCode = e.getError() != null ? e.getError() : OAuth2ErrorCodes.INVALID_REQUEST;
-        String errorDescription = e.getDescription() != null ? e.getDescription() : e.getMessage();
-        String state = e.getState();
         OAuth2Parameters oAuth2Parameters = getOAuth2ParamsFromOAuthMessage(oAuthMessage);
 
         if (StringUtils.equals(oAuthMessage.getRequest().getParameter(RESPONSE_MODE), RESPONSE_MODE_FORM_POST)) {
             e.state(retrieveStateForErrorURL(oAuthMessage.getRequest(), oAuth2Parameters));
             return Response.ok(createErrorFormPage(oAuthMessage.getRequest().getParameter(REDIRECT_URI), e)).build();
         }
+
+        String errorCode = e.getError() != null ? e.getError() : OAuth2ErrorCodes.INVALID_REQUEST;
+        String errorDescription = e.getDescription() != null ? e.getDescription() : e.getMessage();
+        String state = e.getState();
 
         if (StringUtils.isBlank(oAuth2Parameters.getState()) && StringUtils.isNotBlank(state)) {
             oAuth2Parameters.setState(state);

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
@@ -415,7 +415,12 @@ public class EndpointUtil {
         if (request == null) {
             return redirectURL;
         }
-        return getRedirectURL(redirectURL, request);
+        if (isAllowAdditionalParamsFromErrorUrlEnabled()) {
+            // Appending additional parameters if the <AllowAdditionalParamsFromErrorUrl> config is enabled
+            return getRedirectURL(redirectURL, request);
+        } else {
+            return redirectURL;
+        }
     }
 
     /**

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
@@ -744,7 +744,7 @@ public class EndpointUtil {
                     // When request_uri requests come without redirect_uri, we need to append it to the SPQueryParams
                     // to be used in storing consent data
                     entry.setQueryString(entry.getQueryString() +
-                            "&" + PROP_REDIRECT_URI + "=" + params.getRedirectURI());
+                            "&" + PROP_REDIRECT_URI + "=" + URLEncoder.encode(params.getRedirectURI(), UTF_8));
                 }
                 queryString = URLEncoder.encode(entry.getQueryString(), UTF_8);
             }

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
@@ -412,15 +412,10 @@ public class EndpointUtil {
             appName) {
 
         String redirectURL = getErrorPageURL(errorCode, errorMessage, appName);
-        if (request == null) {
+        if (request == null || !isAllowAdditionalParamsFromErrorUrlEnabled()) {
             return redirectURL;
         }
-        if (isAllowAdditionalParamsFromErrorUrlEnabled()) {
-            // Appending additional parameters if the <AllowAdditionalParamsFromErrorUrl> config is enabled
-            return getRedirectURL(redirectURL, request);
-        } else {
-            return redirectURL;
-        }
+        return getRedirectURL(redirectURL, request);
     }
 
     /**

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpointTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpointTest.java
@@ -2186,4 +2186,42 @@ public class OAuth2AuthzEndpointTest extends TestOAuthEndpointBase {
         String tenantDomain = (String) getLoginTenantDomain.invoke(authzEndpointObject, oAuthMessage, CLIENT_ID_VALUE);
         assertEquals(tenantDomain, expectedDomain);
     }
+
+    @DataProvider(name = "provideOAuthProblemExceptionData")
+    public Object[][] provideOAuthProblemExceptionData() {
+
+        return new Object[][]{
+                {"error", "errorDescription", "state", "http://localhost:8080/redirect?" +
+                        "error_description=errorDescription&state=state&error=error", true},
+                {null, "errorDescription", "state", "http://localhost:8080/redirect?" +
+                        "error_description=errorDescription&state=state&error=invalid_request", true},
+                {"error", null, "state", "http://localhost:8080/redirect?error_description=error%2C+state&" +
+                        "state=state&error=error", true},
+                {"error", "errorDescription", null, "http://localhost:8080/redirect?" +
+                        "error_description=errorDescription&error=error", true},
+                {"error", "errorDescription", "state", "https://localhost:9443/authenticationendpoint/" +
+                        "oauth2_error.do?oauthErrorCode=error&oauthErrorMsg=errorDescription&" +
+                        "redirect_uri=http%3A%2F%2Flocalhost%3A8080%2Fredirect" , false}
+        };
+    }
+
+    @Test(dataProvider = "provideOAuthProblemExceptionData")
+    public void testHandleOAuthProblemException(String error, String description, String state, String expectedUrl,
+                                                boolean redirectEnabled) throws Exception {
+
+        Method handleOAuthProblemException = authzEndpointObject.getClass().getDeclaredMethod(
+                "handleOAuthProblemException", OAuthMessage.class, OAuthProblemException.class);
+        handleOAuthProblemException.setAccessible(true);
+        mockOAuthServerConfiguration();
+        when(oAuthMessage.getRequest()).thenReturn(httpServletRequest);
+        when(OAuthServerConfiguration.getInstance()).thenReturn(oAuthServerConfiguration);
+        when(oAuthServerConfiguration.isRedirectToRequestedRedirectUriEnabled()).thenReturn(redirectEnabled);
+        when(httpServletRequest.getParameter("redirect_uri")).thenReturn(APP_REDIRECT_URL);
+        mockStatic(OAuth2Util.OAuthURL.class);
+        when(OAuth2Util.OAuthURL.getOAuth2ErrorPageUrl()).thenReturn(ERROR_PAGE_URL);
+        Response response = (Response) handleOAuthProblemException.invoke(authzEndpointObject, oAuthMessage,
+                OAuthProblemException.error(error).description(description).state(state));
+        String location = String.valueOf(response.getMetadata().get(HTTPConstants.HEADER_LOCATION).get(0));
+        assertEquals(location, expectedUrl);
+    }
 }

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpointTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpointTest.java
@@ -499,8 +499,6 @@ public class OAuth2AuthzEndpointTest extends TestOAuthEndpointBase {
             when(IdentityDatabaseUtil.getDBConnection()).thenReturn(connection);
             mockServiceURLBuilder();
             try {
-                when(oAuthServerConfiguration.getOAuthAuthzRequest(any())).thenThrow(OAuthProblemException
-                        .error("invalid_request"));
                 response = oAuth2AuthzEndpoint.authorize(httpServletRequest, httpServletResponse);
             } catch (InvalidRequestParentException ire) {
                 InvalidRequestExceptionMapper invalidRequestExceptionMapper = new InvalidRequestExceptionMapper();
@@ -1067,13 +1065,6 @@ public class OAuth2AuthzEndpointTest extends TestOAuthEndpointBase {
 
         Response response;
         try {
-            if (StringUtils.isNotBlank(clientId)) {
-                OAuthAuthzRequest oAuthAuthzRequest = new CarbonOAuthAuthzRequest(httpServletRequest);
-                when(oAuthServerConfiguration.getOAuthAuthzRequest(any())).thenReturn(oAuthAuthzRequest);
-            } else {
-                when(oAuthServerConfiguration.getOAuthAuthzRequest(any())).thenThrow(OAuthProblemException
-                        .error("invalid_request"));
-            }
             response = oAuth2AuthzEndpoint.authorize(httpServletRequest, httpServletResponse);
         } catch (InvalidRequestParentException ire) {
             InvalidRequestExceptionMapper invalidRequestExceptionMapper = new InvalidRequestExceptionMapper();
@@ -1851,7 +1842,6 @@ public class OAuth2AuthzEndpointTest extends TestOAuthEndpointBase {
 
         when(oAuthMessage.getRequest()).thenReturn(httpServletRequest);
         when(oAuthMessage.getClientId()).thenReturn(CLIENT_ID_VALUE);
-        when(carbonOAuthAuthzRequest.getResponseType()).thenReturn(ResponseType.TOKEN.toString());
         handleOAuthAuthorizationRequest.invoke(authzEndpointObject, oAuthMessage);
         assertNotNull(cacheEntry[0], "Parameters not saved in cache");
         assertEquals(cacheEntry[0].getoAuth2Parameters().getDisplayName(), savedDisplayName);
@@ -2018,7 +2008,8 @@ public class OAuth2AuthzEndpointTest extends TestOAuthEndpointBase {
                 return invocation.getArguments()[0];
             }
         });
-        when(oAuthServerConfiguration.getOAuthAuthzRequest(any())).thenReturn(carbonOAuthAuthzRequest);
+        when(oAuthServerConfiguration.getOAuthAuthzRequestClass())
+                .thenReturn("org.wso2.carbon.identity.oauth2.model.CarbonOAuthAuthzRequest");
     }
 
     @DataProvider(name = "provideFailedAuthenticationErrorInfo")

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpointTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpointTest.java
@@ -499,6 +499,8 @@ public class OAuth2AuthzEndpointTest extends TestOAuthEndpointBase {
             when(IdentityDatabaseUtil.getDBConnection()).thenReturn(connection);
             mockServiceURLBuilder();
             try {
+                when(oAuthServerConfiguration.getOAuthAuthzRequest(any())).thenThrow(OAuthProblemException
+                        .error("invalid_request"));
                 response = oAuth2AuthzEndpoint.authorize(httpServletRequest, httpServletResponse);
             } catch (InvalidRequestParentException ire) {
                 InvalidRequestExceptionMapper invalidRequestExceptionMapper = new InvalidRequestExceptionMapper();
@@ -1065,7 +1067,13 @@ public class OAuth2AuthzEndpointTest extends TestOAuthEndpointBase {
 
         Response response;
         try {
-            when(carbonOAuthAuthzRequest.getResponseType()).thenReturn(ResponseType.TOKEN.toString());
+            if (StringUtils.isNotBlank(clientId)) {
+                OAuthAuthzRequest oAuthAuthzRequest = new CarbonOAuthAuthzRequest(httpServletRequest);
+                when(oAuthServerConfiguration.getOAuthAuthzRequest(any())).thenReturn(oAuthAuthzRequest);
+            } else {
+                when(oAuthServerConfiguration.getOAuthAuthzRequest(any())).thenThrow(OAuthProblemException
+                        .error("invalid_request"));
+            }
             response = oAuth2AuthzEndpoint.authorize(httpServletRequest, httpServletResponse);
         } catch (InvalidRequestParentException ire) {
             InvalidRequestExceptionMapper invalidRequestExceptionMapper = new InvalidRequestExceptionMapper();

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpointTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpointTest.java
@@ -1065,6 +1065,7 @@ public class OAuth2AuthzEndpointTest extends TestOAuthEndpointBase {
 
         Response response;
         try {
+            when(carbonOAuthAuthzRequest.getResponseType()).thenReturn(ResponseType.TOKEN.toString());
             response = oAuth2AuthzEndpoint.authorize(httpServletRequest, httpServletResponse);
         } catch (InvalidRequestParentException ire) {
             InvalidRequestExceptionMapper invalidRequestExceptionMapper = new InvalidRequestExceptionMapper();
@@ -1842,7 +1843,7 @@ public class OAuth2AuthzEndpointTest extends TestOAuthEndpointBase {
 
         when(oAuthMessage.getRequest()).thenReturn(httpServletRequest);
         when(oAuthMessage.getClientId()).thenReturn(CLIENT_ID_VALUE);
-
+        when(carbonOAuthAuthzRequest.getResponseType()).thenReturn(ResponseType.TOKEN.toString());
         handleOAuthAuthorizationRequest.invoke(authzEndpointObject, oAuthMessage);
         assertNotNull(cacheEntry[0], "Parameters not saved in cache");
         assertEquals(cacheEntry[0].getoAuth2Parameters().getDisplayName(), savedDisplayName);
@@ -2009,6 +2010,7 @@ public class OAuth2AuthzEndpointTest extends TestOAuthEndpointBase {
                 return invocation.getArguments()[0];
             }
         });
+        when(oAuthServerConfiguration.getOAuthAuthzRequest(any())).thenReturn(carbonOAuthAuthzRequest);
     }
 
     @DataProvider(name = "provideFailedAuthenticationErrorInfo")

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpointTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpointTest.java
@@ -2008,7 +2008,7 @@ public class OAuth2AuthzEndpointTest extends TestOAuthEndpointBase {
                 return invocation.getArguments()[0];
             }
         });
-        when(oAuthServerConfiguration.getOAuthAuthzRequestClass())
+        when(oAuthServerConfiguration.getOAuthAuthzRequestClassName())
                 .thenReturn("org.wso2.carbon.identity.oauth2.model.CarbonOAuthAuthzRequest");
     }
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
@@ -205,7 +205,8 @@ public class OAuthServerConfiguration {
             "org.wso2.carbon.identity.openidconnect.RequestObjectValidatorImpl";
     private String defaultCibaRequestValidatorClassName =
             "org.wso2.carbon.identity.openidconnect.CIBARequestObjectValidatorImpl";
-    private String defaultOAuthAuthzRequestClassName =
+    private String oAuthAuthzRequestClassName;
+    public static final String DEFAULT_OAUTH_AUTHZ_REQUEST_CLASSNAME =
             "org.wso2.carbon.identity.oauth2.model.CarbonOAuthAuthzRequest";
     private String openIDConnectIDTokenCustomClaimsHanlderClassName =
             "org.wso2.carbon.identity.openidconnect.SAMLAssertionClaimsCallback";
@@ -1119,9 +1120,9 @@ public class OAuthServerConfiguration {
      *
      * @return OAuthAuthzRequest implementation class name.
      */
-    public String getOAuthAuthzRequestClass() {
+    public String getOAuthAuthzRequestClassName() {
 
-        return defaultOAuthAuthzRequestClassName;
+        return oAuthAuthzRequestClassName;
     }
 
     public Set<String> getSupportedResponseTypeNames() {
@@ -2967,10 +2968,9 @@ public class OAuthServerConfiguration {
                 }
             }
             OMElement oAuthAuthzRequest = openIDConnectConfigElem.getFirstChildWithName(getQNameWithIdentityNS
-                    (ConfigElements.OAUTH_AUTHZ_REQUEST));
-            if (oAuthAuthzRequest != null) {
-                defaultOAuthAuthzRequestClassName = oAuthAuthzRequest.getText().trim();
-            }
+                    (ConfigElements.OAUTH_AUTHZ_REQUEST_CLASS));
+            oAuthAuthzRequestClassName = (oAuthAuthzRequest != null) ? oAuthAuthzRequest.getText().trim() :
+                    DEFAULT_OAUTH_AUTHZ_REQUEST_CLASSNAME;
         }
     }
 
@@ -3240,7 +3240,7 @@ public class OAuthServerConfiguration {
         public static final String SUPPORTED_CLAIMS = "OpenIDConnectClaims";
         public static final String REQUEST_OBJECT = "RequestObject";
         public static final String REQUEST_OBJECT_VALIDATOR = "RequestObjectValidator";
-        public static final String OAUTH_AUTHZ_REQUEST = "OAuthAuthzRequest";
+        public static final String OAUTH_AUTHZ_REQUEST_CLASS = "OAuthAuthzRequestClass";
         public static final String CIBA_REQUEST_OBJECT_VALIDATOR = "CIBARequestObjectValidator";
         public static final String OPENID_CONNECT_BACK_CHANNEL_LOGOUT_TOKEN_EXPIRATION = "LogoutTokenExpiration";
         // Callback handler related configuration elements

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
@@ -1136,10 +1136,21 @@ public class OAuthServerConfiguration {
             Constructor<?> constructor = clazz.getConstructor(HttpServletRequest.class);
             oAuthAuthzRequest = (OAuthAuthzRequest) constructor.newInstance(request);
         } catch (ClassNotFoundException | InstantiationException | IllegalAccessException |
-                NoSuchMethodException | InvocationTargetException e) {
+                NoSuchMethodException e) {
             log.warn("Failed to initiate OAuthAuthzRequest from identity.xml. " +
                     "Hence initiating the default implementation");
             oAuthAuthzRequest = new CarbonOAuthAuthzRequest(request);
+        } catch (InvocationTargetException e) {
+            // Handle OAuthProblemException & OAuthSystemException thrown from extended class.
+            if (e.getTargetException() instanceof OAuthProblemException) {
+                throw (OAuthProblemException) e.getTargetException();
+            } else if (e.getTargetException() instanceof OAuthSystemException) {
+                throw (OAuthSystemException) e.getTargetException();
+            } else {
+                log.warn("Failed to initiate OAuthAuthzRequest from identity.xml. " +
+                        "Hence initiating the default implementation");
+                oAuthAuthzRequest = new CarbonOAuthAuthzRequest(request);
+            }
         }
         return oAuthAuthzRequest;
     }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
@@ -27,11 +27,8 @@ import org.apache.oltu.oauth2.as.issuer.OAuthIssuer;
 import org.apache.oltu.oauth2.as.issuer.OAuthIssuerImpl;
 import org.apache.oltu.oauth2.as.issuer.UUIDValueGenerator;
 import org.apache.oltu.oauth2.as.issuer.ValueGenerator;
-import org.apache.oltu.oauth2.as.request.OAuthAuthzRequest;
 import org.apache.oltu.oauth2.as.validator.CodeValidator;
 import org.apache.oltu.oauth2.as.validator.TokenValidator;
-import org.apache.oltu.oauth2.common.exception.OAuthProblemException;
-import org.apache.oltu.oauth2.common.exception.OAuthSystemException;
 import org.apache.oltu.oauth2.common.message.types.GrantType;
 import org.apache.oltu.oauth2.common.message.types.ResponseType;
 import org.apache.oltu.oauth2.common.validators.OAuthValidator;
@@ -49,7 +46,6 @@ import org.wso2.carbon.identity.oauth.tokenprocessor.PlainTextPersistenceProcess
 import org.wso2.carbon.identity.oauth.tokenprocessor.TokenPersistenceProcessor;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.authz.handlers.ResponseTypeHandler;
-import org.wso2.carbon.identity.oauth2.model.CarbonOAuthAuthzRequest;
 import org.wso2.carbon.identity.oauth2.model.TokenIssuerDO;
 import org.wso2.carbon.identity.oauth2.token.OauthTokenIssuer;
 import org.wso2.carbon.identity.oauth2.token.OauthTokenIssuerImpl;
@@ -69,8 +65,6 @@ import org.wso2.carbon.identity.openidconnect.RequestObjectValidator;
 import org.wso2.carbon.identity.openidconnect.RequestObjectValidatorImpl;
 import org.wso2.carbon.utils.CarbonUtils;
 
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -1121,41 +1115,13 @@ public class OAuthServerConfiguration {
     }
 
     /**
-     * Returns an instance of OAuthAuthzRequest
+     * Returns the configured OAuthAuthzRequest class name. If not configured, the default class name will be returned.
      *
-     * @param request http servlet request.
-     * @return instance of OAuthAuthzRequest.
-     * @throws OAuthProblemException thrown when initializing the OAuthAuthzRequestClass instance.
-     * @throws OAuthSystemException thrown when initializing the OAuthAuthzRequestClass instance.
+     * @return OAuthAuthzRequest implementation class name.
      */
-    public OAuthAuthzRequest getOAuthAuthzRequest(HttpServletRequest request)
-            throws OAuthProblemException, OAuthSystemException {
+    public String getOAuthAuthzRequestClass() {
 
-        OAuthAuthzRequest oAuthAuthzRequest;
-        try {
-            Class clazz = Thread.currentThread().getContextClassLoader()
-                    .loadClass(defaultOAuthAuthzRequestClassName);
-
-            Constructor<?> constructor = clazz.getConstructor(HttpServletRequest.class);
-            oAuthAuthzRequest = (OAuthAuthzRequest) constructor.newInstance(request);
-        } catch (ClassNotFoundException | InstantiationException | IllegalAccessException |
-                NoSuchMethodException e) {
-            log.warn("Failed to initiate OAuthAuthzRequest from identity.xml. " +
-                    "Hence initiating the default implementation");
-            oAuthAuthzRequest = new CarbonOAuthAuthzRequest(request);
-        } catch (InvocationTargetException e) {
-            // Handle OAuthProblemException & OAuthSystemException thrown from extended class.
-            if (e.getTargetException() instanceof OAuthProblemException) {
-                throw (OAuthProblemException) e.getTargetException();
-            } else if (e.getTargetException() instanceof OAuthSystemException) {
-                throw (OAuthSystemException) e.getTargetException();
-            } else {
-                log.warn("Failed to initiate OAuthAuthzRequest from identity.xml. " +
-                        "Hence initiating the default implementation");
-                oAuthAuthzRequest = new CarbonOAuthAuthzRequest(request);
-            }
-        }
-        return oAuthAuthzRequest;
+        return defaultOAuthAuthzRequestClassName;
     }
 
     public Set<String> getSupportedResponseTypeNames() {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
@@ -46,6 +46,7 @@ import org.wso2.carbon.identity.oauth.tokenprocessor.PlainTextPersistenceProcess
 import org.wso2.carbon.identity.oauth.tokenprocessor.TokenPersistenceProcessor;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.authz.handlers.ResponseTypeHandler;
+import org.wso2.carbon.identity.oauth2.model.CarbonOAuthAuthzRequest;
 import org.wso2.carbon.identity.oauth2.model.TokenIssuerDO;
 import org.wso2.carbon.identity.oauth2.token.OauthTokenIssuer;
 import org.wso2.carbon.identity.oauth2.token.OauthTokenIssuerImpl;
@@ -206,8 +207,7 @@ public class OAuthServerConfiguration {
     private String defaultCibaRequestValidatorClassName =
             "org.wso2.carbon.identity.openidconnect.CIBARequestObjectValidatorImpl";
     private String oAuthAuthzRequestClassName;
-    public static final String DEFAULT_OAUTH_AUTHZ_REQUEST_CLASSNAME =
-            "org.wso2.carbon.identity.oauth2.model.CarbonOAuthAuthzRequest";
+    public static final String DEFAULT_OAUTH_AUTHZ_REQUEST_CLASSNAME = CarbonOAuthAuthzRequest.class.getName();
     private String openIDConnectIDTokenCustomClaimsHanlderClassName =
             "org.wso2.carbon.identity.openidconnect.SAMLAssertionClaimsCallback";
     private IDTokenBuilder openIDConnectIDTokenBuilder = null;

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
@@ -1123,7 +1123,10 @@ public class OAuthServerConfiguration {
     /**
      * Returns an instance of OAuthAuthzRequest
      *
-     * @return instance of OAuthAuthzRequest
+     * @param request http servlet request.
+     * @return instance of OAuthAuthzRequest.
+     * @throws OAuthProblemException thrown when initializing the OAuthAuthzRequestClass instance.
+     * @throws OAuthSystemException thrown when initializing the OAuthAuthzRequestClass instance.
      */
     public OAuthAuthzRequest getOAuthAuthzRequest(HttpServletRequest request)
             throws OAuthProblemException, OAuthSystemException {
@@ -2997,11 +3000,10 @@ public class OAuthServerConfiguration {
                     requestObjectEnabled = false;
                 }
             }
-            if (openIDConnectConfigElem.getFirstChildWithName(getQNameWithIdentityNS(ConfigElements.
-                    OAUTH_AUTHZ_REQUEST)) != null) {
-                defaultOAuthAuthzRequestClassName =
-                        openIDConnectConfigElem.getFirstChildWithName(getQNameWithIdentityNS(ConfigElements.
-                                OAUTH_AUTHZ_REQUEST)).getText().trim();
+            OMElement oAuthAuthzRequest = openIDConnectConfigElem.getFirstChildWithName(getQNameWithIdentityNS
+                    (ConfigElements.OAUTH_AUTHZ_REQUEST));
+            if (oAuthAuthzRequest != null) {
+                defaultOAuthAuthzRequestClassName = oAuthAuthzRequest.getText().trim();
             }
         }
     }


### PR DESCRIPTION
Adding support to send PAR authorization requests without scope and response_type parameters.

As discussed in the mail[1], this PR adds an extension point to OAuthAuthzRequest which can be extended to add validations related to the PAR authorization flow.

[1] Clarification of spec compliance for Pushed Authorization Requests (PAR)

issue: https://github.com/wso2/product-is/issues/13416