### PR TITLE
Handle Consent Filtering of Address Claims

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/OpenIDConnectClaimFilterImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/OpenIDConnectClaimFilterImpl.java
@@ -210,18 +210,16 @@ public class OpenIDConnectClaimFilterImpl implements OpenIDConnectClaimFilter {
             JSONObject consentedAddressClaims = new JSONObject();
             Map<String, List<String>> scopeClaimsMap = getOIDCScopeClaimMap(spTenantDomain);
 
-            if (MapUtils.isNotEmpty(scopeClaimsMap)) {
+            if (userClaims.containsKey(ADDRESS) && MapUtils.isNotEmpty(scopeClaimsMap)) {
                 List<String> addressScopeClaimUris = getAddressScopeClaimUris(scopeClaimsMap);
-                if (addressScopeClaimUris != null) {
-                    consentedAddressClaims = (JSONObject) userClaims.get(ADDRESS);
-                    for (String addressScopeClaimEntry : addressScopeClaimUris) {
-                        if (userConsentClaimUrisInOIDCDialect.contains(addressScopeClaimEntry)) {
-                            hasAddressClaims = true;
-                            userConsentClaimUrisInOIDCDialect.remove(addressScopeClaimEntry);
-                        } else {
-                            if (consentedAddressClaims.keySet().contains(addressScopeClaimEntry)) {
-                                consentedAddressClaims.remove(addressScopeClaimEntry);
-                            }
+                consentedAddressClaims = (JSONObject) userClaims.get(ADDRESS);
+                for (String addressScopeClaimEntry : addressScopeClaimUris) {
+                    if (userConsentClaimUrisInOIDCDialect.contains(addressScopeClaimEntry)) {
+                        hasAddressClaims = true;
+                        userConsentClaimUrisInOIDCDialect.remove(addressScopeClaimEntry);
+                    } else {
+                        if (consentedAddressClaims.containsKey(addressScopeClaimEntry)) {
+                            consentedAddressClaims.remove(addressScopeClaimEntry);
                         }
                     }
                 }

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/openidconnect/OpenIDConnectClaimFilterImplTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/openidconnect/OpenIDConnectClaimFilterImplTest.java
@@ -173,6 +173,9 @@ public class OpenIDConnectClaimFilterImplTest extends PowerMockito {
         claims = getClaims();
         AuthenticatedUser user = getDefaultAuthenticatedLocalUser();
         when(ssoConsentService.isSSOConsentManagementEnabled(any())).thenReturn(true);
+        OIDCScopeClaimCacheEntry oidcScopeClaimCacheEntry = new OIDCScopeClaimCacheEntry();
+        oidcScopeClaimCacheEntry.setScopeClaimMapping(getScopeDTOList());
+        OIDCScopeClaimCache.getInstance().addScopeClaimMap(-1234, oidcScopeClaimCacheEntry);
         Map<String, Object> claimFilter = openIDConnectClaimFilter
                 .getClaimsFilteredByUserConsent(claims, user, CLIENT_ID, SP_TENANT_DOMAIN);
         Assert.assertEquals(((ScopeDTO) claimFilter.get("testUserClaimURI")).getName(), "email");


### PR DESCRIPTION
This PR handles how address claims are filtered according to user consent. Since address claims such as `country`, `locality`, `street-address`, `region`, `postal-code` and `address` are added into the user claims as a json object under the claim name `address`, the current implementation of consent filtering will not add the claims inside this object separately unless `address` claim is requested by the SP.

For ex: If the SP requests `country` claim, it will be added to user claims inside the `address` claim object. But during consent filtering, user will be asked consent for `country` claim and current implementation will not add the available `country` claim inside the address claim object, since it will be named as address.

Before this PR, the above mentioned claims will be received in the ID token as shown below.
```
{
   "isk": "88ea73a973cfb1ef888a3725e36ce018e531f55fe3bb4a286dd9efde05042e45",
   "sub": "77be24d5-649f-4de9-9ef8-074fd06b78ef",
   "country": "Andorra",
   "locality":"Wales",
    ...
}
```
After this PR, they will be listed in the ID token under the address claim as shown below.
```
{   
   "isk": "88ea73a973cfb1ef888a3725e36ce018e531f55fe3bb4a286dd9efde05042e45",
   "sub": "77be24d5-649f-4de9-9ef8-074fd06b78ef",
   "address": {
      "country": "Andorra",
      "locality":"Wales"
   },
   ...
}
```

Resolves: https://github.com/wso2/product-is/issues/13899

Related Issue: https://github.com/wso2/product-is/issues/13600