### PR TITLE
[6.9.x] Bump nimbus to 7.9.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -882,8 +882,8 @@
         <waffle-jna.wso2.version>1.6.wso2v6</waffle-jna.wso2.version>
         <waffle-jna.imp.pkg.version.range>[1.6.0, 2.0)</waffle-jna.imp.pkg.version.range>
 
-        <nimbusds.version>7.3.0.wso2v1</nimbusds.version>
-        <nimbusds.osgi.version.range>[7.3.0,8.0.0)</nimbusds.osgi.version.range>
+        <nimbusds.version>7.9.0.wso2v1</nimbusds.version>
+        <nimbusds.osgi.version.range>[7.9.0,8.0.0)</nimbusds.osgi.version.range>
 
         <thetransactioncompany.cors-filter.wso2.version>1.7.0.wso2v1</thetransactioncompany.cors-filter.wso2.version>
         <thetransactioncompany.utils.wso2.version>1.9.0.wso2v1</thetransactioncompany.utils.wso2.version>


### PR DESCRIPTION
### Proposed changes in this pull request

This PR updates the nimbus version to 7.9.0

Related issue: https://github.com/wso2/api-manager/issues/1234