### PR TITLE
Improve setting cookie path for super tenant

### DIFF
--- a/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/DefaultOIDCSessionStateManager.java
+++ b/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/DefaultOIDCSessionStateManager.java
@@ -112,7 +112,7 @@ public class DefaultOIDCSessionStateManager implements OIDCSessionStateManager {
             if (isOrganizationQualifiedRequest()) {
                 cookie.setPath(FrameworkConstants.ORGANIZATION_CONTEXT_PREFIX + loginTenantDomain + "/");
             } else {
-                if (!IdentityTenantUtil.isSuperTenantRequiredInUrl() &&
+                if (!IdentityTenantUtil.isSuperTenantAppendInCookiePath() &&
                         MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equals(loginTenantDomain)) {
                     cookie.setPath("/");
                 } else {

--- a/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/util/OIDCSessionManagementUtil.java
+++ b/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/util/OIDCSessionManagementUtil.java
@@ -242,7 +242,7 @@ public class OIDCSessionManagementUtil {
                             } else {
                                 tenantDomain = resolveTenantDomain(request);
                             }
-                            if (!IdentityTenantUtil.isSuperTenantRequiredInUrl() &&
+                            if (!IdentityTenantUtil.isSuperTenantAppendInCookiePath() &&
                                     MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equals(tenantDomain)) {
                                 servletCookie.setPath("/");
                             } else {

--- a/pom.xml
+++ b/pom.xml
@@ -878,7 +878,7 @@
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!-- Carbon Identity Framework version -->
-        <carbon.identity.framework.version>5.25.502</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.25.507</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.25.234, 7.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 


### PR DESCRIPTION
Add a new config "TenantContext.TenantQualifiedUrls.AppendSuperTenantInCookiePath" to specify whether to append the `carbon.super` in the cookie paths and if enabled append the `carbon.super` to the cookie path.