### PR TITLE
Change the token introspection 

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dao/AccessTokenDAOImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dao/AccessTokenDAOImpl.java
@@ -892,14 +892,14 @@ public class AccessTokenDAOImpl extends AbstractOAuthDAO implements AccessTokenD
 
             if (includeExpired) {
                 if (OAuth2ServiceComponentHolder.isIDPIdColumnEnabled()) {
-                    if ((isTenantQualifiedUrlsEnabled || !isCrossTenantTokenInspectionAllowed)
+                    if ((isTenantQualifiedUrlsEnabled && !isCrossTenantTokenInspectionAllowed)
                             && tenantDomain != null) {
                         sql = SQLQueries.RETRIEVE_ACTIVE_EXPIRED_TENANT_ACCESS_TOKEN_IDP_NAME;
                     } else {
                         sql = SQLQueries.RETRIEVE_ACTIVE_EXPIRED_ACCESS_TOKEN_IDP_NAME;
                     }
                 } else {
-                    if ((isTenantQualifiedUrlsEnabled || !isCrossTenantTokenInspectionAllowed)
+                    if ((isTenantQualifiedUrlsEnabled && !isCrossTenantTokenInspectionAllowed)
                             && tenantDomain != null) {
                         sql = SQLQueries.RETRIEVE_ACTIVE_EXPIRED_TENANT_ACCESS_TOKEN;
                     } else {
@@ -908,14 +908,14 @@ public class AccessTokenDAOImpl extends AbstractOAuthDAO implements AccessTokenD
                 }
             } else {
                 if (OAuth2ServiceComponentHolder.isIDPIdColumnEnabled()) {
-                    if ((isTenantQualifiedUrlsEnabled || !isCrossTenantTokenInspectionAllowed)
+                    if ((isTenantQualifiedUrlsEnabled && !isCrossTenantTokenInspectionAllowed)
                             && tenantDomain != null) {
                         sql = SQLQueries.RETRIEVE_ACTIVE_TENANT_ACCESS_TOKEN_IDP_NAME;
                     } else {
                         sql = SQLQueries.RETRIEVE_ACTIVE_ACCESS_TOKEN_IDP_NAME;
                     }
                 } else {
-                    if ((isTenantQualifiedUrlsEnabled || !isCrossTenantTokenInspectionAllowed)
+                    if ((isTenantQualifiedUrlsEnabled && !isCrossTenantTokenInspectionAllowed)
                             && tenantDomain != null) {
                         sql = SQLQueries.RETRIEVE_ACTIVE_TENANT_ACCESS_TOKEN;
                     } else {
@@ -930,7 +930,7 @@ public class AccessTokenDAOImpl extends AbstractOAuthDAO implements AccessTokenD
 
             prepStmt.setString(1,
                     getHashingPersistenceProcessor().getProcessedAccessTokenIdentifier(accessTokenIdentifier));
-            if ((isTenantQualifiedUrlsEnabled || !isCrossTenantTokenInspectionAllowed)
+            if ((isTenantQualifiedUrlsEnabled && !isCrossTenantTokenInspectionAllowed)
                     && tenantDomain != null) {
                 prepStmt.setInt(2, IdentityTenantUtil.getTenantId(tenantDomain));
             }


### PR DESCRIPTION
### Proposed changes in this pull request

> Change the behavior of token introspection
> With the below two configurations, the token can **only introspect** from token's tenant

```
tenant_context]
enable_tenant_qualified_urls = true
```
```
[oauth.introspect]
allow_cross_tenant = false
```

> otherwise cross tenant introspection is allowed

## Related issues 

Resolved https://github.com/wso2/product-is/issues/13832
