### PR TITLE
Add OAuthClientAuthenticatorProxy filter to authorize EP

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.client.authn.filter/src/main/java/org/wso2/carbon/identity/oauth/client/authn/filter/OAuthClientAuthenticatorProxy.java
+++ b/components/org.wso2.carbon.identity.oauth.client.authn.filter/src/main/java/org/wso2/carbon/identity/oauth/client/authn/filter/OAuthClientAuthenticatorProxy.java
@@ -49,7 +49,7 @@ public class OAuthClientAuthenticatorProxy extends AbstractPhaseInterceptor<Mess
     private static final Log log = LogFactory.getLog(OAuthClientAuthenticatorProxy.class);
     private static final String HTTP_REQUEST = "HTTP.REQUEST";
     private static final List<String> PROXY_ENDPOINT_LIST = Arrays.asList("/oauth2/token", "/oauth2/revoke",
-            "/oauth2/device_authorize", "/oauth2/ciba", "/oauth2/par");
+            "/oauth2/device_authorize", "/oauth2/ciba", "/oauth2/par", "/oauth2/authorize");
     private OAuthClientAuthnService oAuthClientAuthnService;
 
     public OAuthClientAuthenticatorProxy() {

--- a/components/org.wso2.carbon.identity.oauth.client.authn.filter/src/main/java/org/wso2/carbon/identity/oauth/client/authn/filter/OAuthClientAuthenticatorProxy.java
+++ b/components/org.wso2.carbon.identity.oauth.client.authn.filter/src/main/java/org/wso2/carbon/identity/oauth/client/authn/filter/OAuthClientAuthenticatorProxy.java
@@ -51,6 +51,7 @@ public class OAuthClientAuthenticatorProxy extends AbstractPhaseInterceptor<Mess
     private static final List<String> PROXY_ENDPOINT_LIST = Arrays.asList("/oauth2/token", "/oauth2/revoke",
             "/oauth2/device_authorize", "/oauth2/ciba", "/oauth2/par", "/oauth2/authorize");
     private OAuthClientAuthnService oAuthClientAuthnService;
+    private static final String SLASH = "/";
 
     public OAuthClientAuthenticatorProxy() {
 
@@ -106,6 +107,7 @@ public class OAuthClientAuthenticatorProxy extends AbstractPhaseInterceptor<Mess
     private boolean canHandle(Message message) {
 
         String requestPath = (String) message.get(Message.REQUEST_URI);
+        requestPath = removeTrailingSlash(requestPath);
         return PROXY_ENDPOINT_LIST.stream().anyMatch(requestPath::equalsIgnoreCase);
     }
 
@@ -141,4 +143,11 @@ public class OAuthClientAuthenticatorProxy extends AbstractPhaseInterceptor<Mess
                 oAuthClientAuthnContext);
     }
 
+    private String removeTrailingSlash(String url) {
+
+        if (url != null && url.endsWith(SLASH)) {
+            return url.substring(0, url.length() - 1);
+        }
+        return url;
+    }
 }


### PR DESCRIPTION
### Proposed changes in this pull request
Issue: https://github.com/wso2/product-is/issues/17977
With https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2262/files#diff-1308d3b92c48d40ca77ec4b7aa9a293953931862a527a68120cb1b3cdb60fefbR51, we added certain endpoints to OAuthClientAuthenticatorProxy.

But we need to add to /authorize endpoint too for API_Based_Authetnication as per
https://github.com/wso2-extensions/identity-inbound-auth-oauth/blob/9870e8a5b60bb4fe062522a28386739d4bd18ee0/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java#L312
