### PR TITLE
Remove scope param for unnecessary flows in authorize call

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
@@ -538,7 +538,6 @@ public class OAuth2AuthzEndpoint {
         authorizationResponseDTO.setState(oauth2Params.getState());
         authorizationResponseDTO.setResponseMode(oauth2Params.getResponseMode());
         authorizationResponseDTO.setResponseType(oauth2Params.getResponseType());
-        authorizationResponseDTO.getSuccessResponseDTO().setScope(oauth2Params.getScopes());
 
         return authorizationResponseDTO;
     }
@@ -1706,7 +1705,7 @@ public class OAuth2AuthzEndpoint {
         }
         if (isResponseTypeNotIdTokenOrNone(responseType, authzRespDTO)) {
             setAccessToken(authzRespDTO, builder, authorizationResponseDTO);
-            setScopes(authzRespDTO, builder);
+            setScopes(authzRespDTO, builder, authorizationResponseDTO);
         }
         if (isIdTokenExists(authzRespDTO)) {
             setIdToken(authzRespDTO, builder, authorizationResponseDTO);
@@ -1889,12 +1888,15 @@ public class OAuth2AuthzEndpoint {
     }
 
     private void setScopes(OAuth2AuthorizeRespDTO authzRespDTO,
-                           OAuthASResponse.OAuthAuthorizationResponseBuilder builder) {
+                           OAuthASResponse.OAuthAuthorizationResponseBuilder builder, AuthorizationResponseDTO
+                                   authorizationResponseDTO) {
 
         String[] scopes = authzRespDTO.getScope();
         if (scopes != null && scopes.length > 0) {
             String scopeString =  StringUtils.join(scopes, " ");
             builder.setScope(scopeString.trim());
+            Set<String> scopesSet = new HashSet<>(Arrays.asList(scopes));
+            authorizationResponseDTO.getSuccessResponseDTO().setScope(scopesSet);
         }
     }
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/responsemode/provider/SuccessResponseDTO.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/responsemode/provider/SuccessResponseDTO.java
@@ -32,7 +32,7 @@ public class SuccessResponseDTO {
     private String tokenType;
     private long validityPeriod;
     private String formPostBody;
-    private Set<String> scope;
+    private Set<String> scope = null;
 
     public String getAuthorizationCode() {
 
@@ -65,6 +65,10 @@ public class SuccessResponseDTO {
     }
 
     public String getScope() {
+
+        if (scope == null) {
+            return null;
+        }
         return StringUtils.join(scope, "+").trim();
     }
 


### PR DESCRIPTION
### Proposed changes in this pull request

This PR removes the scope param from the /authorize response in the places it is not necessary.
It is identified as an unnecessary param to the redirected callbackurl (authorize response) in a test from the FAPI Conformance Test suite [1]. This behaviour is not in wso2is-6.1 and has been introduced with https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2037.

The issue was, scope param is set to the AuthorizationResponseDTO at the beginning, making it returned every time. With this PR, scope is set in the place it is needed (in `setScopes()` method), same as in wso2is-6.1.

This PR fixes the issue: https://github.com/wso2/product-is/issues/16749

References:
[1] [FAPI Conformance Test Suite](https://openid.net/certification/certification-fapi_op_testing/)