### PR TITLE
Third-party dependency upgrade

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.dcr.endpoint/pom.xml
+++ b/components/org.wso2.carbon.identity.oauth.dcr.endpoint/pom.xml
@@ -56,6 +56,10 @@
             <artifactId>swagger-jaxrs</artifactId>
             <exclusions>
                 <exclusion>
+                    <groupId>javax.validation</groupId>
+                    <artifactId>validation-api</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>com.fasterxml.jackson.core</groupId>
                     <artifactId>jackson-annotations</artifactId>
                 </exclusion>
@@ -139,6 +143,10 @@
             <groupId>org.powermock</groupId>
             <artifactId>powermock-api-mockito</artifactId>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
         </dependency>
     </dependencies>
 

--- a/components/org.wso2.carbon.identity.oauth.scope.endpoint/pom.xml
+++ b/components/org.wso2.carbon.identity.oauth.scope.endpoint/pom.xml
@@ -134,6 +134,10 @@
             <artifactId>swagger-jaxrs</artifactId>
             <exclusions>
                 <exclusion>
+                    <groupId>javax.validation</groupId>
+                    <artifactId>validation-api</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>com.fasterxml.jackson.core</groupId>
                     <artifactId>jackson-annotations</artifactId>
                 </exclusion>
@@ -169,6 +173,10 @@
             <groupId>org.wso2.carbon.identity.framework</groupId>
             <artifactId>org.wso2.carbon.identity.testutil</artifactId>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -527,6 +527,11 @@
                 <version>${spring-web.version}</version>
             </dependency>
             <dependency>
+                <groupId>javax.validation</groupId>
+                <artifactId>validation-api</artifactId>
+                <version>${javax.validation-api}</version>
+            </dependency>
+            <dependency>
                 <groupId>io.swagger</groupId>
                 <artifactId>swagger-jaxrs</artifactId>
                 <version>${swagger-jaxrs.version}</version>
@@ -1011,6 +1016,7 @@
         <com.fasterxml.jackson.version>2.9.7</com.fasterxml.jackson.version>
         <spring-web.version>4.3.29.RELEASE</spring-web.version>
         <swagger-jaxrs.version>1.6.2</swagger-jaxrs.version>
+        <javax.validation-api>2.0.1.Final</javax.validation-api>
         <!-- httpclient dependency Version-->
         <http.client.version>4.5.13.wso2v1</http.client.version>
         <http.core.version>4.4.15.wso2v1</http.core.version>


### PR DESCRIPTION
validation-api has been updated from 1.1.0.Final to 2.0.1.Final from this PR

The following components will be updated from this PR

- ./repository/deployment/server/webapps/api#identity#oauth2#v1.0/WEB-INF/lib/validation-api-1.1.0.Final.jar
- ./repository/deployment/server/webapps/api#identity#oauth2#dcr#v1.1/WEB-INF/lib/validation-api-1.1.0.Final.jar