### PR TITLE
Fix for Multi attribute separator changes

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/token/OAuth2TokenEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/token/OAuth2TokenEndpoint.java
@@ -66,7 +66,6 @@ import javax.ws.rs.core.Response.ResponseBuilder;
 import static org.apache.commons.lang.StringUtils.isNotBlank;
 import static org.wso2.carbon.identity.oauth.endpoint.util.EndpointUtil.parseJsonTokenRequest;
 import static org.wso2.carbon.identity.oauth.endpoint.util.EndpointUtil.startSuperTenantFlow;
-import static org.wso2.carbon.identity.oauth.endpoint.util.EndpointUtil.startTenantFlow;
 import static org.wso2.carbon.identity.oauth.endpoint.util.EndpointUtil.triggerOnTokenExceptionListeners;
 import static org.wso2.carbon.identity.oauth.endpoint.util.EndpointUtil.validateOauthApplication;
 import static org.wso2.carbon.identity.oauth.endpoint.util.EndpointUtil.validateParams;
@@ -91,9 +90,8 @@ public class OAuth2TokenEndpoint {
 
         Map<String, List<String>> paramMap;
         try {
-            if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled()) {
-                startTenantFlow();
-            } else {
+            // Start super tenant flow only if tenant qualified URLs are disabled.
+            if (!IdentityTenantUtil.isTenantQualifiedUrlsEnabled()) {
                 startSuperTenantFlow();
             }
             paramMap = parseJsonTokenRequest(payload);
@@ -110,7 +108,9 @@ public class OAuth2TokenEndpoint {
             triggerOnTokenExceptionListeners(e, request, null);
             throw e;
         } finally {
-            PrivilegedCarbonContext.endTenantFlow();
+            if (!IdentityTenantUtil.isTenantQualifiedUrlsEnabled()) {
+                PrivilegedCarbonContext.endTenantFlow();
+            }
         }
         return issueAccessToken(request, paramMap);
     }
@@ -139,9 +139,8 @@ public class OAuth2TokenEndpoint {
             OAuthSystemException, InvalidRequestParentException {
 
         try {
-            if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled()) {
-                startTenantFlow();
-            } else {
+            // Start super tenant flow only if tenant qualified URLs are disabled.
+            if (!IdentityTenantUtil.isTenantQualifiedUrlsEnabled()) {
                 startSuperTenantFlow();
             }
             validateRepeatedParams(request, paramMap);
@@ -167,7 +166,9 @@ public class OAuth2TokenEndpoint {
             throw e;
 
         } finally {
-            PrivilegedCarbonContext.endTenantFlow();
+            if (!IdentityTenantUtil.isTenantQualifiedUrlsEnabled()) {
+                PrivilegedCarbonContext.endTenantFlow();
+            }
         }
     }
 

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/token/OAuth2TokenEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/token/OAuth2TokenEndpoint.java
@@ -31,6 +31,7 @@ import org.apache.oltu.oauth2.common.message.OAuthResponse;
 import org.apache.oltu.oauth2.common.message.types.GrantType;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.oauth.client.authn.filter.OAuthClientAuthenticatorProxy;
 import org.wso2.carbon.identity.oauth.common.OAuth2ErrorCodes;
 import org.wso2.carbon.identity.oauth.common.OAuthConstants;
@@ -65,6 +66,7 @@ import javax.ws.rs.core.Response.ResponseBuilder;
 import static org.apache.commons.lang.StringUtils.isNotBlank;
 import static org.wso2.carbon.identity.oauth.endpoint.util.EndpointUtil.parseJsonTokenRequest;
 import static org.wso2.carbon.identity.oauth.endpoint.util.EndpointUtil.startSuperTenantFlow;
+import static org.wso2.carbon.identity.oauth.endpoint.util.EndpointUtil.startTenantFlow;
 import static org.wso2.carbon.identity.oauth.endpoint.util.EndpointUtil.triggerOnTokenExceptionListeners;
 import static org.wso2.carbon.identity.oauth.endpoint.util.EndpointUtil.validateOauthApplication;
 import static org.wso2.carbon.identity.oauth.endpoint.util.EndpointUtil.validateParams;
@@ -89,7 +91,11 @@ public class OAuth2TokenEndpoint {
 
         Map<String, List<String>> paramMap;
         try {
-            startSuperTenantFlow();
+            if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled()) {
+                startTenantFlow();
+            } else {
+                startSuperTenantFlow();
+            }
             paramMap = parseJsonTokenRequest(payload);
             if (LoggerUtils.isDiagnosticLogsEnabled()) {
                 Map<String, Object> params = new HashMap<>();
@@ -133,7 +139,11 @@ public class OAuth2TokenEndpoint {
             OAuthSystemException, InvalidRequestParentException {
 
         try {
-            startSuperTenantFlow();
+            if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled()) {
+                startTenantFlow();
+            } else {
+                startSuperTenantFlow();
+            }
             validateRepeatedParams(request, paramMap);
             HttpServletRequestWrapper httpRequest = new OAuthRequestWrapper(request, paramMap);
             CarbonOAuthTokenRequest oauthRequest = buildCarbonOAuthTokenRequest(httpRequest);

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/ClaimUtil.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/ClaimUtil.java
@@ -74,7 +74,6 @@ public class ClaimUtil {
 
     private static final String SP_DIALECT = "http://wso2.org/oidc/claim";
     private static final String GROUPS = "groups";
-    private static final String ATTRIBUTE_SEPARATOR = FrameworkUtils.getMultiAttributeSeparator();
     private static final Log log = LogFactory.getLog(ClaimUtil.class);
 
     private ClaimUtil() {
@@ -381,7 +380,7 @@ public class ClaimUtil {
      */
     public static boolean isMultiValuedAttribute(String claimValue) {
 
-        return StringUtils.contains(claimValue, ATTRIBUTE_SEPARATOR);
+        return StringUtils.contains(claimValue, FrameworkUtils.getMultiAttributeSeparator());
     }
 
     /**
@@ -398,7 +397,7 @@ public class ClaimUtil {
         if (GROUPS.equals(claimUri)) {
             return true;
         }
-        return StringUtils.contains(claimValue, ATTRIBUTE_SEPARATOR);
+        return StringUtils.contains(claimValue, FrameworkUtils.getMultiAttributeSeparator());
     }
 
     /**
@@ -409,6 +408,6 @@ public class ClaimUtil {
      */
     public static String[] processMultiValuedAttribute(String claimValue) {
 
-        return claimValue.split(Pattern.quote(ATTRIBUTE_SEPARATOR));
+        return claimValue.split(Pattern.quote(FrameworkUtils.getMultiAttributeSeparator()));
     }
 }

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
@@ -1421,19 +1421,6 @@ public class EndpointUtil {
     }
 
     /**
-     * This method will start a tenant flow.
-     */
-    public static void startTenantFlow() {
-
-        int tenantId = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantId();
-        String tenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
-        PrivilegedCarbonContext.startTenantFlow();
-        PrivilegedCarbonContext carbonContext = PrivilegedCarbonContext.getThreadLocalCarbonContext();
-        carbonContext.setTenantId(tenantId);
-        carbonContext.setTenantDomain(tenantDomain);
-    }
-
-    /**
      * This API validate the oauth application. Check whether an application exits for given cosumerKey and check
      * it's status
      *

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
@@ -1421,6 +1421,19 @@ public class EndpointUtil {
     }
 
     /**
+     * This method will start a tenant flow.
+     */
+    public static void startTenantFlow() {
+
+        int tenantId = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantId();
+        String tenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
+        PrivilegedCarbonContext.startTenantFlow();
+        PrivilegedCarbonContext carbonContext = PrivilegedCarbonContext.getThreadLocalCarbonContext();
+        carbonContext.setTenantId(tenantId);
+        carbonContext.setTenantDomain(tenantDomain);
+    }
+
+    /**
      * This API validate the oauth application. Check whether an application exits for given cosumerKey and check
      * it's status
      *

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuth2ServiceComponent.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuth2ServiceComponent.java
@@ -31,6 +31,7 @@ import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.identity.application.authentication.framework.ApplicationAuthenticationService;
 import org.wso2.carbon.identity.application.authentication.framework.AuthenticationDataPublisher;
 import org.wso2.carbon.identity.application.authentication.framework.AuthenticationMethodNameTranslator;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
@@ -905,5 +906,24 @@ public class OAuth2ServiceComponent {
             log.debug("Removing JWT Access Token ClaimProvider: " + claimProvider.getClass().getName());
         }
         OAuth2ServiceComponentHolder.getInstance().removeJWTAccessTokenClaimProvider(claimProvider);
+    }
+
+    @Reference(
+            name = "identity.application.authentication.framework",
+            service = ApplicationAuthenticationService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetApplicationAuthenticationService"
+    )
+    protected void setApplicationAuthenticationService(
+            ApplicationAuthenticationService applicationAuthenticationService) {
+        /* reference ApplicationAuthenticationService service to guarantee that this component will wait until
+        authentication framework is started */
+    }
+
+    protected void unsetApplicationAuthenticationService(
+            ApplicationAuthenticationService applicationAuthenticationService) {
+        /* reference ApplicationAuthenticationService service to guarantee that this component will wait until
+        authentication framework is started */
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/JDBCPermissionBasedInternalScopeValidator.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/JDBCPermissionBasedInternalScopeValidator.java
@@ -87,7 +87,6 @@ public class JDBCPermissionBasedInternalScopeValidator {
     private static final String ROOT = "/";
     private static final String ADMIN_PERMISSION_ROOT = "/permission/admin";
     private static final String EVERYONE_PERMISSION = "everyone_permission";
-    private static final String ATTRIBUTE_SEPARATOR = FrameworkUtils.getMultiAttributeSeparator();
 
     /**
      * Execute Internal scope Validation.
@@ -377,11 +376,12 @@ public class JDBCPermissionBasedInternalScopeValidator {
      */
     private List<String> getValuesOfGroupsFromUserAttributes(Map<ClaimMapping, String> userAttributes) {
 
+        String multiAttributeSeparator = FrameworkUtils.getMultiAttributeSeparator();
         if (MapUtils.isNotEmpty(userAttributes)) {
             for (Map.Entry<ClaimMapping, String> entry : userAttributes.entrySet()) {
                 if (entry.getKey().getRemoteClaim() != null) {
                     if (StringUtils.equals(entry.getKey().getRemoteClaim().getClaimUri(), OAuth2Constants.GROUPS)) {
-                        return Arrays.asList(entry.getValue().split(Pattern.quote(ATTRIBUTE_SEPARATOR)));
+                        return Arrays.asList(entry.getValue().split(Pattern.quote(multiAttributeSeparator)));
                     }
                 }
             }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/JDBCScopeValidator.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/JDBCScopeValidator.java
@@ -92,7 +92,6 @@ public class JDBCScopeValidator extends OAuth2ScopeValidator {
             "retrieveRolesFromUserStoreForScopeValidation";
     private static final String SCOPE_VALIDATOR_NAME = "Role based scope validator";
     private static final String OPENID = "openid";
-    private static final String ATTRIBUTE_SEPARATOR = FrameworkUtils.getMultiAttributeSeparator();
     private static final String PRESERVE_CASE_SENSITIVITY = "preservedCaseSensitive";
 
     private static final Log log = LogFactory.getLog(JDBCScopeValidator.class);
@@ -352,11 +351,12 @@ public class JDBCScopeValidator extends OAuth2ScopeValidator {
      */
     private List<String> getValuesOfGroupsFromUserAttributes(Map<ClaimMapping, String> userAttributes) {
 
+        String multiAttributeSeparator = FrameworkUtils.getMultiAttributeSeparator();
         if (MapUtils.isNotEmpty(userAttributes)) {
             for (Map.Entry<ClaimMapping, String> entry : userAttributes.entrySet()) {
                 if (entry.getKey().getRemoteClaim() != null) {
                     if (StringUtils.equals(entry.getKey().getRemoteClaim().getClaimUri(), OAuth2Constants.GROUPS)) {
-                        return Arrays.asList(entry.getValue().split(Pattern.quote(ATTRIBUTE_SEPARATOR)));
+                        return Arrays.asList(entry.getValue().split(Pattern.quote(multiAttributeSeparator)));
                     }
                 }
             }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/DefaultOIDCClaimsCallbackHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/DefaultOIDCClaimsCallbackHandler.java
@@ -87,7 +87,6 @@ public class DefaultOIDCClaimsCallbackHandler implements CustomClaimsCallbackHan
     private static final Log log = LogFactory.getLog(DefaultOIDCClaimsCallbackHandler.class);
     private static final String OAUTH2 = "oauth2";
     private static final String OIDC_DIALECT = "http://wso2.org/oidc/claim";
-    private static final String ATTRIBUTE_SEPARATOR = FrameworkUtils.getMultiAttributeSeparator();
 
     @Override
     public JWTClaimsSet handleCustomClaims(JWTClaimsSet.Builder jwtClaimsSetBuilder, OAuthTokenReqMessageContext
@@ -562,7 +561,8 @@ public class DefaultOIDCClaimsCallbackHandler implements CustomClaimsCallbackHan
                         userClaims.size());
             }
             // Map the local roles to SP defined roles.
-            handleServiceProviderRoleMappings(serviceProvider, ATTRIBUTE_SEPARATOR, userClaims);
+            handleServiceProviderRoleMappings(serviceProvider, FrameworkUtils.getMultiAttributeSeparator(),
+                    userClaims);
 
             // Get the user claims in oidc dialect to be returned in the id_token.
             Map<String, Object> userClaimsInOIDCDialect = getUserClaimsInOIDCDialect(spTenantDomain, userClaims);
@@ -784,12 +784,13 @@ public class DefaultOIDCClaimsCallbackHandler implements CustomClaimsCallbackHan
             userClaimsInOIDCDialect) {
 
         JWTClaimsSet jwtClaimsSet = jwtClaimsSetBuilder.build();
+        String multiAttributeSeparator = FrameworkUtils.getMultiAttributeSeparator();
         for (Map.Entry<String, Object> claimEntry : userClaimsInOIDCDialect.entrySet()) {
             String claimValue = claimEntry.getValue().toString();
             String claimKey = claimEntry.getKey();
-            if (isMultiValuedAttribute(claimKey, claimValue)) {
+            if (isMultiValuedAttribute(claimKey, claimValue, multiAttributeSeparator)) {
                 JSONArray claimValues = new JSONArray();
-                String[] attributeValues = claimValue.split(Pattern.quote(ATTRIBUTE_SEPARATOR));
+                String[] attributeValues = claimValue.split(Pattern.quote(multiAttributeSeparator));
                 for (String attributeValue : attributeValues) {
                     if (StringUtils.isNotBlank(attributeValue)) {
                         claimValues.add(attributeValue);
@@ -827,7 +828,7 @@ public class DefaultOIDCClaimsCallbackHandler implements CustomClaimsCallbackHan
         return !authzReqMessageContext.getAuthorizationReqDTO().getUser().isFederatedUser();
     }
 
-    private boolean isMultiValuedAttribute(String claimKey, String claimValue) {
+    private boolean isMultiValuedAttribute(String claimKey, String claimValue, String multiAttributeSeparator) {
 
         // Address claim contains multi attribute separator but its not a multi valued attribute.
         if (claimKey.equals(ADDRESS)) {
@@ -838,6 +839,6 @@ public class DefaultOIDCClaimsCallbackHandler implements CustomClaimsCallbackHan
         if (claimKey.equals(GROUPS)) {
             return true;
         }
-        return StringUtils.contains(claimValue, ATTRIBUTE_SEPARATOR);
+        return StringUtils.contains(claimValue, multiAttributeSeparator);
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/openidconnect/DefaultOIDCClaimsCallbackHandlerTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/openidconnect/DefaultOIDCClaimsCallbackHandlerTest.java
@@ -239,10 +239,6 @@ public class DefaultOIDCClaimsCallbackHandlerTest extends PowerMockTestCase {
         connection = dataSource1.getConnection();
         connection.createStatement().executeUpdate("RUNSCRIPT FROM '" + getFilePath(H2_SCRIPT_NAME) + "'");
 
-        mockStatic(FrameworkUtils.class);
-        when(FrameworkUtils.getMultiAttributeSeparator()).thenReturn(MULTI_ATTRIBUTE_SEPARATOR_DEFAULT);
-
-
         RequestObjectService requestObjectService = Mockito.mock(RequestObjectService.class);
         List<RequestedClaim> requestedClaims = Collections.emptyList();
         when(requestObjectService.getRequestedClaimsForIDToken(anyString())).
@@ -262,13 +258,18 @@ public class DefaultOIDCClaimsCallbackHandlerTest extends PowerMockTestCase {
         OpenIDConnectServiceComponentHolder.setRequestObjectService(requestObjectService);
         OAuth2ServiceComponentHolder.getInstance().setScopeClaimMappingDAO(new ScopeClaimMappingDAOImpl());
     }
+
     @BeforeMethod
     public void setUpBeforeMethod() throws Exception {
         PrivilegedCarbonContext.startTenantFlow();
         PrivilegedCarbonContext privilegedCarbonContext = PrivilegedCarbonContext.getThreadLocalCarbonContext();
         privilegedCarbonContext.setTenantId(MultitenantConstants.SUPER_TENANT_ID);
         privilegedCarbonContext.setTenantDomain(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+
+        mockStatic(FrameworkUtils.class);
+        when(FrameworkUtils.getMultiAttributeSeparator()).thenReturn(MULTI_ATTRIBUTE_SEPARATOR_DEFAULT);
     }
+
     public static String getFilePath(String fileName) {
 
         if (StringUtils.isNotBlank(fileName)) {
@@ -315,6 +316,8 @@ public class DefaultOIDCClaimsCallbackHandlerTest extends PowerMockTestCase {
 
         ServiceProvider serviceProvider = getSpWithDefaultRequestedClaimsMappings();
         mockApplicationManagementService(serviceProvider);
+
+        when(FrameworkUtils.isContinueOnClaimHandlingErrorAllowed()).thenReturn(true);
 
         JWTClaimsSet jwtClaimsSet = getJwtClaimSet(jwtClaimsSetBuilder, requestMsgCtx);
         assertNotNull(jwtClaimsSet);
@@ -384,6 +387,8 @@ public class DefaultOIDCClaimsCallbackHandlerTest extends PowerMockTestCase {
         ServiceProvider serviceProvider = getSpWithDefaultRequestedClaimsMappings();
         mockApplicationManagementService(serviceProvider);
 
+        when(FrameworkUtils.isContinueOnClaimHandlingErrorAllowed()).thenReturn(true);
+
         UserRealm userRealm = getExceptionThrowingUserRealm(new UserStoreException(USER_NOT_FOUND));
         mockUserRealm(requestMsgCtx.getAuthorizedUser().toString(), userRealm);
 
@@ -400,6 +405,8 @@ public class DefaultOIDCClaimsCallbackHandlerTest extends PowerMockTestCase {
 
         ServiceProvider serviceProvider = getSpWithDefaultRequestedClaimsMappings();
         mockApplicationManagementService(serviceProvider);
+
+        when(FrameworkUtils.isContinueOnClaimHandlingErrorAllowed()).thenReturn(true);
 
         UserRealm userRealm = getExceptionThrowingUserRealm(new UserStoreException(""));
         mockUserRealm(requestMsgCtx.getAuthorizedUser().toString(), userRealm);


### PR DESCRIPTION
### Proposed changes in this pull request

Add a OSGI reference for the authentication framework so that it will guarantee oauth component will wait until the authentication framework is started. This needs to be done as the oauth component calls `FrameworkUtils.getMultiAttributeSeparator()` in several places. With https://github.com/wso2/carbon-identity-framework/pull/4729, we need to ensure that Framework service is up before invoking the getMultiAttributeSeparator() method.

Since the multi attribute separator is organization wide configurable, class level variables needs to be moved into the method level.

When the tenant qualified urls are enabled, need to start the tenant flow instead of the super tenant flow.

### Related Issue
- https://github.com/wso2/product-is/issues/16072

### Related PRs
- https://github.com/wso2/carbon-identity-framework/pull/4729

### When should this PR be merged

[Please describe any preconditions that need to be addressed before we
can merge this pull request.]


### Follow up actions

[List any possible follow-up actions here; for instance, testing data
migrations, software that we need to install on staging and production
environments.]

-


### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description.
- [ ] **Is the PR labeled correctly?**

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled.

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests.
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/).

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components.
- [ ] **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

#### Security

- [ ] **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
- [ ] **Are all UI and API inputs run through forms or serializers?**
- [ ] **Are all external inputs validated and sanitized appropriately?**
- [ ] **Does all branching logic have a default case?**
- [ ] **Does this solution handle outliers and edge cases gracefully?**
- [ ] **Are all external communications secured and restricted to SSL?**

#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes should be documented.
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented.
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki.
