### PR TITLE
Migrate security-mgt module from framework to its own group.

### DIFF
--- a/features/org.wso2.carbon.identity.oauth.dcr.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.oauth.dcr.server.feature/pom.xml
@@ -173,7 +173,7 @@
                                 <importFeatureDef>org.wso2.carbon.identity.core.server:greaterOrEqual:${carbon.identity.framework.version}</importFeatureDef>
                                 <importFeatureDef>org.wso2.carbon.identity.oauth.common:compatible:${project.version}</importFeatureDef>
                                 <importFeatureDef>org.wso2.carbon.idp.mgt.server:greaterOrEqual:${carbon.identity.framework.version}</importFeatureDef>
-                                <importFeatureDef>org.wso2.carbon.security.mgt.server:greaterOrEqual:${carbon.identity.framework.version}</importFeatureDef>
+                                <importFeatureDef>org.wso2.carbon.security.mgt.server:greaterOrEqual:${carbon.security.mgt.version}</importFeatureDef>
                                 <importFeatureDef>org.wso2.carbon.identity.application.mgt.server:greaterOrEqual:${carbon.identity.framework.version}</importFeatureDef>
                                 <importFeatureDef>org.wso2.carbon.identity.application.authentication.framework.server:greaterOrEqual:${carbon.identity.framework.version}</importFeatureDef>
                             </importFeatures>

--- a/features/org.wso2.carbon.identity.oauth.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.oauth.server.feature/pom.xml
@@ -238,7 +238,7 @@
                                 <importFeatureDef>org.wso2.carbon.identity.central.log.mgt.server:greaterOrEqual:${carbon.identity.framework.version}</importFeatureDef>
                                 <importFeatureDef>org.wso2.carbon.identity.oauth.common:compatible:${project.version}</importFeatureDef>
                                 <importFeatureDef>org.wso2.carbon.idp.mgt.server:greaterOrEqual:${carbon.identity.framework.version}</importFeatureDef>
-                                <importFeatureDef>org.wso2.carbon.security.mgt.server:greaterOrEqual:${carbon.identity.framework.version}</importFeatureDef>
+                                <importFeatureDef>org.wso2.carbon.security.mgt.server:greaterOrEqual:${carbon.security.mgt.version}</importFeatureDef>
                                 <importFeatureDef>org.wso2.carbon.identity.application.mgt.server:greaterOrEqual:${carbon.identity.framework.version}</importFeatureDef>
                                 <importFeatureDef>org.wso2.carbon.identity.application.authentication.framework.server:greaterOrEqual:${carbon.identity.framework.version}</importFeatureDef>
                                 <importFeatureDef>org.wso2.carbon.claim.mgt.server:greaterOrEqual:${carbon.identity.framework.version}</importFeatureDef>

--- a/pom.xml
+++ b/pom.xml
@@ -867,6 +867,8 @@
         <carbon.identity.framework.imp.pkg.version.range>[5.25.234, 7.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 
+        <carbon.security.mgt.version>1.0.0</carbon.security.mgt.version>
+
         <carbon.identity.organization.management.version>1.1.14
         </carbon.identity.organization.management.version>
         <carbon.identity.organization.management.version.range>[1.1.14, 2.0.0)


### PR DESCRIPTION
### Proposed changes in this pull request
This PR contains the changes made to migrate the security-mgt component from framework and move it to new carbon.security.mgt group. This is a milestone of the following issue[1].

### Related Issues
- https://github.com/wso2/product-is/issues/16422

### NOTE:
- Product IS PR builder will fail because the the security-mgt component used there is still old version. 
