### PR TITLE
Add Support to Generate JWT token with CNF Claim

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuer.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuer.java
@@ -562,6 +562,7 @@ public class JWTTokenIssuer extends OauthTokenIssuerImpl {
     }
 
     private JWTClaimsSet handleCnf(JWTClaimsSet jwtClaimsSet, OAuthTokenReqMessageContext tokenReqMessageContext) {
+
         JWTClaimsSet.Builder jwtClaimsSetBuilder = new JWTClaimsSet.Builder(jwtClaimsSet);
         Map<String, Object> userClaimsInOIDCDialect = new HashMap<>();
         String mtlsAuthHeaderName = IdentityUtil.getProperty(MTLS_AUTH_HEADER);
@@ -602,6 +603,7 @@ public class JWTTokenIssuer extends OauthTokenIssuerImpl {
 
     private JWTClaimsSet setClaimsToJwtClaimSet(JWTClaimsSet.Builder jwtClaimsSetBuilder, Map<String,
             Object> userClaimsInOIDCDialect) {
+
         JWTClaimsSet jwtClaimsSet = jwtClaimsSetBuilder.build();
         for (Map.Entry<String, Object> claimEntry : userClaimsInOIDCDialect.entrySet()) {
             String claimValue = claimEntry.getValue().toString();
@@ -635,6 +637,7 @@ public class JWTTokenIssuer extends OauthTokenIssuerImpl {
      * @throws CertificateException if error occurs while parsing content
      */
     private static X509Certificate parseCertificate(String content) throws CertificateException {
+
         String decodedContent = StringUtils.trim(content);
         byte[] decoded = Base64.getDecoder().decode(StringUtils.trim(decodedContent.
                 replaceAll(BEGIN_CERT, "").

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuer.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuer.java
@@ -31,7 +31,6 @@ import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.JWTParser;
 import com.nimbusds.jwt.PlainJWT;
 import com.nimbusds.jwt.SignedJWT;
-import net.minidev.json.JSONArray;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
@@ -40,7 +39,6 @@ import org.apache.oltu.oauth2.common.exception.OAuthSystemException;
 import org.json.JSONObject;
 import org.wso2.carbon.identity.application.authentication.framework.exception.UserIdNotFoundException;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
-import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
 import org.wso2.carbon.identity.base.IdentityConstants;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
@@ -77,7 +75,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.regex.Pattern;
 
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.RENEW_TOKEN_WITHOUT_REVOKING_EXISTING_ENABLE_CONFIG;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.REQUEST_BINDING_TYPE;
@@ -564,7 +561,6 @@ public class JWTTokenIssuer extends OauthTokenIssuerImpl {
     private JWTClaimsSet handleCnf(JWTClaimsSet jwtClaimsSet, OAuthTokenReqMessageContext tokenReqMessageContext) {
 
         JWTClaimsSet.Builder jwtClaimsSetBuilder = new JWTClaimsSet.Builder(jwtClaimsSet);
-        Map<String, Object> userClaimsInOIDCDialect = new HashMap<>();
         String mtlsAuthHeaderName = IdentityUtil.getProperty(MTLS_AUTH_HEADER);
         if (mtlsAuthHeaderName != null) {
             HttpRequestHeader[] requestHeaders =
@@ -594,37 +590,8 @@ public class JWTTokenIssuer extends OauthTokenIssuerImpl {
                     String certThumbprintString = certThumbprint.toString();
                     JSONObject json = new JSONObject();
                     json.put(CNF_CLAIM, certThumbprintString);
-                    userClaimsInOIDCDialect.put(CNF, Collections.singletonMap(CNF_CLAIM, certThumbprint));
+                    jwtClaimsSetBuilder.claim(CNF, Collections.singletonMap(CNF_CLAIM, certThumbprint));
                 }
-            }
-        }
-        return setClaimsToJwtClaimSet(jwtClaimsSetBuilder, userClaimsInOIDCDialect);
-    }
-
-    private JWTClaimsSet setClaimsToJwtClaimSet(JWTClaimsSet.Builder jwtClaimsSetBuilder, Map<String,
-            Object> userClaimsInOIDCDialect) {
-
-        JWTClaimsSet jwtClaimsSet = jwtClaimsSetBuilder.build();
-        for (Map.Entry<String, Object> claimEntry : userClaimsInOIDCDialect.entrySet()) {
-            String claimValue = claimEntry.getValue().toString();
-            String claimKey = claimEntry.getKey();
-            if (claimValue.contains(FrameworkUtils.getMultiAttributeSeparator())) {
-                JSONArray claimValues = new JSONArray();
-                String[] split = claimValue.split(Pattern.quote(FrameworkUtils.getMultiAttributeSeparator()));
-                for (String attributeValue : split) {
-                    if (StringUtils.isNotBlank(attributeValue)) {
-                        claimValues.add(attributeValue);
-                    }
-                }
-                if (jwtClaimsSet.getClaim(claimKey) != null) {
-                    continue;
-                }
-                jwtClaimsSetBuilder.claim(claimEntry.getKey(), claimValues);
-            } else {
-                if (jwtClaimsSet.getClaim(claimKey) != null) {
-                    continue;
-                }
-                jwtClaimsSetBuilder.claim(claimEntry.getKey(), claimEntry.getValue());
             }
         }
         return jwtClaimsSetBuilder.build();

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuerTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuerTest.java
@@ -37,6 +37,7 @@ import org.wso2.carbon.base.CarbonBaseConstants;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
 import org.wso2.carbon.identity.common.testng.WithH2Database;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.oauth.common.OAuthConstants;
 import org.wso2.carbon.identity.oauth.common.exception.InvalidOAuthClientException;
 import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
@@ -95,6 +96,7 @@ import static org.wso2.carbon.identity.openidconnect.util.TestUtils.getKeyStoreF
                 JWTTokenIssuer.class,
                 IdentityTenantUtil.class,
                 OIDCClaimUtil.class
+                IdentityUtil.class
         }
 )
 public class JWTTokenIssuerTest extends PowerMockIdentityBaseTest {
@@ -133,6 +135,7 @@ public class JWTTokenIssuerTest extends PowerMockIdentityBaseTest {
     public static final String AUTHZ_FLOW_CUSTOM_CLAIM_VALUE = "authz_flow_custom_claim_value";
     public static final String TOKEN_FLOW_CUSTOM_CLAIM = "token_flow_custom_claim";
     public static final String TOKEN_FLOW_CUSTOM_CLAIM_VALUE = "token_flow_custom_claim_value";
+    private static final String MTLS_AUTH_HEADER = "MutualTLS.ClientCertificateHeader";
 
     @Mock
     private OAuthServerConfiguration oAuthServerConfiguration;
@@ -141,6 +144,8 @@ public class JWTTokenIssuerTest extends PowerMockIdentityBaseTest {
     public void setUp() throws Exception {
         initMocks(this);
         mockStatic(OAuthServerConfiguration.class);
+        mockStatic(IdentityUtil.class);
+        when(IdentityUtil.getProperty(MTLS_AUTH_HEADER)).thenReturn(null);
         when(OAuthServerConfiguration.getInstance()).thenReturn(oAuthServerConfiguration);
     }
 


### PR DESCRIPTION
### Purpose
- Add support to generate JWT token with CNF claim
- Related Issue: https://github.com/wso2/api-manager/issues/2177
- A sample decoded JWT token with the CNF claim will look like follows
```
{
  "sub": "1efed9c1-4075-4262-b64a-5a96cee18e3c",
  "aut": "APPLICATION",
  "aud": "aDRupdqjeqPzATgoAOkH6pNP7s0a",
  "nbf": 1696399827,
  "azp": "aDRupdqjeqPzATgoAOkH6pNP7s0a",
  "scope": "default",
  "iss": "https://localhost:9443/oauth2/token",
  "cnf": {
    "x5t#S256": "8z4a8pqsbF_I-aDzootvANher26TxlX9rYEDuJ43KBg"
  },
  "exp": 1696403427,
  "iat": 1696399827,
  "jti": "175541ad-75bf-46e3-99c7-29c516f6ff81",
  "client_id": "aDRupdqjeqPzATgoAOkH6pNP7s0a"
}
```

### Approach
If `oauth.mutualtls.client_certificate_header` config is defined in the `deployment.toml` and the request header contains a certificate against the defined config value, the certificate thumbprint will get added as the CNF claim to the JWT token