### PR TITLE
Fix the OIDC scopes missing issue in the consent page url

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
@@ -136,6 +136,7 @@ public class EndpointUtil {
     private static final String PROP_GRANT_TYPE = "response_type";
     private static final String PROP_RESPONSE_TYPE = "response_type";
     private static final String PROP_SCOPE = "scope";
+    private static final String PROP_OIDC_SCOPE = "requested_oidc_scopes";
     private static final String PROP_ERROR = "error";
     private static final String PROP_ERROR_DESCRIPTION = "error_description";
     private static final String PROP_REDIRECT_URI = "redirect_uri";
@@ -730,7 +731,7 @@ public class EndpointUtil {
 
         String queryString = "";
         if (log.isDebugEnabled()) {
-            log.debug("Received Session Data Key is :  " + sessionDataKey);
+            log.debug("Received Session Data Key is: " + sessionDataKey);
             if (params == null) {
                 log.debug("Received OAuth2 params are Null for UserConsentURL");
             }
@@ -749,13 +750,20 @@ public class EndpointUtil {
         try {
             if (entry != null && entry.getQueryString() != null) {
 
-                if (entry.getQueryString().contains(REQUEST_URI) && params != null) {
+                queryString = entry.getQueryString();
+                if (queryString.contains(REQUEST_URI) && params != null) {
                     // When request_uri requests come without redirect_uri, we need to append it to the SPQueryParams
                     // to be used in storing consent data
-                    entry.setQueryString(entry.getQueryString() +
-                            "&" + PROP_REDIRECT_URI + "=" + URLEncoder.encode(params.getRedirectURI(), UTF_8));
+                    queryString = queryString +
+                            "&" + PROP_REDIRECT_URI + "=" + URLEncoder.encode(params.getRedirectURI(), UTF_8);
                 }
-                queryString = URLEncoder.encode(entry.getQueryString(), UTF_8);
+
+                if (params != null) {
+                    queryString = queryString + "&" + PROP_OIDC_SCOPE +
+                            "=" + URLEncoder.encode(StringUtils.join(getRequestedOIDCScopes(params), " "), UTF_8);
+                }
+                entry.setQueryString(queryString);
+                queryString = URLEncoder.encode(queryString, UTF_8);
             }
 
             if (isOIDC) {
@@ -786,8 +794,7 @@ public class EndpointUtil {
 
                 consentPage = consentPage + "&" + OAuthConstants.OAuth20Params.SCOPE + "=" + URLEncoder.encode
                         (consentRequiredScopes, UTF_8) + "&" + OAuthConstants.SESSION_DATA_KEY_CONSENT
-                        + "=" + URLEncoder.encode(sessionDataKeyConsent, UTF_8) + "&" +
-                        "&spQueryParams=" + queryString;
+                        + "=" + URLEncoder.encode(sessionDataKeyConsent, UTF_8) + "&" + "&spQueryParams=" + queryString;
 
                 if (entry != null) {
 
@@ -922,23 +929,49 @@ public class EndpointUtil {
     }
 
     /**
-     * Drop OIDC and unregistered scopes from consent required scopes.
+     * Return a list of consent requested OIDC scopes
      *
      * @param params OAuth2 parameters.
-     * @return consent required scopes
+     * @return consent requested OIDC scopes in lower case
      * @throws OAuthSystemException If retrieving OIDC scopes failed.
      */
-    private static List<String> dropOIDCAndUnregisteredScopesFromConsentRequiredScopes(OAuth2Parameters params)
+    private static List<String> getRequestedOIDCScopes(OAuth2Parameters params)
             throws OAuthSystemException {
 
         Set<String> allowedScopes = params.getScopes();
-        List<String> allowedOAuthScopes = new ArrayList<>();
+        List<String> requestedOIDCScopes = new ArrayList<>();
+        try {
+            // Get registered OIDC scopes.
+            List<String> oidcScopeList = oAuthAdminService.getRegisteredOIDCScope(params.getTenantDomain());
+            for (String scope : allowedScopes) {
+                if (oidcScopeList.contains(scope)) {
+                    requestedOIDCScopes.add(scope.toLowerCase());
+                }
+            }
+        } catch (IdentityOAuthAdminException e) {
+            throw new OAuthSystemException("Error while retrieving OIDC scopes.", e);
+        }
+        return requestedOIDCScopes;
+    }
+
+    /**
+     * Drop unregistered scopes from consent required scopes.
+     *
+     * @param params OAuth2 parameters.
+     * @return consent required scopes
+     * @throws OAuthSystemException If dropping unregistered scopes failed.
+     */
+    private static List<String> dropUnregisteredScopesFromConsentRequiredScopes(OAuth2Parameters params)
+            throws OAuthSystemException {
+
+        Set<String> allowedScopes = params.getScopes();
+        List<String> allowedRegisteredScopes = new ArrayList<>();
         if (CollectionUtils.isNotEmpty(allowedScopes)) {
             try {
                 startTenantFlow(params.getTenantDomain());
                 /* If DropUnregisteredScopes scopes config is enabled
                  then any unregistered scopes(excluding internal scopes
-                 and allowed scopes) is be dropped. Therefore they will
+                 and allowed scopes) will be dropped. Therefore, they will
                  not be shown in the user consent screen.*/
                 if (oauthServerConfiguration.isDropUnregisteredScopes()) {
                     if (log.isDebugEnabled()) {
@@ -946,34 +979,28 @@ public class EndpointUtil {
                     }
                     allowedScopes = dropUnregisteredScopes(params);
                 }
-                // Get registered OIDC scopes.
-                String[] oidcScopes = oAuthAdminService.getScopeNames();
-                List<String> oidcScopeList = new ArrayList<>(Arrays.asList(oidcScopes));
                 for (String scope : allowedScopes) {
-                    if (!oidcScopeList.contains(scope)) {
-                        allowedOAuthScopes.add(scope);
-                    }
+                    allowedRegisteredScopes.add(scope);
                 }
-            } catch (IdentityOAuthAdminException e) {
-                throw new OAuthSystemException("Error while retrieving OIDC scopes.", e);
+            } catch (OAuthSystemException e) {
+                throw new OAuthSystemException("Error while dropping unregistered scopes.", e);
             } finally {
                 PrivilegedCarbonContext.endTenantFlow();
             }
         }
         if (log.isDebugEnabled()) {
-            log.debug("Allowed OAuth scopes : " + allowedOAuthScopes.stream()
+            log.debug("Allowed registered scopes : " + allowedRegisteredScopes.stream()
                     .collect(Collectors.joining(" ")) + " for client : " + params.getClientId());
         }
-        return allowedOAuthScopes;
+        return allowedRegisteredScopes;
     }
 
     private static void setConsentRequiredScopesToOAuthParams(AuthenticatedUser user, OAuth2Parameters params)
             throws OAuthSystemException {
 
         try {
-            //Filter out OIDC scopes and unregistered scopes to prevent those scopes prompt for consent in the consent
-            // page.
-            List<String> consentRequiredScopes = dropOIDCAndUnregisteredScopesFromConsentRequiredScopes(params);
+            //Filter out unregistered scopes to prevent those scopes prompt for consent in the consent page.
+            List<String> consentRequiredScopes = dropUnregisteredScopesFromConsentRequiredScopes(params);
 
             if (user != null && !isPromptContainsConsent(params)) {
                 String userId = getUserIdOfAuthenticatedUser(user);
@@ -1060,8 +1087,8 @@ public class EndpointUtil {
         if (log.isDebugEnabled()) {
             log.debug(String.format("Dropping unregistered scopes(excluding internal and allowed scopes). " +
                             "Requested scopes: %s | Filtered result: %s",
-                            requestedScopes,
-                            StringUtils.join(filteredScopes, " ")));
+                    requestedScopes,
+                    StringUtils.join(filteredScopes, " ")));
         }
 
         return filteredScopes;

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtilTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtilTest.java
@@ -797,8 +797,8 @@ public class EndpointUtilTest extends PowerMockIdentityBaseTest {
                 thenReturn(USER_INFO_CLAIM_DIALECT);
     }
 
-    private List<Scope> getScopeList() {
-        List<Scope> scopeList = new ArrayList<>();
+    private Set<Scope> getScopeList() {
+        Set<Scope> scopeList = new HashSet<>();
         // Add some sample scopes.
         scopeList.add(new Scope("internal_login", "Login", "description1"));
         scopeList.add(new Scope("internal_config_mgt_update", "Update Configs", "description2"));

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtilTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtilTest.java
@@ -20,6 +20,7 @@ package org.wso2.carbon.identity.oauth.endpoint.util;
 import org.apache.axiom.util.base64.Base64Utils;
 import org.apache.commons.collections.map.HashedMap;
 import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URLEncodedUtils;
@@ -78,6 +79,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -196,6 +198,9 @@ public class EndpointUtilTest extends PowerMockIdentityBaseTest {
     private static final String USER_INFO_RESPONSE_BUILDER =
             "org.wso2.carbon.identity.oauth.endpoint.user.impl.UserInfoJSONResponseBuilder";
 
+    private static final String REQUESTED_OIDC_SCOPES_KEY = "requested_oidc_scopes=";
+    private static final String REQUESTED_OIDC_SCOPES_VALUES = "openid+profile";
+
     private String username;
     private String password;
     private String sessionDataKey;
@@ -251,7 +256,15 @@ public class EndpointUtilTest extends PowerMockIdentityBaseTest {
         OAuth2Parameters params = new OAuth2Parameters();
         params.setApplicationName("TestApplication");
         params.setClientId("testClientId");
+        params.setTenantDomain("testTenantDomain");
         params.setScopes(new HashSet<String>(Arrays.asList("scope1", "scope2", "internal_login")));
+
+        OAuth2Parameters paramsOIDC = new OAuth2Parameters();
+        paramsOIDC.setApplicationName("TestApplication");
+        paramsOIDC.setClientId("testClientId");
+        paramsOIDC.setTenantDomain("testTenantDomain");
+        paramsOIDC.setScopes(
+                new HashSet<String>(Arrays.asList("openid", "profile", "scope1", "scope2", "internal_login")));
 
         return new Object[][]{
                 {params, true, true, false, "QueryString", true},
@@ -261,6 +274,7 @@ public class EndpointUtilTest extends PowerMockIdentityBaseTest {
                 {params, true, false, false, "QueryString", false},
                 {params, true, true, false, null, true},
                 {params, true, true, true, "QueryString", true},
+                {paramsOIDC, true, true, true, "QueryString", true},
         };
     }
 
@@ -307,7 +321,8 @@ public class EndpointUtilTest extends PowerMockIdentityBaseTest {
         }
 
         EndpointUtil.setOAuthAdminService(mockedOAuthAdminService);
-        when(mockedOAuthAdminService.getScopeNames()).thenReturn(new String[0]);
+        when(mockedOAuthAdminService.getRegisteredOIDCScope(anyString()))
+                .thenReturn(Arrays.asList("openid", "email", "profile", "groups"));
         JDBCPermissionBasedInternalScopeValidator scopeValidatorSpy = PowerMockito.spy(
                 new JDBCPermissionBasedInternalScopeValidator());
         doNothing().when(scopeValidatorSpy, method(JDBCPermissionBasedInternalScopeValidator.class,
@@ -342,8 +357,24 @@ public class EndpointUtilTest extends PowerMockIdentityBaseTest {
                     "is not found in url");
             Assert.assertTrue(ArrayUtils.contains(scopeArray, "internal_login"), "internal_login " +
                     "scope parameter value is not found in url");
+
             if (queryString != null && cacheEntryExists) {
                 Assert.assertTrue(consentUrl.contains(queryString), "spQueryParams value is not found in url");
+            }
+
+            if (parameters.getScopes().contains("openid")) {
+                String decodedConsentUrl = URLDecoder.decode(consentUrl, "UTF-8");
+                int checkIndex = decodedConsentUrl.indexOf(REQUESTED_OIDC_SCOPES_KEY);
+                Assert.assertTrue(checkIndex != -1, "Requested OIDC scopes query parameter is not found in url.");
+
+                String requestedClaimString = decodedConsentUrl.substring(checkIndex);
+                checkIndex = requestedClaimString.indexOf("&");
+                if (checkIndex != -1) {
+                    requestedClaimString = requestedClaimString.substring(0, checkIndex);
+                }
+                Assert.assertTrue(StringUtils.equals(
+                                requestedClaimString, REQUESTED_OIDC_SCOPES_KEY + REQUESTED_OIDC_SCOPES_VALUES),
+                        "Incorrect requested OIDC scopes in query parameter.");
             }
 
         } catch (OAuthSystemException e) {
@@ -766,8 +797,8 @@ public class EndpointUtilTest extends PowerMockIdentityBaseTest {
                 thenReturn(USER_INFO_CLAIM_DIALECT);
     }
 
-    private Set<Scope> getScopeList() {
-        Set<Scope> scopeList = new HashSet<>();
+    private List<Scope> getScopeList() {
+        List<Scope> scopeList = new ArrayList<>();
         // Add some sample scopes.
         scopeList.add(new Scope("internal_login", "Login", "description1"));
         scopeList.add(new Scope("internal_config_mgt_update", "Update Configs", "description2"));


### PR DESCRIPTION
### Proposed changes in this pull request
Restore the previous behaviour of consent page url creation where we sent both OAuth and OIDC scopes in the consent page url under the query parameter named "scope".

### Related Issues
- https://github.com/wso2/product-is/issues/15200

### Related PR
This modification is approved in the following PR and got merged. Then revered back as it was suspected for an integration test failure. But run the integration tests locally and these modification doesn't cause any integration test failure.
- https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/1981