### PR TITLE
Add removeOnConsume attribute to SessionCacheEntry

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
@@ -847,6 +847,9 @@ public class EndpointUtil {
                     // Filter the query parameters from the consent page url.
                     consentPageUrl = filterQueryParamsFromConsentPageUrl(entry.getEndpointParams(), consentPageUrl,
                             sessionDataKeyConsent);
+                    if (isExternalConsentPageEnabledForSP(sp)) {
+                        entry.setRemoveOnConsume(true);
+                    }
                     entry.setValidityPeriod(TimeUnit.MINUTES.toNanos(IdentityUtil.getTempDataCleanUpTimeout()));
                     sessionDataCache.addToCache(new SessionDataCacheKey(sessionDataKeyConsent), entry);
                 } else {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/cache/SessionDataCacheEntry.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/cache/SessionDataCacheEntry.java
@@ -41,6 +41,7 @@ public class SessionDataCacheEntry extends CacheEntry {
     private String authenticatedIdPs;
     private String essentialClaims;
     private String sessionContextIdentifier;
+    private boolean removeOnConsume = false;
 
     private String queryString = null;
 
@@ -135,5 +136,25 @@ public class SessionDataCacheEntry extends CacheEntry {
     public void setSessionContextIdentifier(String sessionContextIdentifier) {
 
         this.sessionContextIdentifier = sessionContextIdentifier;
+    }
+
+    /**
+     * Get removeOnConsume.
+     *
+     * @return removeOnConsume.
+     */
+    public boolean isRemoveOnConsume() {
+
+        return removeOnConsume;
+    }
+
+    /**
+     * Set removeOnConsume.
+     *
+     * @param removeOnConsume removeOnConsume.
+     */
+    public void setRemoveOnConsume(boolean removeOnConsume) {
+
+        this.removeOnConsume = removeOnConsume;
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/cache/SessionDataCacheEntry.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/cache/SessionDataCacheEntry.java
@@ -41,6 +41,8 @@ public class SessionDataCacheEntry extends CacheEntry {
     private String authenticatedIdPs;
     private String essentialClaims;
     private String sessionContextIdentifier;
+
+    /* This is used to clear the cache entry once the data is consumed from the context data API */
     private boolean removeOnConsume = false;
 
     private String queryString = null;

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/cache/SessionDataCacheEntry.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/cache/SessionDataCacheEntry.java
@@ -42,7 +42,7 @@ public class SessionDataCacheEntry extends CacheEntry {
     private String essentialClaims;
     private String sessionContextIdentifier;
 
-    /* This is used to clear the cache entry once the data is consumed from the context data API */
+   // Flag to indicate whether the entry needs to be removed once consumed.
     private boolean removeOnConsume = false;
 
     private String queryString = null;


### PR DESCRIPTION
### Proposed changes in this pull request

- Introduced a new attribute for session cache entry. --> `removeOnConsume`
- By default `removeOnConsume` is **false**.
- In the external consent page flow, if the external consent page is enabled for application, we are setting 
`removeOnConume = true` to remove the data from the cache after reading using context data API from external side.
