### PR TITLE
Add config to skip OIDC claims retrival for client credential grant type

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/pom.xml
+++ b/components/org.wso2.carbon.identity.oauth/pom.xml
@@ -560,6 +560,7 @@
                 <artifactId>spotbugs-maven-plugin</artifactId>
                 <configuration>
                     <threshold>High</threshold>
+                    <maxHeap>2048</maxHeap>
                 </configuration>
             </plugin>
         </plugins>

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
@@ -505,7 +505,6 @@ public class OAuthServerConfiguration {
         setOAuthResponseJspPageAvailable();
     }
 
-
     private void parseSkipOIDCClaimsForClientCredentialGrantConfig(OMElement oauthElem) {
 
         OMElement skipOIDCClaimsForClientCredentialGrantElement = oauthElem
@@ -625,7 +624,6 @@ public class OAuthServerConfiguration {
 
         return skipOIDCClaimsForClientCredentialGrant;
     }
-
 
     /**
      * Get the list of alloed scopes.

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
@@ -281,7 +281,9 @@ public class OAuthServerConfiguration {
     private ValueGenerator tokenValueGenerator;
 
     // property to skip OIDC claims retrieval for client credential grant type.
-    private boolean skipOIDCClaimsForClientCredentialGrant = false;
+    // By default, this is true because OIDC claims are not required for client credential grant type
+    // and CC grant doesn't involve a user.
+    private boolean skipOIDCClaimsForClientCredentialGrant = true;
 
     private String tokenValueGeneratorClassName;
     //property to define hashing algorithm when enabling hashing of tokens and authorization codes.

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
@@ -280,6 +280,10 @@ public class OAuthServerConfiguration {
     // Property added to customize the token valued generation method. (IDENTITY-6139)
     private ValueGenerator tokenValueGenerator;
 
+    // property to skip OIDC claims retrieval for client credential grant type.
+    private boolean skipOIDCClaimsForClientCredentialGrant = false;
+
+
     private String tokenValueGeneratorClassName;
     //property to define hashing algorithm when enabling hashing of tokens and authorization codes.
     private String hashAlgorithm = "SHA-256";
@@ -432,6 +436,8 @@ public class OAuthServerConfiguration {
         // read openid connect configurations
         parseOpenIDConnectConfig(oauthElem);
 
+        parseSkipOIDCClaimsForClientCredentialGrantConfig(oauthElem);
+
         // parse OAuth 2.0 token generator
         parseOAuthTokenGeneratorConfig(oauthElem);
 
@@ -498,6 +504,18 @@ public class OAuthServerConfiguration {
 
         // Set the availability of oauth_response.jsp page.
         setOAuthResponseJspPageAvailable();
+    }
+
+
+    private void parseSkipOIDCClaimsForClientCredentialGrantConfig(OMElement oauthElem) {
+
+        OMElement skipOIDCClaimsForClientCredentialGrantElement = oauthElem
+                .getFirstChildWithName(getQNameWithIdentityNS(ConfigElements
+                        .SKIP_OIDC_CLAIMS_FOR_CLIENT_CREDENTIAL_GRANT));
+        if (skipOIDCClaimsForClientCredentialGrantElement != null) {
+            skipOIDCClaimsForClientCredentialGrant = Boolean.parseBoolean(
+                    skipOIDCClaimsForClientCredentialGrantElement.getText().trim());
+        }
     }
 
     /**
@@ -603,6 +621,12 @@ public class OAuthServerConfiguration {
 
         return dropUnregisteredScopes;
     }
+
+    public boolean isSkipOIDCClaimsForClientCredentialGrant() {
+
+        return skipOIDCClaimsForClientCredentialGrant;
+    }
+
 
     /**
      * Get the list of alloed scopes.
@@ -3749,6 +3773,9 @@ public class OAuthServerConfiguration {
 
         // FAPI Configurations
         private static final String FAPI = "FAPI";
+
+        private static final String SKIP_OIDC_CLAIMS_FOR_CLIENT_CREDENTIAL_GRANT =
+                "SkipOIDCClaimsForClientCredentialGrant";
     }
 
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
@@ -283,7 +283,6 @@ public class OAuthServerConfiguration {
     // property to skip OIDC claims retrieval for client credential grant type.
     private boolean skipOIDCClaimsForClientCredentialGrant = false;
 
-
     private String tokenValueGeneratorClassName;
     //property to define hashing algorithm when enabling hashing of tokens and authorization codes.
     private String hashAlgorithm = "SHA-256";

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuer.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuer.java
@@ -504,11 +504,21 @@ public class JWTTokenIssuer extends OauthTokenIssuerImpl {
         jwtClaimsSetBuilder.audience(audience);
         JWTClaimsSet jwtClaimsSet;
 
-        // Handle custom claims
-        if (authAuthzReqMessageContext != null) {
-            jwtClaimsSet = handleCustomClaims(jwtClaimsSetBuilder, authAuthzReqMessageContext);
+        if (tokenReqMessageContext != null &&
+                tokenReqMessageContext.getOauth2AccessTokenReqDTO() != null &&
+                StringUtils.equals(tokenReqMessageContext.getOauth2AccessTokenReqDTO().getGrantType(),
+                        OAuthConstants.GrantTypes.CLIENT_CREDENTIALS) &&
+                OAuthServerConfiguration.getInstance().isSkipOIDCClaimsForClientCredentialGrant()) {
+
+            jwtClaimsSet = jwtClaimsSetBuilder.build();
         } else {
             jwtClaimsSet = handleCustomClaims(jwtClaimsSetBuilder, tokenReqMessageContext);
+            // Handle custom claims
+            if (authAuthzReqMessageContext != null) {
+                jwtClaimsSet = handleCustomClaims(jwtClaimsSetBuilder, authAuthzReqMessageContext);
+            } else {
+                jwtClaimsSet = handleCustomClaims(jwtClaimsSetBuilder, tokenReqMessageContext);
+            }
         }
 
         if (tokenReqMessageContext != null && tokenReqMessageContext.getOauth2AccessTokenReqDTO() != null &&

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuer.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuer.java
@@ -512,7 +512,6 @@ public class JWTTokenIssuer extends OauthTokenIssuerImpl {
 
             jwtClaimsSet = jwtClaimsSetBuilder.build();
         } else {
-            jwtClaimsSet = handleCustomClaims(jwtClaimsSetBuilder, tokenReqMessageContext);
             // Handle custom claims
             if (authAuthzReqMessageContext != null) {
                 jwtClaimsSet = handleCustomClaims(jwtClaimsSetBuilder, authAuthzReqMessageContext);

--- a/pom.xml
+++ b/pom.xml
@@ -917,7 +917,7 @@
         <oltu.package.import.version.range>[1.0.0, 2.0.0)</oltu.package.import.version.range>
 
         <waffle.imp.pkg.version.range>[1.6.0, 2.0)</waffle.imp.pkg.version.range>
-        <waffle-jna.wso2.version>1.6.wso2v6</waffle-jna.wso2.version>
+        <waffle-jna.wso2.version>1.6.wso2v7</waffle-jna.wso2.version>
         <waffle-jna.imp.pkg.version.range>[1.6.0, 2.0)</waffle-jna.imp.pkg.version.range>
 
         <nimbusds.version>7.9.0.wso2v1</nimbusds.version>


### PR DESCRIPTION
Public Issue: https://github.com/wso2/product-is/issues/16129

Fix: 
$ will skip loading SP which will increase the performance

Config
```
[oauth.grant_type.client_credentials]
skip_oidc_claims = true
```

