### PR TITLE
Bump opensaml version to 3.3.1.wso2v11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -957,7 +957,7 @@
         <json.wso2.version.range>[3.0.0.wso2v1, 4.0.0)</json.wso2.version.range>
 
         <opensaml.version>3.3.1</opensaml.version>
-        <opensaml3.wso2.version>3.3.1.wso2v7</opensaml3.wso2.version>
+        <opensaml3.wso2.version>3.3.1.wso2v11</opensaml3.wso2.version>
         <opensaml3.wso2.osgi.version.range>[3.3.1,3.4.0)</opensaml3.wso2.osgi.version.range>
 
         <joda.version>2.9.4</joda.version>


### PR DESCRIPTION
### Proposed changes in this pull request
- $suject
- From this PR the below dependencies are upgraded in the opensaml orbit jar
   - apache commons codec version from 1.10 to 1.16
   - esapi.version from 2.4.0.0 to 2.5.3.1
   - org.apache.xml.security.version range