### PR TITLE
[FAPI] Add JARM for error flows

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/responsemode/provider/impl/FragmentResponseModeProvider.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/responsemode/provider/impl/FragmentResponseModeProvider.java
@@ -92,8 +92,7 @@ public class FragmentResponseModeProvider extends AbstractResponseModeProvider {
 
         } else {
             redirectUrl += "#" +
-                    OAuthConstants.OAUTH_ERROR + "=" + authorizationResponseDTO.getErrorResponseDTO().getError() +
-                    "&" + OAuthConstants.OAUTH_ERROR_DESCRIPTION + "=" +
+                    OAuthConstants.OAUTH_ERROR_DESCRIPTION + "=" +
                     authorizationResponseDTO.getErrorResponseDTO().getErrorDescription()
                             .replace(" ", "+");
 
@@ -105,6 +104,9 @@ public class FragmentResponseModeProvider extends AbstractResponseModeProvider {
             if (StringUtils.isNotBlank(state)) {
                 redirectUrl += "&" + OAuthConstants.STATE + "=" + state;
             }
+
+            redirectUrl += "&" + OAuthConstants.OAUTH_ERROR + "=" +
+                    authorizationResponseDTO.getErrorResponseDTO().getError();
         }
         authorizationResponseDTO.setRedirectUrl(redirectUrl);
         return redirectUrl;

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/responsemode/provider/impl/QueryResponseModeProvider.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/responsemode/provider/impl/QueryResponseModeProvider.java
@@ -119,8 +119,7 @@ public class QueryResponseModeProvider extends AbstractResponseModeProvider {
                     String.join("&", queryParams));
         } else {
             redirectUrl += "?" +
-                    OAuthConstants.OAUTH_ERROR + "=" + authorizationResponseDTO.getErrorResponseDTO().getError() +
-                    "&" + OAuthConstants.OAUTH_ERROR_DESCRIPTION + "=" +
+                    OAuthConstants.OAUTH_ERROR_DESCRIPTION + "=" +
                     authorizationResponseDTO.getErrorResponseDTO().getErrorDescription()
                             .replace(" ", "+");
 
@@ -132,6 +131,9 @@ public class QueryResponseModeProvider extends AbstractResponseModeProvider {
             if (StringUtils.isNotBlank(state)) {
                 redirectUrl += "&" + OAuthConstants.STATE + "=" + state;
             }
+
+            redirectUrl += "&" + OAuthConstants.OAUTH_ERROR + "=" +
+                    authorizationResponseDTO.getErrorResponseDTO().getError();
         }
         authorizationResponseDTO.setRedirectUrl(redirectUrl);
         return redirectUrl;


### PR DESCRIPTION
Git Issue: https://github.com/wso2/product-is/issues/18062

As in the above git issue, to properly send the request object validation errors in the redirect url (mainly in JARM flows), we need to access couple of parameters inside request object eventhough the request object is not valid.

With this PR, we just do the validation of the request object and pick the needed params (`client_id`, `state`, `response_mode`, `response_type`).