### PR TITLE
Get The Claim values From The Authorization Context

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/DefaultOIDCClaimsCallbackHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/DefaultOIDCClaimsCallbackHandler.java
@@ -380,8 +380,7 @@ public class DefaultOIDCClaimsCallbackHandler implements CustomClaimsCallbackHan
                     }
                     userClaimsInOIDCDialect = retrieveClaimsForLocalUser(authzReqMessageContext);
                 } else {
-                    userClaimsInOIDCDialect = getOIDCClaimMapFromUserAttributes(
-                            authzReqMessageContext.getAuthorizationReqDTO().getUser().getUserAttributes());
+                    userClaimsInOIDCDialect = getOIDCClaimMapFromUserAttributes(userAttributes);
                 }
             } else {
                 if (log.isDebugEnabled()) {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/DefaultOIDCClaimsCallbackHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/DefaultOIDCClaimsCallbackHandler.java
@@ -368,12 +368,17 @@ public class DefaultOIDCClaimsCallbackHandler implements CustomClaimsCallbackHan
         if (isEmpty(userAttributes)) {
             if (isLocalUser(authzReqMessageContext)) {
                 if (log.isDebugEnabled()) {
-                    log.debug("User attributes not found in cache. Trying to retrieve attribute for local user: " +
+                    log.debug("User attributes not found in cache. Trying to retrieve attribute from " +
+                            "auth context for local user: " +
                             authzReqMessageContext.getAuthorizationReqDTO().getUser());
                 }
                 userAttributes = authzReqMessageContext.getAuthorizationReqDTO().getUser()
                         .getUserAttributes();
                 if (isEmpty(userAttributes)) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("User attributes not found in auth context. Trying to retrieve attribute for " +
+                                "local user: " + authzReqMessageContext.getAuthorizationReqDTO().getUser());
+                    }
                     userClaimsInOIDCDialect = retrieveClaimsForLocalUser(authzReqMessageContext);
                 } else {
                     userClaimsInOIDCDialect =

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/DefaultOIDCClaimsCallbackHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/DefaultOIDCClaimsCallbackHandler.java
@@ -371,7 +371,15 @@ public class DefaultOIDCClaimsCallbackHandler implements CustomClaimsCallbackHan
                     log.debug("User attributes not found in cache. Trying to retrieve attribute for local user: " +
                             authzReqMessageContext.getAuthorizationReqDTO().getUser());
                 }
-                userClaimsInOIDCDialect = retrieveClaimsForLocalUser(authzReqMessageContext);
+                userAttributes = authzReqMessageContext.getAuthorizationReqDTO().getUser()
+                        .getUserAttributes();
+                if (isEmpty(userAttributes)) {
+                    userClaimsInOIDCDialect = retrieveClaimsForLocalUser(authzReqMessageContext);
+                } else {
+                    userClaimsInOIDCDialect =
+                            getOIDCClaimMapFromUserAttributes(authzReqMessageContext.getAuthorizationReqDTO().getUser()
+                                    .getUserAttributes());
+                }
             } else {
                 if (log.isDebugEnabled()) {
                     log.debug("User attributes not found in cache. Trying to retrieve attribute for federated " +

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/DefaultOIDCClaimsCallbackHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/DefaultOIDCClaimsCallbackHandler.java
@@ -368,9 +368,8 @@ public class DefaultOIDCClaimsCallbackHandler implements CustomClaimsCallbackHan
         if (isEmpty(userAttributes)) {
             if (isLocalUser(authzReqMessageContext)) {
                 if (log.isDebugEnabled()) {
-                    log.debug("User attributes not found in cache. Trying to retrieve attribute from " +
-                            "auth context for local user: " +
-                            authzReqMessageContext.getAuthorizationReqDTO().getUser());
+                    log.debug("User attributes not found in cache. Trying to retrieve attribute from auth " +
+                            "context for local user: " + authzReqMessageContext.getAuthorizationReqDTO().getUser());
                 }
                 userAttributes = authzReqMessageContext.getAuthorizationReqDTO().getUser()
                         .getUserAttributes();
@@ -381,9 +380,8 @@ public class DefaultOIDCClaimsCallbackHandler implements CustomClaimsCallbackHan
                     }
                     userClaimsInOIDCDialect = retrieveClaimsForLocalUser(authzReqMessageContext);
                 } else {
-                    userClaimsInOIDCDialect =
-                            getOIDCClaimMapFromUserAttributes(authzReqMessageContext.getAuthorizationReqDTO().getUser()
-                                    .getUserAttributes());
+                    userClaimsInOIDCDialect = getOIDCClaimMapFromUserAttributes(
+                            authzReqMessageContext.getAuthorizationReqDTO().getUser().getUserAttributes());
                 }
             } else {
                 if (log.isDebugEnabled()) {


### PR DESCRIPTION
### Proposed changes in this pull request

With the current implementation, the OIDC Implicit flow doesn't return the correct values set for user claims using the adaptive authentication script. Instead, we get the values from the user store in JWT tokens.

This need to be fixed by using the Authorization Message Request Context we receive from the framework.
This public PR fixes the issue : https://github.com/wso2/product-is/issues/14827

