### PR TITLE
Remove unnecessary scope param from authorize response

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/responsemode/provider/impl/FragmentResponseModeProvider.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/responsemode/provider/impl/FragmentResponseModeProvider.java
@@ -52,7 +52,6 @@ public class FragmentResponseModeProvider extends AbstractResponseModeProvider {
             String accessToken = authorizationResponseDTO.getSuccessResponseDTO().getAccessToken();
             String tokenType = authorizationResponseDTO.getSuccessResponseDTO().getTokenType();
             long validityPeriod = authorizationResponseDTO.getSuccessResponseDTO().getValidityPeriod();
-            String scope = authorizationResponseDTO.getSuccessResponseDTO().getScope();
             String authenticatedIdPs = authorizationResponseDTO.getAuthenticatedIDPs();
             List<String> params = new ArrayList<>();
             if (accessToken != null) {
@@ -82,10 +81,6 @@ public class FragmentResponseModeProvider extends AbstractResponseModeProvider {
 
             if (state != null) {
                 params.add(OAuthConstants.STATE + "=" + state);
-            }
-
-            if (scope != null) {
-                params.add(OAuthConstants.SCOPE + "=" + scope);
             }
 
             redirectUrl += "#" + String.join("&", params);

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/responsemode/provider/impl/QueryResponseModeProvider.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/responsemode/provider/impl/QueryResponseModeProvider.java
@@ -79,7 +79,6 @@ public class QueryResponseModeProvider extends AbstractResponseModeProvider {
             String accessToken = authorizationResponseDTO.getSuccessResponseDTO().getAccessToken();
             String tokenType = authorizationResponseDTO.getSuccessResponseDTO().getTokenType();
             long validityPeriod = authorizationResponseDTO.getSuccessResponseDTO().getValidityPeriod();
-            String scope = authorizationResponseDTO.getSuccessResponseDTO().getScope();
             String authenticatedIdPs = authorizationResponseDTO.getAuthenticatedIDPs();
             List<String> queryParams = new ArrayList<>();
             if (accessToken != null) {
@@ -109,10 +108,6 @@ public class QueryResponseModeProvider extends AbstractResponseModeProvider {
 
             if (state != null) {
                 queryParams.add(OAuthConstants.STATE + "=" + state);
-            }
-
-            if (scope != null) {
-                queryParams.add(OAuthConstants.SCOPE + "=" + scope);
             }
 
             redirectUrl = FrameworkUtils.appendQueryParamsStringToUrl(redirectUrl,

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/responsemode/provider/jarm/JarmResponseModeProvider.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/responsemode/provider/jarm/JarmResponseModeProvider.java
@@ -69,7 +69,6 @@ public abstract class JarmResponseModeProvider extends AbstractResponseModeProvi
         String authenticatedIdPs = authorizationResponseDTO.getAuthenticatedIDPs();
         String sessionState = authorizationResponseDTO.getSessionState();
         String state = authorizationResponseDTO.getState();
-        String scope = authorizationResponseDTO.getSuccessResponseDTO().getScope();
 
         JWTClaimsSet.Builder jwtClaimsSet = new JWTClaimsSet.Builder();
         jwtClaimsSet.claim(ISSUER, getIssuer(authorizationResponseDTO));
@@ -109,10 +108,6 @@ public abstract class JarmResponseModeProvider extends AbstractResponseModeProvi
 
         if (authenticatedIdPs != null && !authenticatedIdPs.isEmpty()) {
             jwtClaimsSet.claim(AUTHENTICATED_IDPS, authenticatedIdPs);
-        }
-
-        if (scope != null) {
-            jwtClaimsSet.claim(SCOPE, scope);
         }
 
         return jwtClaimsSet.build();

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/responsemode/provider/ResponseModeProviderTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/responsemode/provider/ResponseModeProviderTest.java
@@ -6,9 +6,6 @@ import org.testng.annotations.Test;
 import org.wso2.carbon.identity.oauth2.responsemode.provider.impl.FragmentResponseModeProvider;
 import org.wso2.carbon.identity.oauth2.responsemode.provider.impl.QueryResponseModeProvider;
 
-import java.util.Arrays;
-import java.util.HashSet;
-
 public class ResponseModeProviderTest {
 
     @DataProvider(name = "fragmentDataProvider")
@@ -18,11 +15,11 @@ public class ResponseModeProviderTest {
                 // AuthorizationResponseDTO, provided callback url, expected redirect url
                 {getAuthResponseDTO("https://www.google.com/redirects/redirect1", "code1"),
                         "https://www.google.com/redirects/redirect1",
-                        "https://www.google.com/redirects/redirect1#code=code1&scope=openid"},
+                        "https://www.google.com/redirects/redirect1#code=code1"},
                 {getAuthResponseDTO("https://www.google.com/redirects/redirect2?param1=abc&param2=xyz",
                         "code2"),
                         "https://www.google.com/redirects/redirect2?param1=abc&param2=xyz",
-                        "https://www.google.com/redirects/redirect2?param1=abc&param2=xyz#code=code2&scope=openid"},
+                        "https://www.google.com/redirects/redirect2?param1=abc&param2=xyz#code=code2"},
 
         };
     }
@@ -49,11 +46,11 @@ public class ResponseModeProviderTest {
                 // AuthorizationResponseDTO, provided callback url, expected redirect url
                 {getAuthResponseDTO("https://www.google.com/redirects/redirect1", "code1"),
                         "https://www.google.com/redirects/redirect1",
-                        "https://www.google.com/redirects/redirect1?code=code1&scope=openid"},
+                        "https://www.google.com/redirects/redirect1?code=code1"},
                 {getAuthResponseDTO("https://www.google.com/redirects/redirect2?param1=abc&param2=xyz",
                         "code2"),
                         "https://www.google.com/redirects/redirect2?param1=abc&param2=xyz",
-                        "https://www.google.com/redirects/redirect2?param1=abc&param2=xyz&code=code2&scope=openid"},
+                        "https://www.google.com/redirects/redirect2?param1=abc&param2=xyz&code=code2"},
 
         };
     }
@@ -83,7 +80,6 @@ public class ResponseModeProviderTest {
         authorizationResponseDTO.setRedirectUrl(redirectURI);
 
         authorizationResponseDTO.getSuccessResponseDTO().setAuthorizationCode(code);
-        authorizationResponseDTO.getSuccessResponseDTO().setScope(new HashSet<>(Arrays.asList("openid")));
 
         return authorizationResponseDTO;
     }


### PR DESCRIPTION
### Proposed changes in this pull request

This PR removes the scope param from the /authorize response since it is not necessary. 
It is identified as an unnecessary param to the redirected callbackurl (authorize response) from the FAPI Conformance Test suite [1] as well. This behaviour is not in wso2is-6.1 and has been introduced with https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2037.

This PR fixes the issue: https://github.com/wso2/product-is/issues/16749

References:
[1] [FAPI Conformance Test Suite](https://openid.net/certification/certification-fapi_op_testing/)
