### PR TITLE
Fix gracefully handle select_account prompt

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
@@ -2363,6 +2363,11 @@ public class OAuth2AuthzEndpoint {
             return handlePromptNone(oAuthMessage, sessionState, oauth2Params, authenticatedUser, hasUserApproved);
         } else if (isPromptLogin(oauth2Params) || isPromptParamsNotPresent(oauth2Params)
                 || isPromptSelectAccount(oauth2Params)) {
+            /*
+             * IS does not currently support multiple logged-in sessions.
+             * Therefore, gracefully handling prompt=select_account by mimicking the behaviour of a request that does
+             * not have a prompt param.
+             */
             return handleConsent(oAuthMessage, sessionDataKeyFromLogin, sessionState, oauth2Params, authenticatedUser,
                     hasUserApproved);
         } else {

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
@@ -2457,11 +2457,10 @@ public class OAuth2AuthzEndpoint {
                 params.put("prompt", oauth2Params.getPrompt());
                 LoggerUtils.triggerDiagnosticLogEvent(OAuthConstants.LogConstants.OAUTH_INBOUND_SERVICE, params,
                         OAuthConstants.LogConstants.FAILED,
-                        "Request with 'prompt=none' but user session does not exist",
-                        "validate-user-session", null);
+                        "Request with 'prompt=none' but user session does not exist", "validate-user-session", null);
             }
             throw OAuthProblemException.error(OAuth2ErrorCodes.LOGIN_REQUIRED,
-                    "Request with 'prompt=none' but user session does not exist");
+                    "Request with \'prompt=none\' but user session does not exist");
         }
 
         if (isIdTokenHintExists(oauth2Params)) {

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpointTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpointTest.java
@@ -1370,13 +1370,15 @@ public class OAuth2AuthzEndpointTest extends TestOAuthEndpointBase {
         assertNotNull(response, "Authorization response is null");
         assertEquals(response.getStatus(), HttpServletResponse.SC_FOUND, "Unexpected HTTP response status");
 
-        if (errorCode != null) {
-            MultivaluedMap<String, Object> responseMetadata = response.getMetadata();
-            assertNotNull(responseMetadata, "Response metadata is null");
+        MultivaluedMap<String, Object> responseMetadata = response.getMetadata();
+        assertNotNull(responseMetadata, "Response metadata is null");
 
-            assertTrue(CollectionUtils.isNotEmpty(responseMetadata.get(HTTPConstants.HEADER_LOCATION)),
-                    "Location header not found in the response");
-            String location = String.valueOf(responseMetadata.get(HTTPConstants.HEADER_LOCATION).get(0));
+        assertTrue(CollectionUtils.isNotEmpty(responseMetadata.get(HTTPConstants.HEADER_LOCATION)),
+                "Location header not found in the response");
+        String location = String.valueOf(responseMetadata.get(HTTPConstants.HEADER_LOCATION).get(0));
+        assertFalse(location.isEmpty(), "Redirect URL is empty");
+
+        if (errorCode != null) {
             assertTrue(location.contains(errorCode), "Expected error code not found in URL");
         }
 


### PR DESCRIPTION
### Proposed changes in this pull request

This PR introduces graceful handling of `prompt=select_account` by handling it similar to `prompt=none` (i.e. Authorize if there is an existing logged-in session. Otherwise, return an error with error code `login_required`).

This is done because IS does not currently support multiple logged-in sessions (https://github.com/wso2/product-is/issues/6372#issuecomment-1188695300). 

Resolves: https://github.com/wso2/product-is/issues/6372
