### PR TITLE
Tenant Qualify Scope API location header URL

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.oauth.scope/src/main/java/org/wso2/carbon/identity/oauth/scope/endpoint/impl/ScopesApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.server.oauth.scope/src/main/java/org/wso2/carbon/identity/oauth/scope/endpoint/impl/ScopesApiServiceImpl.java
@@ -18,13 +18,13 @@ package org.wso2.carbon.identity.oauth.scope.endpoint.impl;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.cxf.jaxrs.impl.UriInfoImpl;
-import org.apache.cxf.message.Message;
-import org.apache.cxf.phase.PhaseInterceptorChain;
 import org.wso2.carbon.CarbonConstants;
 import org.wso2.carbon.base.MultitenantConstants;
 import org.wso2.carbon.context.CarbonContext;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.identity.core.ServiceURLBuilder;
+import org.wso2.carbon.identity.core.URLBuilderException;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.oauth.scope.endpoint.ScopesApiService;
 import org.wso2.carbon.identity.oauth.scope.endpoint.dto.ScopeDTO;
@@ -38,11 +38,9 @@ import org.wso2.carbon.user.api.AuthorizationManager;
 import org.wso2.carbon.user.api.UserStoreException;
 
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.Set;
 
 import javax.ws.rs.core.Response;
-import javax.ws.rs.core.UriInfo;
 
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.TENANT_NAME_FROM_CONTEXT;
 import static org.wso2.carbon.identity.oauth.scope.endpoint.Constants.SERVER_API_PATH_COMPONENT;
@@ -292,23 +290,14 @@ public class ScopesApiServiceImpl extends ScopesApiService {
      */
     private static URI buildURIForHeader(String scopeName) {
 
-        String tenantQualifiedRelativePath =
-                String.format(TENANT_CONTEXT_PATH_COMPONENT, getTenantDomainFromContext()) + SERVER_API_PATH_COMPONENT;
-        String url = IdentityUtil.getEndpointURIPath(tenantQualifiedRelativePath + scopeName, false, true);
+        URI location;
+        String context = getContext(SERVER_API_PATH_COMPONENT + scopeName);
 
-        URI location = URI.create(url);
-        if (!location.isAbsolute()) {
-            Message currentMessage = PhaseInterceptorChain.getCurrentMessage();
-            if (currentMessage != null) {
-                UriInfo ui = new UriInfoImpl(currentMessage.getExchange().getInMessage(), null);
-                try {
-                    return new URI(ui.getBaseUri().getScheme(), ui.getBaseUri().getAuthority(), url, null, null);
-                } catch (URISyntaxException e) {
-                    LOG.error("Server encountered an error while building the location URL with scheme: " +
-                            ui.getBaseUri().getScheme() + ", authority: " + ui.getBaseUri().getAuthority() +
-                            ", url: " + url, e);
-                }
-            }
+        try {
+            String url = ServiceURLBuilder.create().addPath(context).build().getAbsolutePublicURL();
+            location = URI.create(url);
+        } catch (URLBuilderException e) {
+            throw new RuntimeException("Error occurred while building URL in tenant qualified mode.", e);
         }
         return location;
     }
@@ -380,5 +369,24 @@ public class ScopesApiServiceImpl extends ScopesApiService {
             LOG.error("Error while validating user authorization of user: " + authenticatedUser, e);
         }
         return false;
+    }
+
+    /**
+     * Builds the API context on whether the tenant qualified url is enabled or not. In tenant qualified mode the
+     * ServiceURLBuilder appends the tenant domain to the URI as a path param automatically. But
+     * in non tenant qualified mode we need to append the tenant domain to the path manually.
+     *
+     * @param endpoint Relative endpoint path.
+     * @return Context of the API.
+     */
+    private static String getContext(String endpoint) {
+
+        String context;
+        if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled()) {
+            context = endpoint;
+        } else {
+            context = String.format(TENANT_CONTEXT_PATH_COMPONENT, getTenantDomainFromContext()) + endpoint;
+        }
+        return context;
     }
 }

--- a/components/org.wso2.carbon.identity.api.server.oauth.scope/src/main/java/org/wso2/carbon/identity/oauth/scope/endpoint/impl/ScopesApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.server.oauth.scope/src/main/java/org/wso2/carbon/identity/oauth/scope/endpoint/impl/ScopesApiServiceImpl.java
@@ -291,8 +291,9 @@ public class ScopesApiServiceImpl extends ScopesApiService {
     private static URI buildURIForHeader(String scopeName) {
 
         URI location;
-        String context = getContext(SERVER_API_PATH_COMPONENT + scopeName);
-
+        String context = IdentityTenantUtil.isTenantQualifiedUrlsEnabled() ? SERVER_API_PATH_COMPONENT + scopeName :
+                String.format(TENANT_CONTEXT_PATH_COMPONENT, getTenantDomainFromContext()) + SERVER_API_PATH_COMPONENT
+                        + scopeName;
         try {
             String url = ServiceURLBuilder.create().addPath(context).build().getAbsolutePublicURL();
             location = URI.create(url);
@@ -369,24 +370,5 @@ public class ScopesApiServiceImpl extends ScopesApiService {
             LOG.error("Error while validating user authorization of user: " + authenticatedUser, e);
         }
         return false;
-    }
-
-    /**
-     * Builds the API context on whether the tenant qualified url is enabled or not. In tenant qualified mode the
-     * ServiceURLBuilder appends the tenant domain to the URI as a path param automatically. But
-     * in non tenant qualified mode we need to append the tenant domain to the path manually.
-     *
-     * @param endpoint Relative endpoint path.
-     * @return Context of the API.
-     */
-    private static String getContext(String endpoint) {
-
-        String context;
-        if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled()) {
-            context = endpoint;
-        } else {
-            context = String.format(TENANT_CONTEXT_PATH_COMPONENT, getTenantDomainFromContext()) + endpoint;
-        }
-        return context;
     }
 }

--- a/components/org.wso2.carbon.identity.api.server.oauth.scope/src/test/java/org/wso2/carbon/identity/oauth/scope/endpoint/impl/ScopesApiServiceImplTest.java
+++ b/components/org.wso2.carbon.identity.api.server.oauth.scope/src/test/java/org/wso2/carbon/identity/oauth/scope/endpoint/impl/ScopesApiServiceImplTest.java
@@ -25,6 +25,9 @@ import org.powermock.modules.testng.PowerMockTestCase;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+import org.wso2.carbon.identity.core.ServiceURL;
+import org.wso2.carbon.identity.core.ServiceURLBuilder;
+import org.wso2.carbon.identity.core.URLBuilderException;
 import org.wso2.carbon.identity.oauth.scope.endpoint.dto.ErrorDTO;
 import org.wso2.carbon.identity.oauth.scope.endpoint.dto.ScopeDTO;
 import org.wso2.carbon.identity.oauth.scope.endpoint.dto.ScopeToUpdateDTO;
@@ -48,13 +51,15 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.reset;
 import static org.powermock.api.mockito.PowerMockito.doNothing;
 import static org.powermock.api.mockito.PowerMockito.doThrow;
+import static org.powermock.api.mockito.PowerMockito.mock;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
+import static org.wso2.carbon.identity.oauth.scope.endpoint.Constants.SERVER_API_PATH_COMPONENT;
 
 @PowerMockIgnore("javax.*")
-@PrepareForTest({ScopeUtils.class, OAuth2ScopeService.class})
+@PrepareForTest({ScopeUtils.class, OAuth2ScopeService.class, ServiceURLBuilder.class})
 public class ScopesApiServiceImplTest extends PowerMockTestCase {
 
     private ScopesApiServiceImpl scopesApiService = new ScopesApiServiceImpl();
@@ -337,6 +342,7 @@ public class ScopesApiServiceImplTest extends PowerMockTestCase {
         ScopeDTO scopeDTO = new ScopeDTO();
         scopeDTO.setDescription("some description");
         scopeDTO.setBindings(Collections.<String>emptyList());
+        mockServiceURLBuilder(SERVER_API_PATH_COMPONENT + scopeDTO.getName());
         if (Response.Status.OK.equals(expectation)) {
             when(oAuth2ScopeService.registerScope(any(Scope.class))).thenReturn(any(Scope.class));
             assertEquals(scopesApiService.registerScope(scopeDTO).getStatus(), Response.Status.CREATED.getStatusCode(),
@@ -457,6 +463,18 @@ public class ScopesApiServiceImplTest extends PowerMockTestCase {
                 any(String.class), any(String.class), any(String.class), any(boolean.class)).thenCallRealMethod();
         when(ScopeUtils.class, "getErrorDTO", any(String.class), any(String.class),
                 any(String.class)).thenCallRealMethod();
+    }
+
+    private void mockServiceURLBuilder(String url) throws URLBuilderException {
+
+        mockStatic(ServiceURLBuilder.class);
+        ServiceURLBuilder serviceURLBuilder = mock(ServiceURLBuilder.class);
+        when(ServiceURLBuilder.create()).thenReturn(serviceURLBuilder);
+        when(serviceURLBuilder.addPath(any())).thenReturn(serviceURLBuilder);
+
+        ServiceURL serviceURL = mock(ServiceURL.class);
+        when(serviceURL.getAbsolutePublicURL()).thenReturn(url);
+        when(serviceURLBuilder.build()).thenReturn(serviceURL);
     }
 
 }


### PR DESCRIPTION
This PR uses the ServiceURLBuilder to builder the location header for the register scopes API to build the tenant qualified url.

Ported from https://github.com/wso2/identity-api-server/pull/162

Related issue: https://github.com/wso2/product-is/issues/16906