### PR TITLE
Add requestedScope to  OAuthAuthzReqMessageContext

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/AuthorizationHandlerManager.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/AuthorizationHandlerManager.java
@@ -344,6 +344,7 @@ public class AuthorizationHandlerManager {
         // load the SP tenant domain from the OAuth App info
         authorizeRequestMessageContext.getAuthorizationReqDTO()
                 .setTenantDomain(OAuth2Util.getTenantDomainOfOauthApp(oAuthAppDO));
+        authorizeRequestMessageContext.setRequestedScope(authzReqDTO.getScopes());
         return authorizeRequestMessageContext;
     }
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/OAuthAuthzReqMessageContext.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/OAuthAuthzReqMessageContext.java
@@ -31,6 +31,8 @@ public class OAuthAuthzReqMessageContext {
 
     private String[] approvedScope;
 
+    private String[] requestedScope;
+
     private long validityPeriod;
 
     private long authorizationCodeValidityPeriod;
@@ -72,6 +74,14 @@ public class OAuthAuthzReqMessageContext {
     public void setApprovedScope(String[] approvedScope) {
 
         this.approvedScope = approvedScope;
+    }
+
+    public String[] getRequestedScope() {
+        return requestedScope;
+    }
+
+    public void setRequestedScope(String[] requestedScopes) {
+        this.requestedScope = requestedScopes;
     }
 
     @Deprecated


### PR DESCRIPTION
### Proposed changes in this pull request

In this PR, we add define requestedScope in OAuthAuthzReqMessageContext. requestedScope keep user requested scopes in the scope validation flow
