### PR TITLE
Add flow status to api based auth success completed response

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/api/auth/model/SuccessCompleteAuthResponse.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/api/auth/model/SuccessCompleteAuthResponse.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth.endpoint.api.auth.model;
+
+import org.wso2.carbon.identity.application.authentication.framework.util.auth.service.AuthServiceConstants;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Class containing the authentication response for successful flow completion.
+ */
+public class SuccessCompleteAuthResponse {
+
+    private AuthServiceConstants.FlowStatus flowStatus = AuthServiceConstants.FlowStatus.SUCCESS_COMPLETED;
+    private Map<String, String> authData = new HashMap<>();
+
+    public SuccessCompleteAuthResponse() {
+
+    }
+
+    public SuccessCompleteAuthResponse(Map<String, String> authData) {
+
+        this.authData = authData;
+    }
+
+    public AuthServiceConstants.FlowStatus getFlowStatus() {
+
+        return flowStatus;
+    }
+
+    public void setFlowStatus(AuthServiceConstants.FlowStatus flowStatus) {
+
+        this.flowStatus = flowStatus;
+    }
+
+    public Map<String, String> getAuthData() {
+
+        return authData;
+    }
+
+    public void setAuthData(Map<String, String> authData) {
+
+        this.authData = authData;
+    }
+}

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
@@ -102,6 +102,7 @@ import org.wso2.carbon.identity.oauth.endpoint.OAuthRequestWrapper;
 import org.wso2.carbon.identity.oauth.endpoint.api.auth.ApiAuthnHandler;
 import org.wso2.carbon.identity.oauth.endpoint.api.auth.ApiAuthnUtils;
 import org.wso2.carbon.identity.oauth.endpoint.api.auth.model.AuthResponse;
+import org.wso2.carbon.identity.oauth.endpoint.api.auth.model.SuccessCompleteAuthResponse;
 import org.wso2.carbon.identity.oauth.endpoint.exception.ConsentHandlingFailedException;
 import org.wso2.carbon.identity.oauth.endpoint.exception.InvalidRequestException;
 import org.wso2.carbon.identity.oauth.endpoint.exception.InvalidRequestParentException;
@@ -4460,7 +4461,9 @@ public class OAuth2AuthzEndpoint {
                                     "Error while extracting query params from provided url.", e);
                         }
                         if (isRedirectToClient(location)) {
-                            String jsonPayload = new Gson().toJson(queryParams);
+                            SuccessCompleteAuthResponse successCompleteAuthResponse =
+                                    new SuccessCompleteAuthResponse(queryParams);
+                            String jsonPayload = new Gson().toJson(successCompleteAuthResponse);
                             oAuthMessage.getRequest().setAttribute(IS_API_BASED_AUTH_HANDLED, true);
                             return Response.status(HttpServletResponse.SC_OK).entity(jsonPayload).build();
                         } else {


### PR DESCRIPTION
fixes https://github.com/wso2/product-is/issues/17835 additionally improves the way the authn API link is constructed in the response.

With this change the successful flow completion will look like below
```json
{
    "flowStatus": "SUCCESS_COMPLETED",
    "authData": {
        "code": "546cd078-c32c-3319-9a71-a37c7397564a",
        "state": "logpg",
        "session_state": "541b89c0d2494321aa870652c8397ab1c6537295a15b08fd05d2c34e9cc45a65.2e_-zijsu2iTq7VhArQs1Q"
    }
}
```