### PR TITLE
Skip scope validation if organization scope properties are available

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/cache/SessionDataCacheEntry.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/cache/SessionDataCacheEntry.java
@@ -39,6 +39,7 @@ public class SessionDataCacheEntry extends CacheEntry {
     private String authenticatedIdPs;
     private String essentialClaims;
     private String sessionContextIdentifier;
+    private String[] userOrganizationScopes;
 
     private String queryString = null;
 
@@ -125,5 +126,15 @@ public class SessionDataCacheEntry extends CacheEntry {
     public void setSessionContextIdentifier(String sessionContextIdentifier) {
 
         this.sessionContextIdentifier = sessionContextIdentifier;
+    }
+
+    public String[] getUserOrganizationScopes() {
+
+        return userOrganizationScopes;
+    }
+
+    public void setUserOrganizationScopes(String[] userOrganizationScopes) {
+
+        this.userOrganizationScopes = userOrganizationScopes;
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/AuthorizationHandlerManager.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/AuthorizationHandlerManager.java
@@ -199,6 +199,13 @@ public class AuthorizationHandlerManager {
             authzReqMsgCtx.getAuthorizationReqDTO().setScopes(filteredScopes);
         }
 
+        // If the user is federated and organization scopes are available, scopes are already validated at the child org
+        if (authzReqDTO.getUser().isFederatedUser() && ArrayUtils.isNotEmpty(authzReqDTO.getUserOrganizationScopes())) {
+            String[] userOrgScopes = authzReqDTO.getUserOrganizationScopes();
+            addAllowedScopes(authzReqMsgCtx, userOrgScopes);
+            return authorizeRespDTO;
+        }
+
         boolean valid = validateScope(authzReqDTO, authorizeRespDTO, authzReqMsgCtx, authzHandler);
         if (valid) {
             // Add authorized internal scopes to the request for sending in the response.

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dto/OAuth2AuthorizeReqDTO.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dto/OAuth2AuthorizeReqDTO.java
@@ -56,6 +56,8 @@ public class OAuth2AuthorizeReqDTO {
     // Set the login tenant domain.
     private String loggedInTenantDomain;
     private boolean isRequestObjectFlow;
+    // contains the user scopes, if the user logged in from a child organization,
+    private String[] userOrganizationScopes;
 
     public String getSessionDataKey() {
         return sessionDataKey;
@@ -267,5 +269,15 @@ public class OAuth2AuthorizeReqDTO {
     public void setRequestObjectFlow(boolean isRequestObjectFlow) {
 
         this.isRequestObjectFlow = isRequestObjectFlow;
+    }
+
+    public String[] getUserOrganizationScopes() {
+
+        return userOrganizationScopes;
+    }
+
+    public void setUserOrganizationScopes(String[] userOrganizationScopes) {
+
+        this.userOrganizationScopes = userOrganizationScopes;
     }
 }

--- a/components/org.wso2.carbon.identity.webfinger/pom.xml
+++ b/components/org.wso2.carbon.identity.webfinger/pom.xml
@@ -69,6 +69,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.testutil</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.jacoco</groupId>
             <artifactId>org.jacoco.agent</artifactId>
             <classifier>runtime</classifier>

--- a/pom.xml
+++ b/pom.xml
@@ -821,7 +821,7 @@
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!-- Carbon Identity Framework version -->
-        <carbon.identity.framework.version>5.20.337</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.21.26</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.17.5, 6.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 

--- a/pom.xml
+++ b/pom.xml
@@ -583,7 +583,7 @@
             <dependency>
                 <groupId>org.wso2.carbon.identity.framework</groupId>
                 <artifactId>org.wso2.carbon.identity.testutil</artifactId>
-                <version>${carbon.identity.framework.version}</version>
+                <version>${carbon.identity.framework.testutil.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
@@ -824,6 +824,7 @@
         <carbon.identity.framework.version>5.21.26</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.17.5, 6.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
+        <carbon.identity.framework.testutil.version>5.20.211</carbon.identity.framework.testutil.version>
 
         <carbon.identity.organization.management.version>1.0.54</carbon.identity.organization.management.version>
         <carbon.identity.organization.management.version.range>[1.0.46, 2.0.0)
@@ -927,7 +928,6 @@
         <javaee.web.api.version>7.0</javaee.web.api.version>
         <h2database.version>2.1.210</h2database.version>
         <commons-codec.test.version>1.4</commons-codec.test.version>
-        <org.wso2.carbon.identity.testutil.version>5.12.49</org.wso2.carbon.identity.testutil.version>
         <!--SAML component version for test-->
         <carbon.identity.sso.saml.version>5.7.0</carbon.identity.sso.saml.version>
         <spring-context.version>5.1.1.RELEASE</spring-context.version>


### PR DESCRIPTION
### Proposed changes in this pull request
When an business application is shared to a child organization, new fragment application is getting created at the child organization. 
If an user from child organization wants to login to the application, user will be redirected to the fragment application for authentication (using OIDC). 
If OIDC has been used as inbound authentication of the (primary) application, scopes in the authorization request will be passed to the fragment application for validation / approval as well. After the validation, scopes in the Organization authenticator response will be added to the context (https://github.com/wso2-extensions/identity-organization-management/pull/75, https://github.com/wso2/carbon-identity-framework/pull/4107).

Since the scopes are handled at the fragment application, scope handling will be skipped at the primary application and scopes in authenticated results are returned in the authorize request. 
