### PR TITLE
Handle organization_switch_client_credentials grant with M2MScopeValidationHandler

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
+++ b/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
@@ -286,6 +286,7 @@ public final class OAuthConstants {
         public static final String REFRESH_TOKEN = "refresh_token";
         public static final String DEVICE_CODE = "device_code";
         public static final String ORGANIZATION_SWITCH = "organization_switch";
+        public static final String ORGANIZATION_SWITCH_CC = "organization_switch_cc";
 
         private GrantTypes() {
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/DefaultOAuth2ScopeValidator.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/DefaultOAuth2ScopeValidator.java
@@ -128,18 +128,12 @@ public class DefaultOAuth2ScopeValidator {
             appId = SharedAppResolveDAO.resolveSharedApplication(appResideOrgId, appId, orgId);
         }
         String grantType = tokenReqMessageContext.getOauth2AccessTokenReqDTO().getGrantType();
-        /* The APPLICATION type token requests with the organization_switch grant custom grant type will be handled same
-        as client_credentials grant type when scope validation. */
-        if (OAuthConstants.GrantTypes.ORGANIZATION_SWITCH.equals(grantType) &&
-                OAuthConstants.UserType.APPLICATION.equals(
-                        tokenReqMessageContext.getProperty(OAuthConstants.UserType.USER_TYPE))) {
-            grantType = OAuthConstants.GrantTypes.CLIENT_CREDENTIALS;
-        }
         List<String> authorizedScopes = getAuthorizedScopes(requestedScopes, tokenReqMessageContext
-                        .getAuthorizedUser(), appId, grantType, tenantDomain);
+                .getAuthorizedUser(), appId, grantType, tenantDomain);
         removeRegisteredScopes(tokenReqMessageContext);
         handleInternalLoginScope(requestedScopes, authorizedScopes);
-        if (OAuthConstants.GrantTypes.CLIENT_CREDENTIALS.equals(grantType)) {
+        if (OAuthConstants.GrantTypes.CLIENT_CREDENTIALS.equals(grantType)
+                || OAuthConstants.GrantTypes.ORGANIZATION_SWITCH_CC.equals(grantType)) {
             authorizedScopes.remove(INTERNAL_LOGIN_SCOPE);
             authorizedScopes.remove(OPENID_SCOPE);
         }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/validationhandler/impl/M2MScopeValidationHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/validationhandler/impl/M2MScopeValidationHandler.java
@@ -34,8 +34,9 @@ public class M2MScopeValidationHandler implements ScopeValidationHandler {
     @Override
     public boolean canHandle(ScopeValidationContext scopeValidationContext) {
 
-        return OAuthConstants.GrantTypes.CLIENT_CREDENTIALS.equals(scopeValidationContext.getGrantType()) &&
-                scopeValidationContext.getPolicyId().equals("RBAC");
+        return ((OAuthConstants.GrantTypes.CLIENT_CREDENTIALS.equals(scopeValidationContext.getGrantType())
+                || OAuthConstants.GrantTypes.ORGANIZATION_SWITCH_CC.equals(scopeValidationContext.getGrantType()))
+                && scopeValidationContext.getPolicyId().equals("RBAC"));
     }
 
     @Override

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/validationhandler/impl/RoleBasedScopeValidationHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/validationhandler/impl/RoleBasedScopeValidationHandler.java
@@ -49,7 +49,8 @@ public class RoleBasedScopeValidationHandler implements ScopeValidationHandler {
     public boolean canHandle(ScopeValidationContext scopeValidationContext) {
 
         return getPolicyID().equals(scopeValidationContext.getPolicyId())
-                && !OAuthConstants.GrantTypes.CLIENT_CREDENTIALS.equals(scopeValidationContext.getGrantType());
+                && !OAuthConstants.GrantTypes.CLIENT_CREDENTIALS.equals(scopeValidationContext.getGrantType())
+                && !OAuthConstants.GrantTypes.ORGANIZATION_SWITCH_CC.equals(scopeValidationContext.getGrantType());
     }
 
     @Override


### PR DESCRIPTION
### Proposed changes in this pull request
- Remove the temporary fix added to treat `APPLICATION` type token requests with `organization_switch` grant same as CC grant at the scope validator level with https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2234
- Add new grant `organization_switch_cc` to switch `client_credentials` grant for sub organizations.

### Related Issue
- https://github.com/wso2/product-is/issues/17532
