### PR TITLE
Improve api based auth validations

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -5135,4 +5135,28 @@ public class OAuth2Util {
         }
         return true;
     }
+
+    /**
+     * Check whether the request is an API based authentication request.
+     *
+     * @param request HttpServletRequest
+     * @return True if the request is an API based authentication request.
+     */
+    public static boolean isApiBasedAuthenticationFlow(HttpServletRequest request) {
+
+        return StringUtils.equals(OAuthConstants.ResponseModes.DIRECT,
+                request.getParameter(OAuthConstants.OAuth20Params.RESPONSE_MODE));
+    }
+
+    /**
+     * Check whether the invoked grant supports API based authentication.
+     *
+     * @param request HttpServletRequest
+     * @return True if the grant supports API based authentication.
+     */
+    public static boolean isApiBasedAuthSupportedGrant(HttpServletRequest request) {
+
+        return StringUtils.equals(OAuthConstants.CODE,
+                request.getParameter(OAuthConstants.OAuth20Params.RESPONSE_TYPE));
+    }
 }


### PR DESCRIPTION
The PR does the following validation improvements;

- Add a validation to only support 'code' response type
- Add attestation validation to /par endpoint