### PR TITLE
Added json content type for the rest of the places.

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/user/OpenIDConnectUserEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/user/OpenIDConnectUserEndpoint.java
@@ -155,9 +155,12 @@ public class OpenIDConnectUserEndpoint {
         OAuthResponse response = OAuthASResponse.errorResponse(statusCode)
                 .setError(OAuth2ErrorCodes.SERVER_ERROR)
                 .setErrorDescription(ex.getMessage()).buildJSONMessage();
-        return Response.status(response.getResponseStatus()).entity(response.getBody()).build();
+        return Response.status(response.getResponseStatus())
+                .entity(response.getBody())
+                .type(MediaType.APPLICATION_JSON_TYPE)
+                .build();
     }
-
+g
     private Response buildBadRequestErrorResponse(UserInfoEndpointException ex,
                                                   int statusCode) throws OAuthSystemException {
 
@@ -165,7 +168,10 @@ public class OpenIDConnectUserEndpoint {
                 .setError(ex.getErrorCode())
                 .setErrorDescription(ex.getErrorMessage())
                 .buildJSONMessage();
-        return Response.status(res.getResponseStatus()).entity(res.getBody()).build();
+        return Response.status(res.getResponseStatus())
+                .entity(res.getBody())
+                .type(MediaType.APPLICATION_JSON_TYPE)
+                .build();
     }
 
     private Response getErrorResponseWithAuthenticateHeader(UserInfoEndpointException ex,

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/user/OpenIDConnectUserEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/user/OpenIDConnectUserEndpoint.java
@@ -47,6 +47,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.ResponseBuilder;
 
@@ -177,6 +178,7 @@ public class OpenIDConnectUserEndpoint {
         return Response.status(res.getResponseStatus())
                 .header(OAuthConstants.HTTP_RESP_HEADER_AUTHENTICATE, "Bearer error=\"" + ex.getErrorCode() + "\"")
                 .entity(res.getBody())
+                .type(MediaType.APPLICATION_JSON_TYPE)
                 .build();
     }
 

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/user/OpenIDConnectUserEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/user/OpenIDConnectUserEndpoint.java
@@ -160,7 +160,7 @@ public class OpenIDConnectUserEndpoint {
                 .type(MediaType.APPLICATION_JSON_TYPE)
                 .build();
     }
-g
+
     private Response buildBadRequestErrorResponse(UserInfoEndpointException ex,
                                                   int statusCode) throws OAuthSystemException {
 

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/user/OpenIDConnectUserEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/user/OpenIDConnectUserEndpoint.java
@@ -46,8 +46,8 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
-import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.ResponseBuilder;
 


### PR DESCRIPTION
### Proposed changes in this pull request

This fix fixes the issue where an application/octet-stream is returned as the content-type header value when the content is a json.

Fix : https://github.com/wso2/api-manager/issues/155