### PR TITLE
Improvement to exception handling in PAR authorize flow to avoid NPE

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.par/src/main/java/org/wso2/carbon/identity/oauth/par/core/ParAuthServiceImpl.java
+++ b/components/org.wso2.carbon.identity.oauth.par/src/main/java/org/wso2/carbon/identity/oauth/par/core/ParAuthServiceImpl.java
@@ -121,7 +121,7 @@ public class ParAuthServiceImpl implements ParAuthService {
         long currentTimeInMillis = Calendar.getInstance(TimeZone.getTimeZone(ParConstants.UTC)).getTimeInMillis();
 
         if (currentTimeInMillis > expiresIn) {
-            throw new ParClientException(OAuth2ErrorCodes.INVALID_REQUEST, "request_uri expired");
+            throw new ParClientException(OAuth2ErrorCodes.INVALID_REQUEST, "Request uri expired");
         }
     }
 

--- a/components/org.wso2.carbon.identity.oauth.par/src/main/java/org/wso2/carbon/identity/oauth/par/core/ParRequestBuilder.java
+++ b/components/org.wso2.carbon.identity.oauth.par/src/main/java/org/wso2/carbon/identity/oauth/par/core/ParRequestBuilder.java
@@ -21,9 +21,11 @@ import org.apache.commons.lang.StringUtils;
 import org.wso2.carbon.identity.base.IdentityException;
 import org.wso2.carbon.identity.central.log.mgt.utils.LogConstants;
 import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
+import org.wso2.carbon.identity.oauth.common.OAuth2ErrorCodes;
 import org.wso2.carbon.identity.oauth.common.OAuthConstants;
 import org.wso2.carbon.identity.oauth.par.common.ParConstants;
 import org.wso2.carbon.identity.oauth.par.exceptions.ParAuthFailureException;
+import org.wso2.carbon.identity.oauth.par.exceptions.ParClientException;
 import org.wso2.carbon.identity.oauth.par.exceptions.ParCoreException;
 import org.wso2.carbon.identity.oauth.par.internal.ParAuthServiceComponentDataHolder;
 import org.wso2.carbon.identity.oauth2.OAuthAuthorizationRequestBuilder;
@@ -52,8 +54,11 @@ public class ParRequestBuilder implements OAuthAuthorizationRequestBuilder {
         try {
             params = ParAuthServiceComponentDataHolder.getInstance().getParAuthService()
                     .retrieveParams(uuid, request.getParameter(OAuthConstants.OAuth20Params.CLIENT_ID));
+        } catch (ParClientException e) {
+            throw new ParAuthFailureException(e.getErrorCode(), e.getMessage(), e);
         } catch (ParCoreException e) {
-            throw new ParAuthFailureException("Error occurred while retrieving params from PAR request", e);
+            throw new ParAuthFailureException(OAuth2ErrorCodes.SERVER_ERROR,
+                    "Error occurred while retrieving params from PAR request", e);
         }
         return new OAuthParRequestWrapper(request, params);
     }

--- a/components/org.wso2.carbon.identity.oauth.par/src/main/java/org/wso2/carbon/identity/oauth/par/exceptions/ParAuthFailureException.java
+++ b/components/org.wso2.carbon.identity.oauth.par/src/main/java/org/wso2/carbon/identity/oauth/par/exceptions/ParAuthFailureException.java
@@ -45,4 +45,16 @@ public class ParAuthFailureException extends IdentityException {
 
         super(message, cause);
     }
+
+    /**
+     * Constructor with error code, error message and throwable.
+     *
+     * @param errorCode Error code.
+     * @param message Error message.
+     * @param cause Throwable.
+     */
+    public ParAuthFailureException(String errorCode, String message, Throwable cause) {
+
+        super(errorCode, message, cause);
+    }
 }


### PR DESCRIPTION
### Proposed changes in this pull request

Currently when we throw the errors we do not include a sub error code in the PAR exceptions. Due to this, if an error occurs in the PAR authorize flow, since the methods expect a sub error code when redirecting to an error page, it throws a NPE. To fix this, a new method was introduced to the authorize endpoint to properly handle the Identity Exception thrown from the Par core. 

### Related PRs
- [1] PR https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/1754

### Related Issues
-  Issue https://github.com/wso2/product-is/issues/16013
