### PR TITLE
[6.9.x] Add Support to Generate JWT token with CNF Claim

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuer.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuer.java
@@ -25,17 +25,21 @@ import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.JWSHeader;
 import com.nimbusds.jose.JWSSigner;
 import com.nimbusds.jose.util.Base64URL;
+import com.nimbusds.jose.util.X509CertUtils;
 import com.nimbusds.jwt.JWT;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.JWTParser;
 import com.nimbusds.jwt.PlainJWT;
 import com.nimbusds.jwt.SignedJWT;
+import net.minidev.json.JSONArray;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.oltu.oauth2.common.exception.OAuthSystemException;
+import org.json.JSONObject;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
 import org.wso2.carbon.identity.base.IdentityConstants;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
@@ -46,22 +50,31 @@ import org.wso2.carbon.identity.oauth.dao.OAuthAppDO;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.authz.OAuthAuthzReqMessageContext;
 import org.wso2.carbon.identity.oauth2.internal.OAuth2ServiceComponentHolder;
+import org.wso2.carbon.identity.oauth2.model.HttpRequestHeader;
 import org.wso2.carbon.identity.oauth2.token.bindings.TokenBinding;
 import org.wso2.carbon.identity.oauth2.token.handlers.grant.AuthorizationGrantHandler;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 import org.wso2.carbon.identity.openidconnect.CustomClaimsCallbackHandler;
 import org.wso2.carbon.registry.core.utils.UUIDGenerator;
 
+import java.io.ByteArrayInputStream;
 import java.security.Key;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
 import java.security.interfaces.RSAPrivateKey;
 import java.text.ParseException;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Calendar;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
+import java.util.regex.Pattern;
 
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.RENEW_TOKEN_WITHOUT_REVOKING_EXISTING_ENABLE_CONFIG;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.REQUEST_BINDING_TYPE;
@@ -93,6 +106,11 @@ public class JWTTokenIssuer extends OauthTokenIssuerImpl {
     private static final String TOKEN_BINDING_TYPE = "binding_type";
     private static final String DEFAULT_TYP_HEADER_VALUE = "at+jwt";
     private static final String CNF = "cnf";
+    private static final String CNF_CLAIM = "x5t#S256";
+    private static final String BEGIN_CERT = "-----BEGIN CERTIFICATE-----";
+    private static final String END_CERT = "-----END CERTIFICATE-----";
+    private static final String X509_CERT_INSTANCE_NAME = "X.509";
+    private static final String MTLS_AUTH_HEADER = "MutualTLS.ClientCertificateHeader";
 
     private static final Log log = LogFactory.getLog(JWTTokenIssuer.class);
     private static final String INBOUND_AUTH2_TYPE = "oauth2";
@@ -485,11 +503,96 @@ public class JWTTokenIssuer extends OauthTokenIssuerImpl {
         // Include token binding.
         jwtClaimsSet = handleTokenBinding(jwtClaimsSetBuilder, tokenReqMessageContext);
 
-        if (tokenReqMessageContext != null && tokenReqMessageContext.getProperty(CNF) != null) {
-            jwtClaimsSet = handleCnf(jwtClaimsSetBuilder, tokenReqMessageContext);
+        if (tokenReqMessageContext != null) {
+            if (tokenReqMessageContext.getProperty(CNF) != null) {
+                jwtClaimsSet = handleCnf(jwtClaimsSetBuilder, tokenReqMessageContext);
+            } else {
+                jwtClaimsSet = handleCnf(jwtClaimsSet, tokenReqMessageContext);
+            }
         }
-
         return jwtClaimsSet;
+    }
+
+    private JWTClaimsSet handleCnf(JWTClaimsSet jwtClaimsSet, OAuthTokenReqMessageContext tokenReqMessageContext) {
+        JWTClaimsSet.Builder jwtClaimsSetBuilder = new JWTClaimsSet.Builder(jwtClaimsSet);
+        Map<String, Object> userClaimsInOIDCDialect = new HashMap<>();
+        String mtlsAuthHeaderName = IdentityUtil.getProperty(MTLS_AUTH_HEADER);
+        if (mtlsAuthHeaderName != null) {
+            HttpRequestHeader[] requestHeaders =
+                    tokenReqMessageContext.getOauth2AccessTokenReqDTO().getHttpRequestHeaders();
+            Optional<HttpRequestHeader> certHeader = Arrays.stream(requestHeaders).
+                    filter(httpRequestHeader -> mtlsAuthHeaderName.equals(httpRequestHeader.getName())).findFirst();
+            if (certHeader.isPresent()) {
+                Base64URL certThumbprint = null;
+                if (log.isDebugEnabled()) {
+                    log.debug("Client MTLS certificate found: " + certHeader);
+                }
+                try {
+                    if (certHeader.get().getValue() != null) {
+                        X509Certificate certificate = parseCertificate(certHeader.get().getValue()[0]);
+                        certThumbprint = X509CertUtils.computeSHA256Thumbprint(certificate);
+                    }
+                } catch (CertificateException e) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Error occurred while calculating the thumbprint of the MTLS certificate of " +
+                                "the client: " + tokenReqMessageContext.getOauth2AccessTokenReqDTO().getClientId(), e);
+                    }
+                }
+                if (certThumbprint != null) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Client MTLS certificate thumbprint: " + certThumbprint);
+                    }
+                    String certThumbprintString = certThumbprint.toString();
+                    JSONObject json = new JSONObject();
+                    json.put(CNF_CLAIM, certThumbprintString);
+                    userClaimsInOIDCDialect.put(CNF, Collections.singletonMap(CNF_CLAIM, certThumbprint));
+                }
+            }
+        }
+        return setClaimsToJwtClaimSet(jwtClaimsSetBuilder, userClaimsInOIDCDialect);
+    }
+
+    private JWTClaimsSet setClaimsToJwtClaimSet(JWTClaimsSet.Builder jwtClaimsSetBuilder, Map<String,
+            Object> userClaimsInOIDCDialect) {
+        JWTClaimsSet jwtClaimsSet = jwtClaimsSetBuilder.build();
+        for (Map.Entry<String, Object> claimEntry : userClaimsInOIDCDialect.entrySet()) {
+            String claimValue = claimEntry.getValue().toString();
+            String claimKey = claimEntry.getKey();
+            if (claimValue.contains(FrameworkUtils.getMultiAttributeSeparator())) {
+                JSONArray claimValues = new JSONArray();
+                String[] split = claimValue.split(Pattern.quote(FrameworkUtils.getMultiAttributeSeparator()));
+                for (String attributeValue : split) {
+                    if (StringUtils.isNotBlank(attributeValue)) {
+                        claimValues.add(attributeValue);
+                    }
+                }
+                if (jwtClaimsSet.getClaim(claimKey) != null) {
+                    continue;
+                }
+                jwtClaimsSetBuilder.claim(claimEntry.getKey(), claimValues);
+            } else {
+                if (jwtClaimsSet.getClaim(claimKey) != null) {
+                    continue;
+                }
+                jwtClaimsSetBuilder.claim(claimEntry.getKey(), claimEntry.getValue());
+            }
+        }
+        return jwtClaimsSetBuilder.build();
+    }
+
+    /**
+     * Parse the certificate content.
+     *
+     * @param content the content to be parsed
+     * @throws CertificateException if error occurs while parsing content
+     */
+    private static X509Certificate parseCertificate(String content) throws CertificateException {
+        String decodedContent = StringUtils.trim(content);
+        byte[] decoded = Base64.getDecoder().decode(StringUtils.trim(decodedContent.
+                replaceAll(BEGIN_CERT, "").
+                replaceAll(END_CERT, "")));
+        return (X509Certificate) CertificateFactory.getInstance(X509_CERT_INSTANCE_NAME).
+                generateCertificate(new ByteArrayInputStream(decoded));
     }
 
     /**

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuerTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuerTest.java
@@ -36,6 +36,7 @@ import org.testng.annotations.Test;
 import org.wso2.carbon.base.CarbonBaseConstants;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.oauth.common.OAuthConstants;
 import org.wso2.carbon.identity.oauth.common.exception.InvalidOAuthClientException;
 import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
@@ -83,6 +84,7 @@ import static org.wso2.carbon.identity.openidconnect.util.TestUtils.getKeyStoreF
                 OAuth2Util.class,
                 JWTTokenIssuer.class,
                 IdentityTenantUtil.class,
+                IdentityUtil.class
         }
 )
 public class JWTTokenIssuerTest extends PowerMockIdentityBaseTest {
@@ -114,6 +116,7 @@ public class JWTTokenIssuerTest extends PowerMockIdentityBaseTest {
     private static final String CLAIM_CLIENT_ID = "client_id";
     private static final String DEFAULT_TYP_HEADER_VALUE = "at+jwt";
     private static final String THUMBPRINT = "Certificate";
+    private static final String MTLS_AUTH_HEADER = "MutualTLS.ClientCertificateHeader";
 
     @Mock
     private OAuthServerConfiguration oAuthServerConfiguration;
@@ -122,6 +125,8 @@ public class JWTTokenIssuerTest extends PowerMockIdentityBaseTest {
     public void setUp() throws Exception {
         initMocks(this);
         mockStatic(OAuthServerConfiguration.class);
+        mockStatic(IdentityUtil.class);
+        when(IdentityUtil.getProperty(MTLS_AUTH_HEADER)).thenReturn(null);
         when(OAuthServerConfiguration.getInstance()).thenReturn(oAuthServerConfiguration);
     }
 


### PR DESCRIPTION
### Purpose
- Add support to generate JWT token with CNF claim
- Related Issue: https://github.com/wso2/api-manager/issues/2177
- A sample decoded JWT token with the CNF claim will look like follows
```
{
  "sub": "1efed9c1-4075-4262-b64a-5a96cee18e3c",
  "aut": "APPLICATION",
  "aud": "aDRupdqjeqPzATgoAOkH6pNP7s0a",
  "nbf": 1696399827,
  "azp": "aDRupdqjeqPzATgoAOkH6pNP7s0a",
  "scope": "default",
  "iss": "https://localhost:9443/oauth2/token",
  "cnf": {
    "x5t#S256": "8z4a8pqsbF_I-aDzootvANher26TxlX9rYEDuJ43KBg"
  },
  "exp": 1696403427,
  "iat": 1696399827,
  "jti": "175541ad-75bf-46e3-99c7-29c516f6ff81",
  "client_id": "aDRupdqjeqPzATgoAOkH6pNP7s0a"
}
```

### Approach
If `oauth.mutualtls.client_certificate_header` config is defined in the `deployment.toml` and the request header contains a certificate against the defined config value, the certificate thumbprint will get added as the CNF claim to the JWT token