### PR TITLE
Add s_hash claim to the id token

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
+++ b/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
@@ -459,6 +459,7 @@ public final class OAuthConstants {
         public static final String MAX_AGE = "max_age";
         // OIDC Specification : http://openid.net/specs/openid-connect-core-1_0.html
         public static final String C_HASH = "c_hash";
+        public static final String S_HASH = "s_hash";
         public static final String SESSION_ID_CLAIM = "sid";
         public static final String REALM = "realm";
         public static final String TENANT = "tenant";

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
@@ -3441,6 +3441,7 @@ public class OAuth2AuthzEndpoint {
         authzReqDTO.setRequestObjectFlow(oauth2Params.isRequestObjectFlow());
         authzReqDTO.setIdpSessionIdentifier(sessionDataCacheEntry.getSessionContextIdentifier());
         authzReqDTO.setLoggedInTenantDomain(oauth2Params.getLoginTenantDomain());
+        authzReqDTO.setState(oauth2Params.getState());
 
         if (sessionDataCacheEntry.getParamMap() != null && sessionDataCacheEntry.getParamMap().get(OAuthConstants
                 .AMR) != null) {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dto/OAuth2AuthorizeReqDTO.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dto/OAuth2AuthorizeReqDTO.java
@@ -57,6 +57,7 @@ public class OAuth2AuthorizeReqDTO {
     // Set the login tenant domain.
     private String loggedInTenantDomain;
     private boolean isRequestObjectFlow;
+    private String state;
 
     public String getSessionDataKey() {
         return sessionDataKey;
@@ -268,5 +269,15 @@ public class OAuth2AuthorizeReqDTO {
     public void setRequestObjectFlow(boolean isRequestObjectFlow) {
 
         this.isRequestObjectFlow = isRequestObjectFlow;
+    }
+
+    public String getState() {
+
+        return state;
+    }
+
+    public void setState(String state) {
+
+        this.state = state;
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/OpenIDConnectSystemClaimImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/OpenIDConnectSystemClaimImpl.java
@@ -21,8 +21,6 @@ import org.apache.commons.io.Charsets;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.oltu.oauth2.common.message.types.ResponseType;
-import org.wso2.carbon.identity.oauth.cache.SessionDataCache;
-import org.wso2.carbon.identity.oauth.cache.SessionDataCacheKey;
 import org.wso2.carbon.identity.oauth.common.OAuthConstants;
 import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
@@ -64,12 +62,8 @@ public class OpenIDConnectSystemClaimImpl implements ClaimProvider {
         String responseType = authAuthzReqMessageContext.getAuthorizationReqDTO().getResponseType();
         String authorizationCode = authorizeRespDTO.getAuthorizationCode();
         String accessToken = authorizeRespDTO.getAccessToken();
-        String sessionDataKey = authAuthzReqMessageContext.getAuthorizationReqDTO().getSessionDataKey();
-        String stateValue = null;
-        if (isNotBlank(sessionDataKey)) {
-            stateValue = SessionDataCache.getInstance().getValueFromCache(new SessionDataCacheKey(sessionDataKey))
-                            .getoAuth2Parameters().getState();
-        }
+        String stateValue = authAuthzReqMessageContext.getAuthorizationReqDTO().getState();
+
         if (isIDTokenSigned() && isAccessTokenHashApplicable(responseType) && isNotBlank(accessToken)) {
             String atHash = getHashValue(accessToken);
             oidcSystemClaims.put(AT_HASH, atHash);

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/openidconnect/OpenIDConnectSystemClaimImplTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/openidconnect/OpenIDConnectSystemClaimImplTest.java
@@ -28,9 +28,6 @@ import org.testng.annotations.Test;
 import org.wso2.carbon.identity.common.testng.WithCarbonHome;
 import org.wso2.carbon.identity.common.testng.WithRealmService;
 import org.wso2.carbon.identity.common.testng.WithRegistry;
-import org.wso2.carbon.identity.oauth.cache.SessionDataCache;
-import org.wso2.carbon.identity.oauth.cache.SessionDataCacheEntry;
-import org.wso2.carbon.identity.oauth.cache.SessionDataCacheKey;
 import org.wso2.carbon.identity.oauth.common.OAuthConstants;
 import org.wso2.carbon.identity.oauth2.TestConstants;
 import org.wso2.carbon.identity.oauth2.authz.OAuthAuthzReqMessageContext;
@@ -38,7 +35,6 @@ import org.wso2.carbon.identity.oauth2.dto.OAuth2AccessTokenReqDTO;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2AccessTokenRespDTO;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2AuthorizeReqDTO;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2AuthorizeRespDTO;
-import org.wso2.carbon.identity.oauth2.model.OAuth2Parameters;
 import org.wso2.carbon.identity.oauth2.token.OAuthTokenReqMessageContext;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 
@@ -145,14 +141,7 @@ public class OpenIDConnectSystemClaimImplTest extends PowerMockTestCase {
     public void testStateHashClaim() throws Exception {
 
         String state = "testState";
-        String sessionDataKey = "session-data-key";
-        oAuth2AuthorizeReqDTO.setSessionDataKey(sessionDataKey);
-        SessionDataCacheEntry sessionDataCacheEntry = new SessionDataCacheEntry();
-        OAuth2Parameters oAuth2Parameters = new OAuth2Parameters();
-        oAuth2Parameters.setState(state);
-        sessionDataCacheEntry.setoAuth2Parameters(oAuth2Parameters);
-        SessionDataCache.getInstance().addToCache(new SessionDataCacheKey(sessionDataKey),
-                sessionDataCacheEntry);
+        oAuth2AuthorizeReqDTO.setState(state);
         oAuth2AuthorizeReqDTO.setResponseType("code");
         Map<String, Object> claims = openIDConnectSystemClaim.getAdditionalClaims(oAuthAuthzReqMessageContext,
                 oAuth2AuthorizeRespDTO);

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/openidconnect/OpenIDConnectSystemClaimImplTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/openidconnect/OpenIDConnectSystemClaimImplTest.java
@@ -28,6 +28,9 @@ import org.testng.annotations.Test;
 import org.wso2.carbon.identity.common.testng.WithCarbonHome;
 import org.wso2.carbon.identity.common.testng.WithRealmService;
 import org.wso2.carbon.identity.common.testng.WithRegistry;
+import org.wso2.carbon.identity.oauth.cache.SessionDataCache;
+import org.wso2.carbon.identity.oauth.cache.SessionDataCacheEntry;
+import org.wso2.carbon.identity.oauth.cache.SessionDataCacheKey;
 import org.wso2.carbon.identity.oauth.common.OAuthConstants;
 import org.wso2.carbon.identity.oauth2.TestConstants;
 import org.wso2.carbon.identity.oauth2.authz.OAuthAuthzReqMessageContext;
@@ -35,6 +38,7 @@ import org.wso2.carbon.identity.oauth2.dto.OAuth2AccessTokenReqDTO;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2AccessTokenRespDTO;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2AuthorizeReqDTO;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2AuthorizeRespDTO;
+import org.wso2.carbon.identity.oauth2.model.OAuth2Parameters;
 import org.wso2.carbon.identity.oauth2.token.OAuthTokenReqMessageContext;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 
@@ -135,6 +139,24 @@ public class OpenIDConnectSystemClaimImplTest extends PowerMockTestCase {
         Map<String, Object> claims = openIDConnectSystemClaim.getAdditionalClaims(oAuthAuthzReqMessageContext,
                 oAuth2AuthorizeRespDTO);
         Assert.assertEquals(claims.get(AT_HASH), hashAccessToken);
+    }
+
+    @Test
+    public void testStateHashClaim() throws Exception {
+
+        String state = "testState";
+        String sessionDataKey = "session-data-key";
+        oAuth2AuthorizeReqDTO.setSessionDataKey(sessionDataKey);
+        SessionDataCacheEntry sessionDataCacheEntry = new SessionDataCacheEntry();
+        OAuth2Parameters oAuth2Parameters = new OAuth2Parameters();
+        oAuth2Parameters.setState(state);
+        sessionDataCacheEntry.setoAuth2Parameters(oAuth2Parameters);
+        SessionDataCache.getInstance().addToCache(new SessionDataCacheKey(sessionDataKey),
+                sessionDataCacheEntry);
+        oAuth2AuthorizeReqDTO.setResponseType("code");
+        Map<String, Object> claims = openIDConnectSystemClaim.getAdditionalClaims(oAuthAuthzReqMessageContext,
+                oAuth2AuthorizeRespDTO);
+        Assert.assertEquals(claims.get(OAuthConstants.OIDCClaims.S_HASH), getHashValue(state));
     }
 
     private String getHashValue(String value) throws Exception {


### PR DESCRIPTION
### Proposed changes in this pull request

According to the FAPI specification, the hash value of the state parameter needs to be appended as an ID token claim if the state value is passed in the authorization request. This pr adds the s_hash claim based on the presence of the state value.



### Related Issues
https://github.com/wso2/product-is/issues/16495

