### PR TITLE
Handle Issue of Expiry Time of Access Token Becoming Negative When Access Token has a Long Validity Period

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/TokenValidationHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/TokenValidationHandler.java
@@ -474,8 +474,18 @@ public class TokenValidationHandler {
             if (accessTokenDO.getValidityPeriodInMillis() < 0) {
                 introResp.setExp(Long.MAX_VALUE);
             } else {
-                introResp.setExp(
-                        (accessTokenDO.getValidityPeriodInMillis() + accessTokenDO.getIssuedTime().getTime()) / 1000);
+                if (accessTokenDO.getValidityPeriodInMillis() + accessTokenDO.getIssuedTime().getTime() < 0) {
+                    // When the access token have a long validity period (eg: 9223372036854775000), the calculated
+                    // expiry time will be a negative value. The reason is that, max value of long data type of Java is
+                    // "9223372036854775807". So, when the addition of the validity period and the issued time exceeds
+                    // this max value, it will result in a negative value. In those instances, we set the expiry time as
+                    // the max value of long data type.
+                    introResp.setExp(Long.MAX_VALUE);
+                } else {
+                    introResp.setExp(
+                            (accessTokenDO.getValidityPeriodInMillis() + accessTokenDO.getIssuedTime().getTime()) /
+                                    1000);
+                }
             }
 
             // should be in seconds


### PR DESCRIPTION
### Proposed changes in this pull request
- The expiry time of an access token is calculated by adding the access token's validity period and the issued time.
When the access token have a long validity period (eg: 9223372036854775000), the calculated expiry time will be a negative value. The reason is that, max value of long data type of Java is "9223372036854775807". So, when the addition of the validity period and the issued time exceeds this max value, it will result in a negative value. This PR provides a fix to this scenario where the result becomes negative.
- Added the logic to set the expiry time as the max value of long data type when the addition of the validity period and issued time result in a negative value.
- Related Issue: https://github.com/wso2/api-manager/issues/114

### When should this PR be merged

[Please describe any preconditions that need to be addressed before we
can merge this pull request.]


### Follow up actions

[List any possible follow-up actions here; for instance, testing data
migrations, software that we need to install on staging and production
environments.]

-


### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description.
- [ ] **Is the PR labeled correctly?**

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled.

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests.
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/).

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components.
- [ ] **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

#### Security

- [ ] **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
- [ ] **Are all UI and API inputs run through forms or serializers?**
- [ ] **Are all external inputs validated and sanitized appropriately?**
- [ ] **Does all branching logic have a default case?**
- [ ] **Does this solution handle outliers and edge cases gracefully?**
- [ ] **Are all external communications secured and restricted to SSL?**

#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes should be documented.
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented.
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki.
