### PR TITLE
Fix the OIDC scopes missing issue in the consent page url

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/pom.xml
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/pom.xml
@@ -322,7 +322,7 @@
                                         <limit implementation="org.jacoco.report.check.Limit">
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.54</minimum>
+                                            <minimum>0.53</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/components/org.wso2.carbon.identity.oauth.endpoint/pom.xml
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/pom.xml
@@ -322,7 +322,7 @@
                                         <limit implementation="org.jacoco.report.check.Limit">
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.53</minimum>
+                                            <minimum>0.54</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
@@ -757,8 +757,10 @@ public class EndpointUtil {
                             "&" + PROP_REDIRECT_URI + "=" + URLEncoder.encode(params.getRedirectURI(), UTF_8));
                 }
 
-                entry.setQueryString(entry.getQueryString() + "&" + PROP_OIDC_SCOPE +
-                        "=" + URLEncoder.encode(StringUtils.join(getRequestedOIDCScopes(params), "+"), UTF_8));
+                if (params != null) {
+                    entry.setQueryString(entry.getQueryString() + "&" + PROP_OIDC_SCOPE +
+                            "=" + URLEncoder.encode(StringUtils.join(getRequestedOIDCScopes(params), "+"), UTF_8));
+                }
                 queryString = URLEncoder.encode(entry.getQueryString(), UTF_8);
             }
 

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
@@ -939,8 +939,6 @@ public class EndpointUtil {
         Set<String> allowedScopes = params.getScopes();
         List<String> requestedOIDCScopes = new ArrayList<>();
         try {
-            startTenantFlow(params.getTenantDomain());
-
             // Get registered OIDC scopes.
             List<String> oidcScopeList = oAuthAdminService.getRegisteredOIDCScope(params.getTenantDomain());
             for (String scope : allowedScopes) {

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
@@ -759,7 +759,7 @@ public class EndpointUtil {
 
                 if (params != null) {
                     entry.setQueryString(entry.getQueryString() + "&" + PROP_OIDC_SCOPE +
-                            "=" + URLEncoder.encode(StringUtils.join(getRequestedOIDCScopes(params), "+"), UTF_8));
+                            "=" + URLEncoder.encode(StringUtils.join(getRequestedOIDCScopes(params), " "), UTF_8));
                 }
                 queryString = URLEncoder.encode(entry.getQueryString(), UTF_8);
             }

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
@@ -942,8 +942,7 @@ public class EndpointUtil {
             startTenantFlow(params.getTenantDomain());
 
             // Get registered OIDC scopes.
-            String[] oidcScopes = oAuthAdminService.getScopeNames();
-            List<String> oidcScopeList = new ArrayList<>(Arrays.asList(oidcScopes));
+            List<String> oidcScopeList = oAuthAdminService.getRegisteredOIDCScope(params.getTenantDomain());
             for (String scope : allowedScopes) {
                 if (oidcScopeList.contains(scope)) {
                     requestedOIDCScopes.add(scope.toLowerCase());
@@ -951,8 +950,6 @@ public class EndpointUtil {
             }
         } catch (IdentityOAuthAdminException e) {
             throw new OAuthSystemException("Error while retrieving OIDC scopes.", e);
-        } finally {
-            PrivilegedCarbonContext.endTenantFlow();
         }
         return requestedOIDCScopes;
     }

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
@@ -956,7 +956,6 @@ public class EndpointUtil {
         return allowedOAuthScopes;
     }
 
-
     @Deprecated
     private static void setConsentRequiredScopesToOAuthParams(AuthenticatedUser user, OAuth2Parameters params)
             throws OAuthSystemException {

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
@@ -944,9 +944,9 @@ public class EndpointUtil {
                         log.debug("DropUnregisteredScopes config is enabled. Attempting to drop unregistered scopes.");
                     }
                     allowedScopes = dropUnregisteredScopes(params);
-                    for (String scope : allowedScopes) {
-                        allowedRegisteredScopes.add(scope);
-                    }
+                }
+                for (String scope : allowedScopes) {
+                    allowedRegisteredScopes.add(scope);
                 }
             } catch (OAuthSystemException e) {
                 throw new OAuthSystemException("Error while dropping unregistered scopes.", e);

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
@@ -956,37 +956,6 @@ public class EndpointUtil {
         return allowedOAuthScopes;
     }
 
-    @Deprecated
-    private static void setConsentRequiredScopesToOAuthParams(AuthenticatedUser user, OAuth2Parameters params)
-            throws OAuthSystemException {
-
-        try {
-            //Filter out OIDC scopes and unregistered scopes to prevent those scopes prompt for consent in the consent
-            // page.
-            List<String> consentRequiredScopes = dropOIDCAndUnregisteredScopesFromConsentRequiredScopes(params);
-
-            if (user != null && !isPromptContainsConsent(params)) {
-                String userId = getUserIdOfAuthenticatedUser(user);
-                String appId = getAppIdFromClientId(params.getClientId());
-                OAuth2ScopeConsentResponse existingUserConsent = oAuth2ScopeService.getUserConsentForApp(
-                        userId, appId, IdentityTenantUtil.getTenantId(user.getTenantDomain()));
-                if (existingUserConsent != null) {
-                    if (CollectionUtils.isNotEmpty(existingUserConsent.getApprovedScopes())) {
-                        consentRequiredScopes.removeAll(existingUserConsent.getApprovedScopes());
-                    }
-                }
-            }
-            params.setConsentRequiredScopes(new HashSet<>(consentRequiredScopes));
-
-            if (log.isDebugEnabled()) {
-                log.debug("Consent required scopes : " + StringUtils.join(consentRequiredScopes, " ")
-                        + " for request from client : " + params.getClientId());
-            }
-        } catch (IdentityOAuth2ScopeException e) {
-            throw new OAuthSystemException("Error occurred while retrieving user consents OAuth scopes.");
-        }
-    }
-
     private static String getUserIdOfAuthenticatedUser(AuthenticatedUser user) throws OAuthSystemException {
 
         try {

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
@@ -136,7 +136,7 @@ public class EndpointUtil {
     private static final String PROP_GRANT_TYPE = "response_type";
     private static final String PROP_RESPONSE_TYPE = "response_type";
     private static final String PROP_SCOPE = "scope";
-    private static final String PROP_OIDC_SCOPE = "requested_oidc_scope";
+    private static final String PROP_OIDC_SCOPE = "requested_oidc_scopes";
     private static final String PROP_ERROR = "error";
     private static final String PROP_ERROR_DESCRIPTION = "error_description";
     private static final String PROP_REDIRECT_URI = "redirect_uri";

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
@@ -750,18 +750,20 @@ public class EndpointUtil {
         try {
             if (entry != null && entry.getQueryString() != null) {
 
-                if (entry.getQueryString().contains(REQUEST_URI) && params != null) {
+                queryString = entry.getQueryString();
+                if (queryString.contains(REQUEST_URI) && params != null) {
                     // When request_uri requests come without redirect_uri, we need to append it to the SPQueryParams
                     // to be used in storing consent data
-                    entry.setQueryString(entry.getQueryString() +
-                            "&" + PROP_REDIRECT_URI + "=" + URLEncoder.encode(params.getRedirectURI(), UTF_8));
+                    queryString = queryString +
+                            "&" + PROP_REDIRECT_URI + "=" + URLEncoder.encode(params.getRedirectURI(), UTF_8);
                 }
 
                 if (params != null) {
-                    entry.setQueryString(entry.getQueryString() + "&" + PROP_OIDC_SCOPE +
-                            "=" + URLEncoder.encode(StringUtils.join(getRequestedOIDCScopes(params), " "), UTF_8));
+                    queryString = queryString + "&" + PROP_OIDC_SCOPE +
+                            "=" + URLEncoder.encode(StringUtils.join(getRequestedOIDCScopes(params), " "), UTF_8);
                 }
-                queryString = URLEncoder.encode(entry.getQueryString(), UTF_8);
+                entry.setQueryString(queryString);
+                queryString = URLEncoder.encode(queryString, UTF_8);
             }
 
             if (isOIDC) {

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
@@ -774,20 +774,9 @@ public class EndpointUtil {
                 }
                 consentPage += "&tenantDomain=" + getSPTenantDomainFromClientId(params.getClientId());
 
-                if (entry != null) {
-                    user = entry.getLoggedInUser();
-                }
-                setConsentRequiredScopesToOAuthParams(user, params);
-                Set<String> consentRequiredScopesSet = params.getConsentRequiredScopes();
-                String consentRequiredScopes = StringUtils.EMPTY;
-                if (CollectionUtils.isNotEmpty(consentRequiredScopesSet)) {
-                    consentRequiredScopes = String.join(" ", consentRequiredScopesSet).trim();
-                }
-
                 consentPage = consentPage + "&" + OAuthConstants.OAuth20Params.SCOPE + "=" + URLEncoder.encode
-                        (consentRequiredScopes, UTF_8) + "&" + OAuthConstants.SESSION_DATA_KEY_CONSENT
-                        + "=" + URLEncoder.encode(sessionDataKeyConsent, UTF_8) + "&" +
-                        "&spQueryParams=" + queryString;
+                        (EndpointUtil.getScope(params), UTF_8) + "&" + OAuthConstants.SESSION_DATA_KEY_CONSENT
+                        + "=" + URLEncoder.encode(sessionDataKeyConsent, UTF_8) + "&spQueryParams=" + queryString;
 
                 if (entry != null) {
 
@@ -967,6 +956,7 @@ public class EndpointUtil {
         return allowedOAuthScopes;
     }
 
+    @Deprecated
     private static void setConsentRequiredScopesToOAuthParams(AuthenticatedUser user, OAuth2Parameters params)
             throws OAuthSystemException {
 

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
@@ -956,6 +956,7 @@ public class EndpointUtil {
         return allowedOAuthScopes;
     }
 
+
     @Deprecated
     private static void setConsentRequiredScopesToOAuthParams(AuthenticatedUser user, OAuth2Parameters params)
             throws OAuthSystemException {

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtilTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtilTest.java
@@ -345,6 +345,7 @@ public class EndpointUtilTest extends PowerMockIdentityBaseTest {
             if (queryString != null && cacheEntryExists) {
                 Assert.assertTrue(consentUrl.contains(queryString), "spQueryParams value is not found in url");
             }
+
         } catch (OAuthSystemException e) {
             Assert.assertTrue(e.getMessage().contains("Error while retrieving the application name"));
         }

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtilTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtilTest.java
@@ -196,8 +196,6 @@ public class EndpointUtilTest extends PowerMockIdentityBaseTest {
     private static final String USER_INFO_RESPONSE_BUILDER =
             "org.wso2.carbon.identity.oauth.endpoint.user.impl.UserInfoJSONResponseBuilder";
 
-    private static final String REQUESTED_OIDC_SCOPES = "requested_oidc_scopes=openid profile";
-
     private String username;
     private String password;
     private String sessionDataKey;
@@ -255,12 +253,6 @@ public class EndpointUtilTest extends PowerMockIdentityBaseTest {
         params.setClientId("testClientId");
         params.setScopes(new HashSet<String>(Arrays.asList("scope1", "scope2", "internal_login")));
 
-        OAuth2Parameters paramsOIDC = new OAuth2Parameters();
-        paramsOIDC.setApplicationName("TestApplication");
-        paramsOIDC.setClientId("testClientId");
-        paramsOIDC.setScopes(
-                new HashSet<String>(Arrays.asList("openid", "profile", "scope1", "scope2", "internal_login")));
-
         return new Object[][]{
                 {params, true, true, false, "QueryString", true},
                 {null, true, true, false, "QueryString", true},
@@ -269,7 +261,6 @@ public class EndpointUtilTest extends PowerMockIdentityBaseTest {
                 {params, true, false, false, "QueryString", false},
                 {params, true, true, false, null, true},
                 {params, true, true, true, "QueryString", true},
-                {paramsOIDC, true, true, true, "QueryString", true},
         };
     }
 
@@ -351,17 +342,9 @@ public class EndpointUtilTest extends PowerMockIdentityBaseTest {
                     "is not found in url");
             Assert.assertTrue(ArrayUtils.contains(scopeArray, "internal_login"), "internal_login " +
                     "scope parameter value is not found in url");
-
             if (queryString != null && cacheEntryExists) {
                 Assert.assertTrue(consentUrl.contains(queryString), "spQueryParams value is not found in url");
             }
-
-            if (parameters.getScopes().contains("openid")) {
-                Assert.assertTrue(consentUrl.contains(URLEncoder.encode(REQUESTED_OIDC_SCOPES, "UTF-8")),
-                        "incorrect requested OIDC scopes query parameter " + consentUrl +
-                                " " + URLEncoder.encode(REQUESTED_OIDC_SCOPES, "UTF-8"));
-            }
-
         } catch (OAuthSystemException e) {
             Assert.assertTrue(e.getMessage().contains("Error while retrieving the application name"));
         }

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtilTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtilTest.java
@@ -364,16 +364,15 @@ public class EndpointUtilTest extends PowerMockIdentityBaseTest {
             if (parameters.getScopes().contains("openid")) {
                 String requestedClaimString = URLDecoder.decode(consentUrl, "UTF-8");
                 int checkIndex = requestedClaimString.indexOf(REQUESTED_OIDC_SCOPES);
+                Assert.assertTrue(checkIndex != -1, "requested OIDC scopes query parameter is not found in url");
+
                 requestedClaimString = requestedClaimString.substring(checkIndex);
                 checkIndex = requestedClaimString.indexOf("&");
-                if (checkIndex == -1) {
-                    Assert.assertTrue(StringUtils.equals(requestedClaimString, REQUESTED_OIDC_SCOPES),
-                            "incorrect requested OIDC scopes in query parameter");
-                } else {
-                    Assert.assertTrue(
-                            StringUtils.equals(requestedClaimString.substring(0, checkIndex), REQUESTED_OIDC_SCOPES),
-                            "incorrect requested OIDC scopes in query parameter");
+                if (checkIndex != -1) {
+                    requestedClaimString = requestedClaimString.substring(0, checkIndex);
                 }
+                Assert.assertTrue(StringUtils.equals(requestedClaimString, REQUESTED_OIDC_SCOPES),
+                        "incorrect requested OIDC scopes in query parameter");
             }
 
         } catch (OAuthSystemException e) {

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtilTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtilTest.java
@@ -196,7 +196,7 @@ public class EndpointUtilTest extends PowerMockIdentityBaseTest {
     private static final String USER_INFO_RESPONSE_BUILDER =
             "org.wso2.carbon.identity.oauth.endpoint.user.impl.UserInfoJSONResponseBuilder";
 
-    private static final String REQUESTED_OIDC_SCOPE = "requested_oidc_scope";
+    private static final String REQUESTED_OIDC_SCOPES = "requested_oidc_scope=openid email";
 
     private String username;
     private String password;
@@ -258,7 +258,8 @@ public class EndpointUtilTest extends PowerMockIdentityBaseTest {
         OAuth2Parameters paramsOIDC = new OAuth2Parameters();
         paramsOIDC.setApplicationName("TestApplication");
         paramsOIDC.setClientId("testClientId");
-        paramsOIDC.setScopes(new HashSet<String>(Arrays.asList("openid", "profile", "internal_login")));
+        paramsOIDC.setScopes(
+                new HashSet<String>(Arrays.asList("openid", "profile", "scope1", "scope2", "internal_login")));
 
         return new Object[][]{
                 {params, true, true, false, "QueryString", true},
@@ -353,11 +354,9 @@ public class EndpointUtilTest extends PowerMockIdentityBaseTest {
 
             if (queryString != null && cacheEntryExists) {
                 Assert.assertTrue(consentUrl.contains(queryString), "spQueryParams value is not found in url");
-                Assert.assertTrue(consentUrl.contains(REQUESTED_OIDC_SCOPE),
-                        "requested OIDC scopes query parameter are not found in url");
                 if (parameters.getScopes().contains("openid")) {
                     Assert.assertTrue(
-                            consentUrl.contains(URLEncoder.encode(REQUESTED_OIDC_SCOPE + "=openid profile", "UTF-8")),
+                            consentUrl.contains(URLEncoder.encode(REQUESTED_OIDC_SCOPES, "UTF-8")),
                             "incorrect requested OIDC scopes query parameter");
                 }
             }

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtilTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtilTest.java
@@ -20,6 +20,7 @@ package org.wso2.carbon.identity.oauth.endpoint.util;
 import org.apache.axiom.util.base64.Base64Utils;
 import org.apache.commons.collections.map.HashedMap;
 import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URLEncodedUtils;
@@ -361,8 +362,19 @@ public class EndpointUtilTest extends PowerMockIdentityBaseTest {
             }
 
             if (parameters.getScopes().contains("openid")) {
-                Assert.assertTrue(URLDecoder.decode(consentUrl, "UTF-8").contains(REQUESTED_OIDC_SCOPES),
-                        "incorrect requested OIDC scopes query parameter");
+                String requestedClaimString = URLDecoder.decode(consentUrl, "UTF-8");
+                int checkIndex = requestedClaimString.indexOf(REQUESTED_OIDC_SCOPES);
+                Assert.assertTrue(checkIndex != -1, "requested OIDC scopes query parameter is not found in url");
+                requestedClaimString = requestedClaimString.substring(checkIndex);
+                checkIndex = requestedClaimString.indexOf("&");
+                if (checkIndex == -1) {
+                    Assert.assertTrue(StringUtils.equals(requestedClaimString, REQUESTED_OIDC_SCOPES),
+                            "incorrect requested OIDC scopes in query parameter");
+                } else {
+                    Assert.assertTrue(
+                            StringUtils.equals(requestedClaimString.substring(0, checkIndex), REQUESTED_OIDC_SCOPES),
+                            "incorrect requested OIDC scopes in query parameter");
+                }
             }
 
         } catch (OAuthSystemException e) {

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtilTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtilTest.java
@@ -196,7 +196,7 @@ public class EndpointUtilTest extends PowerMockIdentityBaseTest {
     private static final String USER_INFO_RESPONSE_BUILDER =
             "org.wso2.carbon.identity.oauth.endpoint.user.impl.UserInfoJSONResponseBuilder";
 
-    private static final String REQUESTED_OIDC_SCOPES = "requested_oidc_scope=openid email";
+    private static final String REQUESTED_OIDC_SCOPES = "requested_oidc_scopes=openid profile";
 
     private String username;
     private String password;
@@ -354,11 +354,11 @@ public class EndpointUtilTest extends PowerMockIdentityBaseTest {
 
             if (queryString != null && cacheEntryExists) {
                 Assert.assertTrue(consentUrl.contains(queryString), "spQueryParams value is not found in url");
-                if (parameters.getScopes().contains("openid")) {
-                    Assert.assertTrue(
-                            consentUrl.contains(URLEncoder.encode(REQUESTED_OIDC_SCOPES, "UTF-8")),
-                            "incorrect requested OIDC scopes query parameter");
-                }
+            }
+
+            if (parameters.getScopes().contains("openid")) {
+                Assert.assertTrue(consentUrl.contains(URLEncoder.encode(REQUESTED_OIDC_SCOPES, "UTF-8")),
+                        "incorrect requested OIDC scopes query parameter");
             }
 
         } catch (OAuthSystemException e) {

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtilTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtilTest.java
@@ -196,6 +196,8 @@ public class EndpointUtilTest extends PowerMockIdentityBaseTest {
     private static final String USER_INFO_RESPONSE_BUILDER =
             "org.wso2.carbon.identity.oauth.endpoint.user.impl.UserInfoJSONResponseBuilder";
 
+    private static final String REQUESTED_OIDC_SCOPE = "requested_oidc_scope";
+
     private String username;
     private String password;
     private String sessionDataKey;
@@ -253,6 +255,11 @@ public class EndpointUtilTest extends PowerMockIdentityBaseTest {
         params.setClientId("testClientId");
         params.setScopes(new HashSet<String>(Arrays.asList("scope1", "scope2", "internal_login")));
 
+        OAuth2Parameters paramsOIDC = new OAuth2Parameters();
+        paramsOIDC.setApplicationName("TestApplication");
+        paramsOIDC.setClientId("testClientId");
+        paramsOIDC.setScopes(new HashSet<String>(Arrays.asList("openid", "profile", "internal_login")));
+
         return new Object[][]{
                 {params, true, true, false, "QueryString", true},
                 {null, true, true, false, "QueryString", true},
@@ -261,6 +268,7 @@ public class EndpointUtilTest extends PowerMockIdentityBaseTest {
                 {params, true, false, false, "QueryString", false},
                 {params, true, true, false, null, true},
                 {params, true, true, true, "QueryString", true},
+                {paramsOIDC, true, true, true, "QueryString", true},
         };
     }
 
@@ -342,8 +350,16 @@ public class EndpointUtilTest extends PowerMockIdentityBaseTest {
                     "is not found in url");
             Assert.assertTrue(ArrayUtils.contains(scopeArray, "internal_login"), "internal_login " +
                     "scope parameter value is not found in url");
+
             if (queryString != null && cacheEntryExists) {
                 Assert.assertTrue(consentUrl.contains(queryString), "spQueryParams value is not found in url");
+                Assert.assertTrue(consentUrl.contains(REQUESTED_OIDC_SCOPE),
+                        "requested OIDC scopes query parameter are not found in url");
+                if (parameters.getScopes().contains("openid")) {
+                    Assert.assertTrue(
+                            consentUrl.contains(URLEncoder.encode(REQUESTED_OIDC_SCOPE + "=openid profile", "UTF-8")),
+                            "incorrect requested OIDC scopes query parameter");
+                }
             }
 
         } catch (OAuthSystemException e) {

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtilTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtilTest.java
@@ -364,7 +364,6 @@ public class EndpointUtilTest extends PowerMockIdentityBaseTest {
             if (parameters.getScopes().contains("openid")) {
                 String requestedClaimString = URLDecoder.decode(consentUrl, "UTF-8");
                 int checkIndex = requestedClaimString.indexOf(REQUESTED_OIDC_SCOPES);
-                Assert.assertTrue(checkIndex != -1, "requested OIDC scopes query parameter is not found in url");
                 requestedClaimString = requestedClaimString.substring(checkIndex);
                 checkIndex = requestedClaimString.indexOf("&");
                 if (checkIndex == -1) {

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtilTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtilTest.java
@@ -358,7 +358,8 @@ public class EndpointUtilTest extends PowerMockIdentityBaseTest {
 
             if (parameters.getScopes().contains("openid")) {
                 Assert.assertTrue(consentUrl.contains(URLEncoder.encode(REQUESTED_OIDC_SCOPES, "UTF-8")),
-                        "incorrect requested OIDC scopes query parameter");
+                        "incorrect requested OIDC scopes query parameter " + consentUrl +
+                                " " + URLEncoder.encode(REQUESTED_OIDC_SCOPES, "UTF-8"));
             }
 
         } catch (OAuthSystemException e) {

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtilTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtilTest.java
@@ -372,7 +372,7 @@ public class EndpointUtilTest extends PowerMockIdentityBaseTest {
                     requestedClaimString = requestedClaimString.substring(0, checkIndex);
                 }
                 Assert.assertTrue(StringUtils.equals(requestedClaimString, REQUESTED_OIDC_SCOPES),
-                        "incorrect requested OIDC scopes in query parameter");
+                        "Incorrect requested OIDC scopes in query parameter.");
             }
 
         } catch (OAuthSystemException e) {

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtilTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtilTest.java
@@ -364,7 +364,7 @@ public class EndpointUtilTest extends PowerMockIdentityBaseTest {
             if (parameters.getScopes().contains("openid")) {
                 String requestedClaimString = URLDecoder.decode(consentUrl, "UTF-8");
                 int checkIndex = requestedClaimString.indexOf(REQUESTED_OIDC_SCOPES);
-                Assert.assertTrue(checkIndex != -1, "requested OIDC scopes query parameter is not found in url");
+                Assert.assertTrue(checkIndex != -1, "Requested OIDC scopes query parameter is not found in url.");
 
                 requestedClaimString = requestedClaimString.substring(checkIndex);
                 checkIndex = requestedClaimString.indexOf("&");

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtilTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtilTest.java
@@ -198,7 +198,8 @@ public class EndpointUtilTest extends PowerMockIdentityBaseTest {
     private static final String USER_INFO_RESPONSE_BUILDER =
             "org.wso2.carbon.identity.oauth.endpoint.user.impl.UserInfoJSONResponseBuilder";
 
-    private static final String REQUESTED_OIDC_SCOPES = "requested_oidc_scopes=openid+profile";
+    private static final String REQUESTED_OIDC_SCOPES_KEY = "requested_oidc_scopes=";
+    private static final String REQUESTED_OIDC_SCOPES_VALUES = "openid+profile";
 
     private String username;
     private String password;
@@ -362,16 +363,17 @@ public class EndpointUtilTest extends PowerMockIdentityBaseTest {
             }
 
             if (parameters.getScopes().contains("openid")) {
-                String requestedClaimString = URLDecoder.decode(consentUrl, "UTF-8");
-                int checkIndex = requestedClaimString.indexOf(REQUESTED_OIDC_SCOPES);
+                String decodedConsentUrl = URLDecoder.decode(consentUrl, "UTF-8");
+                int checkIndex = decodedConsentUrl.indexOf(REQUESTED_OIDC_SCOPES_KEY);
                 Assert.assertTrue(checkIndex != -1, "Requested OIDC scopes query parameter is not found in url.");
 
-                requestedClaimString = requestedClaimString.substring(checkIndex);
+                String requestedClaimString = decodedConsentUrl.substring(checkIndex);
                 checkIndex = requestedClaimString.indexOf("&");
                 if (checkIndex != -1) {
                     requestedClaimString = requestedClaimString.substring(0, checkIndex);
                 }
-                Assert.assertTrue(StringUtils.equals(requestedClaimString, REQUESTED_OIDC_SCOPES),
+                Assert.assertTrue(StringUtils.equals(
+                        requestedClaimString, REQUESTED_OIDC_SCOPES_KEY + REQUESTED_OIDC_SCOPES_VALUES),
                         "Incorrect requested OIDC scopes in query parameter.");
             }
 


### PR DESCRIPTION
### Proposed changes in this pull request
Restore the previous behaviour of consent page url creation where we sent both OAuth and OIDC scopes in the consent page url under the query parameter named "scope".

### Related Issues
- https://github.com/wso2/product-is/issues/15200
