### PR TITLE
Use scope service

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
@@ -241,12 +241,12 @@ public class OAuth2AuthzEndpoint {
         OAuth2AuthzEndpoint.openIDConnectClaimFilter = openIDConnectClaimFilter;
     }
 
-    public static ScopeMetadataService getScopeService() {
+    public static ScopeMetadataService getScopeMetadataService() {
 
         return scopeMetadataService;
     }
 
-    public static void setScopeService(ScopeMetadataService scopeMetadataService) {
+    public static void setScopeMetadataService(ScopeMetadataService scopeMetadataService) {
 
         OAuth2AuthzEndpoint.scopeMetadataService = scopeMetadataService;
     }

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
@@ -98,6 +98,7 @@ import org.wso2.carbon.identity.oauth2.dto.OAuth2ClientValidationResponseDTO;
 import org.wso2.carbon.identity.oauth2.model.CarbonOAuthAuthzRequest;
 import org.wso2.carbon.identity.oauth2.model.HttpRequestHeaderHandler;
 import org.wso2.carbon.identity.oauth2.model.OAuth2Parameters;
+import org.wso2.carbon.identity.oauth2.scopeservice.ScopeMetadataService;
 import org.wso2.carbon.identity.oauth2.token.bindings.TokenBinder;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 import org.wso2.carbon.identity.oidc.session.OIDCSessionState;
@@ -224,10 +225,11 @@ public class OAuth2AuthzEndpoint {
     private static final String AUTHENTICATION_ENDPOINT = "/authenticationendpoint";
     private static final String OAUTH_RESPONSE_JSP_PAGE = "/oauth_response.jsp";
 
-
     private static final String OIDC_DIALECT = "http://wso2.org/oidc/claim";
 
     private static OpenIDConnectClaimFilterImpl openIDConnectClaimFilter;
+
+    private static ScopeMetadataService scopeMetadataService;
 
     public static OpenIDConnectClaimFilterImpl getOpenIDConnectClaimFilter() {
 
@@ -237,6 +239,16 @@ public class OAuth2AuthzEndpoint {
     public static void setOpenIDConnectClaimFilter(OpenIDConnectClaimFilterImpl openIDConnectClaimFilter) {
 
         OAuth2AuthzEndpoint.openIDConnectClaimFilter = openIDConnectClaimFilter;
+    }
+
+    public static ScopeMetadataService getScopeService() {
+
+        return scopeMetadataService;
+    }
+
+    public static void setScopeService(ScopeMetadataService scopeMetadataService) {
+
+        OAuth2AuthzEndpoint.scopeMetadataService = scopeMetadataService;
     }
 
     private static Class<? extends OAuthAuthzRequest> oAuthAuthzRequestClass;
@@ -3127,6 +3139,7 @@ public class OAuth2AuthzEndpoint {
      * @return
      */
     private OAuth2AuthorizeRespDTO authorize(OAuthAuthzReqMessageContext authzReqMsgCtx) {
+
         return getOAuth2Service().authorize(authzReqMsgCtx);
     }
 

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/factory/ScopeServiceFactory.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/factory/ScopeServiceFactory.java
@@ -63,7 +63,9 @@ public class ScopeServiceFactory extends AbstractFactoryBean<ScopeMetadataServic
                     if (scopeService instanceof OAuth2ScopeService) {
                         continue;
                     }
-                    log.debug("Returning the ScopeService: " + scopeService.getClass().getName());
+                    if (log.isDebugEnabled()) {
+                        log.debug("Returning the ScopeService: " + scopeService.getClass().getName());
+                    }
                     this.scopeMetadataService = (ScopeMetadataService) scopeService;
                 }
             } else {

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/factory/ScopeServiceFactory.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/factory/ScopeServiceFactory.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth.endpoint.factory;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.beans.factory.config.AbstractFactoryBean;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.identity.oauth2.IdentityOAuth2ServerException;
+import org.wso2.carbon.identity.oauth2.OAuth2ScopeService;
+import org.wso2.carbon.identity.oauth2.scopeservice.ScopeMetadataService;
+
+import java.util.List;
+
+/**
+ * Factory bean for ScopeService.
+ */
+public class ScopeServiceFactory extends AbstractFactoryBean<ScopeMetadataService> {
+
+    private ScopeMetadataService scopeMetadataService;
+
+    private static final Log log = LogFactory.getLog(ScopeServiceFactory.class);
+
+    @Override
+    public Class<ScopeMetadataService> getObjectType() {
+
+        return ScopeMetadataService.class;
+    }
+
+    @Override
+    protected ScopeMetadataService createInstance() throws Exception {
+
+        if (this.scopeMetadataService == null) {
+
+            // Get the OSGi service registered for ScopeService interface.
+            List<Object> scopeServices = PrivilegedCarbonContext
+                    .getThreadLocalCarbonContext().getOSGiServices(ScopeMetadataService.class, null);
+
+            if (scopeServices == null || scopeServices.isEmpty()) {
+                throw new IdentityOAuth2ServerException("No ScopeService implementation found.");
+            }
+
+            if (scopeServices.size() > 1) {
+                log.debug("More than one ScopeService implementations found. Returning the first one which is not" +
+                        " OAuth2ScopeService.");
+                for (Object scopeService : scopeServices) {
+                    if (scopeService instanceof OAuth2ScopeService) {
+                        continue;
+                    }
+                    log.debug("Returning the ScopeService: " + scopeService.getClass().getName());
+                    this.scopeMetadataService = (ScopeMetadataService) scopeService;
+                }
+            } else {
+                this.scopeMetadataService = (ScopeMetadataService) scopeServices.get(0);
+            }
+        }
+        return this.scopeMetadataService;
+    }
+
+}

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/webapp/WEB-INF/cxf-servlet.xml
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/webapp/WEB-INF/cxf-servlet.xml
@@ -49,6 +49,7 @@
     </bean>
     <bean id="authzEndpointBean" class="org.wso2.carbon.identity.oauth.endpoint.authz.OAuth2AuthzEndpoint">
         <property name="openIDConnectClaimFilter" ref="openIDConnectClaimFilterFactoryBean"/>
+        <property name="scopeMetadataService" ref="scopeServiceFactoryBean"/>
     </bean>
     <bean id="tokenEndpointBean" class="org.wso2.carbon.identity.oauth.endpoint.token.OAuth2TokenEndpoint"/>
     <bean id="introspectionEndpointBean" class="org.wso2.carbon.identity.oauth.endpoint.introspection.OAuth2IntrospectionEndpoint"/>
@@ -77,6 +78,7 @@
     <bean id="oauthServerConfigurationFactoryBean" class="org.wso2.carbon.identity.oauth.endpoint.factory.OAuthServerConfigurationFactory"/>
     <bean id="requestObjectServiceFactoryBean" class="org.wso2.carbon.identity.oauth.endpoint.factory.RequestObjectServiceFactory"/>
     <bean id="openIDConnectClaimFilterFactoryBean" class="org.wso2.carbon.identity.oauth.endpoint.factory.OpenIDConnectClaimFilterFactory"/>
+    <bean id="scopeServiceFactoryBean" class="org.wso2.carbon.identity.oauth.endpoint.factory.ScopeServiceFactory"/>
     <bean id="deviceAuthServiceFactoryBean" class="org.wso2.carbon.identity.oauth.endpoint.factory.DeviceAuthServiceFactory"/>
     <bean id="deviceAuthEndpointBean" class="org.wso2.carbon.identity.oauth.endpoint.device.DeviceEndpoint">
             <property name="deviceAuthService" ref="deviceAuthServiceFactoryBean"/>

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/OAuth2ScopeService.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/OAuth2ScopeService.java
@@ -837,7 +837,7 @@ public class OAuth2ScopeService implements ScopeMetadataService {
     }
 
     @Override
-    public List<OAuth2Resource> getMetadata(List<String> scopes) throws Exception {
+    public List<OAuth2Resource> getMetadata(List<String> scopes) throws IdentityOAuth2ScopeServerException {
 
         List<ScopeMetadata> scopesArray = new ArrayList<>();
         for (String scopeName : scopes) {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/OAuth2ScopeService.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/OAuth2ScopeService.java
@@ -837,7 +837,7 @@ public class OAuth2ScopeService implements ScopeMetadataService {
     }
 
     @Override
-    public List<OAuth2Resource> getMetadata(List<String> scopes) {
+    public List<OAuth2Resource> getMetadata(List<String> scopes) throws Exception {
 
         List<ScopeMetadata> scopesArray = new ArrayList<>();
         for (String scopeName : scopes) {
@@ -847,7 +847,9 @@ public class OAuth2ScopeService implements ScopeMetadataService {
                         scope.getDescription());
                 scopesArray.add(scopeMetadata);
             } catch (IdentityOAuth2ScopeException e) {
-                log.error("Error while retrieving scope: " + scopeName);
+                log.warn("Error while retrieving scopes", e);
+                throw Oauth2ScopeUtils.generateServerException(Oauth2ScopeConstants.ErrorMessages.
+                        ERROR_CODE_FAILED_TO_GET_SCOPE_METADATA, e);
             }
         }
         if (scopesArray.isEmpty()) {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/OAuth2ScopeService.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/OAuth2ScopeService.java
@@ -831,12 +831,6 @@ public class OAuth2ScopeService implements ScopeMetadataService {
     }
 
     @Override
-    public String getName() {
-
-        return "OAuth2ScopeService";
-    }
-
-    @Override
     public List<OAuth2Resource> getMetadata(List<String> scopes) throws IdentityOAuth2ScopeServerException {
 
         List<ScopeMetadata> scopesArray = new ArrayList<>();

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/Oauth2ScopeConstants.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/Oauth2ScopeConstants.java
@@ -79,8 +79,9 @@ public class Oauth2ScopeConstants {
         ERROR_CODE_FAILED_TO_CHECK_ALREADY_USER_CONSENTED("51015", "Error occurred while checking " +
                 "whether user : %s is already consented for all scopes for application : %s in tenant with Id : %d."),
         ERROR_CODE_FAILED_TO_CHECK_EXISTING_CONSENTS_FOR_USER("51016", "Error occurred while checking " +
-                "whether user : %s has an existing consent for app : %s in tenant with id : %d");
-
+                "whether user : %s has an existing consent for app : %s in tenant with id : %d"),
+        ERROR_CODE_FAILED_TO_GET_SCOPE_METADATA("51017", "Error occurred while retrieving scope metadata " +
+                                                        "for scope %s.");
         private final String code;
         private final String message;
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuth2ServiceComponent.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuth2ServiceComponent.java
@@ -272,10 +272,11 @@ public class OAuth2ServiceComponent {
 
             // Registering OAuth2Service as a OSGIService
             bundleContext.registerService(OAuth2Service.class.getName(), new OAuth2Service(), null);
+            OAuth2ScopeService oAuth2ScopeService = new OAuth2ScopeService();
             // Registering OAuth2ScopeService as a OSGIService
-            bundleContext.registerService(OAuth2ScopeService.class.getName(), new OAuth2ScopeService(), null);
+            bundleContext.registerService(OAuth2ScopeService.class.getName(), oAuth2ScopeService, null);
             // Registering OAuth2ScopeService under ScopeService interface as the default service.
-            bundleContext.registerService(ScopeMetadataService.class, new OAuth2ScopeService(), null);
+            bundleContext.registerService(ScopeMetadataService.class, oAuth2ScopeService, null);
             // Note : DO NOT add any activation related code below this point,
             // to make sure the server doesn't start up if any activation failures occur
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuth2ServiceComponent.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuth2ServiceComponent.java
@@ -60,6 +60,7 @@ import org.wso2.carbon.identity.oauth2.device.response.DeviceFlowResponseTypeReq
 import org.wso2.carbon.identity.oauth2.keyidprovider.DefaultKeyIDProviderImpl;
 import org.wso2.carbon.identity.oauth2.keyidprovider.KeyIDProvider;
 import org.wso2.carbon.identity.oauth2.listener.TenantCreationEventListener;
+import org.wso2.carbon.identity.oauth2.scopeservice.ScopeMetadataService;
 import org.wso2.carbon.identity.oauth2.token.bindings.TokenBinder;
 import org.wso2.carbon.identity.oauth2.token.bindings.handlers.TokenBindingExpiryEventHandler;
 import org.wso2.carbon.identity.oauth2.token.bindings.impl.CookieBasedTokenBinder;
@@ -273,6 +274,8 @@ public class OAuth2ServiceComponent {
             bundleContext.registerService(OAuth2Service.class.getName(), new OAuth2Service(), null);
             // Registering OAuth2ScopeService as a OSGIService
             bundleContext.registerService(OAuth2ScopeService.class.getName(), new OAuth2ScopeService(), null);
+            // Registering OAuth2ScopeService under ScopeService interface as the default service.
+            bundleContext.registerService(ScopeMetadataService.class, new OAuth2ScopeService(), null);
             // Note : DO NOT add any activation related code below this point,
             // to make sure the server doesn't start up if any activation failures occur
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/scopeservice/OAuth2Resource.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/scopeservice/OAuth2Resource.java
@@ -41,30 +41,37 @@ public class OAuth2Resource {
     }
 
     public String getName() {
+
         return name;
     }
 
     public void setName(String name) {
+
         this.name = name;
     }
 
     public String getId() {
+
         return id;
     }
 
     public void setId(String id) {
+
         this.id = id;
     }
 
     public List<ScopeMetadata> getScopes() {
+
         return scopes;
     }
 
     public void setScopes(List<ScopeMetadata> scopes) {
+
         this.scopes = scopes;
     }
 
     public String toJSON() {
+
         StringBuilder builder = new StringBuilder();
         builder.append("{");
         builder.append("\"name\": \"").append(name).append("\",");

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/scopeservice/OAuth2Resource.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/scopeservice/OAuth2Resource.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth2.scopeservice;
+
+import java.util.List;
+
+/**
+ * Represents the metadata of a resource.
+ */
+public class OAuth2Resource {
+
+    String name;
+    String id;
+    List<ScopeMetadata> scopes;
+
+    public OAuth2Resource() {
+
+    }
+
+    public OAuth2Resource(String name, String id, List<ScopeMetadata> scopes) {
+
+        this.name = name;
+        this.id = id;
+        this.scopes = scopes;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public List<ScopeMetadata> getScopes() {
+        return scopes;
+    }
+
+    public void setScopes(List<ScopeMetadata> scopes) {
+        this.scopes = scopes;
+    }
+
+    public String toJSON() {
+        StringBuilder builder = new StringBuilder();
+        builder.append("{");
+        builder.append("\"name\": \"").append(name).append("\",");
+        builder.append("\"id\": \"").append(id).append("\",");
+        builder.append("\"scopes\": [");
+        for (ScopeMetadata scope : scopes) {
+            builder.append(scope.toJSON()).append(",");
+        }
+        builder.deleteCharAt(builder.length() - 1);
+        builder.append("]");
+        builder.append("}");
+        return builder.toString();
+    }
+}
+

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/scopeservice/ScopeMetadata.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/scopeservice/ScopeMetadata.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth2.scopeservice;
+
+/**
+ * Represents the metadata of a scope.
+ */
+public class ScopeMetadata {
+
+    // Identifier will be the unique name of the scope.
+    String identifier;
+    String displayName;
+    String description;
+
+    public ScopeMetadata() {
+    }
+
+    public ScopeMetadata(String identifier, String displayName, String description) {
+        this.identifier = identifier;
+        this.displayName = displayName;
+        this.description = description;
+    }
+
+    public String getIdentifier() {
+        return identifier;
+    }
+
+    public void setIdentifier(String identifier) {
+        this.identifier = identifier;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String toJSON() {
+
+        return "{" +
+                "\"identifier\": \"" + identifier + "\"," +
+                "\"displayName\": \"" + displayName + "\"," +
+                "\"description\": \"" + description + "\"" +
+                "}";
+    }
+}

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/scopeservice/ScopeMetadata.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/scopeservice/ScopeMetadata.java
@@ -32,32 +32,39 @@ public class ScopeMetadata {
     }
 
     public ScopeMetadata(String identifier, String displayName, String description) {
+
         this.identifier = identifier;
         this.displayName = displayName;
         this.description = description;
     }
 
     public String getIdentifier() {
+
         return identifier;
     }
 
     public void setIdentifier(String identifier) {
+
         this.identifier = identifier;
     }
 
     public String getDisplayName() {
+
         return displayName;
     }
 
     public void setDisplayName(String displayName) {
+
         this.displayName = displayName;
     }
 
     public String getDescription() {
+
         return description;
     }
 
     public void setDescription(String description) {
+
         this.description = description;
     }
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/scopeservice/ScopeMetadataService.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/scopeservice/ScopeMetadataService.java
@@ -25,9 +25,6 @@ import java.util.List;
  */
 public interface ScopeMetadataService {
 
-    // Returns the name of Scope Metadata Service.
-    String getName();
-
     // Returns the metadata of the scopes.
     List<OAuth2Resource> getMetadata(List<String> permissions) throws Exception;
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/scopeservice/ScopeMetadataService.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/scopeservice/ScopeMetadataService.java
@@ -25,6 +25,9 @@ import java.util.List;
  */
 public interface ScopeMetadataService {
 
+    // Returns the name of Scope Metadata Service.
     String getName();
-    List<OAuth2Resource> getMetadata(List<String> permissions);
+
+    // Returns the metadata of the scopes.
+    List<OAuth2Resource> getMetadata(List<String> permissions) throws Exception;
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/scopeservice/ScopeMetadataService.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/scopeservice/ScopeMetadataService.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth2.scopeservice;
+
+import java.util.List;
+
+/**
+ * Retrieves the metadata of the scopes.
+ */
+public interface ScopeMetadataService {
+
+    String getName();
+    List<OAuth2Resource> getMetadata(List<String> permissions);
+}


### PR DESCRIPTION
### Proposed changes in this pull request

- Implement `ScopeMetadataService` interface to get the permission metadata.
- Make OAuth2ScopeService implement the interface.
- Register OAuth2ScopeService OSGi service using the interface and inject ScopeMetadataService into OAuth Endpoint.
