### PR TITLE
Fix issue of unable to read post body params in PAR endpoint

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/par/OAuth2ParEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/par/OAuth2ParEndpoint.java
@@ -91,7 +91,9 @@ public class OAuth2ParEndpoint {
 
         try {
             Map<String, String> parameters = transformParams(params);
-            // Wrap the request with the parameters obtained from the PAR endpoint.
+            /* Wrap the request with the parameters obtained from the PAR endpoint.
+            This is to avoid the request body parameters dropping from the http servlet request when the content type
+            'application/x-www-form-urlencoded;charset=utf-8' is sent in request headers.*/
             HttpServletRequestWrapper httpRequest = new OAuthParRequestWrapper(request, parameters);
             checkClientAuthentication(httpRequest);
             handleValidation(httpRequest, params);

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/par/OAuth2ParEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/par/OAuth2ParEndpoint.java
@@ -33,6 +33,7 @@ import org.wso2.carbon.identity.oauth.common.exception.InvalidOAuthClientExcepti
 import org.wso2.carbon.identity.oauth.common.exception.InvalidOAuthRequestException;
 import org.wso2.carbon.identity.oauth.endpoint.util.EndpointUtil;
 import org.wso2.carbon.identity.oauth.par.common.ParConstants;
+import org.wso2.carbon.identity.oauth.par.core.OAuthParRequestWrapper;
 import org.wso2.carbon.identity.oauth.par.exceptions.ParClientException;
 import org.wso2.carbon.identity.oauth.par.exceptions.ParCoreException;
 import org.wso2.carbon.identity.oauth.par.model.ParAuthData;
@@ -50,6 +51,7 @@ import java.util.List;
 import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.POST;
@@ -88,9 +90,11 @@ public class OAuth2ParEndpoint {
                         MultivaluedMap<String, String> params) {
 
         try {
-            checkClientAuthentication(request);
-            handleValidation(request, params);
             Map<String, String> parameters = transformParams(params);
+            // Wrap the request with the parameters obtained from the PAR endpoint.
+            HttpServletRequestWrapper httpRequest = new OAuthParRequestWrapper(request, parameters);
+            checkClientAuthentication(httpRequest);
+            handleValidation(httpRequest, params);
             ParAuthData parAuthData =
                     getParAuthService().handleParAuthRequest(parameters);
             return createAuthResponse(response, parAuthData);

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/par/OAuth2ParEndpointTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/par/OAuth2ParEndpointTest.java
@@ -40,6 +40,7 @@ import org.wso2.carbon.identity.oauth.common.OAuthConstants;
 import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
 import org.wso2.carbon.identity.oauth.endpoint.util.EndpointUtil;
 import org.wso2.carbon.identity.oauth.endpoint.util.TestOAuthEndpointBase;
+import org.wso2.carbon.identity.oauth.par.core.OAuthParRequestWrapper;
 import org.wso2.carbon.identity.oauth.par.core.ParAuthServiceImpl;
 import org.wso2.carbon.identity.oauth.par.model.ParAuthData;
 import org.wso2.carbon.identity.oauth.tokenprocessor.TokenPersistenceProcessor;
@@ -325,7 +326,7 @@ public class OAuth2ParEndpointTest extends TestOAuthEndpointBase {
         spy(EndpointUtil.class);
         doReturn(oAuth2Service).when(EndpointUtil.class, "getOAuth2Service");
         doCallRealMethod().when(oAuth2Service).validateInputParameters(request);
-        doCallRealMethod().when(oAuth2Service).validateClientInfo(request);
+        doCallRealMethod().when(oAuth2Service).validateClientInfo(any(OAuthParRequestWrapper.class));
         doReturn(parAuthService).when(EndpointUtil.class, "getParAuthService");
         if (testOAuthSystemException) {
             doThrow(new OAuthSystemException()).when(EndpointUtil.class, "getOAuthAuthzRequest", any());


### PR DESCRIPTION

### Proposed changes in this pull request

Wrap the http servlet request using the OAuthParRequestWrapper to fix issue when reading POST body parameters for PAR requests with content type 'application/x-www-form-urlencoded;charset=utf-8'

- Fixes https://github.com/wso2/product-is/issues/18053


#### Security

- [ ] **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
- [ ] **Are all UI and API inputs run through forms or serializers?**
- [ ] **Are all external inputs validated and sanitized appropriately?**
- [ ] **Does all branching logic have a default case?**
- [ ] **Does this solution handle outliers and edge cases gracefully?**
- [ ] **Are all external communications secured and restricted to SSL?**

#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes should be documented.
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented.
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki.
