### PR TITLE
Fix logout issue for sub-organization console by setting the userId if not exist in authenticated user object

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dao/AccessTokenDAOImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dao/AccessTokenDAOImpl.java
@@ -2933,6 +2933,7 @@ public class AccessTokenDAOImpl extends AbstractOAuthDAO implements AccessTokenD
                             accessTokenDO.setValidityPeriod(validityPeriodInMillis);
                             accessTokenDO.setRefreshTokenValidityPeriod(refreshTokenValidityPeriodMillis);
                             accessTokenDO.setTokenType(tokenType);
+                            OAuth2Util.setUserIdIfNotExist(accessTokenDO.getAuthzUser(), subjectIdentifier);
                             tokenMap.put(token, accessTokenDO);
                         }
                         return Collections.emptySet();

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dao/AccessTokenDAOImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dao/AccessTokenDAOImpl.java
@@ -1,21 +1,19 @@
 /*
+ * Copyright (c) 2017-2023, WSO2 LLC. (http://www.wso2.com).
  *
- *   Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *   WSO2 Inc. licenses this file to you under the Apache License,
- *   Version 2.0 (the "License"); you may not use this file except
- *   in compliance with the License.
- *   You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *   Unless required by applicable law or agreed to in writing,
- *   software distributed under the License is distributed on an
- *   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- *   KIND, either express or implied.  See the License for the
- *   specific language governing permissions and limitations
- *   under the License.
- * /
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.wso2.carbon.identity.oauth2.dao;

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/bindings/handlers/TokenBindingExpiryEventHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/bindings/handlers/TokenBindingExpiryEventHandler.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2020-2023, WSO2 LLC. (http://www.wso2.com).
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -322,6 +322,10 @@ public class TokenBindingExpiryEventHandler extends AbstractEventHandler {
                             && StringUtils.equalsIgnoreCase(
                                     user.getFederatedIdPName(), authenticatedUser.getFederatedIdPName())
                             && StringUtils.equalsIgnoreCase(user.getUserName(), authenticatedUser.getUserName())) {
+                        revokeFederatedTokens(consumerKey, user, accessTokenDO, tokenBindingReference);
+                    } else if (authenticatedUser.getAuthenticatedSubjectIdentifier() != null &&
+                            StringUtils.equals(userId, authenticatedUser.getAuthenticatedSubjectIdentifier()
+                                    .split("@")[0])) {
                         revokeFederatedTokens(consumerKey, user, accessTokenDO, tokenBindingReference);
                     } else if (StringUtils.equalsIgnoreCase(userId, authenticatedUser.getUserId())) {
                         revokeTokens(consumerKey, accessTokenDO, tokenBindingReference);

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/bindings/handlers/TokenBindingExpiryEventHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/bindings/handlers/TokenBindingExpiryEventHandler.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2020-2023, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
- * WSO2 LLC. licenses this file to you under the Apache License,
+ * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -322,10 +322,6 @@ public class TokenBindingExpiryEventHandler extends AbstractEventHandler {
                             && StringUtils.equalsIgnoreCase(
                                     user.getFederatedIdPName(), authenticatedUser.getFederatedIdPName())
                             && StringUtils.equalsIgnoreCase(user.getUserName(), authenticatedUser.getUserName())) {
-                        revokeFederatedTokens(consumerKey, user, accessTokenDO, tokenBindingReference);
-                    } else if (authenticatedUser.getAuthenticatedSubjectIdentifier() != null &&
-                            StringUtils.equals(userId, authenticatedUser.getAuthenticatedSubjectIdentifier()
-                                    .split("@")[0])) {
                         revokeFederatedTokens(consumerKey, user, accessTokenDO, tokenBindingReference);
                     } else if (StringUtils.equalsIgnoreCase(userId, authenticatedUser.getUserId())) {
                         revokeTokens(consumerKey, accessTokenDO, tokenBindingReference);

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/RefreshGrantHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/RefreshGrantHandler.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2013, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2013-2023, WSO2 LLC. (http://www.wso2.com).
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/RefreshGrantHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/RefreshGrantHandler.java
@@ -344,6 +344,8 @@ public class RefreshGrantHandler extends AbstractAuthorizationGrantHandler {
             // Remove old access token from the OAuthCache
             String scope = OAuth2Util.buildScopeString(tokReqMsgCtx.getScope());
             String userId;
+            OAuth2Util.setUserIdIfNotExist(tokReqMsgCtx.getAuthorizedUser(),
+                    tokReqMsgCtx.getAuthorizedUser().getAuthenticatedSubjectIdentifier());
             try {
                 userId = tokReqMsgCtx.getAuthorizedUser().getUserId();
             } catch (UserIdNotFoundException e) {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2013-2023, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -570,16 +570,14 @@ public class OAuth2Util {
     }
 
     /**
-     * Resolve the user from the ancestor organizations if the authenticated user id is not populated.
+     * Resolve the user from ancestor organizations and set the user ID if the authenticated user id is not populated.
      *
-     * @param authenticatedUser The authenticated user object.
+     * @param authenticatedUser              The authenticated user object.
      * @param authenticatedSubjectIdentifier The authenticated subject identifier.
      */
     public static void setUserIdIfNotExist(AuthenticatedUser authenticatedUser, String authenticatedSubjectIdentifier) {
 
-        try {
-            authenticatedUser.getUserId();
-        } catch (UserIdNotFoundException e) {
+        if (StringUtils.equals(authenticatedUser.getLoggableUserId(), authenticatedUser.toFullQualifiedUsername())) {
             if (authenticatedUser.getAuthenticatedSubjectIdentifier() == null) {
                 return;
             }
@@ -587,7 +585,7 @@ public class OAuth2Util {
             int tenantID = IdentityTenantUtil.getTenantId(authenticatedUser.getTenantDomain());
             try {
                 Tenant tenant = OAuthComponentServiceHolder.getInstance().getRealmService()
-                            .getTenantManager().getTenant(tenantID);
+                        .getTenantManager().getTenant(tenantID);
                 String accessedOrganizationId = tenant.getAssociatedOrganizationUUID();
                 if (accessedOrganizationId != null) {
                     Optional<User> optionalUser = OAuthComponentServiceHolder.getInstance()
@@ -600,6 +598,7 @@ public class OAuth2Util {
             }
         }
     }
+
     public static TokenPersistenceProcessor getPersistenceProcessor() {
 
         TokenPersistenceProcessor persistenceProcessor;

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -569,6 +569,12 @@ public class OAuth2Util {
         }
     }
 
+    /**
+     * Resolve the user from the ancestor organizations if the authenticated user id is not populated.
+     *
+     * @param authenticatedUser The authenticated user object.
+     * @param authenticatedSubjectIdentifier The authenticated subject identifier.
+     */
     public static void setUserIdIfNotExist(AuthenticatedUser authenticatedUser, String authenticatedSubjectIdentifier) {
 
         try {
@@ -584,12 +590,13 @@ public class OAuth2Util {
                             .getTenantManager().getTenant(tenantID);
                 String accessedOrganizationId = tenant.getAssociatedOrganizationUUID();
                 if (accessedOrganizationId != null) {
-                    Optional<User> optionalUser = OAuthComponentServiceHolder.getInstance().getOrganizationUserResidentResolverService()
+                    Optional<User> optionalUser = OAuthComponentServiceHolder.getInstance()
+                            .getOrganizationUserResidentResolverService()
                             .resolveUserFromResidentOrganization(null, userId, accessedOrganizationId);
                     optionalUser.ifPresent(user -> authenticatedUser.setUserId(user.getUserID()));
                 }
             } catch (UserStoreException | OrganizationManagementException ex) {
-                return;
+                log.debug("User could not resolved from the organization hierarchy");
             }
         }
     }


### PR DESCRIPTION
### Proposed changes in this pull request

In this PR, a new method `setUserIdIfNotExist` is proposed to set the userId in the authenticated user if the userId is not populated in the `AuthenticatedUser` object. Normally it should be set, but when the user resides in an ancestor organization, the userId won't be able to resolve by username.

Due to that, two places were affected.

All the flows will be affected for B2B sub-organization related user logout or session extension scenarios.

1 - Building the `accessTokenDO` object when token is about to revoked upon user logout. Ideally userId should be populated, but due to above mentioned reason userId is set to `null`.

2 - When session extend request are sent using the refresh token grant type for the logged in sessions of the sub-organization level users, useID is required to cache the access token when successfully using the token. The cache key includes the userID, hence userID should be able to resolve.

In the above mentioned both cases, the tokens are based on organization switch grant type. It is due to sub-organization level tokens are issued by that grant type. More specifically, when using that grant type, the subject identifier is set in the form of `userId@tenantDomain`. That information is used to first check the existence of the user with that userID and set for authenticated user object incase the userID is missing. 