### PR TITLE
Remove internal scopes when accessing an organization

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/Oauth2ScopeConstants.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/Oauth2ScopeConstants.java
@@ -34,6 +34,7 @@ public class Oauth2ScopeConstants {
     public static final String SCOPE_TYPE_OIDC = "OIDC";
     public static final String CONSOLE_SCOPE_PREFIX = "console:";
     public static final String INTERNAL_SCOPE_PREFIX = "internal_";
+    public static final String INTERNAL_ORG_SCOPE_PREFIX = "internal_org_";
     public static final String CORRELATION_ID_MDC = "Correlation-ID";
 
     /**


### PR DESCRIPTION
### Proposed changes in this pull request

Restrict issuing `internal_` system scopes when accessing an organization and instead issue only `internal_org_` scopes.