### PR TITLE
Fix JWT token cache clearing issue

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AbstractAuthorizationGrantHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AbstractAuthorizationGrantHandler.java
@@ -1017,8 +1017,7 @@ public abstract class AbstractAuthorizationGrantHandler implements Authorization
         return OAuthServerConfiguration.getInstance().isTokenRenewalPerRequestEnabled();
     }
 
-    private void clearExistingTokenFromCache(OAuthTokenReqMessageContext tokenMsgCtx, AccessTokenDO existingTokenBean)
-            throws IdentityOAuth2Exception {
+    private void clearExistingTokenFromCache(OAuthTokenReqMessageContext tokenMsgCtx, AccessTokenDO existingTokenBean) {
 
         if (cacheEnabled) {
             String tokenBindingReference = getTokenBindingReference(tokenMsgCtx);
@@ -1035,8 +1034,11 @@ public abstract class AbstractAuthorizationGrantHandler implements Authorization
                     OAuthUtil.clearOAuthCache(tokenAlias);
                 }
             } catch (OAuthSystemException e) {
-                throw new IdentityOAuth2Exception("Error while clearing the cache for the access token " +
-                        existingTokenBean.getAccessToken(), e);
+                String errorMessage = "Error while clearing cache for the access token";
+                if (IdentityUtil.isTokenLoggable(IdentityConstants.IdentityTokens.ACCESS_TOKEN)) {
+                    errorMessage += " : " + existingTokenBean.getAccessToken();
+                }
+                log.error(errorMessage, e);
             }
         }
     }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AbstractAuthorizationGrantHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AbstractAuthorizationGrantHandler.java
@@ -339,7 +339,7 @@ public abstract class AbstractAuthorizationGrantHandler implements Authorization
         try {
             OAuthTokenPersistenceFactory.getInstance().getAccessTokenDAO()
                     .insertAccessToken(newAccessToken, oAuth2AccessTokenReqDTO.getClientId(),
-                            newTokenBean, existingTokenBean, userStoreDomain);
+                    newTokenBean, existingTokenBean, userStoreDomain);
         } catch (IdentityException e) {
             throw new IdentityOAuth2Exception(
                     "Error occurred while storing new access token : " + newAccessToken, e);
@@ -453,8 +453,8 @@ public abstract class AbstractAuthorizationGrantHandler implements Authorization
     }
 
     private AccessTokenDO createNewTokenBean(OAuthTokenReqMessageContext tokReqMsgCtx, OAuthAppDO oAuthAppBean,
-            AccessTokenDO existingTokenBean, Timestamp timestamp,
-            long validityPeriodInMillis, OauthTokenIssuer oauthTokenIssuer) throws IdentityOAuth2Exception {
+            AccessTokenDO existingTokenBean, Timestamp timestamp, long validityPeriodInMillis,
+            OauthTokenIssuer oauthTokenIssuer) throws IdentityOAuth2Exception {
 
         String tenantDomain = tokReqMsgCtx.getOauth2AccessTokenReqDTO().getTenantDomain();
         OAuth2AccessTokenReqDTO tokenReq = tokReqMsgCtx.getOauth2AccessTokenReqDTO();

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AbstractAuthorizationGrantHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AbstractAuthorizationGrantHandler.java
@@ -1017,7 +1017,8 @@ public abstract class AbstractAuthorizationGrantHandler implements Authorization
         return OAuthServerConfiguration.getInstance().isTokenRenewalPerRequestEnabled();
     }
 
-    private void clearExistingTokenFromCache(OAuthTokenReqMessageContext tokenMsgCtx, AccessTokenDO existingTokenBean) {
+    private void clearExistingTokenFromCache(OAuthTokenReqMessageContext tokenMsgCtx, AccessTokenDO existingTokenBean)
+            throws IdentityOAuth2Exception {
 
         if (cacheEnabled) {
             String tokenBindingReference = getTokenBindingReference(tokenMsgCtx);
@@ -1034,7 +1035,7 @@ public abstract class AbstractAuthorizationGrantHandler implements Authorization
                     OAuthUtil.clearOAuthCache(tokenAlias);
                 }
             } catch (OAuthSystemException e) {
-                log.error("Error while clearing cache for the access token : " +
+                throw new IdentityOAuth2Exception("Error while clearing the cache for the access token " +
                         existingTokenBean.getAccessToken(), e);
             }
         }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2TokenUtil.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2TokenUtil.java
@@ -47,6 +47,7 @@ import static org.wso2.carbon.identity.openidconnect.OIDCConstants.Event.TOKEN_S
 public class OAuth2TokenUtil {
 
     private static final Log log = LogFactory.getLog(OAuth2TokenUtil.class);
+    private static final String DOT_SEPARATOR = ".";
 
     /**
      * Uses to update access token details in the request object reference table.
@@ -300,5 +301,15 @@ public class OAuth2TokenUtil {
         properties.put(OIDCConstants.Event.IS_REQUEST_OBJECT_FLOW, isRequestObjectFlow);
         triggerEvent(eventName, properties);
     }
-}
 
+    /**
+     * Return true if the token identifier is JWT.
+     *
+     * @param tokenIdentifier String JWT token identifier.
+     * @return  true for a JWT token.
+     */
+    public static boolean isJWT(String tokenIdentifier) {
+
+        return StringUtils.countMatches(tokenIdentifier, DOT_SEPARATOR) == 2;
+    }
+}

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/OAuth2JWTTokenValidator.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/OAuth2JWTTokenValidator.java
@@ -42,6 +42,7 @@ import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.internal.OAuth2ServiceComponentHolder;
 import org.wso2.carbon.identity.oauth2.model.AccessTokenDO;
+import org.wso2.carbon.identity.oauth2.util.OAuth2TokenUtil;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
@@ -80,7 +81,7 @@ public class OAuth2JWTTokenValidator extends DefaultOAuth2TokenValidator {
     public boolean validateAccessToken(OAuth2TokenValidationMessageContext validationReqDTO)
             throws IdentityOAuth2Exception {
 
-        if (!isJWT(validationReqDTO.getRequestDTO().getAccessToken().getIdentifier())) {
+        if (!OAuth2TokenUtil.isJWT(validationReqDTO.getRequestDTO().getAccessToken().getIdentifier())) {
             return false;
         }
 
@@ -437,17 +438,6 @@ public class OAuth2JWTTokenValidator extends DefaultOAuth2TokenValidator {
             }
             return accessTokenDO.getAuthzUser().getTenantDomain();
         }
-    }
-
-    /**
-     * Return true if the token identifier is JWT.
-     *
-     * @param tokenIdentifier String JWT token identifier.
-     * @return  true for a JWT token.
-     */
-    private boolean isJWT(String tokenIdentifier) {
-        // JWT token contains 3 base64 encoded components separated by periods.
-        return StringUtils.countMatches(tokenIdentifier, DOT_SEPARATOR) == 2;
     }
 
     private void setJWTMessageContext(OAuth2TokenValidationMessageContext validationReqDTO, JWTClaimsSet claimsSet) {


### PR DESCRIPTION
### Purpose

>  Cache is not being properly cleared when a user attempts to obtain a token using the password grant after having used the refresh grant. This issue arises because when dealing with JWT tokens. With this PR aforementioned issue will be resolved.

### Public Git Issue

- https://github.com/wso2/product-is/issues/16634