### PR TITLE
Fixing InboundConfiguration property export structure

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dao/OAuthAppDO.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dao/OAuthAppDO.java
@@ -17,6 +17,7 @@
 */
 package org.wso2.carbon.identity.oauth.dao;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
 import org.wso2.carbon.identity.application.common.model.InboundConfigurationProtocol;
@@ -71,6 +72,7 @@ public class OAuthAppDO extends InboundConfigurationProtocol implements Serializ
     private String backChannelLogoutUrl;
     private String frontchannelLogoutUrl;
     @XmlTransient
+    @JsonIgnore
     private AuthenticatedUser appOwner;
     private String tokenType;
     private String tokenBindingType;
@@ -90,6 +92,7 @@ public class OAuthAppDO extends InboundConfigurationProtocol implements Serializ
      * @deprecated use {@link #getAppOwner()} instead.
      */
     @Deprecated
+    @JsonIgnore
     public AuthenticatedUser getUser() {
         return this.getAppOwner();
     }
@@ -98,6 +101,7 @@ public class OAuthAppDO extends InboundConfigurationProtocol implements Serializ
      * @deprecated use {@link #setAppOwner(AuthenticatedUser)} instead.
      */
     @Deprecated
+    @JsonIgnore
     public void setUser(AuthenticatedUser user) {
         this.setAppOwner(user);
     }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dao/OAuthAppDO.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dao/OAuthAppDO.java
@@ -17,7 +17,9 @@
 */
 package org.wso2.carbon.identity.oauth.dao;
 
+import com.fasterxml.jackson.annotation.JsonTypeName;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
+import org.wso2.carbon.identity.application.common.model.InboundConfigurationProtocol;
 
 import java.io.Serializable;
 
@@ -31,9 +33,10 @@ import javax.xml.bind.annotation.XmlTransient;
 /**
  * OAuth application data object.
  */
-@XmlRootElement
 @XmlAccessorType(XmlAccessType.FIELD)
-public class OAuthAppDO implements Serializable {
+@XmlRootElement(name = "oAuthAppDO")
+@JsonTypeName("oAuthAppDO")
+public class OAuthAppDO extends InboundConfigurationProtocol implements Serializable {
 
     private static final long serialVersionUID = -6453843721358989519L;
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuthApplicationMgtListener.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuthApplicationMgtListener.java
@@ -292,11 +292,10 @@ public class OAuthApplicationMgtListener extends AbstractApplicationMgtListener 
                                         serviceProvider.getOwner().getTenantDomain());
             authConfig.setInboundConfigurationProtocol(oAuthAppDO);
             return oAuthAppDO;
-        } else {
-            String errorMsg = String.format("No inbound configurations found for oauth in the" +
-                    " imported %s", serviceProvider.getApplicationName());
-            throw new IdentityApplicationManagementException(errorMsg);
         }
+        String errorMsg = String.format("No inbound configurations found for oauth in the imported %s",
+                                        serviceProvider.getApplicationName());
+        throw new IdentityApplicationManagementException(errorMsg);
     }
 
     private IdentityApplicationManagementException handleException(String message, Exception ex) {

--- a/pom.xml
+++ b/pom.xml
@@ -839,7 +839,7 @@
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!-- Carbon Identity Framework version -->
-        <carbon.identity.framework.version>5.25.92</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.25.157</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.17.5, 7.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 


### PR DESCRIPTION
## Purpose
Related to https://github.com/wso2/product-is/issues/15683

This PR resolves the issue of inboundConfiguration property being exported as an XML string instead of being broken down into properties when exporting service providers through the API.

## Goals
When exporting service providers through the API, the "inboundConfiguration" property is exported broken down into individual properties.

## Approach
inboundConfigurationProtocol abstract class property is added and inboundConfiguration is ignored during serialization. OAuthAppDO class is updated to extend the new inboundConfigurationProtocol class.

## Related PRs
https://github.com/wso2/carbon-identity-framework/pull/4505
https://github.com/wso2/identity-api-server/pull/437
https://github.com/wso2-extensions/identity-inbound-auth-saml/pull/391

**Need to bump framework version after merging the following PR:**
https://github.com/wso2/carbon-identity-framework/pull/4505