### PR TITLE
Give an in-detail backend error log if a user tries to generate an ID token by enabling ID Token encryption without configuring a certificate or JWKS endpoint

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -4169,16 +4169,8 @@ public class OAuth2Util {
      */
     public static String getSPJwksUrl(String clientId, String spTenantDomain) throws IdentityOAuth2Exception {
 
-        String jwksUri = null;
         ServiceProvider serviceProvider = OAuth2Util.getServiceProvider(clientId, spTenantDomain);
-        ServiceProviderProperty[] spPropertyArray = serviceProvider.getSpProperties();
-        //get jwks uri from sp-properties
-        for (ServiceProviderProperty spProperty : spPropertyArray) {
-            if (Constants.JWKS_URI.equals(spProperty.getName())) {
-                jwksUri = spProperty.getValue();
-                break;
-            }
-        }
+        String jwksUri = serviceProvider.getJwksUri();
         if (StringUtils.isNotBlank(jwksUri)) {
             if (log.isDebugEnabled()) {
                 log.debug(String.format("Retrieved jwks uri: %s for the service provider associated with client_id: %s",

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -4173,7 +4173,7 @@ public class OAuth2Util {
      * @return Jwks Url
      * @throws IdentityOAuth2Exception
      */
-    private static String getSPJwksUrl(String clientId, String spTenantDomain) throws IdentityOAuth2Exception {
+    public static String getSPJwksUrl(String clientId, String spTenantDomain) throws IdentityOAuth2Exception {
 
         String jwksUri = null;
         ServiceProvider serviceProvider = OAuth2Util.getServiceProvider(clientId, spTenantDomain);

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -4169,7 +4169,7 @@ public class OAuth2Util {
      */
     public static String getSPJwksUrl(String clientId, String spTenantDomain) throws IdentityOAuth2Exception {
 
-        String jwksUri = StringUtils.EMPTY;
+        String jwksUri = null;
         ServiceProvider serviceProvider = OAuth2Util.getServiceProvider(clientId, spTenantDomain);
         ServiceProviderProperty[] spPropertyArray = serviceProvider.getSpProperties();
         //get jwks uri from sp-properties

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -3314,14 +3314,8 @@ public class OAuth2Util {
                 // Build the Certificate object from cert content.
                 return IdentityUtil.convertPEMEncodedContentToCertificate(certificateContent);
             } else {
-                String errorMsg = StringUtils.EMPTY;
-                if (checkIfIDTokenEncryptionEnabled(clientId)) {
-                    errorMsg =  "You have enabled ID token encryption without configuring a certificate or JWKS " +
-                            "endpoint. Configure the JWKS endpoint or the certificate of your application to proceed.";
-                }
-                throw new IdentityOAuth2Exception(String.format("Public certificate not configured for Service " +
-                        "Provider with client_id: " + clientId + " of tenantDomain: " + tenantDomain + ". %s",
-                        errorMsg));
+                throw new IdentityOAuth2Exception("Public certificate not configured for Service Provider with " +
+                        "client_id: " + clientId + " of tenantDomain: " + tenantDomain);
             }
         } catch (CertificateException e) {
             throw new IdentityOAuth2Exception("Error while building X509 cert of oauth app with client_id: "
@@ -4397,28 +4391,5 @@ public class OAuth2Util {
             }
         }
         return IdentityTenantUtil.getTenantDomainFromContext();
-    }
-
-    /**
-     * check if ID token encryption is enabled or not
-     *
-     * @param clientId     OAuth2/OIDC Client Identifier
-     * @return true if ID token encryption is enabled
-     * @throws IdentityOAuth2Exception
-     */
-    private static boolean checkIfIDTokenEncryptionEnabled(String clientId) throws IdentityOAuth2Exception {
-
-        // Initialize OAuthAppDO using the client ID.
-        OAuthAppDO oAuthAppDO;
-        try {
-            oAuthAppDO = OAuth2Util.getAppInformationByClientId(clientId);
-        } catch (InvalidOAuthClientException e) {
-            String error = "Error occurred while getting app information for client_id: " + clientId;
-            throw new IdentityOAuth2Exception(error, e);
-        }
-        if (oAuthAppDO.isIdTokenEncryptionEnabled()) {
-            return true;
-        }
-        return false;
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -72,7 +72,6 @@ import org.wso2.carbon.identity.application.common.IdentityApplicationManagement
 import org.wso2.carbon.identity.application.common.model.FederatedAuthenticatorConfig;
 import org.wso2.carbon.identity.application.common.model.IdentityProvider;
 import org.wso2.carbon.identity.application.common.model.ServiceProvider;
-import org.wso2.carbon.identity.application.common.model.ServiceProviderProperty;
 import org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants;
 import org.wso2.carbon.identity.application.common.util.IdentityApplicationManagementUtil;
 import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -4175,7 +4175,7 @@ public class OAuth2Util {
      */
     public static String getSPJwksUrl(String clientId, String spTenantDomain) throws IdentityOAuth2Exception {
 
-        String jwksUri = null;
+        String jwksUri = StringUtils.EMPTY;
         ServiceProvider serviceProvider = OAuth2Util.getServiceProvider(clientId, spTenantDomain);
         ServiceProviderProperty[] spPropertyArray = serviceProvider.getSpProperties();
         //get jwks uri from sp-properties
@@ -4185,9 +4185,11 @@ public class OAuth2Util {
                 break;
             }
         }
-        if (log.isDebugEnabled()) {
-            log.debug(String.format("Retrieved jwks uri: %s for the service provider associated with client_id: %s",
-                    jwksUri, clientId));
+        if (StringUtils.isNotBlank(jwksUri)) {
+            if (log.isDebugEnabled()) {
+                log.debug(String.format("Retrieved jwks uri: %s for the service provider associated with client_id: %s",
+                        jwksUri, clientId));
+            }
         }
         return jwksUri;
     }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/DefaultIDTokenBuilder.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/DefaultIDTokenBuilder.java
@@ -821,9 +821,9 @@ public class DefaultIDTokenBuilder implements org.wso2.carbon.identity.openidcon
      * Check the requirement of having a configured public certificate or JWKS in SP and throw an exception with an
      * error message if the public certificate or JWKS in SP is not configured.
      *
-     * @param clientId Client ID of the service provider.
+     * @param clientId     Client ID of the service provider.
      * @param tenantDomain Tenant domain of the service provider.
-     * @throws IdentityOAuth2Exception
+     * @throws IdentityOAuth2Exception Error when a JWKS endpoint or the certificate is not configured.
      */
     private void checkIfPublicCertConfigured(String clientId, String tenantDomain) throws IdentityOAuth2Exception {
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/DefaultIDTokenBuilder.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/DefaultIDTokenBuilder.java
@@ -837,9 +837,9 @@ public class DefaultIDTokenBuilder implements org.wso2.carbon.identity.openidcon
                 OAuth2Util.getX509CertOfOAuthApp(clientId, tenantDomain);
             }
         } catch (IdentityOAuth2Exception e) {
-            throw new IdentityOAuth2Exception("You have enabled ID token encryption without configuring a " +
-                    "certificate or JWKS endpoint. Configure the JWKS endpoint or the certificate of your " +
-                    "application to get the ID token.", e);
+            throw new IdentityOAuth2Exception("Cannot encrypt the ID token as the service Provider with client_id: "
+                    + clientId + " of tenantDomain: " + tenantDomain + " does not have a public certificate or a " +
+                    "JWKS endpoint configured.", e);
         }
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/DefaultIDTokenBuilder.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/DefaultIDTokenBuilder.java
@@ -296,7 +296,7 @@ public class DefaultIDTokenBuilder implements org.wso2.carbon.identity.openidcon
                               String signingTenantDomain) throws IdentityOAuth2Exception {
 
         if (oAuthAppDO.isIdTokenEncryptionEnabled()) {
-            checkIfPublicCertConfigured(clientId, spTenantDomain);
+            checkIfPublicCertConfiguredForEncryption(clientId, spTenantDomain);
             setupEncryptionAlgorithms(oAuthAppDO, clientId);
             return OAuth2Util.encryptJWT(jwtClaimsSet, signatureAlgorithm, signingTenantDomain,
                     encryptionAlgorithm, encryptionMethod, spTenantDomain,
@@ -825,7 +825,8 @@ public class DefaultIDTokenBuilder implements org.wso2.carbon.identity.openidcon
      * @param tenantDomain Tenant domain of the service provider.
      * @throws IdentityOAuth2Exception Error when a JWKS endpoint or the certificate is not configured.
      */
-    private void checkIfPublicCertConfigured(String clientId, String tenantDomain) throws IdentityOAuth2Exception {
+    private void checkIfPublicCertConfiguredForEncryption(String clientId, String tenantDomain)
+            throws IdentityOAuth2Exception {
 
         try {
             if (StringUtils.isBlank(OAuth2Util.getSPJwksUrl(clientId, tenantDomain))) {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/DefaultIDTokenBuilder.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/DefaultIDTokenBuilder.java
@@ -838,7 +838,7 @@ public class DefaultIDTokenBuilder implements org.wso2.carbon.identity.openidcon
         } catch (IdentityOAuth2Exception e) {
             throw new IdentityOAuth2Exception("You have enabled ID token encryption without configuring a " +
                     "certificate or JWKS endpoint. Configure the JWKS endpoint or the certificate of your " +
-                    "application to get the ID token.");
+                    "application to get the ID token.", e);
         }
     }
 }


### PR DESCRIPTION
Temporary fix [product-is#11206](https://github.com/wso2/product-is/issues/11206)

The ideal solution should be in both app creation and update flows, blocking the users when they try to enable the ID token encryption or request object validation without a certificate or JWKS URI.
But unable to do that due to our current approach of creating the OAuth application and the service provider application separately and merging them together.

After this fix,

- Response from the ID token generation API call:
```
{
    "error_description": "Internal Server Error.",
    "error": "server_error"
} 
```

- Backend error log:
```
[2022-04-11 14:52:39,408] [50806658-80b2-4b05-b515-bb8cb1c12136] ERROR 
{org.wso2.carbon.identity.oauth2.OAuth2Service} - Error occurred while issuing the access token for Client 
ID : l_dYu1NS4w31kezE02_Wt28T7e4a, User ID admin, Scope : [openid] and Grant Type : password 
org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception: Cannot encrypt the ID token as the service Provider 
with client_id: l_dYu1NS4w31kezE02_Wt28T7e4a of tenantDomain: carbon.super does not have a public certificate 
or a JWKS endpoint configured.
at org.wso2.carbon.identity.openidconnect.DefaultIDTokenBuilder.checkIfPublicCertConfigured(DefaultIDTokenBuilder.java:824)
at org.wso2.carbon.identity.openidconnect.DefaultIDTokenBuilder.getIDToken(DefaultIDTokenBuilder.java:292)
at org.wso2.carbon.identity.openidconnect.DefaultIDTokenBuilder.buildIDToken(DefaultIDTokenBuilder.java:201)
```