### PR TITLE
Resolve console & myaccount callback urls based on a toml config

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.dcr/pom.xml
+++ b/components/org.wso2.carbon.identity.oauth.dcr/pom.xml
@@ -118,6 +118,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.sun.xml.parsers</groupId>
             <artifactId>jaxp-ri</artifactId>
             <scope>test</scope>

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dao/OAuthAppDAO.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dao/OAuthAppDAO.java
@@ -98,6 +98,8 @@ import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCConfigPro
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCConfigProperties.TOKEN_REVOCATION_WITH_IDP_SESSION_TERMINATION;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCConfigProperties.TOKEN_TYPE;
 import static org.wso2.carbon.identity.oauth2.util.OAuth2Util.OPENID_CONNECT_AUDIENCE;
+import static org.wso2.carbon.identity.oauth2.util.OAuth2Util.getConsoleCallbackFromServerConfig;
+import static org.wso2.carbon.identity.oauth2.util.OAuth2Util.getMyAccountCallbackFromServerConfig;
 
 /**
  * JDBC Based data access layer for OAuth Consumer Applications.
@@ -332,6 +334,18 @@ public class OAuthAppDAO {
                                 oauthApp.setCallbackUrl(
                                         ApplicationMgtUtil.resolveOriginUrlFromPlaceholders(rSet.getString(5)));
                             }
+                            if (ApplicationMgtUtil.isConsole(oauthApp.getApplicationName())) {
+                                String consoleCallbackUrl = getConsoleCallbackFromServerConfig(tenantDomain);
+                                if (StringUtils.isNotBlank(consoleCallbackUrl)) {
+                                    oauthApp.setCallbackUrl(consoleCallbackUrl);
+                                }
+                            }
+                            if (ApplicationMgtUtil.isMyAccount(oauthApp.getApplicationName())) {
+                                String myAccountCallbackUrl = getMyAccountCallbackFromServerConfig(tenantDomain);
+                                if (StringUtils.isNotBlank(myAccountCallbackUrl)) {
+                                    oauthApp.setCallbackUrl(myAccountCallbackUrl);
+                                }
+                            }
 
                             oauthApp.setGrantTypes(rSet.getString(6));
                             oauthApp.setId(rSet.getInt(7));
@@ -440,6 +454,19 @@ public class OAuthAppDAO {
                                 oauthApp.setCallbackUrl(
                                         ApplicationMgtUtil.resolveOriginUrlFromPlaceholders(rSet.getString(5)));
                             }
+                            String tenantDomain = IdentityTenantUtil.getTenantDomain(tenantId);
+                            if (ApplicationMgtUtil.isConsole(oauthApp.getApplicationName())) {
+                                String consoleCallbackUrl = getConsoleCallbackFromServerConfig(tenantDomain);
+                                if (StringUtils.isNotBlank(consoleCallbackUrl)) {
+                                    oauthApp.setCallbackUrl(consoleCallbackUrl);
+                                }
+                            }
+                            if (ApplicationMgtUtil.isMyAccount(oauthApp.getApplicationName())) {
+                                String myAccountCallbackUrl = getMyAccountCallbackFromServerConfig(tenantDomain);
+                                if (StringUtils.isNotBlank(myAccountCallbackUrl)) {
+                                    oauthApp.setCallbackUrl(myAccountCallbackUrl);
+                                }
+                            }
 
                             authenticatedUser.setTenantDomain(IdentityTenantUtil.getTenantDomain(rSet.getInt(6)));
                             authenticatedUser.setUserStoreDomain(rSet.getString(7));
@@ -528,6 +555,19 @@ public class OAuthAppDAO {
                             oauthApp.setCallbackUrl(
                                     ApplicationMgtUtil.resolveOriginUrlFromPlaceholders(rSet.getString(CALLBACK_URL)));
                         }
+                        String tenantDomain = IdentityTenantUtil.getTenantDomain(rSet.getInt(TENANT_ID));
+                        if (ApplicationMgtUtil.isConsole(oauthApp.getApplicationName())) {
+                            String consoleCallbackUrl = getConsoleCallbackFromServerConfig(tenantDomain);
+                            if (StringUtils.isNotBlank(consoleCallbackUrl)) {
+                                oauthApp.setCallbackUrl(consoleCallbackUrl);
+                            }
+                        }
+                        if (ApplicationMgtUtil.isMyAccount(oauthApp.getApplicationName())) {
+                            String myAccountCallbackUrl = getMyAccountCallbackFromServerConfig(tenantDomain);
+                            if (StringUtils.isNotBlank(myAccountCallbackUrl)) {
+                                oauthApp.setCallbackUrl(myAccountCallbackUrl);
+                            }
+                        }
 
                         authenticatedUser.setTenantDomain(IdentityTenantUtil.getTenantDomain(rSet.getInt(TENANT_ID)));
                         authenticatedUser.setUserStoreDomain(rSet.getString(USER_DOMAIN));
@@ -601,6 +641,19 @@ public class OAuthAppDAO {
                         if (ApplicationMgtUtil.isConsoleOrMyAccount(oauthApp.getApplicationName())) {
                             oauthApp.setCallbackUrl(
                                     ApplicationMgtUtil.resolveOriginUrlFromPlaceholders(rSet.getString(CALLBACK_URL)));
+                        }
+                        String tenantDomain = IdentityTenantUtil.getTenantDomain(rSet.getInt(TENANT_ID));
+                        if (ApplicationMgtUtil.isConsole(oauthApp.getApplicationName())) {
+                            String consoleCallbackUrl = getConsoleCallbackFromServerConfig(tenantDomain);
+                            if (StringUtils.isNotBlank(consoleCallbackUrl)) {
+                                oauthApp.setCallbackUrl(consoleCallbackUrl);
+                            }
+                        }
+                        if (ApplicationMgtUtil.isMyAccount(oauthApp.getApplicationName())) {
+                            String myAccountCallbackUrl = getMyAccountCallbackFromServerConfig(tenantDomain);
+                            if (StringUtils.isNotBlank(myAccountCallbackUrl)) {
+                                oauthApp.setCallbackUrl(myAccountCallbackUrl);
+                            }
                         }
 
                         authenticatedUser.setTenantDomain(IdentityTenantUtil.getTenantDomain(rSet.getInt(TENANT_ID)));
@@ -685,6 +738,19 @@ public class OAuthAppDAO {
                             if (ApplicationMgtUtil.isConsoleOrMyAccount(oauthApp.getApplicationName())) {
                                 oauthApp.setCallbackUrl(
                                         ApplicationMgtUtil.resolveOriginUrlFromPlaceholders(rSet.getString(6)));
+                            }
+                            String tenantDomain = IdentityTenantUtil.getTenantDomain(tenantID);
+                            if (ApplicationMgtUtil.isConsole(oauthApp.getApplicationName())) {
+                                String consoleCallbackUrl = getConsoleCallbackFromServerConfig(tenantDomain);
+                                if (StringUtils.isNotBlank(consoleCallbackUrl)) {
+                                    oauthApp.setCallbackUrl(consoleCallbackUrl);
+                                }
+                            }
+                            if (ApplicationMgtUtil.isMyAccount(oauthApp.getApplicationName())) {
+                                String myAccountCallbackUrl = getMyAccountCallbackFromServerConfig(tenantDomain);
+                                if (StringUtils.isNotBlank(myAccountCallbackUrl)) {
+                                    oauthApp.setCallbackUrl(myAccountCallbackUrl);
+                                }
                             }
 
                             oauthApp.setGrantTypes(rSet.getString(7));

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/OAuth2Constants.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/OAuth2Constants.java
@@ -41,6 +41,9 @@ public class OAuth2Constants {
     public static final String OAUTH_TOKEN_PERSISTENCE_ENABLE = "OAuth.TokenPersistence.Enable";
     public static final String OAUTH_CODE_PERSISTENCE_ENABLE = "OAuth.EnableAuthCodePersistence";
     public static final String OAUTH_ENABLE_REVOKE_TOKEN_HEADERS = "OAuth.EnableRevokeTokenHeadersInResponse";
+    public static final String CONSOLE_CALLBACK_URL_FROM_SERVER_CONFIGS = "Console.CallbackURL";
+    public static final String MY_ACCOUNT_CALLBACK_URL_FROM_SERVER_CONFIGS = "MyAccount.CallbackURL";
+    public static final String TENANT_DOMAIN_PLACEHOLDER = "{TENANT_DOMAIN}";
 
     /**
      * Constants for global role based scope issuer.

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -5159,4 +5159,54 @@ public class OAuth2Util {
         return StringUtils.equals(OAuthConstants.CODE,
                 request.getParameter(OAuthConstants.OAuth20Params.RESPONSE_TYPE));
     }
+
+    /**
+     * Resolve Console application callback url for a specific tenant based on the callback url configured in toml.
+     *
+     * @param tenantDomain Tenant domain.
+     * @return Console callback url.
+     */
+    public static String getConsoleCallbackFromServerConfig(String tenantDomain) {
+
+        String callbackUrl = IdentityUtil.getProperty(OAuth2Constants.CONSOLE_CALLBACK_URL_FROM_SERVER_CONFIGS);
+        if (StringUtils.isNotBlank(callbackUrl)) {
+            // If callback is a regex pattern, return it as it is.
+            if (callbackUrl.startsWith(OAuthConstants.CALLBACK_URL_REGEXP_PREFIX)) {
+                return callbackUrl;
+            }
+
+            if (MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equals(tenantDomain)) {
+                callbackUrl = callbackUrl.replace("/t/" + OAuth2Constants.TENANT_DOMAIN_PLACEHOLDER, "");
+            } else {
+                callbackUrl = callbackUrl.replace(OAuth2Constants.TENANT_DOMAIN_PLACEHOLDER, tenantDomain);
+            }
+            return callbackUrl;
+        }
+        return null;
+    }
+
+    /**
+     * Resolve MyAccount application callback url for a specific tenant based on the callback url configured in toml.
+     *
+     * @param tenantDomain Tenant domain.
+     * @return MyAccount callback url.
+     */
+    public static String getMyAccountCallbackFromServerConfig(String tenantDomain) {
+
+        String callbackUrl = IdentityUtil.getProperty(OAuth2Constants.MY_ACCOUNT_CALLBACK_URL_FROM_SERVER_CONFIGS);
+        if (StringUtils.isNotBlank(callbackUrl)) {
+            // If callback is a regex pattern, return it as it is.
+            if (callbackUrl.startsWith(OAuthConstants.CALLBACK_URL_REGEXP_PREFIX)) {
+                return callbackUrl;
+            }
+
+            if (MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equals(tenantDomain)) {
+                callbackUrl = callbackUrl.replace("/t/" + OAuth2Constants.TENANT_DOMAIN_PLACEHOLDER, "");
+            } else {
+                callbackUrl = callbackUrl.replace(OAuth2Constants.TENANT_DOMAIN_PLACEHOLDER, tenantDomain);
+            }
+            return callbackUrl;
+        }
+        return null;
+    }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -5176,7 +5176,8 @@ public class OAuth2Util {
             }
 
             if (MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equals(tenantDomain)) {
-                callbackUrl = callbackUrl.replace("/t/" + OAuth2Constants.TENANT_DOMAIN_PLACEHOLDER, "");
+                callbackUrl = "regexp=(" + callbackUrl.replace(OAuth2Constants.TENANT_DOMAIN_PLACEHOLDER, tenantDomain)
+                        + "|" + callbackUrl.replace("/t/" + OAuth2Constants.TENANT_DOMAIN_PLACEHOLDER, "") + ")";
             } else {
                 callbackUrl = callbackUrl.replace(OAuth2Constants.TENANT_DOMAIN_PLACEHOLDER, tenantDomain);
             }
@@ -5201,7 +5202,8 @@ public class OAuth2Util {
             }
 
             if (MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equals(tenantDomain)) {
-                callbackUrl = callbackUrl.replace("/t/" + OAuth2Constants.TENANT_DOMAIN_PLACEHOLDER, "");
+                callbackUrl = "regexp=(" + callbackUrl.replace(OAuth2Constants.TENANT_DOMAIN_PLACEHOLDER, tenantDomain)
+                        + "|" + callbackUrl.replace("/t/" + OAuth2Constants.TENANT_DOMAIN_PLACEHOLDER, "") + ")";
             } else {
                 callbackUrl = callbackUrl.replace(OAuth2Constants.TENANT_DOMAIN_PLACEHOLDER, tenantDomain);
             }

--- a/pom.xml
+++ b/pom.xml
@@ -890,7 +890,7 @@
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!-- Carbon Identity Framework version -->
-        <carbon.identity.framework.version>5.25.520</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.25.640</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.25.234, 7.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 


### PR DESCRIPTION
### Proposed changes in this pull request

- Resolve console & myaccount callback urls based on a toml config

  #### Toml Config

  ```
  [console]
  callback_url = "https://localhost:9001/t/{TENANT_DOMAIN}/console"
  access_url = "https://localhost:9001/t/{TENANT_DOMAIN}/console"
  
  [myaccount]
  callback_url = "https://localhost:9000/t/{TENANT_DOMAIN}/myaccount"
  access_url = "https://localhost:9000/t/{TENANT_DOMAIN}/myaccount"
  ```
  - Can also use regex pattern also as a callback URL regex.
 ex: 
  ```
  [console]
  callback_url = "regexp=(https://localhost:9000/t/(.*)/console|https://localhost:9000/console)"
  
  [myaccount]
  callback_url = "regexp=(https://localhost:9000/t/(.*)/myaccount|https://localhost:9000/myaccount)"
  ```

### When should this PR be merged

- After merging https://github.com/wso2/carbon-identity-framework/pull/5304


### TODO

- [x] Bump framework version


### Related Issue

- https://github.com/wso2/product-is/issues/18164