### PR TITLE
Skip user consent for claims for api based auth

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
@@ -1992,6 +1992,9 @@ public class OAuth2AuthzEndpoint {
         authorizationGrantCacheEntry.setTokenBindingValue(tokenBindingValue);
         authorizationGrantCacheEntry.setSessionContextIdentifier(sessionDataCacheEntry.getSessionContextIdentifier());
         authorizationGrantCacheEntry.setAccessTokenExtensionDO(tokenExtendedAttributes);
+        if (isApiBasedAuthenticationFlow(oAuthMessage)) {
+            authorizationGrantCacheEntry.setApiBasedAuthRequest(true);
+        }
 
         String[] sessionIds = sessionDataCacheEntry.getParamMap().get(FrameworkConstants.SESSION_DATA_KEY);
         if (ArrayUtils.isNotEmpty(sessionIds)) {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/cache/AuthorizationGrantCacheEntry.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/cache/AuthorizationGrantCacheEntry.java
@@ -79,6 +79,7 @@ public class AuthorizationGrantCacheEntry extends CacheEntry {
 
     private boolean isRequestObjectFlow;
     private AccessTokenExtendedAttributes accessTokenExtendedAttributes;
+    private boolean isApiBasedAuthRequest;
 
     public String getSubjectClaim() {
         return subjectClaim;
@@ -325,5 +326,15 @@ public class AuthorizationGrantCacheEntry extends CacheEntry {
     public void setAccessTokenExtensionDO(AccessTokenExtendedAttributes accessTokenExtendedAttributes) {
 
         this.accessTokenExtendedAttributes = accessTokenExtendedAttributes;
+    }
+
+    public boolean isApiBasedAuthRequest() {
+
+        return isApiBasedAuthRequest;
+    }
+
+    public void setApiBasedAuthRequest(boolean apiBasedAuthRequest) {
+
+        isApiBasedAuthRequest = apiBasedAuthRequest;
     }
 }


### PR DESCRIPTION
API based auth is recommended only for 1st party apps and also when performing api based authentication we will have to skip consent handling as there is no effective way to obtain consent as it is not possible to determine whether the actual user provided the consent or the submitted it without the user's knowledge.