### PR TITLE
OIDC scopes are in the response when requesting access token with client credentials

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/OIDCScopeHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/OIDCScopeHandler.java
@@ -65,7 +65,8 @@ public class OIDCScopeHandler extends OAuth2ScopeHandler {
 
             if (log.isDebugEnabled()) {
                 log.debug("id_token is not allowed for requested grant type: " +
-                        grantType + ". Removing all 'OIDC' " + "scopes.");
+                        grantType + ". Removing all 'OIDC' scopes registered in the tenant " +
+                         "from requested scopes.");
             }
             // Returning 'true' since we are dropping openid scope and don't need to prevent issuing the token for
             // remaining scopes.

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/OIDCScopeHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/OIDCScopeHandler.java
@@ -16,7 +16,6 @@
 
 package org.wso2.carbon.identity.oauth2.validators;
 
-import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.oltu.oauth2.common.message.types.GrantType;
@@ -29,6 +28,7 @@ import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Scope handler for token requests with openid scope.
@@ -52,7 +52,6 @@ public class OIDCScopeHandler extends OAuth2ScopeHandler {
             return true;
         } else {
             //Remove OIDC scopes from the token message context
-
             String[] scopes = tokReqMsgCtx.getScope();
             List<String> oidcScopes = OAuth2Util.getOIDCScopes(tokReqMsgCtx.getOauth2AccessTokenReqDTO()
                     .getTenantDomain());
@@ -65,8 +64,8 @@ public class OIDCScopeHandler extends OAuth2ScopeHandler {
             tokReqMsgCtx.setScope(filteredScopes.toArray(new String[0]));
 
             if (log.isDebugEnabled()) {
-                log.debug("id_token is not allowed for requested grant type: " + grantType + ". Removing all 'OIDC' " +
-                        "scopes.");
+                log.debug("id_token is not allowed for requested grant type: " +
+                        grantType + ". Removing all 'OIDC' " + "scopes.");
             }
             // Returning 'true' since we are dropping openid scope and don't need to prevent issuing the token for
             // remaining scopes.

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/OIDCScopeHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/OIDCScopeHandler.java
@@ -65,8 +65,8 @@ public class OIDCScopeHandler extends OAuth2ScopeHandler {
             tokReqMsgCtx.setScope(filteredScopes.toArray(new String[0]));
 
             if (log.isDebugEnabled()) {
-                log.debug("id_token is not allowed for requested grant type: " + grantType + ". Removing 'openid' " +
-                        "scope.");
+                log.debug("id_token is not allowed for requested grant type: " + grantType + ". Removing all 'OIDC' " +
+                        "scopes.");
             }
             // Returning 'true' since we are dropping openid scope and don't need to prevent issuing the token for
             // remaining scopes.

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/OIDCScopeHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/OIDCScopeHandler.java
@@ -51,22 +51,18 @@ public class OIDCScopeHandler extends OAuth2ScopeHandler {
             // if id_token is allowed for requested grant type.
             return true;
         } else {
+            //Remove OIDC scopes from the token message context
 
-            // Remove openid scope from the token message context.
-            String[] scopes = (String[]) ArrayUtils.removeElement(tokReqMsgCtx.getScope(), OAuthConstants.Scope.OPENID);
-
-            //Get all the registered oidc scopes of a tenant
+            String[] scopes = tokReqMsgCtx.getScope();
             List<String> oidcScopes = OAuth2Util.getOIDCScopes(tokReqMsgCtx.getOauth2AccessTokenReqDTO()
                     .getTenantDomain());
 
-            //Check whether the is there any oidc scope in the request
-            for (String scope : scopes) {
-                if (oidcScopes.contains(scope)) {
-                    scopes = (String[]) ArrayUtils.removeElement(scopes, scope);
-                }
-            }
+            List<String> filteredScopes = Arrays.stream(scopes)
+                    .filter(scope -> !OAuthConstants.Scope.OPENID.equals(scope))
+                    .filter(scope -> !oidcScopes.contains(scope))
+                    .collect(Collectors.toList());
 
-            tokReqMsgCtx.setScope(scopes);
+            tokReqMsgCtx.setScope(filteredScopes.toArray(new String[0]));
 
             if (log.isDebugEnabled()) {
                 log.debug("id_token is not allowed for requested grant type: " + grantType + ". Removing 'openid' " +

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/OIDCScopeHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/OIDCScopeHandler.java
@@ -51,6 +51,7 @@ public class OIDCScopeHandler extends OAuth2ScopeHandler {
             // if id_token is allowed for requested grant type.
             return true;
         } else {
+
             // Remove openid scope from the token message context.
             String[] scopes = (String[]) ArrayUtils.removeElement(tokReqMsgCtx.getScope(), OAuthConstants.Scope.OPENID);
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/OIDCScopeHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/OIDCScopeHandler.java
@@ -51,7 +51,7 @@ public class OIDCScopeHandler extends OAuth2ScopeHandler {
             // if id_token is allowed for requested grant type.
             return true;
         } else {
-            //Remove OIDC scopes from the token message context
+            // Remove OIDC scopes from the token message context.
             String[] scopes = tokReqMsgCtx.getScope();
             List<String> oidcScopes = OAuth2Util.getOIDCScopes(tokReqMsgCtx.getOauth2AccessTokenReqDTO()
                     .getTenantDomain());

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/OIDCScopeHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/OIDCScopeHandler.java
@@ -65,7 +65,7 @@ public class OIDCScopeHandler extends OAuth2ScopeHandler {
 
             if (log.isDebugEnabled()) {
                 log.debug("id_token is not allowed for requested grant type: " +
-                        grantType + ". Removing all 'OIDC' scopes registered in the tenant " +
+                        grantType + ". Removing all OIDC scopes registered in the tenant " +
                          "from requested scopes.");
             }
             // Returning 'true' since we are dropping openid scope and don't need to prevent issuing the token for


### PR DESCRIPTION
Issue

OIDC scopes are in the response when requesting access token with client credentials #15486( Fixes https://github.com/wso2/product-is/issues/15486)  - When requesting access token request with client credentials grant type including OIDC scopes,  there are OIDC scopes in the response such as "email", "profile", "phone". These scopes shouldn't be there in the response.

Approach

1. log in to the Product-IS console application as the admin and create a standard-based OAuth2.0 OpenID Connect management application.
2. Send an access token request via Postman with client_credentials grant type including scopes: SYSTEM openid email profile
3. Remote debug the code flow and find the place where the openID scope is removed. 
4. Take all the registered oidc scopes of a tenant
5. check whether there are openid connect scopes in the tokReqMsgCtx and remove them

The logic for this part is in the "validateScope" method at the "OIDCScopeHandler.java" class

Goal

OIDC scopes should not be in the response.

