### PR TITLE
Remove runtime claims before searching user claims from userstore or identity store

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/DefaultOIDCClaimsCallbackHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/DefaultOIDCClaimsCallbackHandler.java
@@ -535,6 +535,7 @@ public class DefaultOIDCClaimsCallbackHandler implements CustomClaimsCallbackHan
         }
 
         List<String> requestedClaimUris = getRequestedClaimUris(requestClaimMappings);
+        // Improve runtime claim value storage in cache through https://github.com/wso2/product-is/issues/15056
         requestedClaimUris.removeIf(claim -> claim.startsWith("http://wso2.org/claims/runtime/"));
         Map<String, String> userClaims =
                 getUserClaimsInLocalDialect(fullQualifiedUsername, realm, requestedClaimUris);

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/DefaultOIDCClaimsCallbackHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/DefaultOIDCClaimsCallbackHandler.java
@@ -67,6 +67,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import static org.apache.commons.collections.MapUtils.isEmpty;
 import static org.apache.commons.collections.MapUtils.isNotEmpty;
@@ -535,7 +536,11 @@ public class DefaultOIDCClaimsCallbackHandler implements CustomClaimsCallbackHan
         }
 
         List<String> requestedClaimUris = getRequestedClaimUris(requestClaimMappings);
-        Map<String, String> userClaims = getUserClaimsInLocalDialect(fullQualifiedUsername, realm, requestedClaimUris);
+        List<String> runtimeClaimsRemovedRequestedClaimUris =
+                requestedClaimUris.stream().filter(claim -> !claim.startsWith("http://wso2.org/claims/runtime/"))
+                        .collect(Collectors.toList());
+        Map<String, String> userClaims =
+                getUserClaimsInLocalDialect(fullQualifiedUsername, realm, runtimeClaimsRemovedRequestedClaimUris);
 
         if (isEmpty(userClaims)) {
             // User claims can be empty if user does not exist in user stores. Probably a federated user.

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/DefaultOIDCClaimsCallbackHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/DefaultOIDCClaimsCallbackHandler.java
@@ -67,7 +67,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 import static org.apache.commons.collections.MapUtils.isEmpty;
 import static org.apache.commons.collections.MapUtils.isNotEmpty;

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/DefaultOIDCClaimsCallbackHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/DefaultOIDCClaimsCallbackHandler.java
@@ -536,11 +536,9 @@ public class DefaultOIDCClaimsCallbackHandler implements CustomClaimsCallbackHan
         }
 
         List<String> requestedClaimUris = getRequestedClaimUris(requestClaimMappings);
-        List<String> runtimeClaimsRemovedRequestedClaimUris =
-                requestedClaimUris.stream().filter(claim -> !claim.startsWith("http://wso2.org/claims/runtime/"))
-                        .collect(Collectors.toList());
+        requestedClaimUris.removeIf(claim -> claim.startsWith("http://wso2.org/claims/runtime/"));
         Map<String, String> userClaims =
-                getUserClaimsInLocalDialect(fullQualifiedUsername, realm, runtimeClaimsRemovedRequestedClaimUris);
+                getUserClaimsInLocalDialect(fullQualifiedUsername, realm, requestedClaimUris);
 
         if (isEmpty(userClaims)) {
             // User claims can be empty if user does not exist in user stores. Probably a federated user.


### PR DESCRIPTION
### Proposed changes in this pull request
Remove http://wso2.org/claims/runtime/ claim URIs in the requested claim list of SP, before searching user claim values from userstore/ identity store