### PR TITLE
Add proposed changes for token persistence removal

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/user/impl/UserInfoISAccessTokenValidator.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/user/impl/UserInfoISAccessTokenValidator.java
@@ -78,7 +78,7 @@ public class UserInfoISAccessTokenValidator implements UserInfoAccessTokenValida
         }
 
         try {
-            accessTokenDO = OAuth2ServiceComponentHolder.getInstance().getAccessTokenProvider()
+            accessTokenDO = OAuth2ServiceComponentHolder.getInstance().getTokenProvider()
                     .getVerifiedAccessToken(accessTokenIdentifier, false);
         } catch (IdentityOAuth2Exception e) {
             throw new UserInfoEndpointException("Error in getting AccessTokenDO", e);

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/user/impl/UserInfoJWTResponse.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/user/impl/UserInfoJWTResponse.java
@@ -120,7 +120,7 @@ public class UserInfoJWTResponse extends AbstractUserInfoResponseBuilder {
 
         AccessTokenDO accessTokenDO;
         try {
-            accessTokenDO = OAuth2ServiceComponentHolder.getInstance().getAccessTokenProvider()
+            accessTokenDO = OAuth2ServiceComponentHolder.getInstance().getTokenProvider()
                     .getVerifiedAccessToken(tokenResponse.getAuthorizationContextToken().getTokenString(), false);
         } catch (IdentityOAuth2Exception e) {
             if (IdentityUtil.isTokenLoggable(IdentityConstants.IdentityTokens.ACCESS_TOKEN)) {

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/ClaimUtil.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/ClaimUtil.java
@@ -115,7 +115,7 @@ public class ClaimUtil {
             String subjectClaimValue = null;
 
             try {
-                AccessTokenDO accessTokenDO = OAuth2ServiceComponentHolder.getInstance().getAccessTokenProvider()
+                AccessTokenDO accessTokenDO = OAuth2ServiceComponentHolder.getInstance().getTokenProvider()
                         .getVerifiedAccessToken(tokenResponse.getAuthorizationContextToken().getTokenString(),
                                 false);
                 userId = accessTokenDO.getAuthzUser().getUserId();

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/user/impl/UserInfoJSONResponseBuilderTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/user/impl/UserInfoJSONResponseBuilderTest.java
@@ -38,7 +38,7 @@ import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.oauth.cache.AuthorizationGrantCache;
 import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
 import org.wso2.carbon.identity.oauth.endpoint.util.ClaimUtil;
-import org.wso2.carbon.identity.oauth.tokenprocessor.DefaultAccessTokenProvider;
+import org.wso2.carbon.identity.oauth.tokenprocessor.DefaultTokenProvider;
 import org.wso2.carbon.identity.oauth2.RequestObjectException;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2TokenValidationResponseDTO;
 import org.wso2.carbon.identity.oauth2.internal.OAuth2ServiceComponentHolder;
@@ -91,7 +91,7 @@ public class UserInfoJSONResponseBuilderTest extends UserInfoResponseBaseTest {
     public void setUpTest() throws Exception {
 
         OAuth2ServiceComponentHolder.getInstance().setScopeClaimMappingDAO(new ScopeClaimMappingDAOImpl());
-        OAuth2ServiceComponentHolder.getInstance().setAccessTokenProvider(new DefaultAccessTokenProvider());
+        OAuth2ServiceComponentHolder.getInstance().setTokenProvider(new DefaultTokenProvider());
         userInfoJSONResponseBuilder = new UserInfoJSONResponseBuilder();
         TestUtils.initiateH2Base();
         con = TestUtils.getConnection();

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/util/ClaimUtilTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/util/ClaimUtilTest.java
@@ -43,7 +43,7 @@ import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.oauth.common.exception.InvalidOAuthClientException;
 import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
 import org.wso2.carbon.identity.oauth.dao.OAuthAppDO;
-import org.wso2.carbon.identity.oauth.tokenprocessor.DefaultAccessTokenProvider;
+import org.wso2.carbon.identity.oauth.tokenprocessor.DefaultTokenProvider;
 import org.wso2.carbon.identity.oauth.user.UserInfoEndpointException;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2TokenValidationResponseDTO;
@@ -320,8 +320,8 @@ public class ClaimUtilTest extends PowerMockIdentityBaseTest {
         OAuth2ServiceComponentHolder oAuth2ServiceComponentHolderInstance =
                 Mockito.mock(OAuth2ServiceComponentHolder.class);
         when(OAuth2ServiceComponentHolder.getInstance()).thenReturn(oAuth2ServiceComponentHolderInstance);
-        when(oAuth2ServiceComponentHolderInstance.getAccessTokenProvider())
-                .thenReturn(new DefaultAccessTokenProvider());
+        when(oAuth2ServiceComponentHolderInstance.getTokenProvider())
+                .thenReturn(new DefaultTokenProvider());
         Map<String, Object> claimsMap;
         try {
             claimsMap = ClaimUtil.getClaimsFromUserStore(mockedValidationTokenResponseDTO);

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/tokenprocessor/DefaultOAuth2RevocationProcessor.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/tokenprocessor/DefaultOAuth2RevocationProcessor.java
@@ -18,20 +18,19 @@
 
 package org.wso2.carbon.identity.oauth.tokenprocessor;
 
-import org.apache.commons.lang.StringUtils;
-import org.apache.oltu.oauth2.common.message.types.GrantType;
 import org.wso2.carbon.identity.oauth.OAuthUtil;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.dao.OAuthTokenPersistenceFactory;
 import org.wso2.carbon.identity.oauth2.dto.OAuthRevocationRequestDTO;
 import org.wso2.carbon.identity.oauth2.model.AccessTokenDO;
 import org.wso2.carbon.identity.oauth2.model.RefreshTokenValidationDataDO;
-import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 import org.wso2.carbon.user.core.UserStoreException;
 import org.wso2.carbon.user.core.UserStoreManager;
 
 /**
- * Handles oauth2 token revocation when persistence layer exists.
+ * DefaultOAuth2RevocationProcessor is responsible for handling OAuth2 token revocation
+ * when a persistence layer is in use. It provides methods to revoke access tokens and
+ * refresh tokens, as well as a mechanism to revoke tokens associated with a specific user.
  */
 public class DefaultOAuth2RevocationProcessor implements OAuth2RevocationProcessor {
 
@@ -49,27 +48,6 @@ public class DefaultOAuth2RevocationProcessor implements OAuth2RevocationProcess
 
         OAuthTokenPersistenceFactory.getInstance().getAccessTokenDAO()
                 .revokeAccessTokens(new String[]{refreshTokenDO.getAccessToken()});
-    }
-
-    @Override
-    public RefreshTokenValidationDataDO getRevocableRefreshToken(OAuthRevocationRequestDTO revokeRequestDTO)
-            throws IdentityOAuth2Exception {
-
-        return OAuthTokenPersistenceFactory.getInstance().getTokenManagementDAO()
-                .validateRefreshToken(revokeRequestDTO.getConsumerKey(), revokeRequestDTO.getToken());
-    }
-
-    @Override
-    public AccessTokenDO getRevocableAccessToken(OAuthRevocationRequestDTO revokeRequestDTO)
-            throws IdentityOAuth2Exception {
-
-        return OAuth2Util.findAccessToken(revokeRequestDTO.getToken(), true);
-    }
-
-    @Override
-    public boolean isRefreshTokenType(OAuthRevocationRequestDTO revokeRequestDTO) {
-
-        return StringUtils.equals(GrantType.REFRESH_TOKEN.toString(), revokeRequestDTO.getTokenType());
     }
 
     @Override

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/tokenprocessor/DefaultTokenProvider.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/tokenprocessor/DefaultTokenProvider.java
@@ -38,7 +38,7 @@ public class DefaultTokenProvider implements TokenProvider {
     }
 
     @Override
-    public RefreshTokenValidationDataDO getVerifiedRefreshToken(String consumerKey, String refreshToken)
+    public RefreshTokenValidationDataDO getVerifiedRefreshToken(String refreshToken, String consumerKey)
             throws IdentityOAuth2Exception {
 
         return OAuthTokenPersistenceFactory.getInstance().getTokenManagementDAO().validateRefreshToken(consumerKey,

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/tokenprocessor/DefaultTokenProvider.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/tokenprocessor/DefaultTokenProvider.java
@@ -19,19 +19,29 @@
 package org.wso2.carbon.identity.oauth.tokenprocessor;
 
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
+import org.wso2.carbon.identity.oauth2.dao.OAuthTokenPersistenceFactory;
 import org.wso2.carbon.identity.oauth2.model.AccessTokenDO;
+import org.wso2.carbon.identity.oauth2.model.RefreshTokenValidationDataDO;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 
 /**
- * Default implementation of AccessTokenProvider for scenarios with token persistence enabled.
+ * Default implementation of TokenProvider for scenarios with token persistence enabled.
  * Verifies access tokens by querying the database, including optional inclusion of expired tokens.
  */
-public class DefaultAccessTokenProvider implements AccessTokenProvider {
+public class DefaultTokenProvider implements TokenProvider {
 
     @Override
     public AccessTokenDO getVerifiedAccessToken(String accessToken, boolean includeExpired)
             throws IdentityOAuth2Exception {
 
         return OAuth2Util.findAccessToken(accessToken, includeExpired);
+    }
+
+    @Override
+    public RefreshTokenValidationDataDO getVerifiedRefreshToken(String consumerKey, String refreshToken)
+            throws IdentityOAuth2Exception {
+
+        return OAuthTokenPersistenceFactory.getInstance().getTokenManagementDAO().validateRefreshToken(consumerKey,
+                refreshToken);
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/tokenprocessor/OAuth2RevocationProcessor.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/tokenprocessor/OAuth2RevocationProcessor.java
@@ -27,8 +27,8 @@ import org.wso2.carbon.user.core.UserStoreException;
 import org.wso2.carbon.user.core.UserStoreManager;
 
 /**
- * Abstraction layer between OAuth2Service and persistence layer to handle
- * revocation logic during token persistence and non-persistence scenarios.
+ * Abstraction layer between OAuth2Service and persistence layer to handle revocation logic during token persistence
+ * and non-persistence scenarios.
  */
 public interface OAuth2RevocationProcessor {
 
@@ -54,42 +54,12 @@ public interface OAuth2RevocationProcessor {
                             RefreshTokenValidationDataDO refreshTokenDO) throws IdentityOAuth2Exception;
 
     /**
-     * Validate and return the refresh token metadata.
-     *
-     * @param revokeRequestDTO Metadata containing revoke token request.
-     * @return RefreshTokenValidationDataDO {@link RefreshTokenValidationDataDO} instance.
-     * @throws IdentityOAuth2Exception If an error occurs while validating the refresh token.
-     */
-    RefreshTokenValidationDataDO getRevocableRefreshToken(OAuthRevocationRequestDTO revokeRequestDTO)
-            throws IdentityOAuth2Exception;
-
-    /**
-     * Validate and return the access token metadata.
-     *
-     * @param revokeRequestDTO Metadata containing revoke token request.
-     * @return AccessTokenDO    {@link AccessTokenDO} instance.
-     * @throws IdentityOAuth2Exception If an error occurs while validating the access token.
-     */
-    AccessTokenDO getRevocableAccessToken(OAuthRevocationRequestDTO revokeRequestDTO)
-            throws IdentityOAuth2Exception;
-
-    /**
-     * Check whether revoke request is related to access token or revoke token.
-     *
-     * @param revokeRequestDTO Metadata containing revoke token request.
-     * @return boolean whether it is a refresh token request or not
-     * @throws IdentityOAuth2Exception If an error occurs while checking the token type.
-     */
-    boolean isRefreshTokenType(OAuthRevocationRequestDTO revokeRequestDTO) throws IdentityOAuth2Exception;
-
-    /**
      * Handle indirect token revocation for internal user events.
      *
-     * @param username User on which the event occurred.
+     * @param username         User on which the event occurred.
      * @param userStoreManager User store manager.
      * @return true if revocation is successful. Else return false.
-     * @throws UserStoreException
+     * @throws UserStoreException If an error occurs while revoking tokens for users.
      */
-    boolean revokeTokens(String username, UserStoreManager userStoreManager)
-            throws UserStoreException;
+    boolean revokeTokens(String username, UserStoreManager userStoreManager) throws UserStoreException;
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/tokenprocessor/TokenProvider.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/tokenprocessor/TokenProvider.java
@@ -54,6 +54,6 @@ public interface TokenProvider {
      * is not found either in ACTIVE or EXPIRED states.
      * @throws IdentityOAuth2Exception If there is an error during the access token retrieval or verification process.
      */
-    RefreshTokenValidationDataDO getVerifiedRefreshToken(String consumerKey, String refreshToken)
+    RefreshTokenValidationDataDO getVerifiedRefreshToken(String refreshToken, String consumerKey)
             throws IdentityOAuth2Exception;
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/tokenprocessor/TokenProvider.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/tokenprocessor/TokenProvider.java
@@ -20,14 +20,14 @@ package org.wso2.carbon.identity.oauth.tokenprocessor;
 
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.model.AccessTokenDO;
+import org.wso2.carbon.identity.oauth2.model.RefreshTokenValidationDataDO;
 
 /**
- * The AccessTokenProvider interface defines the contract for classes that are responsible
- * for verifying and providing access tokens. Implementing classes should offer methods
- * to retrieve access tokens based on token data objects, with the option to include expired
- * tokens in the verification process and handle potential exceptions.
+ * The TokenProvider interface defines the contract for classes that are responsible
+ * for verifying and providing access tokens and refresh tokens. Implementing classes should offer methods
+ * to retrieve access tokens and refresh token based on token data objects.
  */
-public interface AccessTokenProvider {
+public interface TokenProvider {
 
     /**
      * Retrieves and verifies an access token based on the provided access token data object,
@@ -43,4 +43,17 @@ public interface AccessTokenProvider {
      * @throws IdentityOAuth2Exception If there is an error during the access token retrieval or verification process.
      */
     AccessTokenDO getVerifiedAccessToken(String accessToken, boolean includeExpired) throws IdentityOAuth2Exception;
+
+
+    /**
+     * Retrieves and verifies a refresh token.
+     *
+     * @param refreshToken The access token data object to retrieve and verify.
+     * @param consumerKey  Consumer key
+     * @return The RefreshTokenValidationDataDO if the token is valid (ACTIVE or EXPIRED), or null if the token
+     * is not found either in ACTIVE or EXPIRED states.
+     * @throws IdentityOAuth2Exception If there is an error during the access token retrieval or verification process.
+     */
+    RefreshTokenValidationDataDO getVerifiedRefreshToken(String consumerKey, String refreshToken)
+            throws IdentityOAuth2Exception;
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/OAuth2Constants.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/OAuth2Constants.java
@@ -33,6 +33,7 @@ public class OAuth2Constants {
 
     }
     public static final String GROUPS = "groups";
+    public static final String ENTITY_ID = "entity_id";
 
 
     /**

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/OAuth2Constants.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/OAuth2Constants.java
@@ -34,6 +34,7 @@ public class OAuth2Constants {
     }
     public static final String GROUPS = "groups";
     public static final String ENTITY_ID = "entity_id";
+    public static final String IS_CONSENTED = "is_consented";
     public static final boolean DEFAULT_PERSIST_ENABLED = true;
     public static final String OAUTH_TOKEN_PERSISTENCE_ENABLE = "OAuth.TokenPersistence.Enable";
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/OAuth2Constants.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/OAuth2Constants.java
@@ -34,6 +34,8 @@ public class OAuth2Constants {
     }
     public static final String GROUPS = "groups";
     public static final String ENTITY_ID = "entity_id";
+    public static final boolean DEFAULT_PERSIST_ENABLED = true;
+    public static final String OAUTH_TOKEN_PERSISTENCE_ENABLE = "OAuth.TokenPersistence.Enable";
 
 
     /**

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/OAuth2Service.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/OAuth2Service.java
@@ -552,31 +552,29 @@ public class OAuth2Service extends AbstractAdmin {
                     StringUtils.isNotEmpty(revokeRequestDTO.getToken())) {
 
                 boolean refreshTokenFirst = false;
-                if (getRevocationProcessor().isRefreshTokenType(revokeRequestDTO)) {
+                if (isRefreshTokenType(revokeRequestDTO)) {
                     refreshTokenFirst = true;
                 }
-
                 if (refreshTokenFirst) {
-                    refreshTokenDO = getRevocationProcessor().getRevocableRefreshToken(revokeRequestDTO);
-
+                    refreshTokenDO = OAuth2ServiceComponentHolder.getInstance().getTokenProvider()
+                            .getVerifiedRefreshToken(revokeRequestDTO.getToken(), revokeRequestDTO.getConsumerKey());
                     if (refreshTokenDO == null ||
                             StringUtils.isEmpty(refreshTokenDO.getRefreshTokenState()) ||
                             !(OAuthConstants.TokenStates.TOKEN_STATE_ACTIVE
                                     .equals(refreshTokenDO.getRefreshTokenState()) ||
                                     OAuthConstants.TokenStates.TOKEN_STATE_EXPIRED
                                             .equals(refreshTokenDO.getRefreshTokenState()))) {
-
-                        accessTokenDO = getRevocationProcessor().getRevocableAccessToken(revokeRequestDTO);
+                        accessTokenDO = OAuth2ServiceComponentHolder.getInstance().getTokenProvider()
+                                .getVerifiedAccessToken(revokeRequestDTO.getToken(), true);
                         refreshTokenDO = null;
                     }
-
                 } else {
-
-                    accessTokenDO = getRevocationProcessor().getRevocableAccessToken(revokeRequestDTO);
+                    accessTokenDO = OAuth2ServiceComponentHolder.getInstance().getTokenProvider()
+                            .getVerifiedAccessToken(revokeRequestDTO.getToken(), true);
                     if (accessTokenDO == null) {
-
-                        refreshTokenDO = getRevocationProcessor().getRevocableRefreshToken(revokeRequestDTO);
-
+                        refreshTokenDO = OAuth2ServiceComponentHolder.getInstance().getTokenProvider()
+                                .getVerifiedRefreshToken(revokeRequestDTO.getToken(),
+                                        revokeRequestDTO.getConsumerKey());
                         if (refreshTokenDO == null ||
                                 StringUtils.isEmpty(refreshTokenDO.getRefreshTokenState()) ||
                                 !(OAuthConstants.TokenStates.TOKEN_STATE_ACTIVE

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/OAuth2Service.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/OAuth2Service.java
@@ -557,7 +557,7 @@ public class OAuth2Service extends AbstractAdmin {
                 }
                 if (refreshTokenFirst) {
                     refreshTokenDO = OAuth2ServiceComponentHolder.getInstance().getTokenProvider()
-                            .getVerifiedRefreshToken(revokeRequestDTO.getToken(), revokeRequestDTO.getConsumerKey());
+                            .getVerifiedRefreshToken(revokeRequestDTO.getConsumerKey(), revokeRequestDTO.getToken());
                     if (refreshTokenDO == null ||
                             StringUtils.isEmpty(refreshTokenDO.getRefreshTokenState()) ||
                             !(OAuthConstants.TokenStates.TOKEN_STATE_ACTIVE
@@ -573,8 +573,8 @@ public class OAuth2Service extends AbstractAdmin {
                             .getVerifiedAccessToken(revokeRequestDTO.getToken(), true);
                     if (accessTokenDO == null) {
                         refreshTokenDO = OAuth2ServiceComponentHolder.getInstance().getTokenProvider()
-                                .getVerifiedRefreshToken(revokeRequestDTO.getToken(),
-                                        revokeRequestDTO.getConsumerKey());
+                                .getVerifiedRefreshToken(revokeRequestDTO.getConsumerKey(),
+                                        revokeRequestDTO.getToken());
                         if (refreshTokenDO == null ||
                                 StringUtils.isEmpty(refreshTokenDO.getRefreshTokenState()) ||
                                 !(OAuthConstants.TokenStates.TOKEN_STATE_ACTIVE

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/OAuth2Service.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/OAuth2Service.java
@@ -557,7 +557,7 @@ public class OAuth2Service extends AbstractAdmin {
                 }
                 if (refreshTokenFirst) {
                     refreshTokenDO = OAuth2ServiceComponentHolder.getInstance().getTokenProvider()
-                            .getVerifiedRefreshToken(revokeRequestDTO.getConsumerKey(), revokeRequestDTO.getToken());
+                            .getVerifiedRefreshToken(revokeRequestDTO.getToken(), revokeRequestDTO.getConsumerKey());
                     if (refreshTokenDO == null ||
                             StringUtils.isEmpty(refreshTokenDO.getRefreshTokenState()) ||
                             !(OAuthConstants.TokenStates.TOKEN_STATE_ACTIVE
@@ -573,8 +573,8 @@ public class OAuth2Service extends AbstractAdmin {
                             .getVerifiedAccessToken(revokeRequestDTO.getToken(), true);
                     if (accessTokenDO == null) {
                         refreshTokenDO = OAuth2ServiceComponentHolder.getInstance().getTokenProvider()
-                                .getVerifiedRefreshToken(revokeRequestDTO.getConsumerKey(),
-                                        revokeRequestDTO.getToken());
+                                .getVerifiedRefreshToken(revokeRequestDTO.getToken(),
+                                        revokeRequestDTO.getConsumerKey());
                         if (refreshTokenDO == null ||
                                 StringUtils.isEmpty(refreshTokenDO.getRefreshTokenState()) ||
                                 !(OAuthConstants.TokenStates.TOKEN_STATE_ACTIVE

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/handlers/util/ResponseTypeHandlerUtil.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/handlers/util/ResponseTypeHandlerUtil.java
@@ -506,8 +506,11 @@ public class ResponseTypeHandlerUtil {
         String scope = OAuth2Util.buildScopeString(oauthAuthzMsgCtx.getApprovedScope());
         String consumerKey = authorizationReqDTO.getConsumerKey();
         String authenticatedIDP = OAuth2Util.getAuthenticatedIDP(authorizationReqDTO.getUser());
-
-        if (cacheEnabled) {
+        /*
+         * If no token persistence, the token is not cached against a cache key with userId, scope, client and
+         * idp since multiple active tokens can exist for the same key.
+         */
+        if (cacheEnabled && OAuth2Util.isTokenPersistenceEnabled()) {
             existingTokenBean = getExistingTokenFromCache(consumerKey, scope, authorizedUserId, authenticatedIDP);
         }
 
@@ -975,7 +978,13 @@ public class ResponseTypeHandlerUtil {
 
     private static void addTokenToCache(OAuthCacheKey cacheKey, AccessTokenDO tokenBean) {
 
-        OAuthCache.getInstance().addToCache(cacheKey, tokenBean);
+        /*
+         * If no token persistence, the token will be not be cached against a cache key with userId, scope, client and
+         * idp. But, token will be cached and managed as an AccessTokenDO against the token identifier.
+         */
+        if (OAuth2Util.isTokenPersistenceEnabled()) {
+            OAuthCache.getInstance().addToCache(cacheKey, tokenBean);
+        }
         // Adding AccessTokenDO to improve validation performance
         OAuthCacheKey accessTokenCacheKey = new OAuthCacheKey(tokenBean.getAccessToken());
         OAuthCache.getInstance().addToCache(accessTokenCacheKey, tokenBean);

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuth2ServiceComponent.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuth2ServiceComponent.java
@@ -47,9 +47,9 @@ import org.wso2.carbon.identity.oauth.common.token.bindings.TokenBinderInfo;
 import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
 import org.wso2.carbon.identity.oauth.dto.ScopeDTO;
 import org.wso2.carbon.identity.oauth.internal.OAuthComponentServiceHolder;
-import org.wso2.carbon.identity.oauth.tokenprocessor.AccessTokenProvider;
 import org.wso2.carbon.identity.oauth.tokenprocessor.OAuth2RevocationProcessor;
 import org.wso2.carbon.identity.oauth.tokenprocessor.RefreshTokenGrantProcessor;
+import org.wso2.carbon.identity.oauth.tokenprocessor.TokenProvider;
 import org.wso2.carbon.identity.oauth2.OAuth2ScopeService;
 import org.wso2.carbon.identity.oauth2.OAuth2Service;
 import org.wso2.carbon.identity.oauth2.OAuth2TokenValidationService;
@@ -705,36 +705,36 @@ public class OAuth2ServiceComponent {
     }
 
     /**
-     * Sets the access token provider.
+     * Sets the token provider.
      *
-     * @param accessTokenProvider AccessTokenProvider
+     * @param tokenProvider TokenProvider
      */
     @Reference(
-            name = "access.token.provider",
-            service = AccessTokenProvider.class,
+            name = "token.provider",
+            service = TokenProvider.class,
             cardinality = ReferenceCardinality.OPTIONAL,
             policy = ReferencePolicy.DYNAMIC,
-            unbind = "unsetAccessTokenProvider"
+            unbind = "unsetTokenProvider"
     )
-    protected void setAccessTokenProvider(AccessTokenProvider accessTokenProvider) {
+    protected void setTokenProvider(TokenProvider tokenProvider) {
 
         if (log.isDebugEnabled()) {
-            log.debug("Setting access token provider.");
+            log.debug("Setting token provider.");
         }
-        OAuth2ServiceComponentHolder.getInstance().setAccessTokenProvider(accessTokenProvider);
+        OAuth2ServiceComponentHolder.getInstance().setTokenProvider(tokenProvider);
     }
 
     /**
-     * Unsets the access token provider.
+     * Unsets the token provider.
      *
-     * @param accessTokenProvider AccessTokenProvider
+     * @param tokenProvider TokenProvider
      */
-    protected void unsetAccessTokenProvider(AccessTokenProvider accessTokenProvider) {
+    protected void unsetTokenProvider(TokenProvider tokenProvider) {
 
         if (log.isDebugEnabled()) {
-            log.debug("Unset access token provider.");
+            log.debug("Unset token provider.");
         }
-        OAuth2ServiceComponentHolder.getInstance().setAccessTokenProvider(null);
+        OAuth2ServiceComponentHolder.getInstance().setTokenProvider(null);
     }
 
     /**

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuth2ServiceComponentHolder.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuth2ServiceComponentHolder.java
@@ -28,12 +28,12 @@ import org.wso2.carbon.identity.core.handler.HandlerComparator;
 import org.wso2.carbon.identity.event.services.IdentityEventService;
 import org.wso2.carbon.identity.oauth.OAuthAdminServiceImpl;
 import org.wso2.carbon.identity.oauth.dto.ScopeDTO;
-import org.wso2.carbon.identity.oauth.tokenprocessor.AccessTokenProvider;
-import org.wso2.carbon.identity.oauth.tokenprocessor.DefaultAccessTokenProvider;
 import org.wso2.carbon.identity.oauth.tokenprocessor.DefaultOAuth2RevocationProcessor;
 import org.wso2.carbon.identity.oauth.tokenprocessor.DefaultRefreshTokenGrantProcessor;
+import org.wso2.carbon.identity.oauth.tokenprocessor.DefaultTokenProvider;
 import org.wso2.carbon.identity.oauth.tokenprocessor.OAuth2RevocationProcessor;
 import org.wso2.carbon.identity.oauth.tokenprocessor.RefreshTokenGrantProcessor;
+import org.wso2.carbon.identity.oauth.tokenprocessor.TokenProvider;
 import org.wso2.carbon.identity.oauth2.OAuthAuthorizationRequestBuilder;
 import org.wso2.carbon.identity.oauth2.authz.validators.ResponseTypeRequestValidator;
 import org.wso2.carbon.identity.oauth2.bean.Scope;
@@ -103,7 +103,7 @@ public class OAuth2ServiceComponentHolder {
     private boolean isOrganizationManagementEnabled = false;
     private RefreshTokenGrantProcessor refreshTokenGrantProcessor;
     private OAuth2RevocationProcessor revocationProcessor;
-    private AccessTokenProvider accessTokenProvider;
+    private TokenProvider tokenProvider;
 
     private OAuth2ServiceComponentHolder() {
 
@@ -717,25 +717,25 @@ public class OAuth2ServiceComponentHolder {
     }
 
     /**
-     * Get access token provider.
+     * Get token provider.
      *
-     * @return AccessTokenProvider
+     * @return TokenProvider
      */
-    public AccessTokenProvider getAccessTokenProvider() {
+    public TokenProvider getTokenProvider() {
 
-        if (accessTokenProvider == null) {
-            accessTokenProvider = new DefaultAccessTokenProvider();
+        if (tokenProvider == null) {
+            tokenProvider = new DefaultTokenProvider();
         }
-        return accessTokenProvider;
+        return tokenProvider;
     }
 
     /**
-     * Set access token provider.
+     * Set token provider.
      *
-     * @param accessTokenProvider AccessTokenProvider
+     * @param tokenProvider TokenProvider
      */
-    public void setAccessTokenProvider(AccessTokenProvider accessTokenProvider) {
+    public void setTokenProvider(TokenProvider tokenProvider) {
 
-        this.accessTokenProvider = accessTokenProvider;
+        this.tokenProvider = tokenProvider;
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/model/RefreshTokenValidationDataDO.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/model/RefreshTokenValidationDataDO.java
@@ -49,6 +49,7 @@ public class RefreshTokenValidationDataDO {
 
     private long accessTokenValidityInMillis;
     private AccessTokenExtendedAttributes accessTokenExtendedAttributes;
+    private boolean isConsented;
 
     public String getAccessToken() {
         return accessToken;
@@ -149,5 +150,15 @@ public class RefreshTokenValidationDataDO {
             AccessTokenExtendedAttributes accessTokenExtendedAttributes) {
 
         this.accessTokenExtendedAttributes = accessTokenExtendedAttributes;
+    }
+
+    public boolean isConsented() {
+
+        return isConsented;
+    }
+
+    public void setConsented(boolean consented) {
+
+        isConsented = consented;
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuer.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuer.java
@@ -489,7 +489,13 @@ public class JWTTokenIssuer extends OauthTokenIssuerImpl {
         jwtClaimsSetBuilder.notBeforeTime(new Date(curTimeInMillis));
         jwtClaimsSetBuilder.claim(CLIENT_ID, consumerKey);
         try {
-            jwtClaimsSetBuilder.claim(ENTITY_ID, authenticatedUser.getUserId());
+            /*
+             *  The entity_id is used to identify the principal subject for the issuing token. For user access tokens,
+             *  this is the user's unique ID. For application access tokens, this is the application's consumer key.
+             */
+            String entityId = isUserAccessTokenType(tokenReqMessageContext.getOauth2AccessTokenReqDTO().getGrantType())
+                    ? authenticatedUser.getUserId() : oAuthAppDO.getOauthConsumerKey();
+            jwtClaimsSetBuilder.claim(ENTITY_ID, entityId);
         } catch (UserIdNotFoundException e) {
             throw new IdentityOAuth2Exception("User id not found for user: "
                     + authenticatedUser.getLoggableMaskedUserId(), e);

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuer.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuer.java
@@ -35,6 +35,7 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.oltu.oauth2.common.exception.OAuthSystemException;
+import org.wso2.carbon.identity.application.authentication.framework.exception.UserIdNotFoundException;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
 import org.wso2.carbon.identity.base.IdentityConstants;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
@@ -93,6 +94,7 @@ public class JWTTokenIssuer extends OauthTokenIssuerImpl {
     private static final String TOKEN_BINDING_TYPE = "binding_type";
     private static final String DEFAULT_TYP_HEADER_VALUE = "at+jwt";
     private static final String CNF = "cnf";
+    private static final String ENTITY_ID = "entity_id";
 
     private static final Log log = LogFactory.getLog(JWTTokenIssuer.class);
     private static final String INBOUND_AUTH2_TYPE = "oauth2";
@@ -486,6 +488,12 @@ public class JWTTokenIssuer extends OauthTokenIssuerImpl {
         jwtClaimsSetBuilder.jwtID(UUID.randomUUID().toString());
         jwtClaimsSetBuilder.notBeforeTime(new Date(curTimeInMillis));
         jwtClaimsSetBuilder.claim(CLIENT_ID, consumerKey);
+        try {
+            jwtClaimsSetBuilder.claim(ENTITY_ID, authenticatedUser.getUserId());
+        } catch (UserIdNotFoundException e) {
+            throw new IdentityOAuth2Exception("User id not found for user: "
+                    + authenticatedUser.getLoggableMaskedUserId(), e);
+        }
 
         String scope = getScope(authAuthzReqMessageContext, tokenReqMessageContext);
         if (StringUtils.isNotEmpty(scope)) {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/RefreshGrantHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/RefreshGrantHandler.java
@@ -306,37 +306,43 @@ public class RefreshGrantHandler extends AbstractAuthorizationGrantHandler {
                 OAuthCache.getInstance().clearCacheEntry(accessTokenCacheKey,
                         oldAccessToken.getAuthorizedUser().getTenantDomain());
             }
-            AccessTokenDO tokenToCache = AccessTokenDO.clone(accessTokenBean);
-            OauthTokenIssuer oauthTokenIssuer;
-            try {
-                oauthTokenIssuer = OAuth2Util.getOAuthTokenIssuerForOAuthApp(
-                        tokReqMsgCtx.getOauth2AccessTokenReqDTO().getClientId());
-            } catch (InvalidOAuthClientException e) {
-                throw new IdentityOAuth2Exception(
-                        "Error while retrieving oauth issuer for the app with clientId: " +
-                        tokReqMsgCtx.getOauth2AccessTokenReqDTO().getClientId(), e);
-            }
-            if (oauthTokenIssuer.usePersistedAccessTokenAlias()) {
+            /*
+             * If no token persistence, the token will be not be cached against a cache key with userId, scope, client,
+             * idp and binding reference. But, token will be cached and managed as an AccessTokenDO against the
+             * token identifier.
+             */
+            if (OAuth2Util.isTokenPersistenceEnabled()) {
+                AccessTokenDO tokenToCache = AccessTokenDO.clone(accessTokenBean);
+                OauthTokenIssuer oauthTokenIssuer;
                 try {
-                    String persistedTokenIdentifier =
-                            oauthTokenIssuer.getAccessTokenHash(accessTokenBean.getAccessToken());
-                    tokenToCache.setAccessToken(persistedTokenIdentifier);
-                } catch (OAuthSystemException e) {
-                    if (log.isDebugEnabled()) {
-                        if (IdentityUtil.isTokenLoggable(IdentityConstants.IdentityTokens.ACCESS_TOKEN)) {
-                            log.debug("Token issuer: " + oauthTokenIssuer.getClass() + " was tried and" +
-                                    " failed to parse the received token " + tokenToCache.getAccessToken(), e);
-                        } else {
-                            log.debug("Token issuer: " + oauthTokenIssuer.getClass() + " was tried and" +
-                                    " failed to parse the received token.", e);
+                    oauthTokenIssuer = OAuth2Util.getOAuthTokenIssuerForOAuthApp(
+                            tokReqMsgCtx.getOauth2AccessTokenReqDTO().getClientId());
+                } catch (InvalidOAuthClientException e) {
+                    throw new IdentityOAuth2Exception(
+                            "Error while retrieving oauth issuer for the app with clientId: " +
+                                    tokReqMsgCtx.getOauth2AccessTokenReqDTO().getClientId(), e);
+                }
+                if (oauthTokenIssuer.usePersistedAccessTokenAlias()) {
+                    try {
+                        String persistedTokenIdentifier =
+                                oauthTokenIssuer.getAccessTokenHash(accessTokenBean.getAccessToken());
+                        tokenToCache.setAccessToken(persistedTokenIdentifier);
+                    } catch (OAuthSystemException e) {
+                        if (log.isDebugEnabled()) {
+                            if (IdentityUtil.isTokenLoggable(IdentityConstants.IdentityTokens.ACCESS_TOKEN)) {
+                                log.debug("Token issuer: " + oauthTokenIssuer.getClass() + " was tried and" +
+                                        " failed to parse the received token " + tokenToCache.getAccessToken(), e);
+                            } else {
+                                log.debug("Token issuer: " + oauthTokenIssuer.getClass() + " was tried and" +
+                                        " failed to parse the received token.", e);
+                            }
                         }
                     }
                 }
+
+                // Add new access token to the OAuthCache
+                OAuthCache.getInstance().addToCache(oauthCacheKey, tokenToCache);
             }
-
-            // Add new access token to the OAuthCache
-            OAuthCache.getInstance().addToCache(oauthCacheKey, tokenToCache);
-
             // Add new access token to the AccessTokenCache
             OAuth2Util.addTokenDOtoCache(accessTokenBean);
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -114,6 +114,7 @@ import org.wso2.carbon.identity.oauth2.IdentityOAuth2ClientException;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2ScopeException;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2ScopeServerException;
+import org.wso2.carbon.identity.oauth2.OAuth2Constants;
 import org.wso2.carbon.identity.oauth2.authz.OAuthAuthzReqMessageContext;
 import org.wso2.carbon.identity.oauth2.bean.OAuthClientAuthnContext;
 import org.wso2.carbon.identity.oauth2.bean.Scope;
@@ -4224,7 +4225,7 @@ public class OAuth2Util {
         if (tokenResponse.getAuthorizationContextToken().getTokenString() != null) {
             AccessTokenDO accessTokenDO;
             try {
-                accessTokenDO = OAuth2ServiceComponentHolder.getInstance().getAccessTokenProvider()
+                accessTokenDO = OAuth2ServiceComponentHolder.getInstance().getTokenProvider()
                         .getVerifiedAccessToken(tokenResponse.getAuthorizationContextToken().getTokenString(), false);
             } catch (IdentityOAuth2Exception e) {
                 throw new UserInfoEndpointException("Error occurred while obtaining access token.", e);
@@ -4251,7 +4252,7 @@ public class OAuth2Util {
 
         if (tokenResponse.getAuthorizationContextToken().getTokenString() != null) {
             try {
-                AccessTokenDO accessTokenDO = OAuth2ServiceComponentHolder.getInstance().getAccessTokenProvider()
+                AccessTokenDO accessTokenDO = OAuth2ServiceComponentHolder.getInstance().getTokenProvider()
                         .getVerifiedAccessToken(tokenResponse.getAuthorizationContextToken().getTokenString(), false);
                 return Optional.ofNullable(accessTokenDO);
             } catch (IdentityOAuth2Exception e) {
@@ -5028,5 +5029,18 @@ public class OAuth2Util {
             }
         }
         return supportedClientAuthMethods.toArray(new String[0]);
+    }
+
+    /**
+     * Check if token persistence is enabled.
+     *
+     * @return True if token persistence is enabled.
+     */
+    public static boolean isTokenPersistenceEnabled() {
+
+        if (IdentityUtil.getProperty(OAuth2Constants.OAUTH_TOKEN_PERSISTENCE_ENABLE) != null) {
+            return Boolean.parseBoolean(IdentityUtil.getProperty(OAuth2Constants.OAUTH_TOKEN_PERSISTENCE_ENABLE));
+        }
+        return OAuth2Constants.DEFAULT_PERSIST_ENABLED;
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/TokenValidationHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/TokenValidationHandler.java
@@ -32,7 +32,7 @@ import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.oauth.common.OAuthConstants;
 import org.wso2.carbon.identity.oauth.common.exception.InvalidOAuthClientException;
 import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
-import org.wso2.carbon.identity.oauth.tokenprocessor.AccessTokenProvider;
+import org.wso2.carbon.identity.oauth.tokenprocessor.TokenProvider;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.authcontext.AuthorizationContextTokenGenerator;
 import org.wso2.carbon.identity.oauth2.dao.OAuthTokenPersistenceFactory;
@@ -62,7 +62,7 @@ public class TokenValidationHandler {
     AuthorizationContextTokenGenerator tokenGenerator = null;
     private static final Log log = LogFactory.getLog(TokenValidationHandler.class);
     private Map<String, OAuth2TokenValidator> tokenValidators = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
-    private AccessTokenProvider tokenValidationProcessor;
+    private TokenProvider tokenValidationProcessor;
     private static final String BEARER_TOKEN_TYPE = "Bearer";
     private static final String BEARER_TOKEN_TYPE_JWT = "jwt";
     private static final String BUILD_FQU_FROM_SP_CONFIG = "OAuth.BuildSubjectIdentifierFromSPConfig";
@@ -120,7 +120,7 @@ public class TokenValidationHandler {
                 log.error(errorMsg, e);
             }
         }
-        tokenValidationProcessor = OAuth2ServiceComponentHolder.getInstance().getAccessTokenProvider();
+        tokenValidationProcessor = OAuth2ServiceComponentHolder.getInstance().getTokenProvider();
     }
 
     public static TokenValidationHandler getInstance() {
@@ -178,7 +178,7 @@ public class TokenValidationHandler {
         }
 
         try {
-            accessTokenDO = OAuth2ServiceComponentHolder.getInstance().getAccessTokenProvider()
+            accessTokenDO = OAuth2ServiceComponentHolder.getInstance().getTokenProvider()
                     .getVerifiedAccessToken(requestDTO.getAccessToken().getIdentifier(), false);
         } catch (IllegalArgumentException e) {
             // Access token not found in the system.
@@ -276,7 +276,7 @@ public class TokenValidationHandler {
         // Adding the AccessTokenDO as a context property for further use
         AccessTokenDO accessTokenDO;
         try {
-            accessTokenDO = OAuth2ServiceComponentHolder.getInstance().getAccessTokenProvider()
+            accessTokenDO = OAuth2ServiceComponentHolder.getInstance().getTokenProvider()
                     .getVerifiedAccessToken(oAuth2Token.getIdentifier(), true);
             if (accessTokenDO != null) {
                 messageContext.addProperty(OAuthConstants.ACCESS_TOKEN_DO, accessTokenDO);
@@ -500,7 +500,7 @@ public class TokenValidationHandler {
         } else {
             try {
                 String tenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
-                accessTokenDO = OAuth2ServiceComponentHolder.getInstance().getAccessTokenProvider()
+                accessTokenDO = OAuth2ServiceComponentHolder.getInstance().getTokenProvider()
                         .getVerifiedAccessToken(validationRequest.getAccessToken().getIdentifier(), false);
                 boolean isCrossTenantTokenIntrospectionAllowed
                         = OAuthServerConfiguration.getInstance().isCrossTenantTokenIntrospectionAllowed();

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/AbstractUserInfoResponseBuilder.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/AbstractUserInfoResponseBuilder.java
@@ -106,7 +106,7 @@ public abstract class AbstractUserInfoResponseBuilder implements UserInfoRespons
         AccessTokenDO accessTokenDO;
         String accessToken;
         try {
-            accessTokenDO = OAuth2ServiceComponentHolder.getInstance().getAccessTokenProvider()
+            accessTokenDO = OAuth2ServiceComponentHolder.getInstance().getTokenProvider()
                     .getVerifiedAccessToken(tokenResponse.getAuthorizationContextToken().getTokenString(), false);
             accessToken = accessTokenDO == null ? null : accessTokenDO.getAccessToken();
         } catch (IdentityOAuth2Exception e) {
@@ -181,7 +181,7 @@ public abstract class AbstractUserInfoResponseBuilder implements UserInfoRespons
         AuthenticatedUser authenticatedUser;
         try {
             authenticatedUser = OAuth2Util.getAuthenticatedUser(OAuth2ServiceComponentHolder.getInstance()
-                    .getAccessTokenProvider().getVerifiedAccessToken(
+                    .getTokenProvider().getVerifiedAccessToken(
                             tokenResponse.getAuthorizationContextToken().getTokenString(), false));
         } catch (IdentityOAuth2Exception e) {
             throw new UserInfoEndpointException("Error occurred while obtaining access token.", e);
@@ -227,7 +227,7 @@ public abstract class AbstractUserInfoResponseBuilder implements UserInfoRespons
         String grantType;
         try {
             String accessToken = validationResponseDTO.getAuthorizationContextToken().getTokenString();
-            AccessTokenDO accessTokenDO = OAuth2ServiceComponentHolder.getInstance().getAccessTokenProvider()
+            AccessTokenDO accessTokenDO = OAuth2ServiceComponentHolder.getInstance().getTokenProvider()
                     .getVerifiedAccessToken(accessToken, false);
             grantType = getGrantType(accessTokenDO);
             if (OAuth2ServiceComponentHolder.isConsentedTokenColumnEnabled()) {

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuerTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuerTest.java
@@ -257,7 +257,6 @@ public class JWTTokenIssuerTest extends PowerMockIdentityBaseTest {
         when(OAuth2Util.getAppInformationByClientId(null))
                 .thenThrow(new InvalidOAuthClientException("INVALID_CLIENT"));
         when(oAuthServerConfiguration.getSignatureAlgorithm()).thenReturn(SHA256_WITH_HMAC);
-        when(OAuth2Util.isTokenPersistenceEnabled()).thenReturn(true);
         JWTTokenIssuer jwtTokenIssuer = new JWTTokenIssuer();
         jwtTokenIssuer.createJWTClaimSet(null, null, null);
     }
@@ -386,6 +385,12 @@ public class JWTTokenIssuerTest extends PowerMockIdentityBaseTest {
             assertEquals(new Duration(jwtClaimSet.getIssueTime().getTime(), jwtClaimSet.getExpirationTime().getTime())
                     .getMillis(), expectedExpiry);
         }
+        when(OAuth2Util.isTokenPersistenceEnabled()).thenReturn(false);
+        jwtClaimSet = jwtTokenIssuer.createJWTClaimSet(
+                (OAuthAuthzReqMessageContext) authzReqMessageContext,
+                (OAuthTokenReqMessageContext) tokenReqMessageContext,
+                DUMMY_CLIENT_ID
+        );
         assertNotNull(jwtClaimSet.getClaim(OAuth2Constants.ENTITY_ID));
         if (tokenReqMessageContext != null) {
             assertEquals(jwtClaimSet.getClaim(OAuth2Constants.ENTITY_ID), DUMMY_CLIENT_ID);
@@ -393,6 +398,7 @@ public class JWTTokenIssuerTest extends PowerMockIdentityBaseTest {
         if (authzReqMessageContext != null) {
             assertEquals(jwtClaimSet.getClaim(OAuth2Constants.ENTITY_ID), DUMMY_USER_ID);
         }
+        when(OAuth2Util.isTokenPersistenceEnabled()).thenReturn(true);
     }
 
     @Test(dataProvider = "createJWTClaimSetDataProvider")

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuerTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuerTest.java
@@ -68,6 +68,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import static org.junit.Assert.assertNull;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyObject;
@@ -256,6 +257,7 @@ public class JWTTokenIssuerTest extends PowerMockIdentityBaseTest {
         mockStatic(OAuth2Util.class);
         when(OAuth2Util.getAppInformationByClientId(null))
                 .thenThrow(new InvalidOAuthClientException("INVALID_CLIENT"));
+        when(OAuth2Util.isTokenPersistenceEnabled()).thenReturn(true);
         when(oAuthServerConfiguration.getSignatureAlgorithm()).thenReturn(SHA256_WITH_HMAC);
         JWTTokenIssuer jwtTokenIssuer = new JWTTokenIssuer();
         jwtTokenIssuer.createJWTClaimSet(null, null, null);
@@ -339,6 +341,7 @@ public class JWTTokenIssuerTest extends PowerMockIdentityBaseTest {
         when(OAuth2Util.getIdTokenIssuer(anyString())).thenReturn(ID_TOKEN_ISSUER);
         when(OAuth2Util.getOIDCAudience(anyString(), anyObject())).thenReturn(Collections.singletonList
                 (DUMMY_CLIENT_ID));
+        when(OAuth2Util.isTokenPersistenceEnabled()).thenReturn(true);
 
         when(oAuthServerConfiguration.getSignatureAlgorithm()).thenReturn(SHA256_WITH_HMAC);
         when(oAuthServerConfiguration.getUserAccessTokenValidityPeriodInSeconds())
@@ -385,6 +388,8 @@ public class JWTTokenIssuerTest extends PowerMockIdentityBaseTest {
             assertEquals(new Duration(jwtClaimSet.getIssueTime().getTime(), jwtClaimSet.getExpirationTime().getTime())
                     .getMillis(), expectedExpiry);
         }
+        assertNull(jwtClaimSet.getClaim(OAuth2Constants.ENTITY_ID));
+        // The entity_id claim is a mandatory claim in the JWT when token persistence is disabled.
         when(OAuth2Util.isTokenPersistenceEnabled()).thenReturn(false);
         jwtClaimSet = jwtTokenIssuer.createJWTClaimSet(
                 (OAuthAuthzReqMessageContext) authzReqMessageContext,
@@ -398,6 +403,7 @@ public class JWTTokenIssuerTest extends PowerMockIdentityBaseTest {
         if (authzReqMessageContext != null) {
             assertEquals(jwtClaimSet.getClaim(OAuth2Constants.ENTITY_ID), DUMMY_USER_ID);
         }
+        // Enabling persistence back for the rest of the test cases.
         when(OAuth2Util.isTokenPersistenceEnabled()).thenReturn(true);
     }
 
@@ -413,6 +419,7 @@ public class JWTTokenIssuerTest extends PowerMockIdentityBaseTest {
             mockStatic(OAuth2Util.class);
             when(OAuth2Util.getAppInformationByClientId(anyString())).thenReturn(appDO);
             when(OAuth2Util.getThumbPrint(anyString(), anyInt())).thenReturn(THUMBPRINT);
+            when(OAuth2Util.isTokenPersistenceEnabled()).thenReturn(true);
 
             System.setProperty(CarbonBaseConstants.CARBON_HOME,
                     Paths.get(System.getProperty("user.dir"), "src", "test", "resources").toString());
@@ -698,6 +705,7 @@ public class JWTTokenIssuerTest extends PowerMockIdentityBaseTest {
         mockStatic(OAuth2Util.class);
         when(OAuth2Util.getAppInformationByClientId(anyString())).thenReturn(appDO);
         when(OAuth2Util.getTenantDomain(anyInt())).thenReturn("super.wso2");
+        when(OAuth2Util.isTokenPersistenceEnabled()).thenReturn(true);
     }
 
     static class DummyTestJWTAccessTokenClaimProvider implements JWTAccessTokenClaimProvider {

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuerTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuerTest.java
@@ -257,7 +257,7 @@ public class JWTTokenIssuerTest extends PowerMockIdentityBaseTest {
         when(OAuth2Util.getAppInformationByClientId(null))
                 .thenThrow(new InvalidOAuthClientException("INVALID_CLIENT"));
         when(oAuthServerConfiguration.getSignatureAlgorithm()).thenReturn(SHA256_WITH_HMAC);
-
+        when(OAuth2Util.isTokenPersistenceEnabled()).thenReturn(true);
         JWTTokenIssuer jwtTokenIssuer = new JWTTokenIssuer();
         jwtTokenIssuer.createJWTClaimSet(null, null, null);
     }


### PR DESCRIPTION
### Proposed changes in this pull request

Related https://github.com/wso2/api-manager/issues/1664. 
This PR is a continuation of following PRs for token persistence removal feature.
1. https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2091
2. https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2176
3. https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2179

PR #2091 and #2176 introduces new extensions point to plug a custom solution for non persistence feature. Basically it abstracts out the database persistence logic during token generation, refresh token handling, token revocation, token introspection and OIDC user info endpoint response handling. PR #2179 introduces abstractions to handle token revocation events due to user change events. This PR adds the following changes on top of above 3 PRs.

1. Even if we have abstracted out token persistence during token generation, the OAuth2 Caching logic is still common for both cases. Hence even though tokens are not persisted in the database, the recent token is served from token cache, and it is notified as “revoked” to the gateway. Related to https://github.com/wso2/api-manager/issues/2216. With this feature, the behavior of keeping tokens in the tokens cache with user, scope, client, IDP and binding reference as cache key during generation is no longer needed. Tokens handling during introspection happens with the token identifier as the cache key. Hence through a config, I have skipped checking cache and updating the token cache during token generation for cache keys consisting unique user, scope, client, IDP and binding reference.

I am utilizing the following configuration already available in identity.xml but not yet templated. There are no usages of the config other than in AccessTokenDAO (even still the enabling the config is not providing the intended behavior).

deployment.toml
```
[oauth.token_persistence]
enable=false
```

identity.xml
```
        <!-- Configs related to OAuth2 token persistence -->
        <TokenPersistence>
            <Enable>{{oauth.token_persistence.enable}}</Enable>
            <PoolSize>0</PoolSize>
            <RetryCount>5</RetryCount>
        </TokenPersistence>
```


2. Introduced a new unique claim `entity_id` to the JWT access token to identify the principle subject of the token. Eg: User in case of Application_User access tokens, Client Application in case of Application tokens. This is needed to validate the tokens when no persistence is available for the JTI and if there are in direct token revocation events triggered due to client application or user change events (Eg: client secret regeneration, user password change etc).

3. Along with this feature, to identify if the provided refresh token JWT, a new claim is introduced as `is_consented`. For that, in Refresh Grant flow, we need to pass this information through RefreshTokenValidationDO to the code where we generate the new token.

4. Refactored the code in #2176 #2091 as follows.

- Renamed AccessTokenProvider -> TokenProvider
- Added new method to TokenProvider to verify/validate refresh tokens. This was previously in `TokenRevocationProcessor`'s `getRevocableRefreshToken` method. As we have introduce `AccessTokenProvider` (former) to verify access tokens, it make sense to move the refresh token handling to the same interface.
- `isRefreshToken` in `TokenRevocationProcessor` is no longer needed, as we are not keeping the token type in the revoked JTI table with this feature. Refreshtokens can be handled in the same way as access tokens if token type hint is not provided.
- Currently, when no active refresh token is found when token type hint is refresh_grant, we were querying directly in DB through `.getAccessTokenDAO().getAccessToken`. This is same as `OAuth2Util.findAccessToken()`, but latter go through the oauth cache.With the above refactoring, I have change the `OAuth2Service.revokeTokenByOAuthClient` to go through `TokenProvider..getVerifiedAccessToken()`.



### When should this PR be merged
Along with https://github.com/wso2/carbon-identity-framework/pull/5073.


### Follow up actions

N/A


### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description.
- [ ] **Is the PR labeled correctly?**

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled.

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests.
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/).

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components.
- [ ] **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

#### Security

- [ ] **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
- [ ] **Are all UI and API inputs run through forms or serializers?**
- [ ] **Are all external inputs validated and sanitized appropriately?**
- [ ] **Does all branching logic have a default case?**
- [ ] **Does this solution handle outliers and edge cases gracefully?**
- [ ] **Are all external communications secured and restricted to SSL?**

#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes should be documented.
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented.
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki.
