### PR TITLE
Add missing state param in error jwt response

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/responsemode/provider/jarm/JarmResponseModeProvider.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/responsemode/provider/jarm/JarmResponseModeProvider.java
@@ -134,8 +134,11 @@ public abstract class JarmResponseModeProvider extends AbstractResponseModeProvi
 
         jwtClaimsSet.claim(EXPIRATION_TIME, expirationTime);
 
-        if (StringUtils.isNotBlank(authorizationResponseDTO.getSessionState())) {
+        if (StringUtils.isNotBlank(authorizationResponseDTO.getState())) {
             jwtClaimsSet.claim(STATE, authorizationResponseDTO.getState());
+        }
+        if (StringUtils.isNotBlank(authorizationResponseDTO.getSessionState())) {
+            jwtClaimsSet.claim(SESSION_STATE, authorizationResponseDTO.getSessionState());
         }
 
         return jwtClaimsSet.build();


### PR DESCRIPTION
In JarmResponseModeProvider.getErrorJWTClaimsSet, state param is incorrectly added after checking for session_state. Due to this, in error flows, the jwt does not contain state param. This can be reproduced by denying the consent in the /authorize flow.

This issue is fixed with this PR.