### PR TITLE
Improve the OAuth consumer app deletion logic

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dao/OAuthAppDAO.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dao/OAuthAppDAO.java
@@ -985,7 +985,7 @@ public class OAuthAppDAO {
             try (PreparedStatement prepStmt = connection
                     .prepareStatement(SQLQueries.OAuthAppDAOSQLQueries.REMOVE_APPLICATION)) {
                 prepStmt.setString(1, consumerKey);
-                prepStmt.setInt(2, IdentityTenantUtil.getLoginTenantId());
+                prepStmt.setInt(2, PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantId());
                 prepStmt.execute();
                 if (isOIDCAudienceEnabled()) {
                     String tenantDomain = CarbonContext.getThreadLocalCarbonContext().getTenantDomain();


### PR DESCRIPTION
### Proposed changes in this pull request

The tenant ID of the OAuth app is considered as the request initiated login tenant ID. But there can be application deletion operations executed within tenant flows, where the tenant context is changed. In such cases, using the login tenant ID from the request is not valid. 

Note :- It should improve the all the app related operations by overloading the existing methods with tenantID as consumer key is no longer unique per IS deployment. In this PR, the reported [issue](https://github.com/wso2/product-is/issues/17081) is fixed with minimum effort.

### Related Issues.
- https://github.com/wso2/product-is/issues/16927
- https://github.com/wso2/product-is/issues/17081