### PR TITLE
Get error msg from oauthclient context

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/par/OAuth2ParEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/par/OAuth2ParEndpoint.java
@@ -178,7 +178,7 @@ public class OAuth2ParEndpoint {
                         oAuthClientAuthnContext.getErrorMessage());
             } else if (OAuth2ErrorCodes.INVALID_CLIENT.equals(oAuthClientAuthnContext.getErrorCode())) {
                 throw new ParClientException(oAuthClientAuthnContext.getErrorCode(),
-                        ParConstants.INVALID_CLIENT_ERROR + oAuthClientAuthnContext.getClientId());
+                        oAuthClientAuthnContext.getErrorMessage());
             }
             throw new ParClientException(oAuthClientAuthnContext.getErrorCode(),
                     oAuthClientAuthnContext.getErrorMessage());

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/par/OAuth2ParEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/par/OAuth2ParEndpoint.java
@@ -148,7 +148,7 @@ public class OAuth2ParEndpoint {
         parErrorResponse.put(OAuthConstants.OAUTH_ERROR_DESCRIPTION, ParConstants.INTERNAL_SERVER_ERROR);
 
         Response.ResponseBuilder respBuilder = Response.status(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
-        log.debug("Exception occurred when handling the request: ", parCoreException);
+        log.error("Exception occurred when handling the request: ", parCoreException);
         return respBuilder.entity(parErrorResponse.toString()).build();
     }
 


### PR DESCRIPTION
### Proposed changes in this pull request

This PR includes a minor change to set the error message from `OAuthClientAuthnContext` directly in the exception. 

### Related Issues
- Issue https://github.com/wso2/product-is/issues/16549
