### PR TITLE
Filter query params from consent page redirect url

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
@@ -3117,13 +3117,13 @@ public class OAuth2AuthzEndpoint {
             throws OAuthSystemException {
 
         try {
+            IdentityUtil.threadLocalProperties.get().put(OAuthConstants.SESSION_DATA_KEY_CONSENT,
+                    "initialSessionDataKeyConsent");
             String userConsentURL = getUserConsentURL(sessionDataKey, oauth2Params, authenticatedUser, oAuthMessage);
             userConsentURL = FrameworkUtils.appendQueryParamsStringToUrl(userConsentURL, additionalQueryParams);
             return getConsentPageRedirectURLWithFilteredParams(userConsentURL);
         } finally {
-            if (IdentityUtil.threadLocalProperties.get().get(OAuthConstants.SESSION_DATA_KEY_CONSENT) != null) {
-                IdentityUtil.threadLocalProperties.get().remove(OAuthConstants.SESSION_DATA_KEY_CONSENT);
-            }
+            IdentityUtil.threadLocalProperties.get().remove(OAuthConstants.SESSION_DATA_KEY_CONSENT);
         }
     }
 

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
@@ -3107,7 +3107,6 @@ public class OAuth2AuthzEndpoint {
                                      String additionalQueryParams, OAuthMessage oAuthMessage)
             throws OAuthSystemException {
 
-
         String loggedInUser = authenticatedUser.getAuthenticatedSubjectIdentifier();
         return EndpointUtil.getUserConsentURL(oauth2Params, loggedInUser, sessionDataKey,
                 OAuth2Util.isOIDCAuthzRequest(oauth2Params.getScopes()), oAuthMessage, additionalQueryParams);

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
@@ -40,6 +40,7 @@ import org.owasp.encoder.Encode;
 import org.wso2.carbon.identity.application.authentication.framework.AuthenticatorFlowStatus;
 import org.wso2.carbon.identity.application.authentication.framework.CommonAuthenticationHandler;
 import org.wso2.carbon.identity.application.authentication.framework.cache.AuthenticationResultCacheEntry;
+import org.wso2.carbon.identity.application.authentication.framework.config.builder.FileBasedConfigurationBuilder;
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthHistory;
 import org.wso2.carbon.identity.application.authentication.framework.context.SessionContext;
 import org.wso2.carbon.identity.application.authentication.framework.exception.UserIdNotFoundException;
@@ -3129,19 +3130,23 @@ public class OAuth2AuthzEndpoint {
 
     private String getConsentPageRedirectURLWithFilteredParams(String redirectURL) {
 
-        String consentPage = null;
+        String consentPage = redirectURL;
         String sessionDataKeyConsent = (String) IdentityUtil.threadLocalProperties.get().
                 get(OAuthConstants.SESSION_DATA_KEY_CONSENT);
 
         SessionDataCacheEntry entry = SessionDataCache.getInstance().getValueFromCache((
                 new SessionDataCacheKey(sessionDataKeyConsent)));
 
-        if (!EndpointUtil.isConsentPageRedirectParamsAllowed()) {
-            consentPage = FrameworkUtils.getConsentPageRedirectURLWithFilteredParams(redirectURL,
+        if (isFilterAllRedirectQueryParams()) {
+            consentPage = EndpointUtil.getConsentPageRedirectURLWithFilteredParams(redirectURL,
                     entry.getEndpointParams());
         }
 
         return consentPage;
+    }
+
+    private boolean isFilterAllRedirectQueryParams() {
+        return !FileBasedConfigurationBuilder.getInstance().isAuthEndpointRedirectParamsConfigAvailable();
     }
 
     /**

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
@@ -3108,8 +3108,8 @@ public class OAuth2AuthzEndpoint {
             throws OAuthSystemException {
 
         String loggedInUser = authenticatedUser.getAuthenticatedSubjectIdentifier();
-        return EndpointUtil.getUserConsentURL(oauth2Params, loggedInUser, sessionDataKey,
-                OAuth2Util.isOIDCAuthzRequest(oauth2Params.getScopes()), oAuthMessage, additionalQueryParams);
+        return EndpointUtil.getUserConsentURL(oauth2Params, loggedInUser, sessionDataKey, oAuthMessage,
+                additionalQueryParams);
 
     }
 

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
@@ -297,9 +297,6 @@ public class OAuth2AuthzEndpoint {
             if (!IdentityTenantUtil.isTenantedSessionsEnabled()) {
                 FrameworkUtils.endTenantFlow();
             }
-            if (IdentityUtil.threadLocalProperties.get().get(OAuthConstants.SESSION_DATA_KEY_CONSENT) != null) {
-                IdentityUtil.threadLocalProperties.get().remove(OAuthConstants.SESSION_DATA_KEY_CONSENT);
-            }
         }
     }
 
@@ -3119,9 +3116,15 @@ public class OAuth2AuthzEndpoint {
                                      String additionalQueryParams, OAuthMessage oAuthMessage)
             throws OAuthSystemException {
 
-        String userConsentURL = getUserConsentURL(sessionDataKey, oauth2Params, authenticatedUser, oAuthMessage);
-        userConsentURL = FrameworkUtils.appendQueryParamsStringToUrl(userConsentURL, additionalQueryParams);
-        return getConsentPageRedirectURLWithFilteredParams(userConsentURL);
+        try {
+            String userConsentURL = getUserConsentURL(sessionDataKey, oauth2Params, authenticatedUser, oAuthMessage);
+            userConsentURL = FrameworkUtils.appendQueryParamsStringToUrl(userConsentURL, additionalQueryParams);
+            return getConsentPageRedirectURLWithFilteredParams(userConsentURL);
+        } finally {
+            if (IdentityUtil.threadLocalProperties.get().get(OAuthConstants.SESSION_DATA_KEY_CONSENT) != null) {
+                IdentityUtil.threadLocalProperties.get().remove(OAuthConstants.SESSION_DATA_KEY_CONSENT);
+            }
+        }
     }
 
     private String getConsentPageRedirectURLWithFilteredParams(String redirectURL) {

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
@@ -3137,16 +3137,16 @@ public class OAuth2AuthzEndpoint {
         SessionDataCacheEntry entry = SessionDataCache.getInstance().getValueFromCache((
                 new SessionDataCacheKey(sessionDataKeyConsent)));
 
-        if (entry != null && isFilterAllRedirectQueryParams()) {
-                consentPage = EndpointUtil.getConsentPageRedirectURLWithFilteredParams(redirectURL,
+        if (entry != null && !isAuthEndpointRedirectParamsConfigAvailable()) {
+            consentPage = EndpointUtil.getConsentPageRedirectURLWithFilteredParams(redirectURL,
                         entry.getEndpointParams());
         }
 
         return consentPage;
     }
 
-    private boolean isFilterAllRedirectQueryParams() {
-        return !FileBasedConfigurationBuilder.getInstance().isAuthEndpointRedirectParamsConfigAvailable();
+    private boolean isAuthEndpointRedirectParamsConfigAvailable() {
+        return FileBasedConfigurationBuilder.getInstance().isAuthEndpointRedirectParamsConfigAvailable();
     }
 
     /**

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
@@ -3136,7 +3136,10 @@ public class OAuth2AuthzEndpoint {
         }
 
         if (entry != null) {
-            if (!isAuthEndpointRedirectParamsConfigAvailable()) {
+            if (isAuthEndpointRedirectParamsConfigAvailable()) {
+                consentPage = FrameworkUtils.getRedirectURLWithFilteredParams(consentPage,
+                        entry.getEndpointParams());
+            } else {
                 consentPage = EndpointUtil.getConsentPageRedirectURLWithFilteredParams(redirectURL,
                         entry.getEndpointParams());
             }

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
@@ -3137,9 +3137,9 @@ public class OAuth2AuthzEndpoint {
         SessionDataCacheEntry entry = SessionDataCache.getInstance().getValueFromCache((
                 new SessionDataCacheKey(sessionDataKeyConsent)));
 
-        if (isFilterAllRedirectQueryParams()) {
-            consentPage = EndpointUtil.getConsentPageRedirectURLWithFilteredParams(redirectURL,
-                    entry.getEndpointParams());
+        if (entry != null && isFilterAllRedirectQueryParams()) {
+                consentPage = EndpointUtil.getConsentPageRedirectURLWithFilteredParams(redirectURL,
+                        entry.getEndpointParams());
         }
 
         return consentPage;

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
@@ -158,10 +158,6 @@ public class EndpointUtil {
     private static IdpManager idpManager;
     private static final String ALLOW_ADDITIONAL_PARAMS_FROM_ERROR_URL = "OAuth.AllowAdditionalParamsFromErrorUrl";
     private static final String IDP_ENTITY_ID = "IdPEntityId";
-    private static final String HASH_CHAR = "#";
-    private static final String HASH_CHAR_ENCODED = "%23";
-    private static final String QUESTION_MARK = "?";
-
 
     public static void setIdpManager(IdpManager idpManager) {
 

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
@@ -37,6 +37,7 @@ import org.slf4j.MDC;
 import org.wso2.carbon.base.ServerConfiguration;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.application.authentication.framework.cache.AuthenticationRequestCacheEntry;
+import org.wso2.carbon.identity.application.authentication.framework.config.builder.FileBasedConfigurationBuilder;
 import org.wso2.carbon.identity.application.authentication.framework.exception.UserIdNotFoundException;
 import org.wso2.carbon.identity.application.authentication.framework.handler.request.impl.consent.SSOConsentService;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
@@ -99,6 +100,8 @@ import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -153,6 +156,9 @@ public class EndpointUtil {
     private static IdpManager idpManager;
     private static final String ALLOW_ADDITIONAL_PARAMS_FROM_ERROR_URL = "OAuth.AllowAdditionalParamsFromErrorUrl";
     private static final String IDP_ENTITY_ID = "IdPEntityId";
+    private static final String SPLITTING_CHAR = "&";
+    private static final String PADDING_CHAR = "=";
+
 
     public static void setIdpManager(IdpManager idpManager) {
 
@@ -816,6 +822,35 @@ public class EndpointUtil {
         }
 
         return consentPage;
+    }
+
+    /**
+     * Checks if a configuration is available to allow consent page redirect params.
+     *
+     * @return True if query params are allowed in consent page redirect url.
+     */
+    public static boolean isConsentPageRedirectParamsAllowed() {
+        return FileBasedConfigurationBuilder.getInstance().isConsentPageRedirectParamsAllowed();
+    }
+
+    /**
+     * Get a query parameter value from a URL.
+     *
+     * @param url               URL.
+     * @param queryParameter    Required query parameter name.
+     * @return Query parameter value.
+     * @throws URISyntaxException If url is not in valid syntax.
+     */
+    public static String getQueryParameter(String url, String queryParameter) throws URISyntaxException {
+
+        String queryParams = new URI(url).getQuery();
+        Map<String, String> queryParamMap = new HashMap<>();
+        if (StringUtils.isNotBlank(queryParams)) {
+            queryParamMap = Arrays.stream(queryParams.split(SPLITTING_CHAR))
+                    .map(entry -> entry.split(PADDING_CHAR))
+                    .collect(Collectors.toMap(entry -> entry[0], entry -> entry[1]));
+        }
+        return queryParamMap.get(queryParameter);
     }
 
     /**

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
@@ -100,8 +100,6 @@ import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -808,6 +806,8 @@ public class EndpointUtil {
                             entry.getEndpointParams());
                     entry.setValidityPeriod(TimeUnit.MINUTES.toNanos(IdentityUtil.getTempDataCleanUpTimeout()));
                     sessionDataCache.addToCache(new SessionDataCacheKey(sessionDataKeyConsent), entry);
+                    IdentityUtil.threadLocalProperties.get().put(OAuthConstants.SESSION_DATA_KEY_CONSENT,
+                            sessionDataKeyConsent);
                 } else {
                     if (log.isDebugEnabled()) {
                         log.debug("Cache Entry is Null from SessionDataCache.");
@@ -831,26 +831,6 @@ public class EndpointUtil {
      */
     public static boolean isConsentPageRedirectParamsAllowed() {
         return FileBasedConfigurationBuilder.getInstance().isConsentPageRedirectParamsAllowed();
-    }
-
-    /**
-     * Get a query parameter value from a URL.
-     *
-     * @param url               URL.
-     * @param queryParameter    Required query parameter name.
-     * @return Query parameter value.
-     * @throws URISyntaxException If url is not in valid syntax.
-     */
-    public static String getQueryParameter(String url, String queryParameter) throws URISyntaxException {
-
-        String queryParams = new URI(url).getQuery();
-        Map<String, String> queryParamMap = new HashMap<>();
-        if (StringUtils.isNotBlank(queryParams)) {
-            queryParamMap = Arrays.stream(queryParams.split(SPLITTING_CHAR))
-                    .map(entry -> entry.split(PADDING_CHAR))
-                    .collect(Collectors.toMap(entry -> entry[0], entry -> entry[1]));
-        }
-        return queryParamMap.get(queryParameter);
     }
 
     /**

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
@@ -806,8 +806,11 @@ public class EndpointUtil {
                             entry.getEndpointParams());
                     entry.setValidityPeriod(TimeUnit.MINUTES.toNanos(IdentityUtil.getTempDataCleanUpTimeout()));
                     sessionDataCache.addToCache(new SessionDataCacheKey(sessionDataKeyConsent), entry);
-                    IdentityUtil.threadLocalProperties.get().put(OAuthConstants.SESSION_DATA_KEY_CONSENT,
-                            sessionDataKeyConsent);
+                    if( IdentityUtil.threadLocalProperties.get().
+                            get(OAuthConstants.SESSION_DATA_KEY_CONSENT).equals("initialSessionDataKeyConsent")){
+                        IdentityUtil.threadLocalProperties.get().put(OAuthConstants.SESSION_DATA_KEY_CONSENT,
+                                sessionDataKeyConsent);
+                    }
                 } else {
                     if (log.isDebugEnabled()) {
                         log.debug("Cache Entry is Null from SessionDataCache.");

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
@@ -834,7 +834,8 @@ public class EndpointUtil {
     }
 
     private static String filterQueryParamsFromConsentPageUrl(Map<String, Serializable> endpointParams,
-                                                              String consentPageUrl, String sessionDataKeyConsent) {
+                                                              String consentPageUrl, String sessionDataKeyConsent)
+            throws OAuthSystemException {
 
         if (isAuthEndpointRedirectParamsFilterConfigAvailable()) {
             return FrameworkUtils.getRedirectURLWithFilteredParams(consentPageUrl,
@@ -889,7 +890,7 @@ public class EndpointUtil {
      */
     private static String getRedirectURLWithFilteredParams(String redirectUrl,
                                                           Map<String, Serializable> endpointParams, String
-                                                                   sessionDataKeyConsent) {
+                                                                   sessionDataKeyConsent) throws OAuthSystemException {
 
         URIBuilder uriBuilder;
 
@@ -897,7 +898,7 @@ public class EndpointUtil {
             uriBuilder = new URIBuilder(redirectUrl);
         } catch (URISyntaxException e) {
             log.warn("Unable to filter redirect params for url." + redirectUrl, e);
-            return redirectUrl;
+            throw new OAuthSystemException("Unable to filter redirect params for url: " + redirectUrl, e);
         }
 
         List<NameValuePair> queryParamsList = uriBuilder.getQueryParams();

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
@@ -841,13 +841,12 @@ public class EndpointUtil {
                                                               String consentPageUrl, String sessionDataKeyConsent) {
 
         if (isAuthEndpointRedirectParamsFilterConfigAvailable()) {
-            consentPageUrl = FrameworkUtils.getRedirectURLWithFilteredParams(consentPageUrl,
+            return FrameworkUtils.getRedirectURLWithFilteredParams(consentPageUrl,
                     endpointParams);
         } else {
-            consentPageUrl = EndpointUtil.getRedirectURLWithFilteredParams(consentPageUrl,
+            return EndpointUtil.getRedirectURLWithFilteredParams(consentPageUrl,
                     endpointParams, sessionDataKeyConsent);
         }
-        return consentPageUrl;
     }
 
     private static String getConsentRequiredScopesAsString(Set<String> consentRequiredScopesSet) {
@@ -885,12 +884,12 @@ public class EndpointUtil {
     }
 
     /**
-     * Returns the consent page URL with filtered query params.
+     * Returns the consent page URL after filtering the query params.
      *
      * @param redirectUrl           The redirect URL.
      * @param endpointParams        The map for store filtered params.
      * @param sessionDataKeyConsent The value of sessionDataKeyConsent.
-     * @return redirect URL with filtered query params except the key.
+     * @return redirect URL after filtering the query params except the sessionDataKeyConsent.
      */
     private static String getRedirectURLWithFilteredParams(String redirectUrl,
                                                           Map<String, Serializable> endpointParams, String
@@ -898,19 +897,8 @@ public class EndpointUtil {
 
         URIBuilder uriBuilder;
 
-        // Check if the URL is a fragment URL. Only the path of the URL is considered here.
-        boolean isAFragmentURL =
-                redirectUrl != null && redirectUrl.contains(HASH_CHAR) && redirectUrl.contains(QUESTION_MARK)
-                        && redirectUrl.indexOf(HASH_CHAR) < redirectUrl.indexOf(QUESTION_MARK);
         try {
-            // Encode the hash character if the redirect URL is a fragmented URL.
-            if (isAFragmentURL) {
-                int splitIndex = redirectUrl.indexOf(QUESTION_MARK);
-                uriBuilder = new URIBuilder(redirectUrl.substring(0, splitIndex).replace(HASH_CHAR, HASH_CHAR_ENCODED)
-                        + redirectUrl.substring(splitIndex));
-            } else {
-                uriBuilder = new URIBuilder(redirectUrl);
-            }
+            uriBuilder = new URIBuilder(redirectUrl);
         } catch (URISyntaxException e) {
             log.warn("Unable to filter redirect params for url." + redirectUrl, e);
             return redirectUrl;
@@ -931,16 +919,7 @@ public class EndpointUtil {
             uriBuilder.setParameter(OAuthConstants.SESSION_DATA_KEY_CONSENT, sessionDataKeyConsent);
         }
 
-        String redirectURLWithFilteredParams = uriBuilder.toString();
-
-        // Decode the hash character if the redirect URL is a fragmented URL.
-        if (isAFragmentURL) {
-            int splitIndex = redirectUrl.indexOf(QUESTION_MARK);
-            redirectURLWithFilteredParams =
-                    redirectURLWithFilteredParams.substring(0, splitIndex).replace(HASH_CHAR_ENCODED, HASH_CHAR)
-                            + redirectURLWithFilteredParams.substring(splitIndex);
-        }
-        return redirectURLWithFilteredParams;
+        return uriBuilder.toString();
 
     }
 

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
@@ -810,7 +810,6 @@ public class EndpointUtil {
                             entry.getEndpointParams());
                     entry.setValidityPeriod(TimeUnit.MINUTES.toNanos(IdentityUtil.getTempDataCleanUpTimeout()));
                     sessionDataCache.addToCache(new SessionDataCacheKey(sessionDataKeyConsent), entry);
-                    setSessionDataKeyConsentThreadLocal(sessionDataKeyConsent);
 
                 } else {
                     if (log.isDebugEnabled()) {
@@ -826,20 +825,6 @@ public class EndpointUtil {
         }
 
         return consentPage;
-    }
-
-    /**
-     * Set the sessionDataKeyConsent to thread local.
-     */
-    private static void setSessionDataKeyConsentThreadLocal(String sessionDataKeyConsent) {
-        if (IdentityUtil.threadLocalProperties.get().
-                get(OAuthConstants.SESSION_DATA_KEY_CONSENT) != null && IdentityUtil.threadLocalProperties.get().
-                get(OAuthConstants.SESSION_DATA_KEY_CONSENT).equals("initialSessionDataKeyConsent")) {
-
-            IdentityUtil.threadLocalProperties.get().put(OAuthConstants.SESSION_DATA_KEY_CONSENT,
-                    sessionDataKeyConsent);
-        }
-
     }
     
     public static String getConsentPageRedirectURLWithFilteredParams(String redirectUrl,
@@ -895,6 +880,27 @@ public class EndpointUtil {
         }
         return redirectURLWithFilteredParams;
 
+    }
+
+    /**
+     * Get a query parameter value from a URL.
+     *
+     * @param url               URL.
+     * @param queryParameter    Required query parameter name.
+     * @return Query parameter value.
+     * @throws URISyntaxException If url is not in valid syntax.
+     */
+    public static String getQueryParameter(String url, String queryParameter) throws URISyntaxException {
+
+        URIBuilder uriBuilder = new URIBuilder(url);
+        List<NameValuePair> queryParamsList = uriBuilder.getQueryParams();
+        String sessionDataKeyConsent = queryParamsList.stream()
+                .filter(queryParam -> queryParameter.equals(queryParam.getName()))
+                .map(NameValuePair::getValue)
+                .findFirst()
+                .orElse(null);
+
+        return sessionDataKeyConsent;
     }
 
     /**

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpointTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpointTest.java
@@ -2057,7 +2057,7 @@ public class OAuth2AuthzEndpointTest extends TestOAuthEndpointBase {
 
         doReturn(oAuthServerConfiguration).when(EndpointUtil.class, "getOAuthServerConfiguration");
         doReturn(USER_CONSENT_URL).when(EndpointUtil.class, "getUserConsentURL", any(OAuth2Parameters.class),
-                anyString(), anyString(), anyBoolean(), any(OAuthMessage.class), anyString());;
+                anyString(), anyString(), any(OAuthMessage.class), anyString());;
         doReturn(LOGIN_PAGE_URL).when(EndpointUtil.class, "getLoginPageURL", anyString(), anyString(), anyBoolean(),
                 anyBoolean(), anySet(), anyMap(), any());
         doReturn(requestObjectService).when(EndpointUtil.class, "getRequestObjectService");

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpointTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpointTest.java
@@ -2057,7 +2057,7 @@ public class OAuth2AuthzEndpointTest extends TestOAuthEndpointBase {
 
         doReturn(oAuthServerConfiguration).when(EndpointUtil.class, "getOAuthServerConfiguration");
         doReturn(USER_CONSENT_URL).when(EndpointUtil.class, "getUserConsentURL", any(OAuth2Parameters.class),
-                anyString(), anyBoolean(), any(SessionDataCacheEntry.class), anyString());
+                anyString(), anyString(), anyBoolean(), any(OAuthMessage.class), anyString());;
         doReturn(LOGIN_PAGE_URL).when(EndpointUtil.class, "getLoginPageURL", anyString(), anyString(), anyBoolean(),
                 anyBoolean(), anySet(), anyMap(), any());
         doReturn(requestObjectService).when(EndpointUtil.class, "getRequestObjectService");

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpointTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpointTest.java
@@ -2057,7 +2057,7 @@ public class OAuth2AuthzEndpointTest extends TestOAuthEndpointBase {
 
         doReturn(oAuthServerConfiguration).when(EndpointUtil.class, "getOAuthServerConfiguration");
         doReturn(USER_CONSENT_URL).when(EndpointUtil.class, "getUserConsentURL", any(OAuth2Parameters.class),
-                anyString(), anyString(), anyBoolean(), any(OAuthMessage.class));
+                anyString(), anyBoolean(), any(SessionDataCacheEntry.class), anyString());
         doReturn(LOGIN_PAGE_URL).when(EndpointUtil.class, "getLoginPageURL", anyString(), anyString(), anyBoolean(),
                 anyBoolean(), anySet(), anyMap(), any());
         doReturn(requestObjectService).when(EndpointUtil.class, "getRequestObjectService");

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtilTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtilTest.java
@@ -308,9 +308,13 @@ public class EndpointUtilTest extends PowerMockIdentityBaseTest {
         when(FrameworkUtils.resolveUserIdFromUsername(anyInt(), anyString(), anyString())).thenReturn("sample");
         when(FrameworkUtils.getRedirectURLWithFilteredParams(anyString(), anyMap()))
                 .then(i -> i.getArgument(0));
+        when(FrameworkUtils.appendQueryParamsStringToUrl(anyString(), anyString()))
+                .then(i -> i.getArgument(0));
         mockStatic(OAuth2Util.class);
         spy(EndpointUtil.class);
         doReturn("sampleId").when(EndpointUtil.class, "getAppIdFromClientId", anyString());
+        when(EndpointUtil.getRedirectURLWithFilteredParams(anyString(), anyMap(), anyString()))
+                .then(i -> i.getArgument(0));
         mockStatic(SessionDataCache.class);
         when(SessionDataCache.getInstance()).thenReturn(mockedSessionDataCache);
         if (cacheEntryExists) {
@@ -340,8 +344,7 @@ public class EndpointUtilTest extends PowerMockIdentityBaseTest {
 
         String consentUrl;
         try {
-            consentUrl = EndpointUtil.getUserConsentURL(parameters, username, isOIDC, mockedSessionDataCacheEntry,
-                    sessionDataKeyConsent);
+            consentUrl = EndpointUtil.getUserConsentURL(parameters, username, sessionDataKey, isOIDC);
             if (isOIDC) {
                 Assert.assertTrue(consentUrl.contains(OIDC_CONSENT_PAGE_URL), "Incorrect consent page url for OIDC");
             } else {

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtilTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtilTest.java
@@ -75,6 +75,7 @@ import org.wso2.carbon.identity.testutil.powermock.PowerMockIdentityBaseTest;
 import org.wso2.carbon.identity.webfinger.DefaultWebFingerProcessor;
 import org.wso2.carbon.identity.webfinger.WebFingerProcessor;
 
+import java.io.Serializable;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -381,6 +382,34 @@ public class EndpointUtilTest extends PowerMockIdentityBaseTest {
             Assert.assertTrue(e.getMessage().contains("Error while retrieving the application name"));
         }
 
+    }
+
+    @DataProvider(name = "provideDataForConsentURLFilteredParams")
+    public Object[][] provideURLParamData() {
+
+        String url1 = "https://localhost:9443/authenticationendpoint/oauth2_consent.do?queryString=queryString&" +
+                "sessionDataKeyConsent=1234567890";
+        String url2 = "https://localhost:9443/authenticationendpoint/oauth2_consent.do?queryString=queryString";
+        String url3 = "https://localhost:9443/authenticationendpoint/oauth2_consent.do";
+
+        String sessionDataKeyConsentQueryString = "sessionDataKeyConsent=1234567890";
+
+        String expectedOutput1 = OIDC_CONSENT_PAGE_URL + "?" + sessionDataKeyConsentQueryString;
+        String expectedOutput2 = OIDC_CONSENT_PAGE_URL;
+
+        return new Object[][]{
+                {url1, expectedOutput1},
+                {url2, expectedOutput2},
+                {url3, expectedOutput2}
+        };
+    }
+
+    @Test(dataProvider = "provideDataForConsentURLFilteredParams")
+    public void testGetConsentPageRedirectURLWithFilteredParams(String url, String expectedOutput) {
+
+        Map<String, Serializable> endpointParams = new HashMap<>();
+        String modifiedUrl = EndpointUtil.getConsentPageRedirectURLWithFilteredParams(url, endpointParams);
+        assertEquals(modifiedUrl, expectedOutput);
     }
 
     @DataProvider(name = "provideScopeData")

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtilTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtilTest.java
@@ -269,11 +269,11 @@ public class EndpointUtilTest extends PowerMockIdentityBaseTest {
                 new HashSet<String>(Arrays.asList("openid", "profile", "scope1", "scope2", "internal_login")));
 
         return new Object[][]{
-                {params, true, true, false, "QueryString", true, true},
+                {params, true, true, false, "QueryString", true, false},
                 {null, true, true, false, "QueryString", true, false},
                 {params, false, true, false, "QueryString", true, true},
                 {params, true, false, false, "QueryString", true, false},
-                {params, true, false, false, "QueryString", false, true},
+                {params, true, false, false, "QueryString", false, false},
                 {params, true, true, false, null, true, true},
                 {params, true, true, true, "QueryString", true, false},
                 {paramsOIDC, true, true, true, "QueryString", true, false},
@@ -390,6 +390,9 @@ public class EndpointUtilTest extends PowerMockIdentityBaseTest {
             } else {
                 String queryParamString = consentUrl.substring(consentUrl.indexOf("?") + 1);
                 List<NameValuePair> nameValuePairList = URLEncodedUtils.parse(queryParamString, StandardCharsets.UTF_8);
+                if (cacheEntryExists) {
+                    Assert.assertEquals(nameValuePairList.size(), 1);
+                }
                 Optional<NameValuePair> sessionDataKeyConsent = nameValuePairList.stream().filter(nameValuePair ->
                         nameValuePair.getName().equals("sessionDataKeyConsent")).findAny();
                 Assert.assertTrue(sessionDataKeyConsent.isPresent());

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtilTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtilTest.java
@@ -60,6 +60,7 @@ import org.wso2.carbon.identity.oauth.OAuthAdminServiceImpl;
 import org.wso2.carbon.identity.oauth.cache.SessionDataCache;
 import org.wso2.carbon.identity.oauth.cache.SessionDataCacheEntry;
 import org.wso2.carbon.identity.oauth.cache.SessionDataCacheKey;
+import org.wso2.carbon.identity.oauth.common.OAuthConstants;
 import org.wso2.carbon.identity.oauth.common.exception.OAuthClientException;
 import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
 import org.wso2.carbon.identity.oauth2.OAuth2ScopeService;
@@ -205,6 +206,7 @@ public class EndpointUtilTest extends PowerMockIdentityBaseTest {
     private String username;
     private String password;
     private String sessionDataKey;
+    private String sessionDataKeyConsent;
     private String clientId;
     private AuthenticatedUser user;
     private OAuth2ScopeConsentResponse oAuth2ScopeConsentResponse;
@@ -215,6 +217,7 @@ public class EndpointUtilTest extends PowerMockIdentityBaseTest {
         username = "myUsername";
         password = "myPassword";
         sessionDataKey = "1234567890";
+        sessionDataKeyConsent = "1234567891";
         clientId = "myClientId";
         user = new AuthenticatedUser();
         user.setFederatedUser(false);
@@ -337,7 +340,8 @@ public class EndpointUtilTest extends PowerMockIdentityBaseTest {
 
         String consentUrl;
         try {
-            consentUrl = EndpointUtil.getUserConsentURL(parameters, username, sessionDataKey, isOIDC);
+            consentUrl = EndpointUtil.getUserConsentURL(parameters, username, isOIDC, mockedSessionDataCacheEntry,
+                    sessionDataKeyConsent);
             if (isOIDC) {
                 Assert.assertTrue(consentUrl.contains(OIDC_CONSENT_PAGE_URL), "Incorrect consent page url for OIDC");
             } else {
@@ -408,7 +412,8 @@ public class EndpointUtilTest extends PowerMockIdentityBaseTest {
     public void testGetConsentPageRedirectURLWithFilteredParams(String url, String expectedOutput) {
 
         Map<String, Serializable> endpointParams = new HashMap<>();
-        String modifiedUrl = EndpointUtil.getConsentPageRedirectURLWithFilteredParams(url, endpointParams);
+        String modifiedUrl = EndpointUtil.getRedirectURLWithFilteredParams(url, endpointParams,
+                OAuthConstants.SESSION_DATA_KEY_CONSENT);
         assertEquals(modifiedUrl, expectedOutput);
     }
 

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtilTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtilTest.java
@@ -271,20 +271,21 @@ public class EndpointUtilTest extends PowerMockIdentityBaseTest {
                 new HashSet<String>(Arrays.asList("openid", "profile", "scope1", "scope2", "internal_login")));
 
         return new Object[][]{
-                {params, true, true, false, "QueryString", true},
-                {null, true, true, false, "QueryString", true},
-                {params, false, true, false, "QueryString", true},
-                {params, true, false, false, "QueryString", true},
-                {params, true, false, false, "QueryString", false},
-                {params, true, true, false, null, true},
-                {params, true, true, true, "QueryString", true},
-                {paramsOIDC, true, true, true, "QueryString", true},
+                {params, true, true, false, "QueryString", true, true},
+                {null, true, true, false, "QueryString", true, false},
+                {params, false, true, false, "QueryString", true, true},
+                {params, true, false, false, "QueryString", true, false},
+                {params, true, false, false, "QueryString", false, true},
+                {params, true, true, false, null, true, true},
+                {params, true, true, true, "QueryString", true, false},
+                {paramsOIDC, true, true, true, "QueryString", true, false},
         };
     }
 
     @Test(dataProvider = "provideDataForUserConsentURL")
     public void testGetUserConsentURL(Object oAuth2ParamObject, boolean isOIDC, boolean cacheEntryExists,
-                                      boolean throwError, String queryString, boolean isDebugEnabled) throws Exception {
+                                      boolean throwError, String queryString, boolean isDebugEnabled,
+                                      boolean isConfigAvailable) throws Exception {
 
         setMockedLog(isDebugEnabled);
         OAuth2Parameters parameters = (OAuth2Parameters) oAuth2ParamObject;
@@ -301,6 +302,10 @@ public class EndpointUtilTest extends PowerMockIdentityBaseTest {
         mockStatic(OAuth2Util.OAuthURL.class);
         when(OAuth2Util.OAuthURL.getOIDCConsentPageUrl()).thenReturn(OIDC_CONSENT_PAGE_URL);
         when(OAuth2Util.OAuthURL.getOAuth2ConsentPageUrl()).thenReturn(OAUTH2_CONSENT_PAGE_URL);
+
+        mockStatic(FileBasedConfigurationBuilder.class);
+        when(FileBasedConfigurationBuilder.getInstance()).thenReturn(fileBasedConfigurationBuilder);
+        when(fileBasedConfigurationBuilder.isAuthEndpointRedirectParamsConfigAvailable()).thenReturn(isConfigAvailable);
 
         mockStatic(IdentityTenantUtil.class);
         when(IdentityTenantUtil.getTenantId(anyString())).thenReturn(MultitenantConstants.SUPER_TENANT_ID);


### PR DESCRIPTION
### Proposed changes in this pull request

- **Filter all the redirect params from consent url by default**
- Store the filtered params in a cache to serve for data API
- Only sessionDataKeyConsent is append to the consent page url

- If we are adding this below config, the filtering is done according to the  filebased below config

 ```
 [authentication.endpoint.redirect_params]
  filter_policy = "include"
  remove_on_consume_from_api = "true"
  parameters = ["sessionDataKey"]
```


### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description.
- [ ] **Is the PR labeled correctly?**

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled.

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests.
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/).

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components.
- [ ] **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

#### Security

- [ ] **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
- [ ] **Are all UI and API inputs run through forms or serializers?**
- [ ] **Are all external inputs validated and sanitized appropriately?**
- [ ] **Does all branching logic have a default case?**
- [ ] **Does this solution handle outliers and edge cases gracefully?**
- [ ] **Are all external communications secured and restricted to SSL?**

#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes should be documented.
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented.
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki.
