### PR TITLE
Add request binding to JWT tokens

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
+++ b/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
@@ -163,6 +163,12 @@ public final class OAuthConstants {
     // Context tenant domain passed with request parameters.
     public static final String TENANT_DOMAIN_FROM_CONTEXT = "tenant_domain_from_context";
 
+    public static final String RENEW_TOKEN_WITHOUT_REVOKING_EXISTING_ALLOWED_GRANT_TYPES_CONFIG =
+            "OAuth.JWT.RenewTokenWithoutRevokingExisting.AllowedGrantTypes.AllowedGrantType";
+    public static final String RENEW_TOKEN_WITHOUT_REVOKING_EXISTING_ENABLE_CONFIG =
+            "OAuth.JWT.RenewTokenWithoutRevokingExisting.Enable";
+    public static final String REQUEST_BINDING_TYPE = "request";
+
     private OAuthConstants() {
 
     }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuth2ServiceComponent.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuth2ServiceComponent.java
@@ -98,6 +98,7 @@ import static org.wso2.carbon.identity.oauth2.device.constants.Constants.DEVICE_
 import static org.wso2.carbon.identity.oauth2.util.OAuth2Util.checkAudienceEnabled;
 import static org.wso2.carbon.identity.oauth2.util.OAuth2Util.checkConsentedTokenColumnAvailable;
 import static org.wso2.carbon.identity.oauth2.util.OAuth2Util.checkIDPIdColumnAvailable;
+import static org.wso2.carbon.identity.oauth2.util.OAuth2Util.getJWTRenewWithoutRevokeAllowedGrantTypes;
 
 /**
  * OAuth 2 OSGi service component.
@@ -212,6 +213,10 @@ public class OAuth2ServiceComponent {
                             " registered as the default Key ID Provider implementation.");
                 }
             }
+
+            // Read and store the allowed grant types for JWT renew without revoke in OAuth2ServiceComponentHolder.
+            OAuth2ServiceComponentHolder.setJwtRenewWithoutRevokeAllowedGrantTypes(
+                    getJWTRenewWithoutRevokeAllowedGrantTypes());
 
             ServiceRegistration tenantMgtListenerSR = bundleContext.registerService(TenantMgtListener.class.getName(),
                     new OAuthTenantMgtListenerImpl(), null);

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuth2ServiceComponentHolder.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuth2ServiceComponentHolder.java
@@ -70,6 +70,7 @@ public class OAuth2ServiceComponentHolder {
     private List<ScopeDTO> oidcScopesClaims = new ArrayList<>();
     private List<Scope> oauthScopeBinding = new ArrayList<>();
     private ScopeClaimMappingDAO scopeClaimMappingDAO;
+    private static List<String> jwtRenewWithoutRevokeAllowedGrantTypes = new ArrayList<>();
 
     private OAuth2ServiceComponentHolder() {
 
@@ -306,6 +307,28 @@ public class OAuth2ServiceComponentHolder {
     public IdpManager getIdpManager() {
 
         return idpManager;
+    }
+
+    /**
+     * Get the list of grant types which allowed JWT renew without revoke.
+     *
+     * @return JwtRenewWithoutRevokeAllowedGrantTypes
+     */
+    public static List<String> getJwtRenewWithoutRevokeAllowedGrantTypes() {
+
+        return jwtRenewWithoutRevokeAllowedGrantTypes;
+    }
+
+    /**
+     * Set the list of grant types which allowed JWT renew without revoke.
+     *
+     * @param jwtRenewWithoutRevokeAllowedGrantTypes List of grant types.
+     */
+    public static void setJwtRenewWithoutRevokeAllowedGrantTypes(
+            List<String> jwtRenewWithoutRevokeAllowedGrantTypes) {
+
+        OAuth2ServiceComponentHolder.jwtRenewWithoutRevokeAllowedGrantTypes =
+                jwtRenewWithoutRevokeAllowedGrantTypes;
     }
     
     /**

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuer.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuer.java
@@ -45,9 +45,12 @@ import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
 import org.wso2.carbon.identity.oauth.dao.OAuthAppDO;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.authz.OAuthAuthzReqMessageContext;
+import org.wso2.carbon.identity.oauth2.internal.OAuth2ServiceComponentHolder;
+import org.wso2.carbon.identity.oauth2.token.bindings.TokenBinding;
 import org.wso2.carbon.identity.oauth2.token.handlers.grant.AuthorizationGrantHandler;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 import org.wso2.carbon.identity.openidconnect.CustomClaimsCallbackHandler;
+import org.wso2.carbon.registry.core.utils.UUIDGenerator;
 
 import java.security.Key;
 import java.security.interfaces.RSAPrivateKey;
@@ -60,6 +63,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.RENEW_TOKEN_WITHOUT_REVOKING_EXISTING_ENABLE_CONFIG;
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.REQUEST_BINDING_TYPE;
 import static org.wso2.carbon.identity.oauth2.util.OAuth2Util.getPrivateKey;
 
 /**
@@ -722,6 +727,39 @@ public class JWTTokenIssuer extends OauthTokenIssuerImpl {
 
     private JWTClaimsSet handleTokenBinding(JWTClaimsSet.Builder jwtClaimsSetBuilder,
                                             OAuthTokenReqMessageContext tokReqMsgCtx) {
+
+        /**
+         * If OAuth.JWT.RenewTokenWithoutRevokingExisting is enabled from configurations, and current token
+         * binding is null,then we will add a new token binding (request binding) to the token binding with
+         * a value of a random UUID.
+         * The purpose of this new token binding type is to add a random value to the token binding so that
+         * "User, Application, Scope, Binding" combination will be unique for each token.
+         * Previously, if a token issue request come for the same combination of "User, Application, Scope, Binding",
+         * the existing JWT token will be revoked and issue a new token. but with this way, we can issue new tokens
+         * without revoking the old ones.
+         *
+         * Add following configuration to deployment.toml file to enable this feature.
+         *     [oauth.jwt.renew_token_without_revoking_existing]
+         *     enable = true
+         *
+         * By default, the allowed grant type for this feature is "client_credentials". If you need to enable for
+         * other grant types, add the following configuration to deployment.toml file.
+         *     [oauth.jwt.renew_token_without_revoking_existing]
+         *     enable = true
+         *     allowed_grant_types = ["client_credentials","password", ...]
+         */
+        boolean renewWithoutRevokingExistingEnabled = Boolean.parseBoolean(IdentityUtil.
+                getProperty(RENEW_TOKEN_WITHOUT_REVOKING_EXISTING_ENABLE_CONFIG));
+
+        if (renewWithoutRevokingExistingEnabled && tokReqMsgCtx != null && tokReqMsgCtx.getTokenBinding() == null) {
+            if (OAuth2ServiceComponentHolder.getJwtRenewWithoutRevokeAllowedGrantTypes()
+                    .contains(tokReqMsgCtx.getOauth2AccessTokenReqDTO().getGrantType())) {
+                String tokenBindingValue = UUIDGenerator.generateUUID();
+                tokReqMsgCtx.setTokenBinding(
+                        new TokenBinding(REQUEST_BINDING_TYPE, OAuth2Util.getTokenBindingReference(tokenBindingValue),
+                                tokenBindingValue));
+            }
+        }
 
         if (tokReqMsgCtx != null && tokReqMsgCtx.getTokenBinding() != null) {
             // Include token binding into the jwt token.

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -198,6 +198,7 @@ import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OAuth20Endpoi
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OAuth20Endpoints.OAUTH2_USER_INFO_EP_URL;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OAuth20Endpoints.OIDC_CONSENT_EP_URL;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OAuth20Endpoints.OIDC_WEB_FINGER_EP_URL;
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.RENEW_TOKEN_WITHOUT_REVOKING_EXISTING_ALLOWED_GRANT_TYPES_CONFIG;
 import static org.wso2.carbon.identity.oauth2.Oauth2ScopeConstants.PERMISSIONS_BINDING_TYPE;
 import static org.wso2.carbon.identity.oauth2.device.constants.Constants.DEVICE_SUCCESS_ENDPOINT_PATH;
 
@@ -4468,5 +4469,29 @@ public class OAuth2Util {
             }
         }
         return IdentityTenantUtil.getTenantDomainFromContext();
+    }
+
+    /**
+     * Get allowed grant type list for renewing token without revoking existing token.
+     *
+     * @return Allowed grant type list.
+     */
+    public static ArrayList<String> getJWTRenewWithoutRevokeAllowedGrantTypes() {
+
+        ArrayList<String> allowedGrantTypes;
+        Object value = IdentityConfigParser.getInstance().getConfiguration()
+                .get(RENEW_TOKEN_WITHOUT_REVOKING_EXISTING_ALLOWED_GRANT_TYPES_CONFIG);
+        if (value == null) {
+            allowedGrantTypes = new ArrayList<>(Arrays.asList(OAuthConstants.GrantTypes.CLIENT_CREDENTIALS));
+        } else if (value instanceof ArrayList) {
+            allowedGrantTypes = (ArrayList) value;
+        } else {
+            allowedGrantTypes = new ArrayList<>(Collections.singletonList((String) value));
+        }
+        if (log.isDebugEnabled()) {
+            log.debug("Allowed grant types for renewing token without revoking existing token: " + allowedGrantTypes);
+        }
+
+        return allowedGrantTypes;
     }
 }


### PR DESCRIPTION
Fix https://github.com/wso2/api-manager/issues/1691

### Purpose
Currently, when HA enable for a service provider and if each node request for a token, When the token type is opaque (default), IS keep the token in the database and return the same token for combination of application, scope, binding, user. But when it comes to JWT tokens, we cannot keep the token in the database due to the different lengths in different JWT tokens. Hence when application instances in HA request for a JWT token for the same application, scope, binding, user combination, current, IS will revoke the previous issued token and issue a new token. In that case, in HA environment, only one token will be in active state.

To solve this issue, we are adding new binding type called request binding type. When we enable this feature from configurations, we will add a new binding type to JWT tokens based on configured values. We will set a random UUID as the value of this new binding type, so when a HA environment request a token for the combination application, scope, binding, user, the binding value will be different and it will issue a new different token for each request without revoking existing token.

We can enable this feature by adding following config to the deployment.toml file.

> [oauth.jwt.renew_token_without_revoking_existing]
enable = true