### PR TITLE
Fix consent page Issue

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/OAuth2ScopeService.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/OAuth2ScopeService.java
@@ -865,7 +865,7 @@ public class OAuth2ScopeService implements ScopeMetadataService {
             }
         }
         if (scopesArray.isEmpty()) {
-            return Collections.singletonList(new OAuth2Resource());
+            return new ArrayList<>();
         } else {
             OAuth2Resource resource = new OAuth2Resource(OAuth2ScopeResourceName, OAuth2ScopeResourceName, scopesArray);
             return Collections.singletonList(resource);


### PR DESCRIPTION
### Proposed changes in this pull request

$subject

When trying the authorization code flow, before prompting the consent page, the below exception is thrown.

```
ERROR {org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/authenticationendpoint].[oauth2_authz.do]} - Servlet.service() for servlet [oauth2_authz.do] in context with path [/authenticationendpoint] threw exception [An exception occurred processing [/oauth2_authz.jsp] at line [50]

47: 
48:         for (int count = 0; count < scopeMetadataArray.length(); count++) {
49:             JSONObject jsonObj = (JSONObject) scopeMetadataArray.get(count);
50:             String key = (String) jsonObj.get("name");
51:             List<String> scopes = new ArrayList<>();
52:             JSONArray scopeArray = new JSONArray (jsonObj.get("scopes").toString());
53: 


Stacktrace:] with root cause org.json.JSONException: JSONObject["name"] not found.
```

The root cause for the failure was the `scopeMetadata` variable is set to empty object as shown below.

![image](https://github.com/wso2-extensions/identity-inbound-auth-oauth/assets/35717390/535a4760-666d-4fba-b456-6290a6c88182)

The scopeMetadata variable is used to execute the below mentioned for loop.

![image](https://github.com/wso2-extensions/identity-inbound-auth-oauth/assets/35717390/257ddc4a-6cfd-4a62-920e-01389e9f0009)
