### PR TITLE
Re-introduce session state param condition

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
@@ -3708,11 +3708,15 @@ public class OAuth2AuthzEndpoint {
             }
         }
 
-        return OIDCSessionManagementUtil.getSessionStateParam(oAuth2Parameters.getClientId(),
-                oAuth2Parameters.getRedirectURI(),
-                opBrowserStateCookie == null ?
-                        null :
-                        opBrowserStateCookie.getValue());
+        String sessionStateParam = null;
+        if (sessionStateObj.isAddSessionState() && StringUtils.isNotEmpty(oAuth2Parameters.getRedirectURI())) {
+            sessionStateParam = OIDCSessionManagementUtil.getSessionStateParam(oAuth2Parameters.getClientId(),
+                    oAuth2Parameters.getRedirectURI(),
+                    opBrowserStateCookie == null ?
+                            null :
+                            opBrowserStateCookie.getValue());
+        }
+        return sessionStateParam;
     }
 
     private String appendAuthenticatedIDPs(SessionDataCacheEntry sessionDataCacheEntry, String redirectURL,

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
@@ -3712,9 +3712,7 @@ public class OAuth2AuthzEndpoint {
         if (sessionStateObj.isAddSessionState() && StringUtils.isNotEmpty(oAuth2Parameters.getRedirectURI())) {
             sessionStateParam = OIDCSessionManagementUtil.getSessionStateParam(oAuth2Parameters.getClientId(),
                     oAuth2Parameters.getRedirectURI(),
-                    opBrowserStateCookie == null ?
-                            null :
-                            opBrowserStateCookie.getValue());
+                    opBrowserStateCookie == null ? null : opBrowserStateCookie.getValue());
         }
         return sessionStateParam;
     }


### PR DESCRIPTION
### Proposed changes in this pull request

With the changes introduced by PR [1], in the manageOIDCSessionState() method the [if condition](https://github.com/wso2-extensions/identity-inbound-auth-oauth/blob/3d20187ca2db291822e257511c2e88e408088086/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java#L3384) that was present previously has been missed. In the device code grant flow, no redirect url is passed. Therefore this resulted in an NPE.
This PR reintroduces this if condition to resolve the issue.

### Related Issues
- Issue https://github.com/wso2/product-is/issues/16139

### Related PRs

- [1] PR https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2037
