### PR TITLE
Fix no info log when authorization request fails due to expired JWT

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/RequestObjectValidatorUtil.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/RequestObjectValidatorUtil.java
@@ -150,8 +150,8 @@ public class RequestObjectValidatorUtil {
             try {
                 return new JWKSBasedJWTValidator().validateSignature(jwtString, jwksUri, alg, MapUtils.EMPTY_MAP);
             } catch (IdentityOAuth2Exception e) {
-                if (e.getCause() instanceof BadJWTException) {
-                    log.error(e.getCause().getMessage());
+                if (e.getCause() != null && e.getCause() instanceof BadJWTException) {
+                    log.info(e.getCause().getMessage());
                 }
                 String errorMessage = "Error occurred while validating request object signature using jwks endpoint";
                 throw new RequestObjectException(errorMessage, OAuth2ErrorCodes.SERVER_ERROR, e);

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/RequestObjectValidatorUtil.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/RequestObjectValidatorUtil.java
@@ -23,6 +23,7 @@ import com.nimbusds.jose.JWSHeader;
 import com.nimbusds.jose.JWSVerifier;
 import com.nimbusds.jose.crypto.RSASSAVerifier;
 import com.nimbusds.jwt.SignedJWT;
+import com.nimbusds.jwt.proc.BadJWTException;
 import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
@@ -149,6 +150,9 @@ public class RequestObjectValidatorUtil {
             try {
                 return new JWKSBasedJWTValidator().validateSignature(jwtString, jwksUri, alg, MapUtils.EMPTY_MAP);
             } catch (IdentityOAuth2Exception e) {
+                if (e.getCause() instanceof BadJWTException) {
+                    log.error(e.getCause().getMessage());
+                }
                 String errorMessage = "Error occurred while validating request object signature using jwks endpoint";
                 throw new RequestObjectException(errorMessage, OAuth2ErrorCodes.SERVER_ERROR, e);
             }


### PR DESCRIPTION
This PR introduces an info log when an authorization request fails when trying to make an authorization call with a bad JWT in the request object. For an expired JWT, the info log will mention `Expired JWT`.  

Resolves: https://github.com/wso2/product-is/issues/13934
