### PR TITLE
Resolve run time NullPointerException in ErrorDTO class

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.dcr/src/gen/java/org/wso2/carbon/identity/oauth2/dcr/endpoint/dto/ErrorDTO.java
+++ b/components/org.wso2.carbon.identity.api.server.dcr/src/gen/java/org/wso2/carbon/identity/oauth2/dcr/endpoint/dto/ErrorDTO.java
@@ -3,6 +3,7 @@ package org.wso2.carbon.identity.oauth2.dcr.endpoint.dto;
 
 import io.swagger.annotations.*;
 import com.fasterxml.jackson.annotation.*;
+import org.apache.commons.lang3.StringUtils;
 
 import javax.validation.constraints.NotNull;
 
@@ -66,7 +67,7 @@ public class ErrorDTO  {
     
     sb.append("  error: ").append(error).append("\n");
     sb.append("  error_description: ").append(errorDescription).append("\n");
-    if (!ref.isEmpty()) {
+    if (StringUtils.isNotEmpty(ref)) {
       sb.append("  traceId: ").append(ref).append("\n");
     }
     sb.append("}\n");


### PR DESCRIPTION
**Purpose**: 

When ErrorDTO[1] object is created in the flow, at the run time it throws a NullPointerException. This happens due to missing null check in the toString() method in ErrorDTO class. Fixed by adding the null + empty check. 

[1]https://github.com/wso2-extensions/identity-inbound-auth-oauth/blob/8d9a50a4890c7db675d7a651297121b056ff8ca1/components/org.wso2.carbon.identity.api.server.dcr/src/gen/java/org/wso2/carbon/identity/oauth2/dcr/endpoint/dto/ErrorDTO.java#L15