### PR TITLE
[IS 6.0] Pattern validation logic for redirect URI

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/RequestObjectValidatorImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/RequestObjectValidatorImpl.java
@@ -45,6 +45,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 import static org.apache.commons.lang.StringUtils.isEmpty;
 import static org.apache.commons.lang.StringUtils.isNotEmpty;
@@ -348,9 +349,17 @@ public class RequestObjectValidatorImpl implements RequestObjectValidator {
      */
     protected boolean isValidRedirectUri(RequestObject requestObject, OAuth2Parameters oAuth2Parameters) {
 
+        boolean isValid;
         String redirectUriInReqObj = requestObject.getClaimValue(Constants.REDIRECT_URI);
-        boolean isValid = StringUtils.isBlank(redirectUriInReqObj) || StringUtils.equals(redirectUriInReqObj,
-                oAuth2Parameters.getRedirectURI());
+        String redirectURI = oAuth2Parameters.getRedirectURI();
+
+        if (redirectURI.startsWith(OAuthConstants.CALLBACK_URL_REGEXP_PREFIX)) {
+            String regex = redirectURI.substring(OAuthConstants.CALLBACK_URL_REGEXP_PREFIX.length());
+            isValid = Pattern.matches(regex, redirectUriInReqObj);
+        } else {
+            isValid = StringUtils.isBlank(redirectUriInReqObj) || StringUtils.equals(redirectUriInReqObj, redirectURI);
+        }
+
         if (!isValid) {
             if (LoggerUtils.isDiagnosticLogsEnabled()) {
                 Map<String, Object> params = new HashMap<>();

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/RequestObjectValidatorImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/RequestObjectValidatorImpl.java
@@ -353,7 +353,7 @@ public class RequestObjectValidatorImpl implements RequestObjectValidator {
         String redirectUriInReqObj = requestObject.getClaimValue(Constants.REDIRECT_URI);
         String redirectURI = oAuth2Parameters.getRedirectURI();
 
-        if (redirectURI.startsWith(OAuthConstants.CALLBACK_URL_REGEXP_PREFIX)) {
+        if (StringUtils.isNotEmpty(redirectURI) && redirectURI.startsWith(OAuthConstants.CALLBACK_URL_REGEXP_PREFIX)) {
             String regex = redirectURI.substring(OAuthConstants.CALLBACK_URL_REGEXP_PREFIX.length());
             isValid = Pattern.matches(regex, redirectUriInReqObj);
         } else {


### PR DESCRIPTION
Fix for: Authorise call fails when calling only with request_uri and client_id
Issue link: https://github.com/wso2/product-is/issues/13416, https://github.com/wso2/product-is/issues/15817
Related PR: https://github.com/wso2-support/identity-inbound-auth-oauth/pull/1143, https://github.com/wso2-support/identity-inbound-auth-oauth/pull/1354
Related to: OBINTERNAL-830