### PR TITLE
Add a new service to handle token revocations due to internal events.

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/InternalRevocationEventService.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/InternalRevocationEventService.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.identity.oauth2;
+
+/**
+ * This service handles token revocations validations due to internal events.
+ * For example token revocations due to application deletion, user deletion, client secret regeneration, user profile
+ * claim updates and etc...
+ */
+public interface InternalRevocationEventService {
+
+    /**
+     * Add an event to the revocate a token internally.
+     * @param clientId          Client ID
+     * @param authorizedUser    user
+     * @param tenantId          tenantId
+     * @return
+     */
+    boolean addEvent(String clientId, String authorizedUser, String tenantId);
+
+    /**
+     * Check whether a specific token is revoked or not
+     */
+    boolean isTokenValid(String clientId,  String clientSecret, String grantType);
+
+    boolean cleanEventsByUser(String clientId, String timestamp);
+
+    /**
+     * Clean events by tenant.
+     *
+     * @param tenantId  tenant Id
+     * @return
+     */
+    boolean cleanEventsByTenant(String tenantId);
+}

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuth2ServiceComponent.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuth2ServiceComponent.java
@@ -43,9 +43,7 @@ import org.wso2.carbon.identity.oauth.common.token.bindings.TokenBinderInfo;
 import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
 import org.wso2.carbon.identity.oauth.dto.ScopeDTO;
 import org.wso2.carbon.identity.oauth.internal.OAuthComponentServiceHolder;
-import org.wso2.carbon.identity.oauth2.OAuth2ScopeService;
-import org.wso2.carbon.identity.oauth2.OAuth2Service;
-import org.wso2.carbon.identity.oauth2.OAuth2TokenValidationService;
+import org.wso2.carbon.identity.oauth2.*;
 import org.wso2.carbon.identity.oauth2.authz.validators.ResponseTypeRequestValidator;
 import org.wso2.carbon.identity.oauth2.bean.Scope;
 import org.wso2.carbon.identity.oauth2.bean.ScopeBinding;
@@ -631,6 +629,29 @@ public class OAuth2ServiceComponent {
             log.debug("Unset organization user resident resolver service.");
         }
         OAuth2ServiceComponentHolder.setOrganizationUserResidentResolverService(null);
+    }
+
+    @Reference(
+            name = "internal.token.revocation.service",
+            service = InternalRevocationEventService.class,
+            cardinality = ReferenceCardinality.OPTIONAL,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetInternalTokenRevocationService"
+    )
+    protected void setInternalTokenRevocationService(InternalRevocationEventService internalTokenRevocationService) {
+
+        if (log.isDebugEnabled()) {
+            log.debug("Setting InternalTokenRevocationService service.");
+        }
+        OAuth2ServiceComponentHolder.getInstance().setInternalTokenRevocationService(internalTokenRevocationService);
+    }
+
+    protected void unsetInternalTokenRevocationService(InternalRevocationEventService internalTokenRevocationService) {
+
+        if (log.isDebugEnabled()) {
+            log.debug("Unset InternalTokenRevocationService service.");
+        }
+        OAuth2ServiceComponentHolder.getInstance().setInternalTokenRevocationService(null);
     }
 
     private static void loadScopeConfigFile() {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuth2ServiceComponentHolder.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuth2ServiceComponentHolder.java
@@ -25,6 +25,7 @@ import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.core.handler.HandlerComparator;
 import org.wso2.carbon.identity.oauth.OAuthAdminServiceImpl;
 import org.wso2.carbon.identity.oauth.dto.ScopeDTO;
+import org.wso2.carbon.identity.oauth2.*;
 import org.wso2.carbon.identity.oauth2.authz.validators.ResponseTypeRequestValidator;
 import org.wso2.carbon.identity.oauth2.bean.Scope;
 import org.wso2.carbon.identity.oauth2.client.authentication.OAuthClientAuthenticator;
@@ -70,6 +71,7 @@ public class OAuth2ServiceComponentHolder {
     private List<ScopeDTO> oidcScopesClaims = new ArrayList<>();
     private List<Scope> oauthScopeBinding = new ArrayList<>();
     private ScopeClaimMappingDAO scopeClaimMappingDAO;
+    private InternalRevocationEventService internalTokenRevocationService;
 
     private OAuth2ServiceComponentHolder() {
 
@@ -378,5 +380,23 @@ public class OAuth2ServiceComponentHolder {
             OrganizationUserResidentResolverService organizationUserResidentResolverService) {
 
         OAuth2ServiceComponentHolder.organizationUserResidentResolverService = organizationUserResidentResolverService;
+    }
+
+    /**
+     * Get internal token revocation service instance.
+     *
+     * @return InternalTokenRevocationService
+     */
+    public InternalRevocationEventService getInternalTokenRevocationService() {
+        return internalTokenRevocationService;
+    }
+
+    /**
+     * Set internal token revocation service instance.
+     *
+     * @param internalTokenRevocationService
+     */
+    public void setInternalTokenRevocationService(InternalRevocationEventService internalTokenRevocationService) {
+        this.internalTokenRevocationService = internalTokenRevocationService;
     }
 }


### PR DESCRIPTION
### Proposed changes in this pull request

 This service handles token revocations validations due to internal events.
 For example token revocations due to application deletion, user deletion, client secret regeneration, user profile
 claim updates and etc...

