### PR TITLE
Add missing validations to PAR

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/par/OAuth2ParEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/par/OAuth2ParEndpoint.java
@@ -30,6 +30,7 @@ import org.wso2.carbon.identity.oauth.client.authn.filter.OAuthClientAuthenticat
 import org.wso2.carbon.identity.oauth.common.OAuth2ErrorCodes;
 import org.wso2.carbon.identity.oauth.common.OAuthConstants;
 import org.wso2.carbon.identity.oauth.common.exception.InvalidOAuthRequestException;
+import org.wso2.carbon.identity.oauth.endpoint.util.EndpointUtil;
 import org.wso2.carbon.identity.oauth.par.common.ParConstants;
 import org.wso2.carbon.identity.oauth.par.exceptions.ParClientException;
 import org.wso2.carbon.identity.oauth.par.exceptions.ParCoreException;
@@ -131,7 +132,8 @@ public class OAuth2ParEndpoint {
 
         Response.ResponseBuilder responseBuilder;
         if (OAuth2ErrorCodes.INVALID_CLIENT.equals(errorCode)) {
-            responseBuilder = Response.status(HttpServletResponse.SC_UNAUTHORIZED);
+            responseBuilder = Response.status(HttpServletResponse.SC_UNAUTHORIZED)
+                    .header(OAuthConstants.HTTP_RESP_HEADER_AUTHENTICATE, EndpointUtil.getRealmInfo());
         } else {
             responseBuilder = Response.status(HttpServletResponse.SC_BAD_REQUEST);
         }

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/par/OAuth2ParEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/par/OAuth2ParEndpoint.java
@@ -265,7 +265,6 @@ public class OAuth2ParEndpoint {
                 }
             }
         } catch (RequestObjectException e) {
-
             if (OAuth2ErrorCodes.SERVER_ERROR.equals(e.getErrorCode())) {
                 throw new ParCoreException(e.getErrorCode(), e.getMessage(), e);
             }

--- a/components/org.wso2.carbon.identity.oauth.par/src/main/java/org/wso2/carbon/identity/oauth/par/common/ParConstants.java
+++ b/components/org.wso2.carbon.identity.oauth.par/src/main/java/org/wso2/carbon/identity/oauth/par/common/ParConstants.java
@@ -40,8 +40,9 @@ public class ParConstants {
     public static final String PAR_CLIENT_AUTH_ERROR = "Client Authentication Failed.";
     public static final String CLIENT_AUTH_REQUIRED_ERROR = "Client authentication required.";
     public static final String INTERNAL_SERVER_ERROR = "Internal Server Error.";
-    public static final String INVALID_REQUEST_URI_FORMAT = "Invalid request_uri format";
     public static final String INVALID_CLIENT_ERROR = "A valid OAuth client could not be found for client_id: ";
+    public static final String INVALID_REQUEST_OBJECT = "Unable to build a valid Request Object from the" +
+            " pushed authorization request.";
 
     private ParConstants() {
 

--- a/components/org.wso2.carbon.identity.oauth.par/src/main/java/org/wso2/carbon/identity/oauth/par/common/ParConstants.java
+++ b/components/org.wso2.carbon.identity.oauth.par/src/main/java/org/wso2/carbon/identity/oauth/par/common/ParConstants.java
@@ -23,7 +23,7 @@ package org.wso2.carbon.identity.oauth.par.common;
  */
 public class ParConstants {
 
-    public static final long EXPIRES_IN_DEFAULT_VALUE = 60;
+    public static final int EXPIRES_IN_DEFAULT_VALUE = 60;
     public static final long SEC_TO_MILLISEC_FACTOR = 1000;
     public static final String UTC = "UTC";
     public static final String EXPIRES_IN = "expires_in";

--- a/components/org.wso2.carbon.identity.oauth.par/src/main/java/org/wso2/carbon/identity/oauth/par/core/ParAuthServiceImpl.java
+++ b/components/org.wso2.carbon.identity.oauth.par/src/main/java/org/wso2/carbon/identity/oauth/par/core/ParAuthServiceImpl.java
@@ -140,11 +140,11 @@ public class ParAuthServiceImpl implements ParAuthService {
             Object expiryTimeValue = IdentityConfigParser.getInstance().getConfiguration().get(PAR_EXPIRY_TIME);
             if (expiryTimeValue != null && (StringUtils.isNotBlank((String) expiryTimeValue))) {
                 long expiryTime = Long.parseLong(((String) expiryTimeValue).trim());
-                if (expiryTime > 0) {
+                if (expiryTime > 0 && expiryTime <= 600) {
                     return expiryTime;
                 }
-                log.warn(String.format("PAR expiry time should be positive. Default value: %s will be used.",
-                        ParConstants.EXPIRES_IN_DEFAULT_VALUE));
+                log.warn(String.format("PAR expiry time should be a positive integer less than or equal to 600. " +
+                                "Default value: %s will be used.", ParConstants.EXPIRES_IN_DEFAULT_VALUE));
             } else {
                 log.debug(String.format("PAR expiry time is not configured. Default value: %s will be used.",
                         ParConstants.EXPIRES_IN_DEFAULT_VALUE));

--- a/components/org.wso2.carbon.identity.oauth.par/src/main/java/org/wso2/carbon/identity/oauth/par/core/ParAuthServiceImpl.java
+++ b/components/org.wso2.carbon.identity.oauth.par/src/main/java/org/wso2/carbon/identity/oauth/par/core/ParAuthServiceImpl.java
@@ -128,18 +128,19 @@ public class ParAuthServiceImpl implements ParAuthService {
     private void validateClientID(String clientId, String parClientId) throws ParClientException {
 
         if (!StringUtils.equals(parClientId, clientId)) {
-            throw new ParClientException(OAuth2ErrorCodes.INVALID_CLIENT,
+            throw new ParClientException(OAuth2ErrorCodes.INVALID_REQUEST,
                     String.format("Received client_id %s does not match the client_id from the initial PAR request %s",
                             clientId, parClientId));
         }
     }
 
-    private static long getExpiresInValue() throws ParCoreException {
+    private static int getExpiresInValue() throws ParCoreException {
 
         try {
-            Object expiryTimeValue = IdentityConfigParser.getInstance().getConfiguration().get(PAR_EXPIRY_TIME);
-            if (expiryTimeValue != null && (StringUtils.isNotBlank((String) expiryTimeValue))) {
-                long expiryTime = Long.parseLong(((String) expiryTimeValue).trim());
+            String expiryTimeValue =
+                    (String) IdentityConfigParser.getInstance().getConfiguration().get(PAR_EXPIRY_TIME);
+            if ((StringUtils.isNotBlank(expiryTimeValue))) {
+                int expiryTime = Integer.parseInt((expiryTimeValue).trim());
                 if (expiryTime > 0 && expiryTime <= 600) {
                     return expiryTime;
                 }

--- a/components/org.wso2.carbon.identity.oauth.par/src/main/java/org/wso2/carbon/identity/oauth/par/core/ParAuthServiceImpl.java
+++ b/components/org.wso2.carbon.identity.oauth.par/src/main/java/org/wso2/carbon/identity/oauth/par/core/ParAuthServiceImpl.java
@@ -128,7 +128,7 @@ public class ParAuthServiceImpl implements ParAuthService {
     private void validateClientID(String clientId, String parClientId) throws ParClientException {
 
         if (!StringUtils.equals(parClientId, clientId)) {
-            throw new ParClientException(OAuth2ErrorCodes.INVALID_REQUEST,
+            throw new ParClientException(OAuth2ErrorCodes.INVALID_CLIENT,
                     String.format("Received client_id %s does not match the client_id from the initial PAR request %s",
                             clientId, parClientId));
         }

--- a/components/org.wso2.carbon.identity.oauth.par/src/test/java/org/wso2/carbon/identity/oauth/par/core/ParAuthServiceTest.java
+++ b/components/org.wso2.carbon.identity.oauth.par/src/test/java/org/wso2/carbon/identity/oauth/par/core/ParAuthServiceTest.java
@@ -86,9 +86,15 @@ public class ParAuthServiceTest extends PowerMockTestCase {
     public Object[][] provideExpiryTimeConfigData() {
 
         return new Object[][]{
+                // invalid negative number
                 {"-1"},
+                // invalid zero
                 {"0"},
+                // valid positive integer
                 {"60"},
+                // invalid integer surpassing the max value
+                {"601"},
+                // no config value
                 {null}
         };
     }
@@ -111,14 +117,25 @@ public class ParAuthServiceTest extends PowerMockTestCase {
         assertEquals(parAuthData.getExpiryTime(), defaultExpiry);
     }
 
-    @Test
-    public void testNotANumberExpiryTimeFailure() throws ParCoreException {
+    @DataProvider(name = "provideNotANumberExpiryTimeConfigData")
+    public Object[][] provideNotANumberExpiryTimeConfigData() {
+
+        return new Object[][]{
+                // invalid string
+                {"NaN"},
+                // invalid decimal
+                {"50.45"}
+        };
+    }
+
+    @Test(dataProvider = "provideNotANumberExpiryTimeConfigData")
+    public void testNotANumberExpiryTimeFailure(String expiryTime) throws ParCoreException {
 
         doNothing().when(parMgtDAO).persistRequestData(anyString(), anyString(), anyLong(), anyMap());
         mockStatic(IdentityConfigParser.class);
         when(IdentityConfigParser.getInstance()).thenReturn(identityConfigParser);
         Map<String, Object> config = new HashMap<>();
-        config.put("OAuth.PAR.ExpiryTime", "NaN");
+        config.put("OAuth.PAR.ExpiryTime", expiryTime);
         when(identityConfigParser.getConfiguration()).thenReturn(config);
 
         try {


### PR DESCRIPTION
### Proposed changes in this pull request

This PR adds the following validations to PAR endpoint.
1. Validates request objects when request parameter is present
2. Validates that the configured expiry time does not exceed 600.

### Related Issues
-  Issue https://github.com/wso2/product-is/issues/16013
- Issue https://github.com/wso2/product-is/issues/16475
