### PR TITLE
Fix: Getting HTTP - 500 Internal Server Error when invalid Basic is passed

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/token/OAuth2TokenEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/token/OAuth2TokenEndpoint.java
@@ -199,6 +199,11 @@ public class OAuth2TokenEndpoint {
     private void validateOAuthApplication(OAuthClientAuthnContext oAuthClientAuthnContext)
             throws InvalidApplicationClientException {
 
+        if (!oAuthClientAuthnContext.isAuthenticated()) {
+            throw new InvalidApplicationClientException(oAuthClientAuthnContext.getErrorMessage(),
+                    oAuthClientAuthnContext.getErrorCode());
+        }
+
         if (isNotBlank(oAuthClientAuthnContext.getClientId()) && !oAuthClientAuthnContext
                 .isMultipleAuthenticatorsEngaged()) {
             validateOauthApplication(oAuthClientAuthnContext.getClientId());

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/token/OAuth2TokenEndpointTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/token/OAuth2TokenEndpointTest.java
@@ -52,6 +52,7 @@ import org.wso2.carbon.identity.oauth.endpoint.util.TestOAuthEndpointBase;
 import org.wso2.carbon.identity.oauth.tokenprocessor.TokenPersistenceProcessor;
 import org.wso2.carbon.identity.oauth2.OAuth2Service;
 import org.wso2.carbon.identity.oauth2.ResponseHeader;
+import org.wso2.carbon.identity.oauth2.bean.OAuthClientAuthnContext;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2AccessTokenReqDTO;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2AccessTokenRespDTO;
 import org.wso2.carbon.identity.oauth2.model.CarbonOAuthTokenRequest;
@@ -86,7 +87,7 @@ import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
 @PrepareForTest({EndpointUtil.class, IdentityDatabaseUtil.class, OAuthServerConfiguration.class,
-        CarbonOAuthTokenRequest.class, LoggerUtils.class, IdentityTenantUtil.class})
+        CarbonOAuthTokenRequest.class, LoggerUtils.class, IdentityTenantUtil.class, })
 public class OAuth2TokenEndpointTest extends TestOAuthEndpointBase {
 
     @Mock
@@ -250,11 +251,17 @@ public class OAuth2TokenEndpointTest extends TestOAuthEndpointBase {
         requestParams.put(OAuth.OAUTH_USERNAME, new String[]{USERNAME});
         requestParams.put(OAuth.OAUTH_PASSWORD, new String[]{"password"});
 
+        OAuthClientAuthnContext oAuthClientAuthnContext = new OAuthClientAuthnContext();
+        oAuthClientAuthnContext.setAuthenticated(true);
+
         mockStatic(LoggerUtils.class);
         when(LoggerUtils.isDiagnosticLogsEnabled()).thenReturn(true);
         mockStatic(IdentityTenantUtil.class);
         when(IdentityTenantUtil.getTenantId(anyString())).thenReturn(-1234);
         HttpServletRequest request = mockHttpRequest(requestParams, new HashMap<String, Object>());
+
+        request.setAttribute(OAuthConstants.CLIENT_AUTHN_CONTEXT, oAuthClientAuthnContext);
+
         when(request.getHeader(OAuthConstants.HTTP_REQ_HEADER_AUTHZ)).thenReturn(authzHeader);
         when(request.getHeaderNames()).thenReturn(
                 Collections.enumeration(new ArrayList<String>() {{
@@ -347,11 +354,15 @@ public class OAuth2TokenEndpointTest extends TestOAuthEndpointBase {
         requestParams.put(OAuth.OAUTH_USERNAME, new String[]{USERNAME});
         requestParams.put(OAuth.OAUTH_PASSWORD, new String[]{"password"});
 
+        OAuthClientAuthnContext oAuthClientAuthnContext = new OAuthClientAuthnContext();
+        oAuthClientAuthnContext.setAuthenticated(true);
+
         mockStatic(LoggerUtils.class);
         when(LoggerUtils.isDiagnosticLogsEnabled()).thenReturn(true);
         mockStatic(IdentityTenantUtil.class);
         when(IdentityTenantUtil.getTenantId(anyString())).thenReturn(-1234);
         HttpServletRequest request = mockHttpRequest(requestParams, new HashMap<String, Object>());
+        request.setAttribute(OAuthConstants.CLIENT_AUTHN_CONTEXT, oAuthClientAuthnContext);
         when(request.getHeader(OAuthConstants.HTTP_REQ_HEADER_AUTHZ)).thenReturn(AUTHORIZATION_HEADER);
         when(request.getHeaderNames()).thenReturn(
                 Collections.enumeration(new ArrayList<String>() {{


### PR DESCRIPTION
**Purpose**
When a user removes one or more characters at the end of a `base64` encoded token, an `IllegalArgumentException` was throwing out and not getting a proper error message as the response. Linked issue states the scenario which we're trying to fix.

**Changes**
With the added change, it throws `InvalidApplicationClientException` with the corresponding error message and error.
![Screenshot 2023-02-28 at 14 18 46](https://user-images.githubusercontent.com/43112139/221801198-e29a6d9a-e5a4-4c6f-883c-7562368ee6bf.png)

**Related Issues**
- Public Fix: https://github.com/wso2/api-manager/issues/1514