### PR TITLE
Scope metadata for consent page

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
@@ -826,7 +826,7 @@ public class EndpointUtil {
                 consentPageUrl = FrameworkUtils.appendQueryParamsStringToUrl(consentPageUrl, additionalQueryParams);
 
                 // Append scope metadata to the consent page url.
-                consentPageUrl = getConsentPageURLWithScopeMetadata(consentPageUrl, params.getScopes(),
+                consentPageUrl = getConsentPageURLWithScopeMetadata(consentPageUrl, params.getConsentRequiredScopes(),
                         params.getTenantDomain());
 
                 if (entry != null) {

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/webapp/WEB-INF/cxf-servlet.xml
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/webapp/WEB-INF/cxf-servlet.xml
@@ -69,6 +69,7 @@
         <property name="requestObjectService"  ref="requestObjectServiceFactoryBean"/>
         <property name="cibaAuthService"  ref="cibaAuthServiceFactoryBean"/>
         <property name="idpManager" ref="idpManagerBean"/>
+        <property name="scopeMetadataService" ref="scopeServiceFactoryBean"/>
     </bean>
     <bean id="oidcProviderResponseBuilderBean" class="org.wso2.carbon.identity.oauth.endpoint.oidcdiscovery.impl.OIDProviderJSONResponseBuilder"/>
     <bean id="oAuth2ServiceFactoryBean" class="org.wso2.carbon.identity.oauth.endpoint.factory.OAuth2ServiceFactory"/>


### PR DESCRIPTION
### Proposed changes in this pull request

> Scope metadata including display name and description will be obtained using `ScopeMetadataService`. Those data will be sent to the FE so that meaningful permission details will be displayed on the consent page.
