### PR TITLE
Improve resolving subject claim when user resides in ancestor organization.

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuth2ServiceComponent.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuth2ServiceComponent.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2013, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2013-2023, WSO2 LLC. (http://www.wso2.com).
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -11,7 +11,7 @@
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the
+ * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
  */
@@ -78,11 +78,13 @@ import org.wso2.carbon.identity.openidconnect.OpenIDConnectClaimFilterImpl;
 import org.wso2.carbon.identity.openidconnect.dao.ScopeClaimMappingDAO;
 import org.wso2.carbon.identity.openidconnect.dao.ScopeClaimMappingDAOImpl;
 import org.wso2.carbon.identity.organization.management.role.management.service.RoleManager;
+import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
 import org.wso2.carbon.identity.organization.management.service.OrganizationUserResidentResolverService;
 import org.wso2.carbon.identity.user.store.configuration.listener.UserStoreConfigListener;
 import org.wso2.carbon.idp.mgt.IdpManager;
 import org.wso2.carbon.registry.core.service.RegistryService;
 import org.wso2.carbon.stratos.common.listeners.TenantMgtListener;
+import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.carbon.utils.CarbonUtils;
 import org.wso2.carbon.utils.ConfigurationContextService;
 
@@ -925,5 +927,57 @@ public class OAuth2ServiceComponent {
             ApplicationAuthenticationService applicationAuthenticationService) {
         /* reference ApplicationAuthenticationService service to guarantee that this component will wait until
         authentication framework is started */
+    }
+
+    /**
+     * Set organization management service implementation.
+     *
+     * @param organizationManager OrganizationManager
+     */
+    @Reference(name = "identity.organization.management.component",
+            service = OrganizationManager.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetOrganizationManager")
+    protected void setOrganizationManager(OrganizationManager organizationManager) {
+
+        OAuth2ServiceComponentHolder.getInstance().setOrganizationManager(organizationManager);
+    }
+
+    /**
+     * Unset organization management service implementation.
+     *
+     * @param organizationManager OrganizationManager
+     */
+    protected void unsetOrganizationManager(OrganizationManager organizationManager) {
+
+        OAuth2ServiceComponentHolder.getInstance().setOrganizationManager(null);
+    }
+
+    /**
+     * Set realm service implementation.
+     *
+     * @param realmService RealmService
+     */
+    @Reference(
+            name = "user.realmservice.default",
+            service = RealmService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetRealmService"
+    )
+    protected void setRealmService(RealmService realmService) {
+
+        OAuth2ServiceComponentHolder.getInstance().setRealmService(realmService);
+    }
+
+    /**
+     * Unset realm service implementation.
+     *
+     * @param realmService RealmService
+     */
+    protected void unsetRealmService(RealmService realmService) {
+
+        OAuth2ServiceComponentHolder.getInstance().setRealmService(null);
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuth2ServiceComponent.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuth2ServiceComponent.java
@@ -78,6 +78,7 @@ import org.wso2.carbon.identity.openidconnect.OpenIDConnectClaimFilterImpl;
 import org.wso2.carbon.identity.openidconnect.dao.ScopeClaimMappingDAO;
 import org.wso2.carbon.identity.openidconnect.dao.ScopeClaimMappingDAOImpl;
 import org.wso2.carbon.identity.organization.management.role.management.service.RoleManager;
+import org.wso2.carbon.identity.organization.management.service.OrganizationManagementInitialize;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
 import org.wso2.carbon.identity.organization.management.service.OrganizationUserResidentResolverService;
 import org.wso2.carbon.identity.user.store.configuration.listener.UserStoreConfigListener;
@@ -979,5 +980,25 @@ public class OAuth2ServiceComponent {
     protected void unsetRealmService(RealmService realmService) {
 
         OAuth2ServiceComponentHolder.getInstance().setRealmService(null);
+    }
+
+    @Reference(
+            name = "organization.mgt.initialize.service",
+            service = OrganizationManagementInitialize.class,
+            cardinality = ReferenceCardinality.OPTIONAL,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetOrganizationManagementEnablingService"
+    )
+    protected void setOrganizationManagementEnablingService(
+            OrganizationManagementInitialize organizationManagementInitializeService) {
+
+        OAuth2ServiceComponentHolder.getInstance()
+                .setOrganizationManagementEnable(organizationManagementInitializeService);
+    }
+
+    protected void unsetOrganizationManagementEnablingService(
+            OrganizationManagementInitialize organizationManagementInitializeInstance) {
+
+        OAuth2ServiceComponentHolder.getInstance().setOrganizationManagementEnable(null);
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuth2ServiceComponent.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuth2ServiceComponent.java
@@ -993,12 +993,12 @@ public class OAuth2ServiceComponent {
             OrganizationManagementInitialize organizationManagementInitializeService) {
 
         OAuth2ServiceComponentHolder.getInstance()
-                .setOrganizationManagementEnable(organizationManagementInitializeService);
+                .setOrganizationManagementEnabled(organizationManagementInitializeService);
     }
 
     protected void unsetOrganizationManagementEnablingService(
             OrganizationManagementInitialize organizationManagementInitializeInstance) {
 
-        OAuth2ServiceComponentHolder.getInstance().setOrganizationManagementEnable(null);
+        OAuth2ServiceComponentHolder.getInstance().setOrganizationManagementEnabled(null);
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuth2ServiceComponentHolder.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuth2ServiceComponentHolder.java
@@ -37,6 +37,7 @@ import org.wso2.carbon.identity.oauth2.token.handlers.claims.JWTAccessTokenClaim
 import org.wso2.carbon.identity.openidconnect.ClaimProvider;
 import org.wso2.carbon.identity.openidconnect.dao.ScopeClaimMappingDAO;
 import org.wso2.carbon.identity.organization.management.role.management.service.RoleManager;
+import org.wso2.carbon.identity.organization.management.service.OrganizationManagementInitialize;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
 import org.wso2.carbon.identity.organization.management.service.OrganizationUserResidentResolverService;
 import org.wso2.carbon.idp.mgt.IdpManager;
@@ -89,6 +90,7 @@ public class OAuth2ServiceComponentHolder {
     private static boolean restrictUnassignedScopes;
     private static ConfigurationContextService configurationContextService;
     private List<JWTAccessTokenClaimProvider> jwtAccessTokenClaimProviders = new ArrayList<>();
+    private boolean isOrganizationManagementEnable = false;
 
     private OAuth2ServiceComponentHolder() {
 
@@ -582,5 +584,28 @@ public class OAuth2ServiceComponentHolder {
             return getDefaultResponseModeProvider();
         }
         return responseModeProvider;
+    }
+
+    /**
+     * Get is organization management enabled.
+     *
+     * @return True if organization management is enabled.
+     */
+    public boolean isOrganizationManagementEnabled() {
+
+        return isOrganizationManagementEnable;
+    }
+
+    /**
+     * Set organization management enable/disable state.
+     *
+     * @param organizationManagementInitializeService OrganizationManagementInitializeInstance.
+     */
+    public void setOrganizationManagementEnable(
+            OrganizationManagementInitialize organizationManagementInitializeService) {
+
+        if (organizationManagementInitializeService != null) {
+            isOrganizationManagementEnable = organizationManagementInitializeService.isOrganizationManagementEnabled();
+        }
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuth2ServiceComponentHolder.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuth2ServiceComponentHolder.java
@@ -90,7 +90,7 @@ public class OAuth2ServiceComponentHolder {
     private static boolean restrictUnassignedScopes;
     private static ConfigurationContextService configurationContextService;
     private List<JWTAccessTokenClaimProvider> jwtAccessTokenClaimProviders = new ArrayList<>();
-    private boolean isOrganizationManagementEnable = false;
+    private boolean isOrganizationManagementEnabled = false;
 
     private OAuth2ServiceComponentHolder() {
 
@@ -593,7 +593,7 @@ public class OAuth2ServiceComponentHolder {
      */
     public boolean isOrganizationManagementEnabled() {
 
-        return isOrganizationManagementEnable;
+        return isOrganizationManagementEnabled;
     }
 
     /**
@@ -601,11 +601,11 @@ public class OAuth2ServiceComponentHolder {
      *
      * @param organizationManagementInitializeService OrganizationManagementInitializeInstance.
      */
-    public void setOrganizationManagementEnable(
+    public void setOrganizationManagementEnabled(
             OrganizationManagementInitialize organizationManagementInitializeService) {
 
         if (organizationManagementInitializeService != null) {
-            isOrganizationManagementEnable = organizationManagementInitializeService.isOrganizationManagementEnabled();
+            isOrganizationManagementEnabled = organizationManagementInitializeService.isOrganizationManagementEnabled();
         }
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuth2ServiceComponentHolder.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuth2ServiceComponentHolder.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2014, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2014-2023, WSO2 LLC. (http://www.wso2.com).
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -11,7 +11,7 @@
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the
+ * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
  */
@@ -37,9 +37,11 @@ import org.wso2.carbon.identity.oauth2.token.handlers.claims.JWTAccessTokenClaim
 import org.wso2.carbon.identity.openidconnect.ClaimProvider;
 import org.wso2.carbon.identity.openidconnect.dao.ScopeClaimMappingDAO;
 import org.wso2.carbon.identity.organization.management.role.management.service.RoleManager;
+import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
 import org.wso2.carbon.identity.organization.management.service.OrganizationUserResidentResolverService;
 import org.wso2.carbon.idp.mgt.IdpManager;
 import org.wso2.carbon.registry.core.service.RegistryService;
+import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.carbon.utils.ConfigurationContextService;
 
 import java.util.ArrayList;
@@ -71,6 +73,8 @@ public class OAuth2ServiceComponentHolder {
     private List<TokenBinder> tokenBinders = new ArrayList<>();
     private Map<String, ResponseTypeRequestValidator> responseTypeRequestValidators = new HashMap<>();
     private OAuthAdminServiceImpl oauthAdminService;
+    private OrganizationManager organizationManager;
+    private RealmService realmService;
     private static AuthenticationDataPublisher authenticationDataPublisherProxy;
     private static KeyIDProvider keyIDProvider = null;
     private IdpManager idpManager;
@@ -270,6 +274,36 @@ public class OAuth2ServiceComponentHolder {
     public void setOAuthAdminService(OAuthAdminServiceImpl oauthAdminService) {
 
         this.oauthAdminService = oauthAdminService;
+    }
+
+    /**
+     * Get {@link OrganizationManager}.
+     *
+     * @return organization manager instance {@link OrganizationManager}.
+     */
+    public OrganizationManager getOrganizationManager() {
+
+        return organizationManager;
+    }
+
+    /**
+     * Set {@link OrganizationManager}.
+     *
+     * @param organizationManager Instance of {@link OrganizationManager}.
+     */
+    public void setOrganizationManager(OrganizationManager organizationManager) {
+
+        this.organizationManager = organizationManager;
+    }
+
+    public RealmService getRealmService() {
+
+        return realmService;
+    }
+
+    public void setRealmService(RealmService realmService) {
+
+        this.realmService = realmService;
     }
 
     /**

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuer.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuer.java
@@ -785,8 +785,8 @@ public class AccessTokenIssuer {
         AbstractUserStoreManager userStoreManager = (AbstractUserStoreManager) IdentityTenantUtil
                 .getRealm(authenticatedUser.getTenantDomain(), authenticatedUser.toFullQualifiedUsername())
                 .getUserStoreManager();
-        if (!userStoreManager.isExistingUserWithID(authenticatedUser.getUserId()) && OAuth2ServiceComponentHolder
-                .getInstance().isOrganizationManagementEnabled()) {
+        if (OAuth2ServiceComponentHolder.getInstance().isOrganizationManagementEnabled() &&
+                !userStoreManager.isExistingUserWithID(authenticatedUser.getUserId())) {
             userStoreManager = getUserStoreManagerFromUserResideOrganization(authenticatedUser.getTenantDomain(),
                     authenticatedUser.getUserId()).orElse(userStoreManager);
         }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuer.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuer.java
@@ -787,7 +787,8 @@ public class AccessTokenIssuer {
                 .getUserStoreManager();
         if (OAuth2ServiceComponentHolder.getInstance().isOrganizationManagementEnabled() &&
                 !userStoreManager.isExistingUserWithID(authenticatedUser.getUserId())) {
-            userStoreManager = getUserStoreManagerFromUserResideOrganization(authenticatedUser.getTenantDomain(),
+            // Fetch the user realm's user store manager corresponds to the tenant domain where the userID exists.
+            userStoreManager = getUserStoreManagerFromRealmOfUserResideOrganization(authenticatedUser.getTenantDomain(),
                     authenticatedUser.getUserId()).orElse(userStoreManager);
         }
         return userStoreManager.getUserClaimValueWithID(authenticatedUser.getUserId(), subjectClaimUri, null);
@@ -1106,14 +1107,14 @@ public class AccessTokenIssuer {
 
     /**
      * If the user is not found in the given tenant domain, check the user existence from ancestor organizations and
-     * provide the correct user store manager.
+     * provide the correct user store manager from the user realm.
      *
      * @param tenantDomain The tenant domain of the authenticated user.
      * @param userId The ID of the authenticated user.
      * @return User store manager of the user reside organization.
      */
-    private Optional<AbstractUserStoreManager> getUserStoreManagerFromUserResideOrganization(String tenantDomain,
-                                                                                             String userId) {
+    private Optional<AbstractUserStoreManager> getUserStoreManagerFromRealmOfUserResideOrganization(String tenantDomain,
+                                                                                                    String userId) {
 
         try {
             String organizationId = OAuth2ServiceComponentHolder.getInstance().getOrganizationManager()


### PR DESCRIPTION
### Proposed changes in this pull request

The subject claim for the given user ID can only be resolved if user exist in that tenant(organization). Therefore the logic is improved to first check the user's existence. If user not found, user should be resolved from the ancestor organizations before trying to resolve the subject claim.