### PR TITLE
Fix x5t issue in JWKS endpoint

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/pom.xml
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/pom.xml
@@ -346,6 +346,7 @@
                 <artifactId>spotbugs-maven-plugin</artifactId>
                 <configuration>
                     <threshold>High</threshold>
+                    <maxHeap>2048</maxHeap>
                 </configuration>
             </plugin>
         </plugins>

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/jwks/JwksEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/jwks/JwksEndpoint.java
@@ -19,10 +19,10 @@ package org.wso2.carbon.identity.oauth.endpoint.jwks;
 
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSAlgorithm;
-import com.nimbusds.jose.jwk.JWK;
 import com.nimbusds.jose.jwk.KeyUse;
 import com.nimbusds.jose.jwk.RSAKey;
 import com.nimbusds.jose.util.Base64;
+import com.nimbusds.jose.util.Base64URL;
 import net.minidev.json.JSONArray;
 import net.minidev.json.JSONObject;
 import org.apache.commons.lang.StringUtils;
@@ -158,6 +158,7 @@ public class JwksEndpoint {
     private RSAKey.Builder getJWK(JWSAlgorithm algorithm, List<Base64> encodedCertList, X509Certificate certificate,
                                   String kidAlgorithm, String alias)
             throws ParseException, IdentityOAuth2Exception, JOSEException {
+
         RSAKey.Builder jwk = new RSAKey.Builder((RSAPublicKey) certificate.getPublicKey());
         if (kidAlgorithm.equals(OAuthConstants.SignatureAlgorithms.KID_HASHING_ALGORITHM)) {
             jwk.keyID(OAuth2Util.getKID(certificate, algorithm, getTenantDomain()));
@@ -167,8 +168,7 @@ public class JwksEndpoint {
         jwk.algorithm(algorithm);
         jwk.keyUse(KeyUse.parse(KEY_USE));
         jwk.x509CertChain(encodedCertList);
-        JWK parsedJWK = JWK.parse(certificate);
-        jwk.x509CertSHA256Thumbprint(parsedJWK.getX509CertSHA256Thumbprint());
+        jwk.x509CertSHA256Thumbprint(new Base64URL(OAuth2Util.getThumbPrint(certificate, alias)));
         return jwk;
     }
 

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/jwks/JwksEndpointTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/jwks/JwksEndpointTest.java
@@ -86,9 +86,9 @@ public class JwksEndpointTest extends PowerMockIdentityBaseTest {
     private static final JSONArray X5C_ARRAY = new JSONArray();
     private static final String X5T = "YmUwN2EzOGI3ZTI0Y2NiNTNmZWFlZjI5MmVjZjdjZTYzZjI0M2MxNDQ1YjQwNjI3NjY" +
             "yZmZlYzkwNzY0YjU4NQ";
-
     private static final String rsa256Thumbprint = "be:07:a3:8b:7e:24:cc:b5:3f:ea:ef:29:2e:cf:7c:e6:3f:24:3c:" +
-            "14:45:b4:06:27:66:2f:fe:c9:07:64:b5:85";    private JwksEndpoint jwksEndpoint;
+            "14:45:b4:06:27:66:2f:fe:c9:07:64:b5:85";
+    private JwksEndpoint jwksEndpoint;
     private Object identityUtilObj;
 
     @BeforeTest

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/jwks/JwksEndpointTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/jwks/JwksEndpointTest.java
@@ -18,6 +18,7 @@
 package org.wso2.carbon.identity.oauth.endpoint.jwks;
 
 import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.util.Base64URL;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -50,7 +51,6 @@ import java.lang.reflect.Modifier;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.KeyStore;
-import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -84,8 +84,11 @@ public class JwksEndpointTest extends PowerMockIdentityBaseTest {
     private static final String ALG = "RS256";
     private static final String USE = "sig";
     private static final JSONArray X5C_ARRAY = new JSONArray();
-    private static final JSONArray X5T_ARRAY = new JSONArray();
-    private JwksEndpoint jwksEndpoint;
+    private static final String X5T = "YmUwN2EzOGI3ZTI0Y2NiNTNmZWFlZjI5MmVjZjdjZTYzZjI0M2MxNDQ1YjQwNjI3NjY" +
+            "yZmZlYzkwNzY0YjU4NQ";
+
+    private static final String rsa256Thumbprint = "be:07:a3:8b:7e:24:cc:b5:3f:ea:ef:29:2e:cf:7c:e6:3f:24:3c:" +
+            "14:45:b4:06:27:66:2f:fe:c9:07:64:b5:85";    private JwksEndpoint jwksEndpoint;
     private Object identityUtilObj;
 
     @BeforeTest
@@ -125,9 +128,6 @@ public class JwksEndpointTest extends PowerMockIdentityBaseTest {
                 "EJCSfsvswtLVDZ7GDvTHKojJjQvdVCzRj6XH5Truwefb4BJz9APtnlyJIvjHk1hdozqyOniVZd0QOxLAbcdt946chNdQvCm6aUOp" +
                 "utp8Xogr0KBnEy3U8es2cAfNZaEkPU8Va5bU6Xjny8zGQnXCXxPKp7sMpgO93nPBt/liX1qfyXM7xEotWoxmm6HZx8oWQ8U5aiXj" +
                 "Z5RKDWCCq4ZuXl6wVsUz1iE61suO5yWi8=");
-        X5T_ARRAY.put("vgeji34kzLU_6u8pLs985j8kPBRFtAYnZi_-yQdktYU");
-        X5T_ARRAY.put("UPDtpYmK86EVwsUIGUlW5-EU_iNHQ-nSL3Ca58uAG70");
-
     }
 
     @DataProvider(name = "provideTenantDomain")
@@ -200,6 +200,8 @@ public class JwksEndpointTest extends PowerMockIdentityBaseTest {
         if ("foo.com".equals(tenantDomain)) {
             when(OAuth2Util.mapSignatureAlgorithmForJWSAlgorithm("SHA512withRSA")).thenReturn(JWSAlgorithm.RS256);
         }
+        when(OAuth2Util.getThumbPrint(any(), anyString())).thenReturn("YmUwN2EzOGI3ZTI0Y2NiNTNmZWFlZjI5Mm" +
+                "VjZjdjZTYzZjI0M2MxNDQ1YjQwNjI3NjYyZmZlYzkwNzY0YjU4NQ");
         mockStatic(KeyStoreManager.class);
         when(KeyStoreManager.getInstance(anyInt())).thenReturn(keyStoreManager);
         when(keyStoreManager.getKeyStore("foo-com.jks")).thenReturn(getKeyStoreFromFile("foo-com.jks", "foo.com"));
@@ -214,19 +216,16 @@ public class JwksEndpointTest extends PowerMockIdentityBaseTest {
             assertEquals(keyObject.get("alg"), ALG, "Incorrect alg value");
             assertEquals(keyObject.get("use"), USE, "Incorrect use value");
             assertEquals(keyObject.get("kty"), "RSA", "Incorrect kty value");
+            assertEquals(keyObject.get("x5t#S256"),
+                    Base64URL.encode(rsa256Thumbprint.replaceAll(":", "")).toString());
+            assertEquals(keyObject.get("x5t#S256"), X5T, "Incorrect x5t#S256 value");
             if ("foo.com".equals(tenantDomain)) {
                 assertEquals(objectArray.length(), 2, "Incorrect no of keysets");
                 assertEquals(((JSONArray) keyObject.get("x5c")).get(0), X5C_ARRAY.get(0), "Incorrect x5c value");
-                assertEquals(keyObject.get("x5t#S256"), X5T_ARRAY.get(0), "Incorrect x5t#S256 value");
             } else {
                 assertEquals(objectArray.length(), 3, "Incorrect no of keysets");
                 assertEquals(((JSONArray) keyObject.get("x5c")).get(0), X5C_ARRAY.get(1), "Incorrect x5c value");
-                assertEquals(keyObject.get("x5t#S256"), X5T_ARRAY.get(1), "Incorrect x5t#S256 value");
             }
-            String base64UrlEncodedString = (String) keyObject.get("x5t#S256");
-            byte[] decodedBytes = Base64.getUrlDecoder().decode(base64UrlEncodedString);
-            assertEquals(decodedBytes.length, 32, "Incorrect x5t#S256 size");
-
         } catch (JSONException e) {
             if ("invalid.com".equals(tenantDomain)) {
                 // This is expected. We don't validate for invalid tenants.

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -3015,6 +3015,7 @@ public class OAuth2Util {
      * @throws IdentityOAuth2Exception
      */
     public static String getThumbPrint(Certificate certificate, String alias) throws IdentityOAuth2Exception {
+
         return getThumbPrint(certificate);
     }
 
@@ -3038,6 +3039,7 @@ public class OAuth2Util {
 
     private static String getThumbPrintWithAlgorithm(Certificate certificate, String algorithm)
             throws IdentityOAuth2Exception {
+
         try {
             MessageDigest digestValue = MessageDigest.getInstance(algorithm);
             byte[] der = certificate.getEncoded();

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/util/OAuth2UtilTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/util/OAuth2UtilTest.java
@@ -19,6 +19,7 @@
 package org.wso2.carbon.identity.oauth2.util;
 
 import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.util.Base64URL;
 import org.apache.axiom.om.OMElement;
 import org.apache.axis2.context.ConfigurationContext;
 import org.apache.axis2.engine.AxisConfiguration;
@@ -92,6 +93,8 @@ import org.wso2.carbon.utils.NetworkUtils;
 
 import java.net.SocketException;
 import java.nio.file.Paths;
+import java.security.KeyStore;
+import java.security.cert.Certificate;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -118,6 +121,7 @@ import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 import static org.wso2.carbon.identity.oauth2.util.OAuth2Util.getIdTokenIssuer;
+import static org.wso2.carbon.identity.openidconnect.util.TestUtils.getKeyStoreFromFile;
 
 @WithCarbonHome
 @PrepareForTest({OAuthServerConfiguration.class, OAuthCache.class, IdentityUtil.class, OAuthConsumerDAO.class,
@@ -207,6 +211,8 @@ public class OAuth2UtilTest extends PowerMockIdentityBaseTest {
     @Mock
     OAuthAdminServiceImpl oAuthAdminService;
 
+    private KeyStore wso2KeyStore;
+
     @BeforeMethod
     public void setUp() throws Exception {
         System.setProperty(
@@ -251,6 +257,8 @@ public class OAuth2UtilTest extends PowerMockIdentityBaseTest {
         mockStatic(LoggerUtils.class);
         when(LoggerUtils.isDiagnosticLogsEnabled()).thenReturn(true);
         when(IdentityTenantUtil.getTenantId(anyString())).thenReturn(-1234);
+        wso2KeyStore = getKeyStoreFromFile("wso2carbon.jks", "wso2carbon",
+                System.getProperty(CarbonBaseConstants.CARBON_HOME));
     }
 
     @AfterMethod
@@ -2295,5 +2303,16 @@ public class OAuth2UtilTest extends PowerMockIdentityBaseTest {
             return;
         }
         fail("Expected IdentityOAuth2Exception was not thrown by getServiceProvider method");
+    }
+
+    @Test
+    public void testGetThumbPrint() throws Exception {
+
+        Certificate certificate = wso2KeyStore.getCertificate("wso2carbon");
+
+        String thumbPrint = OAuth2Util.getThumbPrint(certificate);
+        String rsa256Thumbprint = "50:f0:ed:a5:89:8a:f3:a1:15:c2:c5:08:19:49:56:e7:e1:14:fe:23:47:43:e9:d2:2f:70:9a:" +
+                "e7:cb:80:1b:bd";
+        assertEquals(thumbPrint, Base64URL.encode(rsa256Thumbprint.replaceAll(":", "")).toString());
     }
 }


### PR DESCRIPTION
**Before this fix** 
```
"x5t#S256": "AuYhelj-jvDRkeMPas9Ezwj0e0wYxsZKvfLUh7SMCgA"
```

**After the fix**
```
"x5t#S256": "MDJlNjIxN2E1OGZlOGVmMGQxOTFlMzBmNmFjZjQ0Y2YwOGY0N2I0YzE4YzZjNjRhYmRmMmQ0ODdiNDhjMGEwMA"
```

**Based 64 decoded value after the fix**
```
02e6217a58fe8ef0d191e30f6acf44cf08f47b4c18c6c64abdf2d487b48c0a00
```
### Related Issues

- Public Issue: https://github.com/wso2/product-is/issues/14899
- Internal Issue: https://github.com/wso2-enterprise/wso2-iam-internal/issues/633