### PR TITLE
Improve Tenant Resolving Logic during logout for Tenant Qualified URLs

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -4788,14 +4788,7 @@ public class OAuth2Util {
         if (!IdentityTenantUtil.isTenantedSessionsEnabled()) {
             return MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
         }
-
-        if (request != null) {
-            String tenantDomainFromReq = request.getParameter(FrameworkConstants.RequestParams.LOGIN_TENANT_DOMAIN);
-            if (StringUtils.isNotBlank(tenantDomainFromReq)) {
-                return tenantDomainFromReq;
-            }
-        }
-        return IdentityTenantUtil.getTenantDomainFromContext();
+        return IdentityTenantUtil.resolveTenantDomain();
     }
 
     /**


### PR DESCRIPTION
This PR will use the resolveTenantDomain method in IdentityTenantUtil to resolve the tenant domain of tenant qualified URLs. When tenant qualified URLs and tenanted sessions are enabled, the super tenant urls will not contain the tenant domain in the request path. Therefore the request will not be used to derive tenant domain, instead it will be retrieved from the context.

Related issue: https://github.com/wso2/product-is/issues/16906