### PR TITLE
[6.4.x] Updating httpclient and httpcore dependencies as provided

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/pom.xml
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/pom.xml
@@ -49,10 +49,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.wso2.orbit.org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-        </dependency>
-        <dependency>
             <groupId>commons-codec.wso2</groupId>
             <artifactId>commons-codec</artifactId>
         </dependency>
@@ -200,8 +196,14 @@
         <!--Adding the below 2 dependencies to the webapp itself because the jars provided by the runtime
         are of older versions and have API changes-->
         <dependency>
+            <groupId>org.wso2.orbit.org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.httpcomponents.wso2</groupId>
             <artifactId>httpcore</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.wso2.carbon.identity.framework</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1012,8 +1012,8 @@
         <spring-web.version>4.3.29.RELEASE</spring-web.version>
         <swagger-jaxrs.version>1.6.2</swagger-jaxrs.version>
         <!-- httpclient dependency Version-->
-        <http.client.version>4.3.6.wso2v1</http.client.version>
-        <http.core.version>4.3.3.wso2v1</http.core.version>
+        <http.client.version>4.5.13.wso2v1</http.client.version>
+        <http.core.version>4.4.15.wso2v1</http.core.version>
 
         <!--Test Dependencies-->
         <junit.version>4.13.1</junit.version>


### PR DESCRIPTION
### Proposed changes in this pull request
The httpclient and httpcore dependencies were modified by [1] long time ago not to have as "provided", because at that time the jars supplied by the runtime are of older versions and had API changes so that the ouath2.war should have embedded these two (2) dependencies. Because of that, APIM packs were packing duplicated httpclient and httpcore jars (two inside oauth.war and another two inside plugins). 
This PR removes these jars from oauth2.war.

[1] https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/846
