### PR TITLE
Update DCR endpoint version

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.dcr/src/main/resources/api.identity.oauth.dcr.endpoint.yaml
+++ b/components/org.wso2.carbon.identity.api.server.dcr/src/main/resources/api.identity.oauth.dcr.endpoint.yaml
@@ -54,7 +54,7 @@ paths:
          "grant_types": ["password"], 
          "ext_param_client_id":"provided_client_id0001", 
          "ext_param_client_secret":"provided_client_secret0001" }' 
-        "https://localhost:9443/api/identity/oauth2/dcr/v1.0/register"
+        "https://localhost:9443/api/identity/oauth2/dcr/v1.1/register"
       x-wso2-response: |
         "HTTP/1.1 201 Created"
         {"client_name”:"application_test",

--- a/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
+++ b/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
@@ -308,7 +308,7 @@ public final class OAuthConstants {
         public static final String OAUTH20_AUTHORIZE_TOKEN_URL = "/authorize";
         public static final String OAUTH2_AUTHZ_EP_URL = "oauth2/authorize";
         public static final String OAUTH2_TOKEN_EP_URL = "oauth2/token";
-        public static final String OAUTH2_DCR_EP_URL = "/api/identity/oauth2/dcr/v1.0/register";
+        public static final String OAUTH2_DCR_EP_URL = "/api/identity/oauth2/dcr/v1.1/register";
         public static final String OAUTH2_JWKS_EP_URL = "/oauth2/jwks";
         public static final String  OAUTH2_DISCOVERY_EP_URL = "/oauth2/oidcdiscovery";
         public static final String OAUTH2_USER_INFO_EP_URL = "oauth2/userinfo";

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/resources/repository/conf/identity/identity.xml
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/resources/repository/conf/identity/identity.xml
@@ -663,7 +663,7 @@
             <Context>/oauth2</Context>
             <Context>/scim2</Context>
             <Context>/api/identity/entitlement</Context>
-            <Context>/api/identity/oauth2/dcr/v1.0</Context>
+            <Context>/api/identity/oauth2/dcr/v1.1</Context>
         </WebApp>
         <Servlet>
             <Context>/identity/(.*)</Context>

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/util/OAuth2UtilTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/util/OAuth2UtilTest.java
@@ -1228,11 +1228,11 @@ public class OAuth2UtilTest extends PowerMockIdentityBaseTest {
                 // tenantDomain
                 // oauthUrl
                 {true, "https://localhost:9443/testUrl", "https://localhost:9443/testUrl", "testDomain",
-                        "https://localhost:9443/t/testDomain/api/identity/oauth2/dcr/v1.0/register"},
+                        "https://localhost:9443/t/testDomain/api/identity/oauth2/dcr/v1.1/register"},
                 {true, "", "https://localhost:9443/testUrl", "",
-                        "https://localhost:9443/api/identity/oauth2/dcr/v1.0/register"},
+                        "https://localhost:9443/api/identity/oauth2/dcr/v1.1/register"},
                 {true, "", "https://localhost:9443/testUrl", "testDomain",
-                        "https://localhost:9443/t/testDomain/api/identity/oauth2/dcr/v1.0/register"},
+                        "https://localhost:9443/t/testDomain/api/identity/oauth2/dcr/v1.1/register"},
                 {false, "", "https://localhost:9443/testUrl", "testDomain",
                         "https://localhost:9443/t/testDomain/testUrl"},
                 {false, "", "https://localhost:9443/testUrl", "",


### PR DESCRIPTION
## Description

Fix `/.well-known/openid-configuration` to return the registration endpoint with v1.1

```
{...
    "registration_endpoint": "https://api.asgardeo.io/t/asgardeokm/api/identity/oauth2/dcr/v1.1/register"
...}
```

