### PR TITLE
Upgrade opensaml version to 3.3.1.wso2v6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -862,7 +862,7 @@
         <json.wso2.version.range>[3.0.0.wso2v1, 4.0.0)</json.wso2.version.range>
 
         <opensaml.version>3.3.1</opensaml.version>
-        <opensaml3.wso2.version>3.3.1.wso2v5</opensaml3.wso2.version>
+        <opensaml3.wso2.version>3.3.1.wso2v6</opensaml3.wso2.version>
         <opensaml3.wso2.osgi.version.range>[3.3.1,3.4.0)</opensaml3.wso2.osgi.version.range>
 
         <joda.version>2.9.4</joda.version>


### PR DESCRIPTION
### Proposed changes in this pull request
Upgrade opensaml version to `3.3.1.wso2v6` which upgrades `org.owasp.esapi:esapi` to `2.4.0.0` from `2.2.3.1`.