### PR TITLE
Improvements to PAR implementation

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
+++ b/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
@@ -406,6 +406,22 @@ public final class OAuthConstants {
 
             }
         }
+
+        /**
+         * Define Authorization request constants.
+         */
+        public static class AuthorizationResponse {
+
+            public static final String CALLBACK_NOT_MATCH = "Registered callback does not match with the provided url.";
+            public static final String APPLICATION_NOT_FOUND = "Cannot find an application associated with the given " +
+                    "consumer key.";
+            public static final String INVALID_REDIRECT_URI = "Redirect URI is not present in the authorization " +
+                    "request.";
+
+            private AuthorizationResponse() {
+
+            }
+        }
     }
 
     /**

--- a/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
+++ b/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
@@ -408,21 +408,19 @@ public final class OAuthConstants {
         }
 
         /**
-         * Define Authorization request constants.
+         * Define Authorization request constants with i18n keys which will be mapped to the error
+         * message in the frontend.
          */
-        public static class AuthorizationResponse {
+        public static class AuthorizationResponsei18nKey {
 
-            public static final String CALLBACK_NOT_MATCH = "Registered callback does not match with the provided url.";
-            public static final String APPLICATION_NOT_FOUND = "Cannot find an application associated with the given " +
-                    "consumer key.";
-            public static final String INVALID_REDIRECT_URI = "Redirect URI is not present in the authorization " +
-                    "request.";
-            public static final String INVALID_REQUEST_URI = "A PAR request does not exist for the uuid: .+";
-            public static final String CLIENT_IDS_NOT_MATCH = "Received client_id .+ does not match the " +
-                    "client_id from the initial PAR request .+";
-            public static final String REQUEST_URI_EXPIRED = "Request uri expired";
+            public static final String CALLBACK_NOT_MATCH = "callback.not.match";
+            public static final String APPLICATION_NOT_FOUND = "application.not.found";
+            public static final String INVALID_REDIRECT_URI = "invalid.redirect.uri";
+            public static final String INVALID_REQUEST_URI = "par.invalid.request.uri";
+            public static final String CLIENT_IDS_NOT_MATCH = "par.client.id.not.match";
+            public static final String REQUEST_URI_EXPIRED = "par.request.uri.expired";
 
-            private AuthorizationResponse() {
+            private AuthorizationResponsei18nKey() {
 
             }
         }

--- a/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
+++ b/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
@@ -1,17 +1,17 @@
 /*
- * Copyright (c) 2013, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2013, WSO2 LLC. (https://www.wso2.com).
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
+ * KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations
  * under the License.
  */
@@ -417,6 +417,10 @@ public final class OAuthConstants {
                     "consumer key.";
             public static final String INVALID_REDIRECT_URI = "Redirect URI is not present in the authorization " +
                     "request.";
+            public static final String INVALID_REQUEST_URI = "A PAR request does not exist for the uuid: .+";
+            public static final String CLIENT_IDS_NOT_MATCH = "Received client_id .+ does not match the " +
+                    "client_id from the initial PAR request .+";
+            public static final String REQUEST_URI_EXPIRED = "Request uri expired";
 
             private AuthorizationResponse() {
 

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
@@ -2495,9 +2495,9 @@ public class OAuth2AuthzEndpoint {
         if (StringUtils.isBlank(parameters.getRedirectURI()) ||
                 StringUtils.startsWith(parameters.getRedirectURI(), REGEX_PATTERN)) {
             LoggerUtils.triggerDiagnosticLogEvent(OAuthConstants.LogConstants.OAUTH_INBOUND_SERVICE, null,
-                    OAuthConstants.LogConstants.FAILED, "Redirect URI is not present in the authorization request.",
-                    "validate-input-parameters", null);
-            throw new InvalidRequestException("Redirect URI is not present in the authorization request.",
+                    OAuthConstants.LogConstants.FAILED, OAuthConstants.OAuthError.AuthorizationResponse
+                            .INVALID_REDIRECT_URI, "validate-input-parameters", null);
+            throw new InvalidRequestException(OAuthConstants.OAuthError.AuthorizationResponse.INVALID_REDIRECT_URI,
                     OAuth2ErrorCodes.INVALID_REQUEST, OAuth2ErrorCodes.OAuth2SubErrorCodes.INVALID_REDIRECT_URI);
         }
         persistRequestObject(parameters, requestObject);

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
@@ -2535,11 +2535,12 @@ public class OAuth2AuthzEndpoint {
                 LoggerUtils.triggerDiagnosticLogEvent(new DiagnosticLog.DiagnosticLogBuilder(
                         OAuthConstants.LogConstants.OAUTH_INBOUND_SERVICE,
                         OAuthConstants.LogConstants.ActionIDs.VALIDATE_INPUT_PARAMS)
-                        .resultMessage(OAuthConstants.OAuthError.AuthorizationResponse.INVALID_REDIRECT_URI)
+                        .resultMessage("Redirect URI is not present in the authorization request.")
                         .logDetailLevel(DiagnosticLog.LogDetailLevel.APPLICATION)
                         .resultStatus(DiagnosticLog.ResultStatus.FAILED));
             }
-            throw new InvalidRequestException(OAuthConstants.OAuthError.AuthorizationResponse.INVALID_REDIRECT_URI,
+            throw new InvalidRequestException(
+                    OAuthConstants.OAuthError.AuthorizationResponsei18nKey.INVALID_REDIRECT_URI,
                     OAuth2ErrorCodes.INVALID_REQUEST, OAuth2ErrorCodes.OAuth2SubErrorCodes.INVALID_REDIRECT_URI);
         }
         persistRequestObject(parameters, requestObject);

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
@@ -125,7 +125,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import javax.servlet.http.HttpServletRequest;
@@ -515,18 +514,17 @@ public class EndpointUtil {
         // For the backward compatibility, this property can be set to false and then the error page is
         // redirected to a common OAuth Error page.
         if (!OAuthServerConfiguration.getInstance().isRedirectToRequestedRedirectUriEnabled()) {
-            return getErrorPageURL(request, errorCode, getErrorMessageToi18nMapping(errorMessage), appName);
+            return getErrorPageURL(request, errorCode, errorMessage, appName);
         } else if (subErrorCode.equals(OAuth2ErrorCodes.OAuth2SubErrorCodes.INVALID_REDIRECT_URI) ||
                 subErrorCode.equals(OAuth2ErrorCodes.OAuth2SubErrorCodes.INVALID_CLIENT) ||
                 StringUtils.isBlank(request.getParameter(PROP_REDIRECT_URI))) {
-            return getErrorPageURL(request, errorCode, getErrorMessageToi18nMapping(errorMessage), appName);
+            return getErrorPageURL(request, errorCode, errorMessage, appName);
         } else {
             String redirectUri = request.getParameter(OAuthConstants.OAuth20Params.REDIRECT_URI);
 
             // If the redirect url is not set in the request, page is redirected to common OAuth error page.
             if (StringUtils.isBlank(redirectUri)) {
-                redirectUri = getErrorPageURL(request, errorCode,
-                        getErrorMessageToi18nMapping(errorMessage), appName);
+                redirectUri = getErrorPageURL(request, errorCode, errorMessage, appName);
             } else {
                 String state = retrieveStateForErrorURL(request, oAuth2Parameters);
                 redirectUri = getUpdatedRedirectURL(request, redirectUri, errorCode, errorMessage, state, appName);
@@ -1900,37 +1898,5 @@ public class EndpointUtil {
                     .getContextClassLoader().loadClass(oauthAuthzRequestClassName);
         }
         return oAuthAuthzRequestClass;
-    }
-
-    /**
-     * Returns the i18n key for the given error message.
-     *
-     * @param errorMsg Error message.
-     * @return The i18n key defined in Resources.properties file of the authentication endpoint.
-     */
-    private static String getErrorMessageToi18nMapping(String errorMsg) {
-
-        Pattern invalidRequestUri = Pattern.compile(OAuthConstants.OAuthError
-                .AuthorizationResponse.INVALID_REQUEST_URI);
-        Pattern clientIdNotMatchRegex = Pattern.compile(OAuthConstants.OAuthError
-                .AuthorizationResponse.CLIENT_IDS_NOT_MATCH);
-        if (invalidRequestUri.matcher(errorMsg).matches()) {
-            return "par.invalid.request.uri";
-        } else if (clientIdNotMatchRegex.matcher(errorMsg).matches()) {
-            return "par.client.id.not.match";
-        }
-
-        switch (errorMsg) {
-            case OAuthConstants.OAuthError.AuthorizationResponse.CALLBACK_NOT_MATCH:
-                return "callback.not.match";
-            case OAuthConstants.OAuthError.AuthorizationResponse.APPLICATION_NOT_FOUND:
-                return "application.not.found";
-            case OAuthConstants.OAuthError.AuthorizationResponse.INVALID_REDIRECT_URI:
-                return "invalid.redirect.uri";
-            case OAuthConstants.OAuthError.AuthorizationResponse.REQUEST_URI_EXPIRED:
-                return "par.request.uri.expired";
-            default:
-                return errorMsg;
-        }
     }
 }

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
@@ -1,12 +1,12 @@
 /*
- * Copyright (c) 2013, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2013, WSO2 LLC. (https://www.wso2.com).
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
@@ -125,6 +125,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import javax.servlet.http.HttpServletRequest;
@@ -1909,6 +1910,16 @@ public class EndpointUtil {
      */
     private static String getErrorMessageToi18nMapping(String errorMsg) {
 
+        Pattern invalidRequestUri = Pattern.compile(OAuthConstants.OAuthError
+                .AuthorizationResponse.INVALID_REQUEST_URI);
+        Pattern clientIdNotMatchRegex = Pattern.compile(OAuthConstants.OAuthError
+                .AuthorizationResponse.CLIENT_IDS_NOT_MATCH);
+        if (invalidRequestUri.matcher(errorMsg).matches()) {
+            return "par.invalid.request.uri";
+        } else if (clientIdNotMatchRegex.matcher(errorMsg).matches()) {
+            return "par.client.id.not.match";
+        }
+
         switch (errorMsg) {
             case OAuthConstants.OAuthError.AuthorizationResponse.CALLBACK_NOT_MATCH:
                 return "callback.not.match";
@@ -1916,6 +1927,8 @@ public class EndpointUtil {
                 return "application.not.found";
             case OAuthConstants.OAuthError.AuthorizationResponse.INVALID_REDIRECT_URI:
                 return "invalid.redirect.uri";
+            case OAuthConstants.OAuthError.AuthorizationResponse.REQUEST_URI_EXPIRED:
+                return "par.request.uri.expired";
             default:
                 return errorMsg;
         }

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
@@ -514,17 +514,18 @@ public class EndpointUtil {
         // For the backward compatibility, this property can be set to false and then the error page is
         // redirected to a common OAuth Error page.
         if (!OAuthServerConfiguration.getInstance().isRedirectToRequestedRedirectUriEnabled()) {
-            return getErrorPageURL(request, errorCode, errorMessage, appName);
+            return getErrorPageURL(request, errorCode, getErrorMessageToi18nMapping(errorMessage), appName);
         } else if (subErrorCode.equals(OAuth2ErrorCodes.OAuth2SubErrorCodes.INVALID_REDIRECT_URI) ||
                 subErrorCode.equals(OAuth2ErrorCodes.OAuth2SubErrorCodes.INVALID_CLIENT) ||
                 StringUtils.isBlank(request.getParameter(PROP_REDIRECT_URI))) {
-            return getErrorPageURL(request, errorCode, errorMessage, appName);
+            return getErrorPageURL(request, errorCode, getErrorMessageToi18nMapping(errorMessage), appName);
         } else {
             String redirectUri = request.getParameter(OAuthConstants.OAuth20Params.REDIRECT_URI);
 
             // If the redirect url is not set in the request, page is redirected to common OAuth error page.
             if (StringUtils.isBlank(redirectUri)) {
-                redirectUri = getErrorPageURL(request, errorCode, errorMessage, appName);
+                redirectUri = getErrorPageURL(request, errorCode,
+                        getErrorMessageToi18nMapping(errorMessage), appName);
             } else {
                 String state = retrieveStateForErrorURL(request, oAuth2Parameters);
                 redirectUri = getUpdatedRedirectURL(request, redirectUri, errorCode, errorMessage, state, appName);
@@ -1874,5 +1875,25 @@ public class EndpointUtil {
                     .getContextClassLoader().loadClass(oauthAuthzRequestClassName);
         }
         return oAuthAuthzRequestClass;
+    }
+
+    /**
+     * Returns the i18n key for the given error message.
+     *
+     * @param errorMsg Error message.
+     * @return The i18n key defined in Resources.properties file of the authentication endpoint.
+     */
+    private static String getErrorMessageToi18nMapping(String errorMsg) {
+
+        switch (errorMsg) {
+            case OAuthConstants.OAuthError.AuthorizationResponse.CALLBACK_NOT_MATCH:
+                return "callback.not.match";
+            case OAuthConstants.OAuthError.AuthorizationResponse.APPLICATION_NOT_FOUND:
+                return "application.not.found";
+            case OAuthConstants.OAuthError.AuthorizationResponse.INVALID_REDIRECT_URI:
+                return "invalid.redirect.uri";
+            default:
+                return errorMsg;
+        }
     }
 }

--- a/components/org.wso2.carbon.identity.oauth.par/src/main/java/org/wso2/carbon/identity/oauth/par/core/ParAuthServiceImpl.java
+++ b/components/org.wso2.carbon.identity.oauth.par/src/main/java/org/wso2/carbon/identity/oauth/par/core/ParAuthServiceImpl.java
@@ -92,8 +92,8 @@ public class ParAuthServiceImpl implements ParAuthService {
 
         Optional<ParRequestDO> optionalParRequestDO = parMgtDAO.getRequestData(uuid);
         if (!optionalParRequestDO.isPresent()) {
-            throw new ParClientException(OAuth2ErrorCodes.INVALID_REQUEST, "A PAR request does not exist for the " +
-                    "uuid: " + uuid);
+            throw new ParClientException(OAuth2ErrorCodes.INVALID_REQUEST,
+                    OAuthConstants.OAuthError.AuthorizationResponsei18nKey.INVALID_REQUEST_URI);
         }
 
         ParRequestDO parRequestDO = optionalParRequestDO.get();
@@ -121,7 +121,8 @@ public class ParAuthServiceImpl implements ParAuthService {
         long currentTimeInMillis = Calendar.getInstance(TimeZone.getTimeZone(ParConstants.UTC)).getTimeInMillis();
 
         if (currentTimeInMillis > expiresIn) {
-            throw new ParClientException(OAuth2ErrorCodes.INVALID_REQUEST, "Request uri expired");
+            throw new ParClientException(OAuth2ErrorCodes.INVALID_REQUEST,
+                    OAuthConstants.OAuthError.AuthorizationResponsei18nKey.REQUEST_URI_EXPIRED);
         }
     }
 
@@ -129,7 +130,7 @@ public class ParAuthServiceImpl implements ParAuthService {
 
         if (!StringUtils.equals(parClientId, clientId)) {
             throw new ParClientException(OAuth2ErrorCodes.INVALID_CLIENT,
-                    String.format("Received client_id %s does not match the client_id from the initial PAR request %s",
+                    String.format(OAuthConstants.OAuthError.AuthorizationResponsei18nKey.CLIENT_IDS_NOT_MATCH,
                             clientId, parClientId));
         }
     }

--- a/components/org.wso2.carbon.identity.oauth.par/src/main/java/org/wso2/carbon/identity/oauth/par/core/ParAuthServiceImpl.java
+++ b/components/org.wso2.carbon.identity.oauth.par/src/main/java/org/wso2/carbon/identity/oauth/par/core/ParAuthServiceImpl.java
@@ -141,10 +141,10 @@ public class ParAuthServiceImpl implements ParAuthService {
                     (String) IdentityConfigParser.getInstance().getConfiguration().get(PAR_EXPIRY_TIME);
             if ((StringUtils.isNotBlank(expiryTimeValue))) {
                 int expiryTime = Integer.parseInt((expiryTimeValue).trim());
-                if (expiryTime > 0 && expiryTime <= 600) {
+                if (expiryTime > 0) {
                     return expiryTime;
                 }
-                log.warn(String.format("PAR expiry time should be a positive integer less than or equal to 600. " +
+                log.warn(String.format("PAR expiry time should be a positive integer. " +
                                 "Default value: %s will be used.", ParConstants.EXPIRES_IN_DEFAULT_VALUE));
             } else {
                 log.debug(String.format("PAR expiry time is not configured. Default value: %s will be used.",

--- a/components/org.wso2.carbon.identity.oauth.par/src/main/java/org/wso2/carbon/identity/oauth/par/dao/ParMgtDAOImpl.java
+++ b/components/org.wso2.carbon.identity.oauth.par/src/main/java/org/wso2/carbon/identity/oauth/par/dao/ParMgtDAOImpl.java
@@ -54,6 +54,7 @@ public class ParMgtDAOImpl implements ParMgtDAO {
                 prepStmt.setString(4, getSerializedParams(parameters));
 
                 prepStmt.execute();
+                IdentityDatabaseUtil.commitTransaction(connection);
             }
         } catch (SQLException e) {
             throw new ParCoreException("Error occurred in persisting PAR request.", e);

--- a/components/org.wso2.carbon.identity.oauth.par/src/test/java/org/wso2/carbon/identity/oauth/par/core/ParAuthServiceTest.java
+++ b/components/org.wso2.carbon.identity.oauth.par/src/test/java/org/wso2/carbon/identity/oauth/par/core/ParAuthServiceTest.java
@@ -92,8 +92,6 @@ public class ParAuthServiceTest extends PowerMockTestCase {
                 {"0"},
                 // valid positive integer
                 {"60"},
-                // invalid integer surpassing the max value
-                {"601"},
                 // no config value
                 {null}
         };

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dao/OAuthAppDAO.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dao/OAuthAppDAO.java
@@ -1359,7 +1359,7 @@ public class OAuthAppDAO {
     }
 
     private void handleRequestForANonExistingConsumerKey(String consumerKey) throws InvalidOAuthClientException {
-        String message = "application.not.found";
+        String message = OAuthConstants.OAuthError.AuthorizationResponse.APPLICATION_NOT_FOUND;
         if (LOG.isDebugEnabled()) {
             LOG.debug("Cannot find an application associated with the given consumer key: " + consumerKey);
         }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dao/OAuthAppDAO.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dao/OAuthAppDAO.java
@@ -1359,7 +1359,7 @@ public class OAuthAppDAO {
     }
 
     private void handleRequestForANonExistingConsumerKey(String consumerKey) throws InvalidOAuthClientException {
-        String message = OAuthConstants.OAuthError.AuthorizationResponse.APPLICATION_NOT_FOUND;
+        String message = OAuthConstants.OAuthError.AuthorizationResponsei18nKey.APPLICATION_NOT_FOUND;
         if (LOG.isDebugEnabled()) {
             LOG.debug("Cannot find an application associated with the given consumer key: " + consumerKey);
         }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/OAuth2Service.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/OAuth2Service.java
@@ -315,7 +315,7 @@ public class OAuth2Service extends AbstractAdmin {
                 }
                 validationResponseDTO.setValidClient(false);
                 validationResponseDTO.setErrorCode(OAuth2ErrorCodes.INVALID_CALLBACK);
-                validationResponseDTO.setErrorMsg("callback.not.match");
+                validationResponseDTO.setErrorMsg(OAuthConstants.OAuthError.AuthorizationResponse.CALLBACK_NOT_MATCH);
                 return validationResponseDTO;
             }
         } catch (InvalidOAuthClientException e) {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/OAuth2Service.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/OAuth2Service.java
@@ -328,7 +328,8 @@ public class OAuth2Service extends AbstractAdmin {
                 }
                 validationResponseDTO.setValidClient(false);
                 validationResponseDTO.setErrorCode(OAuth2ErrorCodes.INVALID_CALLBACK);
-                validationResponseDTO.setErrorMsg(OAuthConstants.OAuthError.AuthorizationResponse.CALLBACK_NOT_MATCH);
+                validationResponseDTO.setErrorMsg(
+                        OAuthConstants.OAuthError.AuthorizationResponsei18nKey.CALLBACK_NOT_MATCH);
                 return validationResponseDTO;
             }
         } catch (InvalidOAuthClientException e) {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/validators/AbstractResponseTypeRequestValidator.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/validators/AbstractResponseTypeRequestValidator.java
@@ -77,7 +77,7 @@ public abstract class AbstractResponseTypeRequestValidator implements ResponseTy
             LoggerUtils.triggerDiagnosticLogEvent(OAuthConstants.LogConstants.OAUTH_INBOUND_SERVICE, null,
                     OAuthConstants.LogConstants.FAILED, "redirect_uri is not present in the authorization request",
                     "validate-input-parameters", null);
-            throw new InvalidOAuthRequestException("Redirect URI is not present in the authorization request",
+            throw new InvalidOAuthRequestException(OAuthConstants.OAuthError.AuthorizationResponse.INVALID_REDIRECT_URI,
                     OAuth2ErrorCodes.INVALID_REQUEST, OAuth2ErrorCodes.OAuth2SubErrorCodes.INVALID_REDIRECT_URI);
         }
     }
@@ -235,7 +235,7 @@ public abstract class AbstractResponseTypeRequestValidator implements ResponseTy
             }
             validationResponseDTO.setValidClient(false);
             validationResponseDTO.setErrorCode(OAuth2ErrorCodes.INVALID_CALLBACK);
-            validationResponseDTO.setErrorMsg("callback.not.match");
+            validationResponseDTO.setErrorMsg(OAuthConstants.OAuthError.AuthorizationResponse.CALLBACK_NOT_MATCH);
         }
         return validationResponseDTO;
     }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/validators/AbstractResponseTypeRequestValidator.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/validators/AbstractResponseTypeRequestValidator.java
@@ -81,10 +81,11 @@ public abstract class AbstractResponseTypeRequestValidator implements ResponseTy
             }
             LoggerUtils.triggerDiagnosticLogEvent(new DiagnosticLog.DiagnosticLogBuilder(
                     OAUTH_INBOUND_SERVICE, VALIDATE_INPUT_PARAMS)
-                    .resultMessage(OAuthConstants.OAuthError.AuthorizationResponse.INVALID_REDIRECT_URI)
+                    .resultMessage("Redirect URI is not present in the authorization request.")
                     .logDetailLevel(DiagnosticLog.LogDetailLevel.APPLICATION)
                     .resultStatus(DiagnosticLog.ResultStatus.FAILED));
-            throw new InvalidOAuthRequestException(OAuthConstants.OAuthError.AuthorizationResponse.INVALID_REDIRECT_URI,
+            throw new InvalidOAuthRequestException(
+                    OAuthConstants.OAuthError.AuthorizationResponsei18nKey.INVALID_REDIRECT_URI,
                     OAuth2ErrorCodes.INVALID_REQUEST, OAuth2ErrorCodes.OAuth2SubErrorCodes.INVALID_REDIRECT_URI);
         }
     }
@@ -248,7 +249,8 @@ public abstract class AbstractResponseTypeRequestValidator implements ResponseTy
             }
             validationResponseDTO.setValidClient(false);
             validationResponseDTO.setErrorCode(OAuth2ErrorCodes.INVALID_CALLBACK);
-            validationResponseDTO.setErrorMsg(OAuthConstants.OAuthError.AuthorizationResponse.CALLBACK_NOT_MATCH);
+            validationResponseDTO.setErrorMsg(
+                    OAuthConstants.OAuthError.AuthorizationResponsei18nKey.CALLBACK_NOT_MATCH);
         }
         return validationResponseDTO;
     }


### PR DESCRIPTION
### Proposed changes in this pull request

This PR introduces the following changes.
1. i18n keys are introduced for PAR errors that arise at the authorize EP. These keys will be mapped to the correct error messages at the frontend.
2. The PAR request persisting logic does not commit the transaction, which locks the database when a persist call is made. To resolve this, the transaction is committed once the SQL statement is executed.
3. The upper limit for expiry time is removed.

### Related PRs
- PR https://github.com/wso2/carbon-identity-framework/pull/4874
- PR https://github.com/wso2/identity-apps/pull/4052

### Related Issues
- Issue https://github.com/wso2/product-is/issues/16013