### PR TITLE
Add organization ID to the context when start tenant flow while authorization flow

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/pom.xml
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/pom.xml
@@ -59,6 +59,11 @@
         </dependency>
         <dependency>
             <groupId>org.wso2.carbon</groupId>
+            <artifactId>org.wso2.carbon.utils</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon</groupId>
             <artifactId>org.wso2.carbon.ui</artifactId>
             <scope>provided</scope>
         </dependency>

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
@@ -39,6 +39,7 @@ import org.apache.oltu.oauth2.common.message.OAuthResponse;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.owasp.encoder.Encode;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.application.authentication.framework.AuthenticatorFlowStatus;
 import org.wso2.carbon.identity.application.authentication.framework.CommonAuthenticationHandler;
 import org.wso2.carbon.identity.application.authentication.framework.cache.AuthenticationResultCacheEntry;
@@ -301,7 +302,9 @@ public class OAuth2AuthzEndpoint {
                     OAuth2Parameters oauth2Params = getOauth2Params(oAuthMessage);
                     tenantDomain = oauth2Params.getTenantDomain();
                 }
+                String organizationId = PrivilegedCarbonContext.getThreadLocalCarbonContext().getOrganizationId();
                 FrameworkUtils.startTenantFlow(tenantDomain);
+                PrivilegedCarbonContext.getThreadLocalCarbonContext().setOrganizationId(organizationId);
             }
 
             if (isPassthroughToFramework(oAuthMessage)) {


### PR DESCRIPTION
### Proposed changes in this pull request

For the organization qualified `oauth2/authorize` requests, the URLs build from the Identity server was not organization qualified unless tenanted sessions enabled. With this fix, even tenanted session is disabled, for the organization qualified requests, the organization ID is saved and re added to the priviledge carbon context in order to avoid loss of organization ID information while building the service URLs.

### Related Issues
- https://github.com/wso2/product-is/issues/16650
