### PR TITLE
Format the groups claim to return an array for userinfo endpoint 

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/user/impl/UserInfoUserStoreClaimRetriever.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/user/impl/UserInfoUserStoreClaimRetriever.java
@@ -42,7 +42,8 @@ public class UserInfoUserStoreClaimRetriever implements UserInfoClaimRetriever {
                     continue;
                 }
                 String claimValue = entry.getValue();
-                if (ClaimUtil.isMultiValuedAttribute(claimValue)) {
+                String claimUri = entry.getKey().getRemoteClaim().getClaimUri();
+                if (ClaimUtil.isMultiValuedAttribute(claimUri, claimValue)) {
                     String[] attributeValues = ClaimUtil.processMultiValuedAttribute(claimValue);
                     claims.put(entry.getKey().getRemoteClaim().getClaimUri(), attributeValues);
                 } else {

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/ClaimUtil.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/ClaimUtil.java
@@ -385,7 +385,7 @@ public class ClaimUtil {
     }
 
     /**
-     * Check whether claim value is multivalued attribute or not by using attribute separator.
+     * Check whether claim value is multivalued attribute or not by using claim uri and attribute separator.
      *
      * @param claimUri String value contains claim uri.
      * @param claimValue String value contains claims.

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/ClaimUtil.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/ClaimUtil.java
@@ -385,7 +385,7 @@ public class ClaimUtil {
     }
 
     /**
-     * Check whether claim value is multivalued attribute or not by using claim uri and attribute separator.
+     * Checks whether a user value is multivalued or not.
      *
      * @param claimUri String value contains claim uri.
      * @param claimValue String value contains claims.

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/ClaimUtil.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/ClaimUtil.java
@@ -189,9 +189,7 @@ public class ClaimUtil {
                                         continue;
                                     }
                                 }
-                                // To format the groups claim to always return as an array, we should consider single
-                                // group as multi value attribute.
-                                if (isMultiValuedAttribute(claimValue) || GROUPS.equals(oidcClaimUri)) {
+                                if (isMultiValuedAttribute(oidcClaimUri, claimValue)) {
                                     String[] attributeValues = processMultiValuedAttribute(claimValue);
                                     mappedAppClaims.put(oidcClaimUri, attributeValues);
                                 } else {
@@ -383,6 +381,22 @@ public class ClaimUtil {
      */
     public static boolean isMultiValuedAttribute(String claimValue) {
 
+        return StringUtils.contains(claimValue, ATTRIBUTE_SEPARATOR);
+    }
+
+    /**
+     * Check whether claim value is multivalued attribute or not by using attribute separator.
+     *
+     * @param claimUri String value contains claim uri.
+     * @param claimValue String value contains claims.
+     * @return Whether it is multivalued attribute or not.
+     */
+    public static boolean isMultiValuedAttribute(String claimUri, String claimValue) {
+        // To format the groups claim to always return as an array, we should consider single
+        // group as multi value attribute.
+        if (GROUPS.equals(claimUri)) {
+            return true;
+        }
         return StringUtils.contains(claimValue, ATTRIBUTE_SEPARATOR);
     }
 

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/ClaimUtil.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/ClaimUtil.java
@@ -73,6 +73,7 @@ import static org.wso2.carbon.identity.core.util.IdentityUtil.isTokenLoggable;
 public class ClaimUtil {
 
     private static final String SP_DIALECT = "http://wso2.org/oidc/claim";
+    private static final String GROUPS = "groups";
     private static final String ATTRIBUTE_SEPARATOR = FrameworkUtils.getMultiAttributeSeparator();
     private static final Log log = LogFactory.getLog(ClaimUtil.class);
 
@@ -188,8 +189,9 @@ public class ClaimUtil {
                                         continue;
                                     }
                                 }
-
-                                if (isMultiValuedAttribute(claimValue)) {
+                                // To format the groups claim to always return as an array, we should consider single
+                                // group as multi value attribute.
+                                if (isMultiValuedAttribute(claimValue) || GROUPS.equals(oidcClaimUri)) {
                                     String[] attributeValues = processMultiValuedAttribute(claimValue);
                                     mappedAppClaims.put(oidcClaimUri, attributeValues);
                                 } else {

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/user/impl/UserInfoUserStoreClaimRetrieverTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/user/impl/UserInfoUserStoreClaimRetrieverTest.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.when;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 
 @PrepareForTest({FrameworkUtils.class})
 public class UserInfoUserStoreClaimRetrieverTest extends PowerMockIdentityBaseTest {
@@ -58,5 +59,28 @@ public class UserInfoUserStoreClaimRetrieverTest extends PowerMockIdentityBaseTe
 
         UserInfoUserStoreClaimRetriever claimsRetriever = new UserInfoUserStoreClaimRetriever();
         assertNotNull(claimsRetriever.getClaimsMap(claims));
+    }
+
+    @DataProvider
+    public Object[][] getUserAttributesWithGroupsClaim() {
+
+        ClaimMapping map1 = ClaimMapping.build("groups", "groups", "defaultValue1", true);
+        Map<ClaimMapping, Object> claims1 = new HashMap<ClaimMapping, Object>();
+        claims1.put(map1, "group1");
+        return new Object[][] {
+                {claims1}
+        };
+    }
+
+    @Test(dataProvider = "getUserAttributesWithGroupsClaim")
+    public void testGroupsClaimUserInfoUserStoreClaimRetriever(HashMap<ClaimMapping, String> claims) {
+
+        mockStatic(FrameworkUtils.class);
+        when(FrameworkUtils.getMultiAttributeSeparator()).thenReturn(",");
+
+        UserInfoUserStoreClaimRetriever claimsRetriever = new UserInfoUserStoreClaimRetriever();
+        Map<String, Object> retrievedClaims = claimsRetriever.getClaimsMap(claims);
+        assertNotNull(retrievedClaims);
+        assertTrue(retrievedClaims.get("groups") instanceof String[]);
     }
 }


### PR DESCRIPTION
### Proposed changes in this pull request

If a user only has one group, userinfo endpoint return groups claim as a string. If there are several groups, the groups claim return as an array. In this PR, we format the groups claim to always return as an array.

Fixes https://github.com/wso2/product-is/issues/14887

### When should this PR be merged

[Please describe any preconditions that need to be addressed before we
can merge this pull request.]


### Follow up actions

[List any possible follow-up actions here; for instance, testing data
migrations, software that we need to install on staging and production
environments.]

-


### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description.
- [ ] **Is the PR labeled correctly?**

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled.

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests.
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/).

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components.
- [ ] **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

#### Security

- [ ] **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
- [ ] **Are all UI and API inputs run through forms or serializers?**
- [ ] **Are all external inputs validated and sanitized appropriately?**
- [ ] **Does all branching logic have a default case?**
- [ ] **Does this solution handle outliers and edge cases gracefully?**
- [ ] **Are all external communications secured and restricted to SSL?**

#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes should be documented.
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented.
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki.
