### PR TITLE
Fix federated claims are not updated in the cache issue

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/DefaultOIDCClaimsCallbackHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/DefaultOIDCClaimsCallbackHandler.java
@@ -284,25 +284,27 @@ public class DefaultOIDCClaimsCallbackHandler implements CustomClaimsCallbackHan
 
     private Map<ClaimMapping, String> getCachedUserAttributes(OAuthTokenReqMessageContext requestMsgCtx) {
 
-        Map<ClaimMapping, String> userAttributes = getUserAttributesCachedAgainstToken(getAccessToken(requestMsgCtx));
+        Map<ClaimMapping, String> userAttributes = getUserAttributesCachedAgainstAuthorizationCode(
+                getAuthorizationCode(requestMsgCtx));
         if (log.isDebugEnabled()) {
-            log.debug("Retrieving claims cached against access_token for user: " + requestMsgCtx.getAuthorizedUser());
+            log.debug("Retrieving claims cached against authorization_code for user: " +
+                    requestMsgCtx.getAuthorizedUser());
         }
         if (isEmpty(userAttributes)) {
             if (log.isDebugEnabled()) {
-                log.debug("No claims cached against the access_token for user: " + requestMsgCtx.getAuthorizedUser() +
-                        ". Retrieving claims cached against the authorization code.");
+                log.debug("No claims cached against the authorization_code for user: " + requestMsgCtx.
+                        getAuthorizedUser() + ". Retrieving claims cached against the access_token.");
             }
-            userAttributes = getUserAttributesCachedAgainstAuthorizationCode(getAuthorizationCode(requestMsgCtx));
+            userAttributes = getUserAttributesCachedAgainstToken(getAccessToken(requestMsgCtx));
             if (log.isDebugEnabled()) {
-                log.debug("Retrieving claims cached against authorization_code for user: " +
+                log.debug("Retrieving claims cached against access_token for user: " +
                         requestMsgCtx.getAuthorizedUser());
             }
         }
         // Check for claims cached against the device code.
         if (isEmpty(userAttributes)) {
             if (log.isDebugEnabled()) {
-                log.debug("No claims cached against the authorization_code for user: " +
+                log.debug("No claims cached against the access_token for user: " +
                         requestMsgCtx.getAuthorizedUser() + ". Retrieving claims cached against the device code.");
             }
             userAttributes = getUserAttributesCachedAgainstDeviceCode(getDeviceCode(requestMsgCtx));


### PR DESCRIPTION
### Proposed changes in this pull request
* Fixes : https://github.com/wso2/product-is/issues/16984
* Extracting the cached user attributes first from the authorization code, then from access token.
  * When the refresh request comes, then the cache from the access token will be resolved because from the first token call in the authz code grant, the authz code grant cache will be added to the access token cache and removed.