### PR TITLE
Fixing not identifying the commonAuthId cookie value issue

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
@@ -3382,21 +3382,6 @@ public class OAuth2AuthzEndpoint {
     }
 
     /**
-     * Associates the authentication method references done while logged into the session (if any) to the OAuth cache.
-     * The SessionDataCacheEntry then will be used when getting "AuthenticationMethodReferences". Please see
-     * <a href="https://tools.ietf.org/html/draft-ietf-oauth-amr-values-02" >draft-ietf-oauth-amr-values-02</a>.
-     *
-     * @param resultFromLogin The session context.
-     * @param cookie The cookie string which contains the commonAuthId value.
-     */
-    private void associateAuthenticationHistory(SessionDataCacheEntry resultFromLogin, Cookie cookie) {
-
-        if (cookie != null) {
-            associateAuthenticationHistory(resultFromLogin, cookie.getValue());
-        }
-    }
-
-    /**
      *  Associates the authentication method references done while logged into the session (if any) to the OAuth cache.
      *  The SessionDataCacheEntry then will be used when getting "AuthenticationMethodReferences". Please see
      *  <a href="https://tools.ietf.org/html/draft-ietf-oauth-amr-values-02" >draft-ietf-oauth-amr-values-02</a>.
@@ -3419,21 +3404,6 @@ public class OAuth2AuthzEndpoint {
     }
 
     /**
-     * Returns the SessionContext associated with the cookie, if there is a one.
-     *
-     * @param cookie String value of the cookie of commonAuthId.
-     * @param loginTenantDomain Login tenant domain.
-     * @return the associate SessionContext or null.
-     */
-    private SessionContext getSessionContext(Cookie cookie, String loginTenantDomain) {
-
-        if (cookie != null) {
-            return getSessionContext(cookie.getValue(), loginTenantDomain);
-        }
-        return null;
-    }
-
-    /**
      * Returns the SessionContext associated with the cookie value, if there is a one.
      * @param cookieValue String value of the cookie of commonAuthId.
      * @param loginTenantDomain Login tenant domain.
@@ -3446,22 +3416,6 @@ public class OAuth2AuthzEndpoint {
             return FrameworkUtils.getSessionContextFromCache(sessionContextKey, loginTenantDomain);
         }
         return null;
-    }
-
-    /**
-     * Gets the last authenticated value from the commonAuthId cookie.
-     *
-     * @param cookie CommonAuthId cookie.
-     * @param loginTenantDomain Login tenant domain.
-     * @return the last authenticated timestamp.
-     */
-    private long getAuthenticatedTimeFromCommonAuthCookie(Cookie cookie, String loginTenantDomain) {
-
-        long authTime = 0;
-        if (cookie != null) {
-            authTime = getAuthenticatedTimeFromCommonAuthCookieValue(cookie.getValue(), loginTenantDomain);
-        }
-        return authTime;
     }
 
     /**

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
@@ -696,12 +696,32 @@ public class OAuth2AuthzEndpoint {
 
     private void addSessionDataKeyToSessionDataCacheEntry(OAuthMessage oAuthMessage) {
 
-        Cookie cookie = FrameworkUtils.getAuthCookie(oAuthMessage.getRequest());
-        if (cookie != null) {
-            String sessionContextKey = DigestUtils.sha256Hex(cookie.getValue());
+        String commonAuthIdCookieValue = getCommonAuthCookieString(oAuthMessage.getRequest());
+        if (StringUtils.isNotBlank(commonAuthIdCookieValue)) {
+            String sessionContextKey = DigestUtils.sha256Hex(commonAuthIdCookieValue);
             oAuthMessage.getSessionDataCacheEntry().getParamMap().put(FrameworkConstants.SESSION_DATA_KEY, new String[]
                     {sessionContextKey});
         }
+    }
+
+    /**
+     * Retrieves the value of the commonAuthId cookie either from request cookies if available or
+     * from the request attribute where the response header contains commonAuthId value.
+     *
+     * @param request HttpServletRequest An authorization or authentication request.
+     * @return String commonAuthId value.
+     */
+    private String getCommonAuthCookieString(HttpServletRequest request) {
+
+        Cookie cookie = FrameworkUtils.getAuthCookie(request);
+        String commonAuthIdCookieValue = null;
+
+        if (cookie != null) {
+            commonAuthIdCookieValue = cookie.getValue();
+        } else if (request.getAttribute(COMMONAUTH_COOKIE) != null) {
+            commonAuthIdCookieValue = (String) request.getAttribute(COMMONAUTH_COOKIE);
+        }
+        return commonAuthIdCookieValue;
     }
 
     private String getConsentFromRequest(OAuthMessage oAuthMessage) {
@@ -1005,15 +1025,15 @@ public class OAuth2AuthzEndpoint {
 
     private void updateAuthTimeInSessionDataCacheEntry(OAuthMessage oAuthMessage) {
 
-        Cookie cookie = FrameworkUtils.getAuthCookie(oAuthMessage.getRequest());
-        long authTime = getAuthenticatedTimeFromCommonAuthCookie(cookie,
+        String commonAuthIdCookieValue = getCommonAuthCookieString(oAuthMessage.getRequest());
+        long authTime = getAuthenticatedTimeFromCommonAuthCookieValue(commonAuthIdCookieValue,
                 oAuthMessage.getSessionDataCacheEntry().getoAuth2Parameters().getLoginTenantDomain());
 
         if (authTime > 0) {
             oAuthMessage.getSessionDataCacheEntry().setAuthTime(authTime);
         }
 
-        associateAuthenticationHistory(oAuthMessage.getSessionDataCacheEntry(), cookie);
+        associateAuthenticationHistory(oAuthMessage.getSessionDataCacheEntry(), commonAuthIdCookieValue);
     }
 
     private boolean isFormPostResponseMode(OAuthMessage oAuthMessage, String redirectURL) {
@@ -3366,12 +3386,27 @@ public class OAuth2AuthzEndpoint {
      * The SessionDataCacheEntry then will be used when getting "AuthenticationMethodReferences". Please see
      * <a href="https://tools.ietf.org/html/draft-ietf-oauth-amr-values-02" >draft-ietf-oauth-amr-values-02</a>.
      *
-     * @param resultFromLogin
-     * @param cookie
+     * @param resultFromLogin The session context.
+     * @param cookie The cookie string which contains the commonAuthId value.
      */
     private void associateAuthenticationHistory(SessionDataCacheEntry resultFromLogin, Cookie cookie) {
 
-        SessionContext sessionContext = getSessionContext(cookie,
+        if (cookie != null) {
+            associateAuthenticationHistory(resultFromLogin, cookie.getValue());
+        }
+    }
+
+    /**
+     *  Associates the authentication method references done while logged into the session (if any) to the OAuth cache.
+     *  The SessionDataCacheEntry then will be used when getting "AuthenticationMethodReferences". Please see
+     *  <a href="https://tools.ietf.org/html/draft-ietf-oauth-amr-values-02" >draft-ietf-oauth-amr-values-02</a>.
+     *
+     * @param resultFromLogin The session context.
+     * @param cookieValue The cookie string which contains the commonAuthId value.
+     */
+    private void associateAuthenticationHistory(SessionDataCacheEntry resultFromLogin, String cookieValue) {
+
+        SessionContext sessionContext = getSessionContext(cookieValue,
                 resultFromLogin.getoAuth2Parameters().getLoginTenantDomain());
         if (sessionContext != null && sessionContext.getSessionAuthHistory() != null
                 && sessionContext.getSessionAuthHistory().getHistory() != null) {
@@ -3386,41 +3421,67 @@ public class OAuth2AuthzEndpoint {
     /**
      * Returns the SessionContext associated with the cookie, if there is a one.
      *
-     * @param cookie
+     * @param cookie String value of the cookie of commonAuthId.
      * @param loginTenantDomain Login tenant domain.
      * @return the associate SessionContext or null.
      */
     private SessionContext getSessionContext(Cookie cookie, String loginTenantDomain) {
 
         if (cookie != null) {
-            String sessionContextKey = DigestUtils.sha256Hex(cookie.getValue());
+            return getSessionContext(cookie.getValue(), loginTenantDomain);
+        }
+        return null;
+    }
+
+    /**
+     * Returns the SessionContext associated with the cookie value, if there is a one.
+     * @param cookieValue String value of the cookie of commonAuthId.
+     * @param loginTenantDomain Login tenant domain.
+     * @return he associate SessionContext or null.
+     */
+    private SessionContext getSessionContext(String cookieValue, String loginTenantDomain) {
+
+        if (StringUtils.isNotBlank(cookieValue)) {
+            String sessionContextKey = DigestUtils.sha256Hex(cookieValue);
             return FrameworkUtils.getSessionContextFromCache(sessionContextKey, loginTenantDomain);
         }
         return null;
     }
 
     /**
-     * Gets the last authenticated value from the commonAuthId cookie
+     * Gets the last authenticated value from the commonAuthId cookie.
      *
-     * @param cookie CommonAuthId cookie
-     * @param loginTenantDomain Login tenant domain
-     * @return the last authenticated timestamp
+     * @param cookie CommonAuthId cookie.
+     * @param loginTenantDomain Login tenant domain.
+     * @return the last authenticated timestamp.
      */
     private long getAuthenticatedTimeFromCommonAuthCookie(Cookie cookie, String loginTenantDomain) {
 
         long authTime = 0;
         if (cookie != null) {
-            String sessionContextKey = DigestUtils.sha256Hex(cookie.getValue());
-            SessionContext sessionContext = FrameworkUtils.getSessionContextFromCache(sessionContextKey,
-                    loginTenantDomain);
-            if (sessionContext != null) {
-                if (sessionContext.getProperty(FrameworkConstants.UPDATED_TIMESTAMP) != null) {
-                    authTime = Long.parseLong(
-                            sessionContext.getProperty(FrameworkConstants.UPDATED_TIMESTAMP).toString());
-                } else {
-                    authTime = Long.parseLong(
-                            sessionContext.getProperty(FrameworkConstants.CREATED_TIMESTAMP).toString());
-                }
+            authTime = getAuthenticatedTimeFromCommonAuthCookieValue(cookie.getValue(), loginTenantDomain);
+        }
+        return authTime;
+    }
+
+    /**
+     * Gets the last authenticated value from the commonAuthId cookie value.
+     *
+     * @param cookieValue       String CommonAuthId cookie values.
+     * @param loginTenantDomain String Login tenant domain.
+     * @return long The last authenticated timestamp.
+     */
+    private long getAuthenticatedTimeFromCommonAuthCookieValue(String cookieValue, String loginTenantDomain) {
+
+        long authTime = 0;
+        SessionContext sessionContext = getSessionContext(cookieValue, loginTenantDomain);
+        if (sessionContext != null) {
+            if (sessionContext.getProperty(FrameworkConstants.UPDATED_TIMESTAMP) != null) {
+                authTime = Long.parseLong(
+                        sessionContext.getProperty(FrameworkConstants.UPDATED_TIMESTAMP).toString());
+            } else {
+                authTime = Long.parseLong(
+                        sessionContext.getProperty(FrameworkConstants.CREATED_TIMESTAMP).toString());
             }
         }
         return authTime;

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpointTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpointTest.java
@@ -1682,7 +1682,7 @@ public class OAuth2AuthzEndpointTest extends TestOAuthEndpointBase {
     }
 
     @Test(dataProvider = "provideAuthenticatedTimeFromCommonAuthData")
-    public void testGetAuthenticatedTimeFromCommonAuthCookie(Object sessionContextObject, Object updatedTimestamp,
+    public void testGetAuthenticatedTimeFromCommonAuthCookieValue(Object sessionContextObject, Object updatedTimestamp,
                                                              Object createdTimeStamp) throws Exception {
 
         SessionContext sessionContext = (SessionContext) sessionContextObject;
@@ -1696,10 +1696,11 @@ public class OAuth2AuthzEndpointTest extends TestOAuthEndpointBase {
         mockStatic(FrameworkUtils.class);
         when(FrameworkUtils.getSessionContextFromCache(anyString(), anyString())).thenReturn(sessionContext);
 
-        Method getAuthenticatedTimeFromCommonAuthCookie = authzEndpointObject.getClass().
-                getDeclaredMethod("getAuthenticatedTimeFromCommonAuthCookie", Cookie.class, String.class);
-        getAuthenticatedTimeFromCommonAuthCookie.setAccessible(true);
-        long timestamp = (long) getAuthenticatedTimeFromCommonAuthCookie.invoke(authzEndpointObject, commonAuthCookie,
+        Method getAuthenticatedTimeFromCommonAuthCookieValue = authzEndpointObject.getClass().
+                getDeclaredMethod("getAuthenticatedTimeFromCommonAuthCookieValue", String.class, String.class);
+        getAuthenticatedTimeFromCommonAuthCookieValue.setAccessible(true);
+        long timestamp = (long) getAuthenticatedTimeFromCommonAuthCookieValue.invoke(authzEndpointObject,
+                commonAuthCookie.getValue(),
                 "abc");
 
         if (sessionContext == null) {


### PR DESCRIPTION
This PR enables identifying the commonAuthId sent via both request and respond.