### PR TITLE
Upgrade swagger jaxrs version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -941,7 +941,7 @@
         <jackson-databind.version>2.13.2.1</jackson-databind.version>
         <com.fasterxml.jackson.version>2.13.2</com.fasterxml.jackson.version>
         <spring-web.version>4.3.29.RELEASE</spring-web.version>
-        <swagger-jaxrs.version>1.6.2</swagger-jaxrs.version>
+        <swagger-jaxrs.version>1.6.9</swagger-jaxrs.version>
 
         <!--Test Dependencies-->
         <junit.version>4.13.1</junit.version>


### PR DESCRIPTION
### Purpose
To upgrade the swagger-jaxrs version to fix known vulnerabilities.

Note:
Previously, in [identity-inbound-auth-oauth](https://github.com/wso2-extensions/identity-inbound-auth-oauth/blob/master/pom.xml) master has used `<swagger.jaxrs.version>1.6.2</swagger.jaxrs.version>` which is vulnerable against:

[CVE-2022-42004](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-42004)
[CVE-2022-42003](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-42003)
[CVE-2022-4065](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-4065)
[CVE-2021-42550](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-42550)
[CVE-2021-29425](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-29425)
[CVE-2020-8908](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-8908)
[CVE-2020-36518](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-36518)