### PR TITLE
Third-party dependency upgrade

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.dcr.endpoint/pom.xml
+++ b/components/org.wso2.carbon.identity.oauth.dcr.endpoint/pom.xml
@@ -41,6 +41,10 @@
             <artifactId>swagger-jaxrs</artifactId>
             <exclusions>
                 <exclusion>
+                    <groupId>javax.validation</groupId>
+                    <artifactId>validation-api</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>com.fasterxml.jackson.core</groupId>
                     <artifactId>jackson-annotations</artifactId>
                 </exclusion>
@@ -106,6 +110,10 @@
                     <artifactId>*</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
         </dependency>
     </dependencies>
 

--- a/components/org.wso2.carbon.identity.oauth.scope.endpoint/pom.xml
+++ b/components/org.wso2.carbon.identity.oauth.scope.endpoint/pom.xml
@@ -119,6 +119,10 @@
             <artifactId>swagger-jaxrs</artifactId>
             <exclusions>
                 <exclusion>
+                    <groupId>javax.validation</groupId>
+                    <artifactId>validation-api</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>com.fasterxml.jackson.core</groupId>
                     <artifactId>jackson-annotations</artifactId>
                 </exclusion>
@@ -149,6 +153,10 @@
                     <artifactId>*</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -526,6 +526,11 @@
                 <version>${spring-web.version}</version>
             </dependency>
             <dependency>
+                <groupId>javax.validation</groupId>
+                <artifactId>validation-api</artifactId>
+                <version>${javax.validation-api}</version>
+            </dependency>
+            <dependency>
                 <groupId>io.swagger</groupId>
                 <artifactId>swagger-jaxrs</artifactId>
                 <version>${swagger-jaxrs.version}</version>
@@ -922,6 +927,7 @@
         <com.fasterxml.jackson.version>2.13.2</com.fasterxml.jackson.version>
         <spring-web.version>4.3.29.RELEASE</spring-web.version>
         <swagger-jaxrs.version>1.6.2</swagger-jaxrs.version>
+        <javax.validation-api>2.0.1.Final</javax.validation-api>
 
         <!--Test Dependencies-->
         <junit.version>4.13.1</junit.version>


### PR DESCRIPTION
Fix https://github.com/wso2/api-manager/issues/1017
Related PR https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/1944
validation-api has been updated from 1.1.0.Final to 2.0.1.Final from this PR

The following components will be updated from this PR

- ./repository/deployment/server/webapps/api#identity#oauth2#v1.0/WEB-INF/lib/validation-api-1.1.0.Final.jar
- ./repository/deployment/server/webapps/api#identity#oauth2#dcr#v1.1/WEB-INF/lib/validation-api-1.1.0.Final.jar