### PR TITLE
Add public client support to grant type level

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
@@ -172,6 +172,7 @@ public class OAuthServerConfiguration {
     private Map<String, Class<? extends OAuthValidator<HttpServletRequest>>> supportedResponseTypeValidators;
     private Map<String, TokenIssuerDO> supportedTokenIssuers = new HashMap<>();
     private List<String> supportedTokenTypes = new ArrayList<>();
+    private List<String> publicClientSupportedGrantTypes = new ArrayList<>();
     private Map<String, OauthTokenIssuer> oauthTokenIssuerMap = new HashMap<>();
     private String[] supportedClaims = null;
     private boolean isFapiCiba = false;
@@ -375,6 +376,9 @@ public class OAuthServerConfiguration {
 
         // read supported grant types
         parseSupportedGrantTypesConfig(oauthElem);
+
+        // Read public client supported grant type names in <PublicClientSupportedGrantTypes>.
+        parsePublicClientSupportedGrantTypesConfig(oauthElem);
 
         // Read <UserConsentEnabledGrantTypes> under <OAuth> tag and populate data.
         parseUserConsentEnabledGrantTypesConfig(oauthElem);
@@ -1192,6 +1196,11 @@ public class OAuthServerConfiguration {
 
     public Set<String> getIdTokenNotAllowedGrantTypesSet() {
         return idTokenNotAllowedGrantTypesSet;
+    }
+
+    public List<String> getPublicClientSupportedGrantTypesList() {
+
+        return publicClientSupportedGrantTypes;
     }
 
     public boolean isRedirectToRequestedRedirectUriEnabled() {
@@ -2267,6 +2276,22 @@ public class OAuthServerConfiguration {
                 String grantTypeName = entry.getKey().toString();
                 String authzGrantHandlerImplClass = entry.getValue().toString();
                 log.debug(grantTypeName + "supported by" + authzGrantHandlerImplClass);
+            }
+        }
+    }
+
+    private void parsePublicClientSupportedGrantTypesConfig(OMElement oauthConfigElem) {
+
+        OMElement publicClientGrantTypesElem = oauthConfigElem.getFirstChildWithName(getQNameWithIdentityNS(
+                ConfigElements.PUBLIC_CLIENT_SUPPORTED_GRANT_TYPES));
+        if (publicClientGrantTypesElem != null) {
+            Iterator iterator = publicClientGrantTypesElem
+                    .getChildrenWithName(getQNameWithIdentityNS(ConfigElements.PUBLIC_CLIENT_ENABLED_GRANT_TYPE_NAME));
+            while (iterator.hasNext()) {
+                OMElement publicClientSupportedGrantName = (OMElement) iterator.next();
+                if (publicClientSupportedGrantName != null) {
+                    publicClientSupportedGrantTypes.add(publicClientSupportedGrantName.getText());
+                }
             }
         }
     }
@@ -3395,6 +3420,10 @@ public class OAuthServerConfiguration {
         private static final String SUPPORTED_GRANT_TYPES = "SupportedGrantTypes";
         private static final String SUPPORTED_GRANT_TYPE = "SupportedGrantType";
         private static final String GRANT_TYPE_NAME = "GrantTypeName";
+
+        // Public client supported Grant Types
+        private static final String PUBLIC_CLIENT_SUPPORTED_GRANT_TYPES = "PublicClientSupportedGrantTypes";
+        private static final String PUBLIC_CLIENT_ENABLED_GRANT_TYPE_NAME = "GrantTypeName";
 
         //Supported Token Types
         private static final String SUPPORTED_TOKEN_TYPES = "SupportedTokenTypes";


### PR DESCRIPTION
### Purpose
Improve the public client authenticator to authenticate configured grant types only.

### Related PRs
* https://github.com/wso2/carbon-identity-framework/pull/4467

### Related Issues
* https://github.com/wso2-enterprise/wso2-iam-internal/issues/343