### PR TITLE
Fix B2B organization login relates scopes resolving issue

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/AuthzUtil.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/AuthzUtil.java
@@ -24,7 +24,6 @@ import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.CarbonConstants;
 import org.wso2.carbon.identity.application.authentication.framework.exception.UserIdNotFoundException;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
-import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
 import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
 import org.wso2.carbon.identity.application.common.model.ClaimMapping;
@@ -51,6 +50,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static org.wso2.carbon.identity.oauth2.util.OAuth2Util.INTERNAL_LOGIN_SCOPE;
+import static org.wso2.carbon.identity.oauth2.util.OAuth2Util.OIDC_ROLE_CLAIM_URI;
 import static org.wso2.carbon.identity.role.v2.mgt.core.RoleConstants.APPLICATION;
 import static org.wso2.carbon.identity.role.v2.mgt.core.RoleConstants.ORGANIZATION;
 import static org.wso2.carbon.user.core.UserCoreConstants.APPLICATION_DOMAIN;
@@ -142,7 +142,7 @@ public class AuthzUtil {
             return new ArrayList<>();
         }
         for (Map.Entry<ClaimMapping, String> entry : claimMappingStringMap.entrySet()) {
-            if (FrameworkConstants.LOCAL_ROLE_CLAIM_URI.equals(entry.getKey().getLocalClaim().getClaimUri())) {
+            if (OIDC_ROLE_CLAIM_URI.equals(entry.getKey().getLocalClaim().getClaimUri())) {
                 roleNamesString = entry.getValue();
                 break;
             }
@@ -431,5 +431,17 @@ public class AuthzUtil {
     public static boolean isLegacyAuthzRuntime() {
 
         return CarbonConstants.ENABLE_LEGACY_AUTHZ_RUNTIME;
+    }
+
+    /**
+     * Check whether the authenticated user is accessing the resident organization where the identity is managed.
+     *
+     * @param authenticatedUser The authenticated user.
+     * @return True if the authenticated user is accessing the resident organization.
+     */
+    public static boolean isUserAccessingResidentOrganization(AuthenticatedUser authenticatedUser) {
+
+        return authenticatedUser.getAccessingOrganization() == null ||
+                authenticatedUser.getAccessingOrganization().equals(authenticatedUser.getUserResidentOrganization());
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -243,7 +243,7 @@ public class OAuth2Util {
     private static final String OPENID_CONNECT_AUDIENCES = "Audiences";
     private static final String DOT_SEPARATER = ".";
     private static final String IDP_ENTITY_ID = "IdPEntityId";
-    private static final String OIDC_ROLE_CLAIM_URI = "roles";
+    public static final String OIDC_ROLE_CLAIM_URI = "roles";
 
     public static final String DEFAULT_TOKEN_TYPE = "Default";
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/validationhandler/impl/RoleBasedScopeValidationHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/validationhandler/impl/RoleBasedScopeValidationHandler.java
@@ -18,7 +18,6 @@
 
 package org.wso2.carbon.identity.oauth2.validators.validationhandler.impl;
 
-import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
@@ -63,9 +62,10 @@ public class RoleBasedScopeValidationHandler implements ScopeValidationHandler {
                 return new ArrayList<>();
             }
             String tenantDomain = scopeValidationContext.getAuthenticatedUser().getTenantDomain();
-            String accessingOrganization = scopeValidationContext.getAuthenticatedUser().getAccessingOrganization();
-            if (StringUtils.isNotEmpty(accessingOrganization)) {
-                tenantDomain = resolveTenantDomainByOrgId(accessingOrganization);
+            // When user is not accessing the resident organization, resolve the tenant domain of the accessing org.
+            if (!AuthzUtil.isUserAccessingResidentOrganization(scopeValidationContext.getAuthenticatedUser())) {
+                tenantDomain = resolveTenantDomainByOrgId(scopeValidationContext.getAuthenticatedUser()
+                        .getAccessingOrganization());
             }
             List<String> filteredRoleIds = getFilteredRoleIds(userRoles, scopeValidationContext.getAppId(),
                     tenantDomain);


### PR DESCRIPTION
### Proposed changes in this pull request

When tokens requested via `organization login` and `organization switch grant` requests should be identified precisely. The introduced `isUserAccessingResidentOrganization` method can identity whether user is accessing the organization where his identity is managed or a different organization. 