### PR TITLE
Upgrade Jackson Dependencies version range to [2.13.0, 2.16.0)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -962,11 +962,11 @@
         <maven-war-plugin.version>3.3.1</maven-war-plugin.version>
 
         <!--Swagger Dependency Version-->
-        <jackson-databind.version>2.13.2.1</jackson-databind.version>
-        <com.fasterxml.jackson.version>2.13.2</com.fasterxml.jackson.version>
+        <jackson-databind.version>2.15.2</jackson-databind.version>
+        <com.fasterxml.jackson.version>2.15.2</com.fasterxml.jackson.version>
         <spring-web.version>4.3.29.RELEASE</spring-web.version>
         <swagger-jaxrs.version>1.6.2</swagger-jaxrs.version>
-        <com.fasterxml.jackson.databind.version.range>[2.13.0, 2.14.0)</com.fasterxml.jackson.databind.version.range>
+        <com.fasterxml.jackson.databind.version.range>[2.13.0, 2.16.0)</com.fasterxml.jackson.databind.version.range>
 
         <!--Test Dependencies-->
         <junit.version>4.13.1</junit.version>


### PR DESCRIPTION
### Purpose
Upgrading Jackson dependencies to 2.15.2 requires updating this version range.