### PR TITLE
Fix the issue with scopes during refresh grant

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuer.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuer.java
@@ -505,7 +505,18 @@ public class AccessTokenIssuer {
             return true;
         }
         if (GrantType.REFRESH_TOKEN.toString().equals(grantType)) {
+            /*
+             In the refresh token flow, we have already completed scope validation during the initial token call and
+             issued the token with authorized scopes. Therefore, during the refresh flow we don't need to do the
+             internal scope validation again. But we need to call the grant type specific scope validation handler to
+             issue the token with only the authorized scopes.
+            */
             AuthorizationGrantHandler authzGrantHandler = authzGrantHandlers.get(grantType);
+            if (log.isDebugEnabled()) {
+                log.debug("Calling grant type specific scope validation handler for the refresh token grant and " +
+                        "omitting internal scope validation as internal scope validation already done " +
+                        "during the token issuance.");
+            }
             boolean isValidScope = authzGrantHandler.validateScope(tokReqMsgCtx);
             if (isValidScope) {
                 if (LoggerUtils.isDiagnosticLogsEnabled()) {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuer.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuer.java
@@ -504,7 +504,22 @@ public class AccessTokenIssuer {
             }
             return true;
         }
-
+        if (GrantType.REFRESH_TOKEN.toString().equals(grantType)) {
+            AuthorizationGrantHandler authzGrantHandler = authzGrantHandlers.get(grantType);
+            boolean isValidScope = authzGrantHandler.validateScope(tokReqMsgCtx);
+            if (isValidScope) {
+                if (LoggerUtils.isDiagnosticLogsEnabled()) {
+                    Map<String, Object> params = new HashMap<>();
+                    params.put("clientId", tokenReqDTO.getClientId());
+                    params.put("requestedScopes", getScopeList(tokenReqDTO.getScope()));
+                    params.put("authorizedScopes", getScopeList(tokReqMsgCtx.getScope()));
+                    LoggerUtils.triggerDiagnosticLogEvent(OAuthConstants.LogConstants.OAUTH_INBOUND_SERVICE, params,
+                            OAuthConstants.LogConstants.SUCCESS, "OAuth scope validation is successful.",
+                            "validate-scope", null);
+                }
+            }
+            return isValidScope;
+        }
         List<String> allowedScopes = OAuthServerConfiguration.getInstance().getAllowedScopes();
         List<String> requestedAllowedScopes = new ArrayList<>();
         String[] requestedScopes = tokReqMsgCtx.getScope();

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/RefreshGrantHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/RefreshGrantHandler.java
@@ -165,12 +165,10 @@ public class RefreshGrantHandler extends AbstractAuthorizationGrantHandler {
                     if (log.isDebugEnabled()) {
                         log.debug("scope: " + scope + "is not granted for this refresh token");
                     }
-                    requestedScopes = (String[]) ArrayUtils.removeElement(requestedScopes, scope);
+                    return false;
                 }
             }
             tokReqMsgCtx.setScope(requestedScopes);
-        } else {
-            tokReqMsgCtx.setScope(grantedScopes);
         }
         return true;
     }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/RefreshGrantHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/RefreshGrantHandler.java
@@ -149,13 +149,14 @@ public class RefreshGrantHandler extends AbstractAuthorizationGrantHandler {
             if (ArrayUtils.isEmpty(grantedScopes) && ArrayUtils.isEmpty(grantedInternalScopes)) {
                 return false;
             }
-            List<String> grantedScopeList = Stream
-                    .concat(grantedScopes == null
-                            ? Stream.empty()
-                            : Arrays.stream(grantedScopes), grantedInternalScopes == null
-                            ? Stream.empty()
-                            : Arrays.stream(grantedInternalScopes))
-                    .collect(Collectors.toList());
+            if (ArrayUtils.isEmpty(grantedScopes)) {
+                grantedScopes = new String[0];
+            }
+            if (ArrayUtils.isEmpty(grantedInternalScopes)) {
+                grantedInternalScopes = new String[0];
+            }
+            List<String> grantedScopeList = Stream.concat(Arrays.stream(grantedScopes),
+                    Arrays.stream(grantedInternalScopes)).collect(Collectors.toList());
             for (String scope : requestedScopes) {
                 if (!grantedScopeList.contains(scope)) {
                     if (log.isDebugEnabled()) {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/RefreshGrantHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/RefreshGrantHandler.java
@@ -154,17 +154,23 @@ public class RefreshGrantHandler extends AbstractAuthorizationGrantHandler {
                 return false;
             }
             List<String> grantedScopeList = Stream
-                    .concat(Arrays.stream(grantedScopes), Arrays.stream(grantedInternalScopes))
+                    .concat(grantedScopes == null
+                            ? Stream.empty()
+                            : Arrays.stream(grantedScopes), grantedInternalScopes == null
+                            ? Stream.empty()
+                            : Arrays.stream(grantedInternalScopes))
                     .collect(Collectors.toList());
             for (String scope : requestedScopes) {
                 if (!grantedScopeList.contains(scope)) {
                     if (log.isDebugEnabled()) {
                         log.debug("scope: " + scope + "is not granted for this refresh token");
                     }
-                    return false;
+                    requestedScopes = (String[]) ArrayUtils.removeElement(requestedScopes, scope);
                 }
             }
             tokReqMsgCtx.setScope(requestedScopes);
+        } else {
+            tokReqMsgCtx.setScope(grantedScopes);
         }
         return true;
     }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/RefreshGrantHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/RefreshGrantHandler.java
@@ -136,10 +136,6 @@ public class RefreshGrantHandler extends AbstractAuthorizationGrantHandler {
     public boolean validateScope(OAuthTokenReqMessageContext tokReqMsgCtx)
             throws IdentityOAuth2Exception {
 
-        if (!super.validateScope(tokReqMsgCtx)) {
-            return false;
-        }
-
         /*
           The requested scope MUST NOT include any scope
           not originally granted by the resource owner, and if omitted is


### PR DESCRIPTION
### Proposed changes in this pull request

The fixes were done in this PR

Ideally for the refresh grant, only refresh grant-related scope validation should happen, other scope validation is not needed for the refresh grant as the scope validation is already done during the token issuing time. In this PR I have removed the extra scope validation added(role-based scope validation and etc) to refresh grant and kept only refresh grant-related scope validation.

For the refresh grant scope validation, we have implemented the following flow.
1. When using the Refresh token grant if there are no scopes provided in the request then **we don't need to do a scope validation, we should return the scopes which are used for the access token**. If there are scopes requested through the refresh token then we can divide the use cases as below. The below cases are already covered with the existing code.
             1. Request scopes that are the same as the scopes sent with the previous access token:- We should give a refresh token with the requested scopes
             2. **Request scopes that include more scopes than the one sent with a previous access token:- throw exception as it can lead to an attack.
             [According to the spec authorization server should decide](https://www.rfc-editor.org/rfc/rfc6749#section-3.3) 
             3. Request scopes that include less number of scopes than the one sent with the previous access token:-  We should only give a refresh token with the scopes which are requested through a refresh grant request.


### When should this PR be merged

[Please describe any preconditions that need to be addressed before we
can merge this pull request.]


### Follow up actions

[List any possible follow-up actions here; for instance, testing data
migrations, software that we need to install on staging and production
environments.]

-


### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description.
- [ ] **Is the PR labeled correctly?**

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled.

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests.
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/).

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components.
- [ ] **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

#### Security

- [ ] **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
- [ ] **Are all UI and API inputs run through forms or serializers?**
- [ ] **Are all external inputs validated and sanitized appropriately?**
- [ ] **Does all branching logic have a default case?**
- [ ] **Does this solution handle outliers and edge cases gracefully?**
- [ ] **Are all external communications secured and restricted to SSL?**

#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes should be documented.
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented.
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki.
