### PR TITLE
Add attribute to DCR register api to create a management app

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.dcr/src/gen/java/org/wso2/carbon/identity/oauth2/dcr/endpoint/dto/RegistrationRequestDTO.java
+++ b/components/org.wso2.carbon.identity.api.server.dcr/src/gen/java/org/wso2/carbon/identity/oauth2/dcr/endpoint/dto/RegistrationRequestDTO.java
@@ -30,6 +30,7 @@ public class RegistrationRequestDTO  {
   private String spTemplateName = null;
   private String backchannelLogoutUri = null;
   private boolean backchannelLogoutSessionRequired;
+  private boolean isManagementApp;
 
   @ApiModelProperty(required = true)
   @JsonProperty("redirect_uris")
@@ -191,6 +192,18 @@ public class RegistrationRequestDTO  {
     this.spTemplateName = spTemplateName;
   }
 
+  @ApiModelProperty
+  @JsonProperty("is_management_app")
+  public boolean isManagementApp() {
+
+    return isManagementApp;
+  }
+
+  public void setManagementApp(boolean isManagementApp) {
+
+    this.isManagementApp = isManagementApp;
+  }
+
   @Override
   public String toString()  {
     StringBuilder sb = new StringBuilder();
@@ -212,6 +225,7 @@ public class RegistrationRequestDTO  {
     sb.append("  ext_param_sp_template: ").append(spTemplateName).append("\n");
     sb.append("  backchannel_logout_uri: ").append(backchannelLogoutUri).append("\n");
     sb.append("  backchannel_logout_session_required: ").append(backchannelLogoutSessionRequired).append("\n");
+    sb.append("  is_management_app: ").append(isManagementApp).append("\n");
     sb.append("}\n");
     return sb.toString();
   }

--- a/components/org.wso2.carbon.identity.api.server.dcr/src/main/java/org/wso2/carbon/identity/oauth2/dcr/endpoint/util/DCRMUtils.java
+++ b/components/org.wso2.carbon.identity.api.server.dcr/src/main/java/org/wso2/carbon/identity/oauth2/dcr/endpoint/util/DCRMUtils.java
@@ -68,6 +68,7 @@ public class DCRMUtils {
         appRegistrationRequest.setConsumerSecret(registrationRequestDTO.getClientSecret());
         appRegistrationRequest.setSpTemplateName(registrationRequestDTO.getSpTemplateName());
         appRegistrationRequest.setBackchannelLogoutUri(registrationRequestDTO.getBackchannelLogoutUri());
+        appRegistrationRequest.setIsManagementApp(registrationRequestDTO.isManagementApp());
         return appRegistrationRequest;
 
     }

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/bean/ApplicationRegistrationRequest.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/bean/ApplicationRegistrationRequest.java
@@ -37,6 +37,7 @@ public class ApplicationRegistrationRequest implements Serializable {
     private String consumerSecret = null;
     private String spTemplateName = null;
     private String backchannelLogoutUri = null;
+    private boolean isManagementApp;
 
     public List<String> getRedirectUris() {
 
@@ -126,5 +127,26 @@ public class ApplicationRegistrationRequest implements Serializable {
     public void setSpTemplateName(String spTemplateName) {
 
         this.spTemplateName = spTemplateName;
+    }
+
+    /**
+     * Set whether the app is a management app or not.
+     *
+     * @param isManagementApp Denotes whether app is a management app.
+     */
+    public void setIsManagementApp(boolean isManagementApp) {
+
+        this.isManagementApp = isManagementApp;
+    }
+
+
+    /**
+     * Returns true is the app is a management app.
+     *
+     * @return true if it is a management app.
+     */
+    public boolean isManagementApp() {
+
+        return this.isManagementApp;
     }
 }

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/service/DCRMService.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/service/DCRMService.java
@@ -284,6 +284,7 @@ public class DCRMService {
         String tenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
         String spName = registrationRequest.getClientName();
         String templateName = registrationRequest.getSpTemplateName();
+        boolean isManagementApp = registrationRequest.isManagementApp();
 
         // Regex validation of the application name.
         if (!DCRMUtils.isRegexValidated(spName)) {
@@ -303,7 +304,8 @@ public class DCRMService {
         }
 
         // Create a service provider.
-        ServiceProvider serviceProvider = createServiceProvider(applicationOwner, tenantDomain, spName, templateName);
+        ServiceProvider serviceProvider = createServiceProvider(applicationOwner, tenantDomain, spName, templateName,
+                isManagementApp);
 
         OAuthConsumerAppDTO createdApp;
         try {
@@ -424,8 +426,8 @@ public class DCRMService {
         return createdApp;
     }
 
-    private ServiceProvider createServiceProvider(String applicationOwner, String tenantDomain,
-                                                  String spName, String templateName) throws DCRMException {
+    private ServiceProvider createServiceProvider(String applicationOwner, String tenantDomain, String spName,
+                                                  String templateName, boolean isManagementApp) throws DCRMException {
         // Create the Service Provider
         ServiceProvider sp = new ServiceProvider();
         sp.setApplicationName(spName);
@@ -434,6 +436,7 @@ public class DCRMService {
         user.setTenantDomain(tenantDomain);
         sp.setOwner(user);
         sp.setDescription("Service Provider for application " + spName);
+        sp.setManagementApp(isManagementApp);
 
         createServiceProvider(sp, tenantDomain, applicationOwner, templateName);
 


### PR DESCRIPTION
### Proposed changes in this pull request
Resolves https://github.com/wso2/product-is/issues/13727

A management app can be created by passing `is_management_app` as true.

```
curl --location --request POST 'https://localhost:9443/api/identity/oauth2/dcr/v1.1/register' \
--header 'Authorization: Basic YWRtaW46YWRtaW4=' \
--header 'Content-Type: application/json' \
--data-raw '{
    "client_name": "application_test2",
    "grant_types": [
        "password"
    ],
    "ext_param_client_id": "provided_client_id00021",
    "ext_param_client_secret": "provided_client_secret0001",
    "is_management_app": true
}'
```

There is a behaviour change for new apps https://github.com/wso2/product-is/issues/12852. In older IS versions, all the tokens obtained by apps created with DCR can access the management apis if they have enough scope.

But, with this change, dcr apps needs to be creates created by using the  `"is_management_app": true`, to access the system apis. 


### When should this PR be merged

[Please describe any preconditions that need to be addressed before we
can merge this pull request.]


### Follow up actions

[List any possible follow-up actions here; for instance, testing data
migrations, software that we need to install on staging and production
environments.]

-


### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description.
- [ ] **Is the PR labeled correctly?**

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled.

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests.
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/).

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components.
- [ ] **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

#### Security

- [ ] **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
- [ ] **Are all UI and API inputs run through forms or serializers?**
- [ ] **Are all external inputs validated and sanitized appropriately?**
- [ ] **Does all branching logic have a default case?**
- [ ] **Does this solution handle outliers and edge cases gracefully?**
- [ ] **Are all external communications secured and restricted to SSL?**

#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes should be documented.
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented.
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki.
