### PR TITLE
Add support to skip revoking the current token when updating the password

### DIFF
--- a/components/org.wso2.carbon.identity.webfinger/pom.xml
+++ b/components/org.wso2.carbon.identity.webfinger/pom.xml
@@ -52,6 +52,10 @@
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.testutil</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.apache.felix</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -821,7 +821,7 @@
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!-- Carbon Identity Framework version -->
-        <carbon.identity.framework.version>5.20.337</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.21.63</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.17.5, 6.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 

--- a/pom.xml
+++ b/pom.xml
@@ -583,7 +583,7 @@
             <dependency>
                 <groupId>org.wso2.carbon.identity.framework</groupId>
                 <artifactId>org.wso2.carbon.identity.testutil</artifactId>
-                <version>${carbon.identity.framework.version}</version>
+                <version>${carbon.identity.testutil.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
@@ -927,7 +927,7 @@
         <javaee.web.api.version>7.0</javaee.web.api.version>
         <h2database.version>2.1.210</h2database.version>
         <commons-codec.test.version>1.4</commons-codec.test.version>
-        <org.wso2.carbon.identity.testutil.version>5.12.49</org.wso2.carbon.identity.testutil.version>
+        <carbon.identity.testutil.version>5.20.211</carbon.identity.testutil.version>
         <!--SAML component version for test-->
         <carbon.identity.sso.saml.version>5.7.0</carbon.identity.sso.saml.version>
         <spring-context.version>5.1.1.RELEASE</spring-context.version>


### PR DESCRIPTION
### Proposed changes in this pull request
Add support to skip revoking the current token when updating the password

Related to wso2/product-is#11786

Depends on: wso2/carbon-identity-framework#4189