### PR TITLE
Push pwd grant authenticated user attributes to sessionStore

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuer.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuer.java
@@ -558,6 +558,10 @@ public class AccessTokenIssuer {
             cacheUserAttributesAgainstAccessToken(authorizationGrantCacheEntry.get(), tokenRespDTO);
         }
 
+        if (GrantType.PASSWORD.toString().equals(grantType)) {
+            addUserAttributesAgainstAccessTokenForPasswordGrant(tokenRespDTO, tokReqMsgCtx);
+        }
+
         if (GrantType.AUTHORIZATION_CODE.toString().equals(grantType)) {
             // Cache entry against the authorization code has no value beyond the token request.
             clearCacheEntryAgainstAuthorizationCode(getAuthorizationCode(tokenReqDTO));
@@ -1092,6 +1096,21 @@ public class AccessTokenIssuer {
         authorizationGrantCacheEntry.setValidityPeriod(
                 TimeUnit.MILLISECONDS.toNanos(tokenRespDTO.getExpiresInMillis()));
         AuthorizationGrantCache.getInstance().addToCacheByToken(newCacheKey, authorizationGrantCacheEntry);
+    }
+
+    private void addUserAttributesAgainstAccessTokenForPasswordGrant(OAuth2AccessTokenRespDTO tokenRespDTO,
+                                                           OAuthTokenReqMessageContext tokReqMsgCtx) {
+
+        if (tokReqMsgCtx.getAuthorizedUser() != null) {
+            AuthorizationGrantCacheKey newCacheKey = new AuthorizationGrantCacheKey(tokenRespDTO.getAccessToken());
+            AuthorizationGrantCacheEntry authorizationGrantCacheEntry =
+                    new AuthorizationGrantCacheEntry(tokReqMsgCtx.getAuthorizedUser().getUserAttributes());
+            authorizationGrantCacheEntry.setTokenId(tokenRespDTO.getTokenId());
+
+            authorizationGrantCacheEntry.setValidityPeriod(
+                    TimeUnit.MILLISECONDS.toNanos(tokenRespDTO.getExpiresInMillis()));
+            AuthorizationGrantCache.getInstance().addToCacheByToken(newCacheKey, authorizationGrantCacheEntry);
+        }
     }
 
     private void clearCacheEntryAgainstAuthorizationCode(String authorizationCode) {


### PR DESCRIPTION
### Proposed changes in this pull request
This PR adds authenticated user attributes to the session store so that it will be available for the refresh grant.
There is a default fallback to get the user attributes from the local store if the attributes are empty from the session store entry. For enhanced password grant flow where temp claim values can be set through adaptive scripts, it is essential to persist those values so that it will be available for refresh token

fixes: https://github.com/wso2/product-is/issues/16855