### PR TITLE
Add additional request object validations for FAPI compliance

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/par/OAuth2ParEndpointTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/par/OAuth2ParEndpointTest.java
@@ -44,6 +44,7 @@ import org.wso2.carbon.identity.oauth.par.model.ParAuthData;
 import org.wso2.carbon.identity.oauth.tokenprocessor.TokenPersistenceProcessor;
 import org.wso2.carbon.identity.oauth2.OAuth2Service;
 import org.wso2.carbon.identity.oauth2.bean.OAuthClientAuthnContext;
+import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 import org.wso2.carbon.identity.openidconnect.OIDCRequestObjectUtil;
 import org.wso2.carbon.identity.openidconnect.model.RequestObject;
 
@@ -78,7 +79,7 @@ import static org.testng.Assert.assertTrue;
  */
 @PrepareForTest({OAuthServerConfiguration.class, EndpointUtil.class, ServiceURL.class, ServiceURLBuilder.class,
         IdentityTenantUtil.class, LoggerUtils.class, IdentityDatabaseUtil.class, IdentityUtil.class,
-        OIDCRequestObjectUtil.class})
+        OIDCRequestObjectUtil.class, OAuth2Util.class})
 public class OAuth2ParEndpointTest extends TestOAuthEndpointBase {
 
     @Mock
@@ -276,6 +277,9 @@ public class OAuth2ParEndpointTest extends TestOAuthEndpointBase {
 
         mockStatic(OIDCRequestObjectUtil.class);
         when(OIDCRequestObjectUtil.buildRequestObject(any(), any())).thenReturn(new RequestObject());
+
+        spy(OAuth2Util.class);
+        when(OAuth2Util.isFapiConformantApp(anyString())).thenReturn(false);
 
         Response response;
         response = oAuth2ParEndpoint.par(request, httpServletResponse, paramMap);


### PR DESCRIPTION
### Proposed changes in this pull request

This PR adds the following request object validations for the FAPI requests.

- Request object signature validation
- Nbf and exp claim validations
- Mandate PKCE code challenge and code challenge method for PAR requests

### When should this PR be merged

Please merge this PR after merging https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2152

### Related Issues
https://github.com/wso2/product-is/issues/16515