### PR TITLE
Fixed the DEBUG logs which showed a misleading error

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.ui/src/main/resources/web/oauth/add-finish-ajaxprocessor.jsp
+++ b/components/org.wso2.carbon.identity.oauth.ui/src/main/resources/web/oauth/add-finish-ajaxprocessor.jsp
@@ -108,7 +108,7 @@
     OAuthConsumerAppDTO consumerApp = null;
     
     try {
-        if (OAuthUIUtil.isValidURI(callback) || callback.startsWith(OAuthConstants.CALLBACK_URL_REGEXP_PREFIX)) {
+        if (callback.startsWith(OAuthConstants.CALLBACK_URL_REGEXP_PREFIX) || OAuthUIUtil.isValidURI(callback)) {
             String cookie = (String) session.getAttribute(ServerConstants.ADMIN_SERVICE_COOKIE);
             String backendServerURL = CarbonUIUtil.getServerURL(config.getServletContext(), session);
             ConfigurationContext configContext =

--- a/components/org.wso2.carbon.identity.oauth.ui/src/main/resources/web/oauth/edit-finish-ajaxprocessor.jsp
+++ b/components/org.wso2.carbon.identity.oauth.ui/src/main/resources/web/oauth/edit-finish-ajaxprocessor.jsp
@@ -110,7 +110,7 @@
     boolean isError = false;
     
     try {
-        if (OAuthUIUtil.isValidURI(callback) || callback.startsWith(OAuthConstants.CALLBACK_URL_REGEXP_PREFIX)) {
+        if (callback.startsWith(OAuthConstants.CALLBACK_URL_REGEXP_PREFIX) || OAuthUIUtil.isValidURI(callback)) {
             String cookie = (String) session.getAttribute(ServerConstants.ADMIN_SERVICE_COOKIE);
             String backendServerURL = CarbonUIUtil.getServerURL(config.getServletContext(), session);
             ConfigurationContext configContext =


### PR DESCRIPTION
Issue :  DEBUG logs showing a misleading error when clicking the update button after giving a regex callback URL for a service provider in the OAuth configuration but the flow works as expected.

Ref to the issue : https://github.com/wso2/product-is/issues/13937

Solution : The conditions in the if statement were interchanged in both add-finish-ajaxprocessor.jsp and edit-finish-ajaxprocessor.jsp files.