### PR TITLE
Adding authentication methods display name for the client authenticators

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/client/authentication/BasicAuthClientAuthenticator.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/client/authentication/BasicAuthClientAuthenticator.java
@@ -30,6 +30,7 @@ import org.wso2.carbon.identity.oauth.common.OAuth2ErrorCodes;
 import org.wso2.carbon.identity.oauth.common.exception.InvalidOAuthClientException;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.bean.OAuthClientAuthnContext;
+import org.wso2.carbon.identity.oauth2.model.ClientAuthenticationMethodModel;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 
 import java.util.ArrayList;
@@ -52,6 +53,8 @@ public class BasicAuthClientAuthenticator extends AbstractOAuthClientAuthenticat
     private static final int CREDENTIAL_LENGTH = 2;
     private static final String CLIENT_SECRET_BASIC = "client_secret_basic";
     private static final String CLIENT_SECRET_POST = "client_secret_post";
+    private static final String CLIENT_SECRET_BASIC_DISPLAY_NAME = "Client Secret Basic";
+    private static final String CLIENT_SECRET_POST_DISPLAY_NAME = "Client Secret Post";
 
     /**
      * Returns the execution order of this authenticator
@@ -278,11 +281,13 @@ public class BasicAuthClientAuthenticator extends AbstractOAuthClientAuthenticat
      * @return      Authentication methods supported by the authenticator.
      */
     @Override
-    public List<String> getSupportedClientAuthenticationMethods() {
+    public List<ClientAuthenticationMethodModel> getSupportedClientAuthenticationMethods() {
 
-        List<String> supportedAuthMethods = new ArrayList<>();
-        supportedAuthMethods.add(CLIENT_SECRET_BASIC);
-        supportedAuthMethods.add(CLIENT_SECRET_POST);
+        List<ClientAuthenticationMethodModel> supportedAuthMethods = new ArrayList<>();
+        supportedAuthMethods.add(new ClientAuthenticationMethodModel(CLIENT_SECRET_BASIC,
+                CLIENT_SECRET_BASIC_DISPLAY_NAME));
+        supportedAuthMethods.add(new ClientAuthenticationMethodModel(CLIENT_SECRET_POST,
+                CLIENT_SECRET_POST_DISPLAY_NAME));
         return supportedAuthMethods;
     }
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/client/authentication/OAuthClientAuthenticator.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/client/authentication/OAuthClientAuthenticator.java
@@ -20,6 +20,7 @@ package org.wso2.carbon.identity.oauth2.client.authentication;
 
 import org.wso2.carbon.identity.core.handler.IdentityHandler;
 import org.wso2.carbon.identity.oauth2.bean.OAuthClientAuthnContext;
+import org.wso2.carbon.identity.oauth2.model.ClientAuthenticationMethodModel;
 
 import java.util.Collections;
 import java.util.List;
@@ -72,7 +73,7 @@ public interface OAuthClientAuthenticator extends IdentityHandler {
      *
      * @return      Authentication methods supported by the authenticator.
      */
-    default List<String> getSupportedClientAuthenticationMethods() {
+    default List<ClientAuthenticationMethodModel> getSupportedClientAuthenticationMethods() {
 
         return Collections.emptyList();
     }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/client/authentication/OAuthClientAuthnService.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/client/authentication/OAuthClientAuthnService.java
@@ -30,6 +30,7 @@ import org.wso2.carbon.identity.oauth2.IdentityOAuth2ClientException;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.bean.OAuthClientAuthnContext;
 import org.wso2.carbon.identity.oauth2.internal.OAuth2ServiceComponentHolder;
+import org.wso2.carbon.identity.oauth2.model.ClientAuthenticationMethodModel;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 
 import java.util.ArrayList;
@@ -383,8 +384,11 @@ public class OAuthClientAuthnService {
 
         List<OAuthClientAuthenticator> filteredAuthenticators = new ArrayList<>();
         for (OAuthClientAuthenticator authenticator : configuredAuthenticators) {
-            if (fapiAllowedAuthMethods.stream().anyMatch(authenticator
-                    .getSupportedClientAuthenticationMethods()::contains)) {
+            List<String> supportedClientAuthMethods = new ArrayList<>();
+            for (ClientAuthenticationMethodModel authMethod : authenticator.getSupportedClientAuthenticationMethods()) {
+                supportedClientAuthMethods.add(authMethod.getName());
+            }
+            if (fapiAllowedAuthMethods.stream().anyMatch(supportedClientAuthMethods::contains)) {
                 filteredAuthenticators.add(authenticator);
             }
         }
@@ -402,8 +406,11 @@ public class OAuthClientAuthnService {
 
         List<OAuthClientAuthenticator> applicableClientAuthenticators = new ArrayList<>();
         for (OAuthClientAuthenticator authenticator : this.getClientAuthenticators()) {
-            if (configuredAuthenticators.stream().anyMatch(
-                    authenticator.getSupportedClientAuthenticationMethods()::contains)) {
+            List<String> supportedClientAuthMethods = new ArrayList<>();
+            for (ClientAuthenticationMethodModel authMethod : authenticator.getSupportedClientAuthenticationMethods()) {
+                supportedClientAuthMethods.add(authMethod.getName());
+            }
+            if (configuredAuthenticators.stream().anyMatch(supportedClientAuthMethods::contains)) {
                 applicableClientAuthenticators.add(authenticator);
             }
         }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/model/ClientAuthenticationMethodModel.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/model/ClientAuthenticationMethodModel.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth2.model;
+
+/**
+ * Client authentication method model.
+ */
+public class ClientAuthenticationMethodModel {
+
+    private String name;
+    private String displayName;
+
+    public ClientAuthenticationMethodModel(String name, String displayName) {
+
+        this.name = name;
+        this.displayName = displayName;
+    }
+
+    public String getName() {
+
+        return name;
+    }
+
+    public void setName(String name) {
+
+        this.name = name;
+    }
+
+    public String getDisplayName() {
+
+        return displayName;
+    }
+
+    public void setDisplayName(String displayName) {
+
+        this.displayName = displayName;
+    }
+}

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -130,6 +130,7 @@ import org.wso2.carbon.identity.oauth2.dto.OAuth2TokenValidationResponseDTO;
 import org.wso2.carbon.identity.oauth2.dto.OAuthRevocationRequestDTO;
 import org.wso2.carbon.identity.oauth2.internal.OAuth2ServiceComponentHolder;
 import org.wso2.carbon.identity.oauth2.model.AccessTokenDO;
+import org.wso2.carbon.identity.oauth2.model.ClientAuthenticationMethodModel;
 import org.wso2.carbon.identity.oauth2.model.ClientCredentialDO;
 import org.wso2.carbon.identity.oauth2.token.JWTTokenIssuer;
 import org.wso2.carbon.identity.oauth2.token.OAuthTokenReqMessageContext;
@@ -5020,15 +5021,31 @@ public class OAuth2Util {
      */
     public static String[] getSupportedClientAuthMethods() {
 
-        List<OAuthClientAuthenticator> clientAuthenticators = OAuth2ServiceComponentHolder.getAuthenticationHandlers();
+        HashSet<ClientAuthenticationMethodModel> clientAuthenticators = OAuth2Util.getSupportedAuthenticationMethods();
         HashSet<String> supportedClientAuthMethods = new HashSet<>();
+        for (ClientAuthenticationMethodModel authMethod : clientAuthenticators) {
+            supportedClientAuthMethods.add(authMethod.getName());
+        }
+        return supportedClientAuthMethods.toArray(new String[0]);
+    }
+
+    /**
+     * Retrieve the list of client authentication methods supported by the server with the authenticator display name.
+     *
+     * @return     Client authentication methods supported by the server.
+     */
+    public static HashSet<ClientAuthenticationMethodModel> getSupportedAuthenticationMethods() {
+
+        List<OAuthClientAuthenticator> clientAuthenticators = OAuth2ServiceComponentHolder.getAuthenticationHandlers();
+        HashSet<ClientAuthenticationMethodModel> supportedClientAuthMethods = new HashSet<>();
         for (OAuthClientAuthenticator clientAuthenticator : clientAuthenticators) {
-            List<String> supportedAuthMethods = clientAuthenticator.getSupportedClientAuthenticationMethods();
+            List<ClientAuthenticationMethodModel> supportedAuthMethods = clientAuthenticator
+                    .getSupportedClientAuthenticationMethods();
             if (!supportedAuthMethods.isEmpty()) {
                 supportedClientAuthMethods.addAll(supportedAuthMethods);
             }
         }
-        return supportedClientAuthMethods.toArray(new String[0]);
+        return supportedClientAuthMethods;
     }
 
     /**

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/client/authentication/BasicAuthClientAuthenticatorTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/client/authentication/BasicAuthClientAuthenticatorTest.java
@@ -33,11 +33,13 @@ import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.oauth.IdentityOAuthAdminException;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.bean.OAuthClientAuthnContext;
+import org.wso2.carbon.identity.oauth2.model.ClientAuthenticationMethodModel;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 import org.wso2.carbon.identity.testutil.powermock.PowerMockIdentityBaseTest;
 
 import java.io.File;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
@@ -289,7 +291,11 @@ public class BasicAuthClientAuthenticatorTest extends PowerMockIdentityBaseTest 
     @Test
     public void testGetSupportedClientAuthenticationMethods() {
 
-        List<String> supportedAuthMethods = basicAuthClientAuthenticator.getSupportedClientAuthenticationMethods();
+        List<String> supportedAuthMethods = new ArrayList<>();
+        for (ClientAuthenticationMethodModel clientAuthenticationMethodModel : basicAuthClientAuthenticator
+                .getSupportedClientAuthenticationMethods()) {
+            supportedAuthMethods.add(clientAuthenticationMethodModel.getName());
+        }
         Assert.assertTrue(supportedAuthMethods.contains("client_secret_basic"));
         Assert.assertTrue(supportedAuthMethods.contains("client_secret_post"));
         assertEquals(supportedAuthMethods.size(), 2);

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/client/authentication/OAuthClientAuthnServiceTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/client/authentication/OAuthClientAuthnServiceTest.java
@@ -36,6 +36,7 @@ import org.wso2.carbon.identity.oauth.common.OAuthConstants;
 import org.wso2.carbon.identity.oauth.dao.OAuthAppDO;
 import org.wso2.carbon.identity.oauth2.bean.OAuthClientAuthnContext;
 import org.wso2.carbon.identity.oauth2.internal.OAuth2ServiceComponentHolder;
+import org.wso2.carbon.identity.oauth2.model.ClientAuthenticationMethodModel;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 import org.wso2.carbon.identity.testutil.powermock.PowerMockIdentityBaseTest;
 
@@ -258,7 +259,7 @@ public class OAuthClientAuthnServiceTest extends PowerMockIdentityBaseTest {
         PowerMockito.when(oAuthClientAuthenticator.getClientId(Mockito.any(), Mockito.any(), Mockito.any()))
                 .thenReturn(CLIENT_ID);
         PowerMockito.when(oAuthClientAuthenticator.getSupportedClientAuthenticationMethods())
-                .thenReturn(Arrays.asList("private_key_jwt"));
+                .thenReturn(Arrays.asList(new ClientAuthenticationMethodModel("private_key_jwt", "Private Key JWT")));
         OAuthClientAuthnService oAuthClientAuthnService = Mockito.spy(OAuthClientAuthnService.class);
         PowerMockito.when(oAuthClientAuthnService.getClientAuthenticators()).thenReturn
                 (Arrays.asList(oAuthClientAuthenticator));

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/client/authentication/SampleClientAuthenticator.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/client/authentication/SampleClientAuthenticator.java
@@ -17,6 +17,7 @@
 package org.wso2.carbon.identity.oauth2.client.authentication;
 
 import org.wso2.carbon.identity.oauth2.bean.OAuthClientAuthnContext;
+import org.wso2.carbon.identity.oauth2.model.ClientAuthenticationMethodModel;
 
 import java.util.Arrays;
 import java.util.List;
@@ -87,8 +88,9 @@ public class SampleClientAuthenticator extends AbstractOAuthClientAuthenticator 
     }
 
     @Override
-    public List<String> getSupportedClientAuthenticationMethods() {
+    public List<ClientAuthenticationMethodModel> getSupportedClientAuthenticationMethods() {
 
-        return Arrays.asList(SAMPLE_CLIENT_AUTHENTICATOR_AUTH_METHOD);
+        return Arrays.asList(new ClientAuthenticationMethodModel(SAMPLE_CLIENT_AUTHENTICATOR_AUTH_METHOD,
+                SAMPLE_CLIENT_AUTHENTICATOR));
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/util/OAuth2UtilTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/util/OAuth2UtilTest.java
@@ -81,6 +81,7 @@ import org.wso2.carbon.identity.oauth2.dao.AccessTokenDAO;
 import org.wso2.carbon.identity.oauth2.dao.OAuthTokenPersistenceFactory;
 import org.wso2.carbon.identity.oauth2.internal.OAuth2ServiceComponentHolder;
 import org.wso2.carbon.identity.oauth2.model.AccessTokenDO;
+import org.wso2.carbon.identity.oauth2.model.ClientAuthenticationMethodModel;
 import org.wso2.carbon.identity.oauth2.model.ClientCredentialDO;
 import org.wso2.carbon.identity.oauth2.token.OAuthTokenReqMessageContext;
 import org.wso2.carbon.identity.oauth2.token.OauthTokenIssuer;
@@ -2610,26 +2611,41 @@ public class OAuth2UtilTest extends PowerMockIdentityBaseTest {
     @Test
     public void testGetSupportedClientAuthMethods() {
 
+        ClientAuthenticationMethodModel secretBasic = new ClientAuthenticationMethodModel("client_secret_basic",
+                "Client Secret Basic");
+        ClientAuthenticationMethodModel secretPost = new ClientAuthenticationMethodModel("client_secret_post",
+                "Client Secret Post");
+        ClientAuthenticationMethodModel mtls = new ClientAuthenticationMethodModel("tls_client_auth",
+                "Mutual TLS");
+        ClientAuthenticationMethodModel pkJwt = new ClientAuthenticationMethodModel("private_key_jwt",
+                "Private Key JWT");
         List<OAuthClientAuthenticator> clientAuthenticators = new ArrayList<>();
         OAuthClientAuthenticator basicClientAuthenticator = PowerMockito.mock(OAuthClientAuthenticator.class);
         PowerMockito.when(basicClientAuthenticator.getSupportedClientAuthenticationMethods())
-                .thenReturn(Arrays.asList("client_secret_basic", "client_secret_post"));
+                .thenReturn(Arrays.asList(secretBasic, secretPost));
         clientAuthenticators.add(basicClientAuthenticator);
         OAuthClientAuthenticator mtlsClientAuthenticator = PowerMockito.mock(OAuthClientAuthenticator.class);
         PowerMockito.when(mtlsClientAuthenticator.getSupportedClientAuthenticationMethods())
-                .thenReturn(Arrays.asList("tls_client_auth"));
+                .thenReturn(Arrays.asList(mtls));
         clientAuthenticators.add(mtlsClientAuthenticator);
         OAuthClientAuthenticator pkjwtClientAuthenticator = PowerMockito.mock(OAuthClientAuthenticator.class);
         PowerMockito.when(pkjwtClientAuthenticator.getSupportedClientAuthenticationMethods())
-                .thenReturn(Arrays.asList("private_key_jwt"));
+                .thenReturn(Arrays.asList(pkJwt));
         clientAuthenticators.add(pkjwtClientAuthenticator);
         mockStatic(OAuth2ServiceComponentHolder.class);
         when(OAuth2ServiceComponentHolder.getAuthenticationHandlers()).thenReturn(clientAuthenticators);
-        List<String> supportedClientAuthMethods = Arrays.asList(OAuth2Util.getSupportedClientAuthMethods());
-        assertTrue(supportedClientAuthMethods.contains("client_secret_basic"));
-        assertTrue(supportedClientAuthMethods.contains("client_secret_post"));
-        assertTrue(supportedClientAuthMethods.contains("tls_client_auth"));
-        assertTrue(supportedClientAuthMethods.contains("private_key_jwt"));
+        HashSet<ClientAuthenticationMethodModel> supportedClientAuthMethods = OAuth2Util
+                .getSupportedAuthenticationMethods();
+        assertTrue(supportedClientAuthMethods.contains(secretBasic));
+        assertTrue(supportedClientAuthMethods.contains(secretPost));
+        assertTrue(supportedClientAuthMethods.contains(mtls));
+        assertTrue(supportedClientAuthMethods.contains(pkJwt));
         assertEquals(supportedClientAuthMethods.size(), 4);
+        List<String> supportedAuthMethods = Arrays.asList(OAuth2Util.getSupportedClientAuthMethods());
+        assertTrue(supportedAuthMethods.contains("client_secret_basic"));
+        assertTrue(supportedAuthMethods.contains("client_secret_post"));
+        assertTrue(supportedAuthMethods.contains("tls_client_auth"));
+        assertTrue(supportedAuthMethods.contains("private_key_jwt"));
+        assertEquals(supportedAuthMethods.size(), 4);
     }
 }


### PR DESCRIPTION
## Purpose
> This PR updates the getSupportedClientAuthenticationMethods() method in the OAuthClientAuthenticator so that it could return both supported authentication mechanisms by the authenticator and their respective display names which could be displayed in the console UI.