### PR TITLE
Clear domain value in thread local at the end of issue token request.

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/token/OAuth2TokenEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/token/OAuth2TokenEndpoint.java
@@ -47,6 +47,7 @@ import org.wso2.carbon.identity.oauth2.dto.OAuth2AccessTokenReqDTO;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2AccessTokenRespDTO;
 import org.wso2.carbon.identity.oauth2.model.CarbonOAuthTokenRequest;
 import org.wso2.carbon.identity.oauth2.token.handlers.response.OAuth2TokenResponse;
+import org.wso2.carbon.user.core.util.UserCoreUtil;
 import org.wso2.carbon.utils.DiagnosticLog;
 
 import java.util.List;
@@ -177,6 +178,7 @@ public class OAuth2TokenEndpoint {
             throw e;
 
         } finally {
+            UserCoreUtil.setDomainInThreadLocal(null);
             if (!IdentityTenantUtil.isTenantQualifiedUrlsEnabled()) {
                 PrivilegedCarbonContext.endTenantFlow();
             }


### PR DESCRIPTION
$subject

Describe:
> In this effort we will be clearing the domain value saved in thread local at the end of API request process.  There are 3 endpoints which handles authentication requests of a user.

1. `/authorize`
- Authorize request are handled through framework. The fix done in [1] handles this case.

2. `/token`
- We can do direct API based authorization, for grant types such as `password, implicit` via the `/token` endpoint. Here the authentication part is handled by the respective grant handlers. At the end of successful authentication, the issueToken method will issue the token. 

> In this effort we clear the user domain value stored in the thread local at the end of issuing the token.

3. `/authn`
- This is a newly introduced API based authentication mechanism, where we can authorize users solely via on API calls. By setting `response_mode=redirect` of the API request, we can invoke the new API based flow using the same `/authorize` endpoint. The response of this API call then be sent to the new `/authn` endpoint to authenticate users using next authenticator configured. As this request again through handles through the framework, the fix done in [1] can be applied here as well.

[1] https://github.com/wso2/carbon-identity-framework/pull/3357

Resolves https://github.com/wso2/product-is/issues/17723