### PR TITLE
x5t#sha256 size issue in jwks endpoint

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/jwks/JwksEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/jwks/JwksEndpoint.java
@@ -17,11 +17,12 @@
  */
 package org.wso2.carbon.identity.oauth.endpoint.jwks;
 
+import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.jwk.JWK;
 import com.nimbusds.jose.jwk.KeyUse;
 import com.nimbusds.jose.jwk.RSAKey;
 import com.nimbusds.jose.util.Base64;
-import com.nimbusds.jose.util.Base64URL;
 import net.minidev.json.JSONArray;
 import net.minidev.json.JSONObject;
 import org.apache.commons.lang.StringUtils;
@@ -111,7 +112,7 @@ public class JwksEndpoint {
     }
 
     private String buildResponse(List<CertificateInfo> certInfoList)
-            throws IdentityOAuth2Exception, ParseException, CertificateEncodingException {
+            throws IdentityOAuth2Exception, ParseException, CertificateEncodingException, JOSEException {
 
         JSONArray jwksArray = new JSONArray();
         JSONObject jwksJson = new JSONObject();
@@ -139,7 +140,7 @@ public class JwksEndpoint {
 
     private void populateJWKSArray(List<CertificateInfo> certInfoList, List<JWSAlgorithm> diffAlgorithms,
                                    JSONArray jwksArray, String hashingAlgorithm)
-            throws IdentityOAuth2Exception, ParseException, CertificateEncodingException {
+            throws IdentityOAuth2Exception, ParseException, CertificateEncodingException, JOSEException {
 
         for (CertificateInfo certInfo : certInfoList) {
             for (JWSAlgorithm algorithm : diffAlgorithms) {
@@ -156,7 +157,7 @@ public class JwksEndpoint {
 
     private RSAKey.Builder getJWK(JWSAlgorithm algorithm, List<Base64> encodedCertList, X509Certificate certificate,
                                   String kidAlgorithm, String alias)
-            throws ParseException, IdentityOAuth2Exception {
+            throws ParseException, IdentityOAuth2Exception, JOSEException {
         RSAKey.Builder jwk = new RSAKey.Builder((RSAPublicKey) certificate.getPublicKey());
         if (kidAlgorithm.equals(OAuthConstants.SignatureAlgorithms.KID_HASHING_ALGORITHM)) {
             jwk.keyID(OAuth2Util.getKID(certificate, algorithm, getTenantDomain()));
@@ -166,7 +167,8 @@ public class JwksEndpoint {
         jwk.algorithm(algorithm);
         jwk.keyUse(KeyUse.parse(KEY_USE));
         jwk.x509CertChain(encodedCertList);
-        jwk.x509CertSHA256Thumbprint(Base64URL.encode(OAuth2Util.getThumbPrint(certificate, alias)));
+        JWK parsedJWK = JWK.parse(certificate);
+        jwk.x509CertSHA256Thumbprint(parsedJWK.getX509CertSHA256Thumbprint());
         return jwk;
     }
 
@@ -195,8 +197,9 @@ public class JwksEndpoint {
             jwksArray.add(jwk.build().toJSONObject());
         }
     }
+
     /**
-     * This method read identity.xml and find different signing algorithms
+     * This method read identity.xml and find different signing algorithms.
      *
      * @param accessTokenSignAlgorithm
      * @param config
@@ -242,7 +245,7 @@ public class JwksEndpoint {
     }
 
     /**
-     * This method generates the key store file name from the Domain Name
+     * This method generates the key store file name from the Domain Name.
      *
      * @return key store file name
      */

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/jwks/JwksEndpointTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/jwks/JwksEndpointTest.java
@@ -50,6 +50,7 @@ import java.lang.reflect.Modifier;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.KeyStore;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -83,7 +84,7 @@ public class JwksEndpointTest extends PowerMockIdentityBaseTest {
     private static final String ALG = "RS256";
     private static final String USE = "sig";
     private static final JSONArray X5C_ARRAY = new JSONArray();
-    private static final String X5T = "ZHVtbXlUaHVtYlByaW50VmFsdWU";
+    private static final JSONArray X5T_ARRAY = new JSONArray();
     private JwksEndpoint jwksEndpoint;
     private Object identityUtilObj;
 
@@ -124,6 +125,9 @@ public class JwksEndpointTest extends PowerMockIdentityBaseTest {
                 "EJCSfsvswtLVDZ7GDvTHKojJjQvdVCzRj6XH5Truwefb4BJz9APtnlyJIvjHk1hdozqyOniVZd0QOxLAbcdt946chNdQvCm6aUOp" +
                 "utp8Xogr0KBnEy3U8es2cAfNZaEkPU8Va5bU6Xjny8zGQnXCXxPKp7sMpgO93nPBt/liX1qfyXM7xEotWoxmm6HZx8oWQ8U5aiXj" +
                 "Z5RKDWCCq4ZuXl6wVsUz1iE61suO5yWi8=");
+        X5T_ARRAY.put("vgeji34kzLU_6u8pLs985j8kPBRFtAYnZi_-yQdktYU");
+        X5T_ARRAY.put("UPDtpYmK86EVwsUIGUlW5-EU_iNHQ-nSL3Ca58uAG70");
+
     }
 
     @DataProvider(name = "provideTenantDomain")
@@ -196,7 +200,6 @@ public class JwksEndpointTest extends PowerMockIdentityBaseTest {
         if ("foo.com".equals(tenantDomain)) {
             when(OAuth2Util.mapSignatureAlgorithmForJWSAlgorithm("SHA512withRSA")).thenReturn(JWSAlgorithm.RS256);
         }
-        when(OAuth2Util.getThumbPrint(any(), anyString())).thenReturn("dummyThumbPrintValue");
         mockStatic(KeyStoreManager.class);
         when(KeyStoreManager.getInstance(anyInt())).thenReturn(keyStoreManager);
         when(keyStoreManager.getKeyStore("foo-com.jks")).thenReturn(getKeyStoreFromFile("foo-com.jks", "foo.com"));
@@ -211,14 +214,19 @@ public class JwksEndpointTest extends PowerMockIdentityBaseTest {
             assertEquals(keyObject.get("alg"), ALG, "Incorrect alg value");
             assertEquals(keyObject.get("use"), USE, "Incorrect use value");
             assertEquals(keyObject.get("kty"), "RSA", "Incorrect kty value");
-            assertEquals(keyObject.get("x5t#S256"), X5T, "Incorrect x5t#S256 value");
             if ("foo.com".equals(tenantDomain)) {
                 assertEquals(objectArray.length(), 2, "Incorrect no of keysets");
                 assertEquals(((JSONArray) keyObject.get("x5c")).get(0), X5C_ARRAY.get(0), "Incorrect x5c value");
+                assertEquals(keyObject.get("x5t#S256"), X5T_ARRAY.get(0), "Incorrect x5t#S256 value");
             } else {
                 assertEquals(objectArray.length(), 3, "Incorrect no of keysets");
                 assertEquals(((JSONArray) keyObject.get("x5c")).get(0), X5C_ARRAY.get(1), "Incorrect x5c value");
+                assertEquals(keyObject.get("x5t#S256"), X5T_ARRAY.get(1), "Incorrect x5t#S256 value");
             }
+            String base64UrlEncodedString = (String) keyObject.get("x5t#S256");
+            byte[] decodedBytes = Base64.getUrlDecoder().decode(base64UrlEncodedString);
+            assertEquals(decodedBytes.length, 32, "Incorrect x5t#S256 size");
+
         } catch (JSONException e) {
             if ("invalid.com".equals(tenantDomain)) {
                 // This is expected. We don't validate for invalid tenants.


### PR DESCRIPTION
### Proposed changes in this pull request

Fix for the issue [wso2/product-is#14899](https://github.com/wso2/product-is/issues/14899).

The current implementation sets the base64url encoded value of the thumbprint generated by the OAuth2Util to x5t#sha256, which is incompatible with the [RFC](https://www.rfc-editor.org/rfc/rfc7515#page-12) specification. This fix uses the nimbusds library to generate a thumbprint and creates a 32-byte base64url encoded string for x5t#sha256, which is compatible with the [RFC](https://www.rfc-editor.org/rfc/rfc7515#page-12) specification.

### When should this PR be merged

N/A


### Follow up actions

N/A


### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description.
- [ ] **Is the PR labeled correctly?**

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled.

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests.
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/).

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components.
- [ ] **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

#### Security

- [ ] **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
- [ ] **Are all UI and API inputs run through forms or serializers?**
- [ ] **Are all external inputs validated and sanitized appropriately?**
- [ ] **Does all branching logic have a default case?**
- [ ] **Does this solution handle outliers and edge cases gracefully?**
- [ ] **Are all external communications secured and restricted to SSL?**

#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes should be documented.
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented.
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki.
