### PR TITLE
Synchronize persisting token in RefreshGrantHandler

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AbstractAuthorizationGrantHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AbstractAuthorizationGrantHandler.java
@@ -1079,7 +1079,7 @@ public abstract class AbstractAuthorizationGrantHandler implements Authorization
      * @param tokReqMsgCtx OAuthTokenReqMessageContext.
      * @return token binding reference.
      */
-    private String getTokenBindingReference(OAuthTokenReqMessageContext tokReqMsgCtx) {
+    protected String getTokenBindingReference(OAuthTokenReqMessageContext tokReqMsgCtx) {
 
         if (tokReqMsgCtx.getTokenBinding() == null) {
             if (log.isDebugEnabled()) {


### PR DESCRIPTION
### Proposed changes in this pull request

The `RefreshGrantHandler` bypasses the synchronized token issuing behavior of the super class `AbstractAuthorizationGrantHandler` by adopting an overidden `issue` method. This can potentially be the reason for the related issue. Therefore this PR adopts the same synchronization method when persisting the token in `RefreshGrantHandler`.

### Related Issues
- Issue https://github.com/wso2-enterprise/asgardeo-product/issues/20065
