### PR TITLE
Allow sending PAR requests without duplicate parameters

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/par/OAuth2ParEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/par/OAuth2ParEndpoint.java
@@ -283,6 +283,8 @@ public class OAuth2ParEndpoint {
         if (!validationResponse.isValidClient()) {
             if (OAuth2ErrorCodes.INVALID_CLIENT.equals(validationResponse.getErrorCode())) {
                 throw new ParClientException(OAuth2ErrorCodes.INVALID_REQUEST, validationResponse.getErrorMsg());
+            } else if (OAuth2ErrorCodes.INVALID_CALLBACK.equals(validationResponse.getErrorCode())) {
+                throw new ParClientException(OAuth2ErrorCodes.INVALID_REQUEST, validationResponse.getErrorMsg());
             }
             throw new ParClientException(validationResponse.getErrorCode(), validationResponse.getErrorMsg());
         }
@@ -395,7 +397,8 @@ public class OAuth2ParEndpoint {
             if (OAuth2ErrorCodes.SERVER_ERROR.equals(e.getErrorCode())) {
                 throw new ParCoreException(e.getErrorCode(), e.getMessage(), e);
             }
-            throw new ParClientException(e.getErrorCode(), e.getMessage(), e);
+            throw new ParClientException(OAuth2ErrorCodes.OAuth2SubErrorCodes.INVALID_REQUEST_OBJECT,
+                    e.getMessage(), e);
         }
     }
 

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/par/OAuth2ParEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/par/OAuth2ParEndpoint.java
@@ -107,7 +107,8 @@ public class OAuth2ParEndpoint {
             Until the JAR(rfc 9101) specification is implemented, this is added as a workaround to allow sending PAR
             requests without duplicates of oauth2 parameters inside and outside the request object.
             Extracting parameters from request object will happen only if required parameters are not present outside
-            request object. Error scenarios due to missing parameters will be handled in handleValidation logic. */
+            request object. Only the request object signature validation is performed here prior to overriding the
+            parameters. Request validations will be handled in handleValidation logic. */
             if (!containsRequiredParameters(parameters) && StringUtils.isNotBlank(parameters.get(REQUEST))) {
                 extractParamsFromRequestObject(parameters);
             }

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/par/OAuth2ParEndpointTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/par/OAuth2ParEndpointTest.java
@@ -209,9 +209,6 @@ public class OAuth2ParEndpointTest extends TestOAuthEndpointBase {
         requestParams13.put(OAuthConstants.OAUTH_PKCE_CODE_CHALLENGE_METHOD,
                 new String[]{"Invalid-code-challenge-method"});
 
-        Map<String, String[]> requestParams14 = new HashMap<>();
-        requestParams14.put(OAuthConstants.OAuth20Params.REQUEST, new String[]{"dummyRequest"});
-
         MultivaluedMap<String, String> paramMap1 = new MultivaluedHashMap<>();
         paramMap1.add(OAuth.OAUTH_CLIENT_ID, CLIENT_ID_VALUE);
         paramMap1.add(OAuth.OAUTH_REDIRECT_URI, APP_REDIRECT_URL);
@@ -230,7 +227,7 @@ public class OAuth2ParEndpointTest extends TestOAuthEndpointBase {
         JWTClaimsSet.Builder jwtClaimsSetBuilder = new JWTClaimsSet.Builder();
         jwtClaimsSetBuilder.claim(OAuth.OAUTH_CLIENT_ID, CLIENT_ID_VALUE);
         jwtClaimsSetBuilder.claim(OAuth.OAUTH_REDIRECT_URI, APP_REDIRECT_URL);
-        jwtClaimsSetBuilder.claim(OAuth.OAUTH_RESPONSE_TYPE, RESPONSE_TYPE_CODE);
+        jwtClaimsSetBuilder.claim(OAuth.OAUTH_RESPONSE_TYPE, RESPONSE_TYPE_CODE_ID_TOKEN);
         jwtClaimsSetBuilder.claim(OAuthConstants.OAuth20Params.SCOPE, "openid");
         JWTClaimsSet jwtClaimsSet = jwtClaimsSetBuilder.build();
         String requestJwt = new PlainJWT(jwtClaimsSet).serialize();
@@ -306,8 +303,8 @@ public class OAuth2ParEndpointTest extends TestOAuthEndpointBase {
                 // FAPI request with response type code, response mode query.jwt. Will return bad request error.
                 {requestParams10, paramMap1, oAuthClientAuthnContext1, HttpServletResponse.SC_BAD_REQUEST,
                         OAuth2ErrorCodes.INVALID_REQUEST, false, true},
-                // FAPI request with response type code id_token, response mode query.jwt. Return bad request error.
-                {requestParams11, paramMap4, oAuthClientAuthnContext1, HttpServletResponse.SC_BAD_REQUEST, "", false,
+                // FAPI request with response type code id_token, response mode query.jwt. Will return success
+                {requestParams11, paramMap4, oAuthClientAuthnContext1, HttpServletResponse.SC_CREATED, "", false,
                         true},
                 // FAPI request without code challenge. Will return bad request error.
                 {requestParams11, paramMap1, oAuthClientAuthnContext1, HttpServletResponse.SC_BAD_REQUEST,
@@ -319,7 +316,7 @@ public class OAuth2ParEndpointTest extends TestOAuthEndpointBase {
                 {requestParams13, paramMap1, oAuthClientAuthnContext1, HttpServletResponse.SC_BAD_REQUEST,
                         OAuth2ErrorCodes.INVALID_REQUEST, false, true},
                 // PAR request without duplicate oauth parameters. Will return success.
-                {requestParams14, paramMap5, oAuthClientAuthnContext1, HttpServletResponse.SC_CREATED, "", false, false}
+                {new HashMap<>(), paramMap5, oAuthClientAuthnContext1, HttpServletResponse.SC_CREATED, "", false, false}
         };
     }
 

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/par/OAuth2ParEndpointTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/par/OAuth2ParEndpointTest.java
@@ -18,6 +18,7 @@
 package org.wso2.carbon.identity.oauth.endpoint.par;
 
 import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.PlainJWT;
 import org.apache.oltu.oauth2.as.validator.CodeValidator;
 import org.apache.oltu.oauth2.common.OAuth;
 import org.apache.oltu.oauth2.common.exception.OAuthSystemException;
@@ -35,6 +36,7 @@ import org.wso2.carbon.identity.core.ServiceURLBuilder;
 import org.wso2.carbon.identity.core.util.IdentityDatabaseUtil;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.oauth.common.CodeTokenResponseValidator;
 import org.wso2.carbon.identity.oauth.common.OAuth2ErrorCodes;
 import org.wso2.carbon.identity.oauth.common.OAuthConstants;
 import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
@@ -48,11 +50,14 @@ import org.wso2.carbon.identity.oauth2.OAuth2Service;
 import org.wso2.carbon.identity.oauth2.bean.OAuthClientAuthnContext;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 import org.wso2.carbon.identity.openidconnect.OIDCRequestObjectUtil;
+import org.wso2.carbon.identity.openidconnect.RequestObjectBuilder;
+import org.wso2.carbon.identity.openidconnect.RequestParamRequestObjectBuilder;
 import org.wso2.carbon.identity.openidconnect.model.RequestObject;
 
 import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Hashtable;
 import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
@@ -188,6 +193,7 @@ public class OAuth2ParEndpointTest extends TestOAuthEndpointBase {
         requestParams11.put(OAuthConstants.OAUTH_PKCE_CODE_CHALLENGE, new String[]{"code-challenge-string"});
         requestParams11.put(OAuthConstants.OAUTH_PKCE_CODE_CHALLENGE_METHOD,
                 new String[]{OAuthConstants.OAUTH_PKCE_S256_CHALLENGE});
+        requestParams11.put(OAuthConstants.OAuth20Params.SCOPE, new String[]{"openid"});
 
         Map<String, String[]> requestParams12 = createRequestParamsMap(new String[]{CLIENT_ID_VALUE},
                 new String[]{APP_REDIRECT_URL}, new String[]{RESPONSE_TYPE_CODE});
@@ -202,6 +208,9 @@ public class OAuth2ParEndpointTest extends TestOAuthEndpointBase {
         requestParams13.put(OAuthConstants.OAUTH_PKCE_CODE_CHALLENGE, new String[]{"code-challenge-string"});
         requestParams13.put(OAuthConstants.OAUTH_PKCE_CODE_CHALLENGE_METHOD,
                 new String[]{"Invalid-code-challenge-method"});
+
+        Map<String, String[]> requestParams14 = new HashMap<>();
+        requestParams14.put(OAuthConstants.OAuth20Params.REQUEST, new String[]{"dummyRequest"});
 
         MultivaluedMap<String, String> paramMap1 = new MultivaluedHashMap<>();
         paramMap1.add(OAuth.OAUTH_CLIENT_ID, CLIENT_ID_VALUE);
@@ -218,9 +227,21 @@ public class OAuth2ParEndpointTest extends TestOAuthEndpointBase {
         paramMap3.add(OAuth.OAUTH_RESPONSE_TYPE, RESPONSE_TYPE_CODE);
         paramMap3.add(OAuthConstants.OAuth20Params.SCOPE, null);
 
+        JWTClaimsSet.Builder jwtClaimsSetBuilder = new JWTClaimsSet.Builder();
+        jwtClaimsSetBuilder.claim(OAuth.OAUTH_CLIENT_ID, CLIENT_ID_VALUE);
+        jwtClaimsSetBuilder.claim(OAuth.OAUTH_REDIRECT_URI, APP_REDIRECT_URL);
+        jwtClaimsSetBuilder.claim(OAuth.OAUTH_RESPONSE_TYPE, RESPONSE_TYPE_CODE);
+        jwtClaimsSetBuilder.claim(OAuthConstants.OAuth20Params.SCOPE, "openid");
+        JWTClaimsSet jwtClaimsSet = jwtClaimsSetBuilder.build();
+        String requestJwt = new PlainJWT(jwtClaimsSet).serialize();
+
         MultivaluedMap<String, String> paramMap4 = new MultivaluedHashMap<>();
         paramMap4.add(OAuth.OAUTH_CLIENT_ID, CLIENT_ID_VALUE);
         paramMap4.add(OAuth.OAUTH_RESPONSE_TYPE, RESPONSE_TYPE_CODE_ID_TOKEN);
+        paramMap4.add(OAuthConstants.OAuth20Params.REQUEST, requestJwt);
+
+        MultivaluedMap<String, String> paramMap5 = new MultivaluedHashMap<>();
+        paramMap5.add(OAuthConstants.OAuth20Params.REQUEST, requestJwt);
 
         OAuthClientAuthnContext oAuthClientAuthnContext1 = new OAuthClientAuthnContext();
         oAuthClientAuthnContext1.setAuthenticated(true);
@@ -257,7 +278,7 @@ public class OAuth2ParEndpointTest extends TestOAuthEndpointBase {
                         HttpServletResponse.SC_BAD_REQUEST, OAuth2ErrorCodes.INVALID_REQUEST, false, false},
                 // Request with invalid redirect uri. Will return bad request error
                 {requestParams7, new MultivaluedHashMap<>(), oAuthClientAuthnContext1,
-                        HttpServletResponse.SC_BAD_REQUEST, OAuth2ErrorCodes.INVALID_CALLBACK, false, false},
+                        HttpServletResponse.SC_BAD_REQUEST, OAuth2ErrorCodes.INVALID_REQUEST, false, false},
                 // Request with request uri provided. Will return bad request error
                 {requestParams1, paramMap2, oAuthClientAuthnContext1,
                         HttpServletResponse.SC_BAD_REQUEST, OAuth2ErrorCodes.INVALID_REQUEST, false, false},
@@ -285,8 +306,9 @@ public class OAuth2ParEndpointTest extends TestOAuthEndpointBase {
                 // FAPI request with response type code, response mode query.jwt. Will return bad request error.
                 {requestParams10, paramMap1, oAuthClientAuthnContext1, HttpServletResponse.SC_BAD_REQUEST,
                         OAuth2ErrorCodes.INVALID_REQUEST, false, true},
-                // FAPI request with response type code id_token, response mode query.jwt. Will return success
-                {requestParams11, paramMap4, oAuthClientAuthnContext1, HttpServletResponse.SC_CREATED, "", false, true},
+                // FAPI request with response type code id_token, response mode query.jwt. Return bad request error.
+                {requestParams11, paramMap4, oAuthClientAuthnContext1, HttpServletResponse.SC_BAD_REQUEST, "", false,
+                        true},
                 // FAPI request without code challenge. Will return bad request error.
                 {requestParams11, paramMap1, oAuthClientAuthnContext1, HttpServletResponse.SC_BAD_REQUEST,
                         OAuth2ErrorCodes.INVALID_REQUEST, false, true},
@@ -295,7 +317,9 @@ public class OAuth2ParEndpointTest extends TestOAuthEndpointBase {
                         OAuth2ErrorCodes.INVALID_REQUEST, false, true},
                 // FAPI request with invalid code challenge method. Will return bad request error.
                 {requestParams13, paramMap1, oAuthClientAuthnContext1, HttpServletResponse.SC_BAD_REQUEST,
-                        OAuth2ErrorCodes.INVALID_REQUEST, false, true}
+                        OAuth2ErrorCodes.INVALID_REQUEST, false, true},
+                // PAR request without duplicate oauth parameters. Will return success.
+                {requestParams14, paramMap5, oAuthClientAuthnContext1, HttpServletResponse.SC_CREATED, "", false, false}
         };
     }
 
@@ -415,15 +439,19 @@ public class OAuth2ParEndpointTest extends TestOAuthEndpointBase {
 
         mockStatic(OAuthServerConfiguration.class);
         when(OAuthServerConfiguration.getInstance()).thenReturn(oAuthServerConfiguration);
-        when(oAuthServerConfiguration.getSupportedResponseTypeValidators()).thenReturn(
-                new HashMap<String, Class<? extends OAuthValidator<HttpServletRequest>>>() {{
-                    put(paramMap.getFirst(OAuth.OAUTH_RESPONSE_TYPE), CodeValidator.class);
-                }});
+        Map<String, Class<? extends OAuthValidator<HttpServletRequest>>> responseTypeValidators = new Hashtable<>();
+        responseTypeValidators.put(OAuthConstants.CODE, CodeValidator.class);
+        responseTypeValidators.put(OAuthConstants.CODE_IDTOKEN, CodeTokenResponseValidator.class);
+        when(oAuthServerConfiguration.getSupportedResponseTypeValidators()).thenReturn(responseTypeValidators);
 
         when(oAuthServerConfiguration.getPersistenceProcessor()).thenReturn(tokenPersistenceProcessor);
         when(tokenPersistenceProcessor.getProcessedClientId(anyString())).thenAnswer(
                 invocation -> invocation.getArguments()[0]);
         when(oAuthServerConfiguration.getOAuthAuthzRequestClassName())
                 .thenReturn("org.wso2.carbon.identity.oauth2.model.CarbonOAuthAuthzRequest");
+        when(oAuthServerConfiguration.getRequestObjectBuilders()).thenReturn(
+                new HashMap<String, RequestObjectBuilder>() {{
+                    put("request_param_value_builder", new RequestParamRequestObjectBuilder());
+                }});
     }
 }

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/par/OAuth2ParEndpointTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/par/OAuth2ParEndpointTest.java
@@ -304,8 +304,7 @@ public class OAuth2ParEndpointTest extends TestOAuthEndpointBase {
                 {requestParams10, paramMap1, oAuthClientAuthnContext1, HttpServletResponse.SC_BAD_REQUEST,
                         OAuth2ErrorCodes.INVALID_REQUEST, false, true},
                 // FAPI request with response type code id_token, response mode query.jwt. Will return success
-                {requestParams11, paramMap4, oAuthClientAuthnContext1, HttpServletResponse.SC_CREATED, "", false,
-                        true},
+                {requestParams11, paramMap4, oAuthClientAuthnContext1, HttpServletResponse.SC_CREATED, "", false, true},
                 // FAPI request without code challenge. Will return bad request error.
                 {requestParams11, paramMap1, oAuthClientAuthnContext1, HttpServletResponse.SC_BAD_REQUEST,
                         OAuth2ErrorCodes.INVALID_REQUEST, false, true},

--- a/components/org.wso2.carbon.identity.oauth.par/src/main/java/org/wso2/carbon/identity/oauth/par/core/ParAuthServiceImpl.java
+++ b/components/org.wso2.carbon.identity.oauth.par/src/main/java/org/wso2/carbon/identity/oauth/par/core/ParAuthServiceImpl.java
@@ -92,7 +92,7 @@ public class ParAuthServiceImpl implements ParAuthService {
 
         Optional<ParRequestDO> optionalParRequestDO = parMgtDAO.getRequestData(uuid);
         if (!optionalParRequestDO.isPresent()) {
-            throw new ParClientException(OAuth2ErrorCodes.INVALID_REQUEST,
+            throw new ParClientException(OAuth2ErrorCodes.OAuth2SubErrorCodes.INVALID_REQUEST_URI,
                     OAuthConstants.OAuthError.AuthorizationResponsei18nKey.INVALID_REQUEST_URI);
         }
 
@@ -121,7 +121,7 @@ public class ParAuthServiceImpl implements ParAuthService {
         long currentTimeInMillis = Calendar.getInstance(TimeZone.getTimeZone(ParConstants.UTC)).getTimeInMillis();
 
         if (currentTimeInMillis > expiresIn) {
-            throw new ParClientException(OAuth2ErrorCodes.INVALID_REQUEST,
+            throw new ParClientException(OAuth2ErrorCodes.OAuth2SubErrorCodes.INVALID_REQUEST_URI,
                     OAuthConstants.OAuthError.AuthorizationResponsei18nKey.REQUEST_URI_EXPIRED);
         }
     }

--- a/components/org.wso2.carbon.identity.oauth.par/src/test/java/org/wso2/carbon/identity/oauth/par/core/ParAuthServiceTest.java
+++ b/components/org.wso2.carbon.identity.oauth.par/src/test/java/org/wso2/carbon/identity/oauth/par/core/ParAuthServiceTest.java
@@ -148,7 +148,8 @@ public class ParAuthServiceTest extends PowerMockTestCase {
 
         return new Object[][]{
                 // Expired request uri
-                {System.currentTimeMillis() - 5, CLIENT_ID_VALUE, OAuth2ErrorCodes.INVALID_REQUEST},
+                {System.currentTimeMillis() - 5, CLIENT_ID_VALUE,
+                        OAuth2ErrorCodes.OAuth2SubErrorCodes.INVALID_REQUEST_URI},
                 // Mismatching client ids
                 {System.currentTimeMillis() + 60, "ga39a580f545777860e44e75b605d920", OAuth2ErrorCodes.INVALID_REQUEST}
         };

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/RequestObjectValidatorUtil.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/RequestObjectValidatorUtil.java
@@ -77,8 +77,8 @@ public class RequestObjectValidatorUtil {
                     oAuth2Parameters.getTenantDomain());
             String algorithm = oAuthAppDO.getRequestObjectSignatureAlgorithm();
             if (StringUtils.isNotEmpty(algorithm) && !algorithm.equals(jwt.getHeader().getAlgorithm().getName())) {
-                throw new RequestObjectException("Request Object signature verification failed. Invalid signature " +
-                        "algorithm.", OAuth2ErrorCodes.INVALID_REQUEST);
+                throw new RequestObjectException(OAuth2ErrorCodes.INVALID_REQUEST,
+                        "Request Object signature verification failed. Invalid signature algorithm.");
             }
         } catch (IdentityOAuth2Exception | InvalidOAuthClientException e) {
             throw new RequestObjectException(OAuth2ErrorCodes.SERVER_ERROR, "Error while retrieving Oauth application "
@@ -100,12 +100,12 @@ public class RequestObjectValidatorUtil {
         String clientId = oAuth2Parameters.getClientId();
 
         if (!isValidSignatureAlgorithm(clientId, alg)) {
-            throw new RequestObjectException("Request Object signature verification failed. Invalid signature " +
-                    "algorithm.", OAuth2ErrorCodes.INVALID_REQUEST);
+            throw new RequestObjectException(OAuth2ErrorCodes.INVALID_REQUEST,
+                    "Request Object signature verification failed. Invalid signature algorithm.");
         }
         if (isFapiConformant(clientId) && !isValidFAPISignatureAlgorithm(clientId, alg)) {
-            throw new RequestObjectException("Request Object signature verification failed. Invalid signature " +
-                    "algorithm.", OAuth2ErrorCodes.INVALID_REQUEST);
+            throw new RequestObjectException(OAuth2ErrorCodes.INVALID_REQUEST,
+                    "Request Object signature verification failed. Invalid signature algorithm.");
         }
         if (certificate == null) {
             if (log.isDebugEnabled()) {
@@ -144,8 +144,8 @@ public class RequestObjectValidatorUtil {
         try {
             spProperties = OAuth2Util.getServiceProvider(clientId).getSpProperties();
         } catch (IdentityOAuth2Exception e) {
-            throw new RequestObjectException("Error while getting the service provider for client ID " + clientId,
-                    OAuth2ErrorCodes.SERVER_ERROR, e);
+            throw new RequestObjectException(OAuth2ErrorCodes.SERVER_ERROR,
+                    "Error while getting the service provider for client ID " + clientId, e);
         }
 
         if (spProperties != null) {
@@ -183,7 +183,9 @@ public class RequestObjectValidatorUtil {
                 return new JWKSBasedJWTValidator().validateSignature(jwtString, jwksUri, alg, MapUtils.EMPTY_MAP);
             } catch (IdentityOAuth2Exception e) {
                 String errorMessage = "Error occurred while validating request object signature using jwks endpoint";
-                throw new RequestObjectException(errorMessage, OAuth2ErrorCodes.SERVER_ERROR, e);
+                String errorDetail = e.getCause() != null && StringUtils.isNotBlank(e.getCause().getMessage()) ?
+                        ": " + e.getCause().getMessage() : StringUtils.EMPTY;
+                throw new RequestObjectException(OAuth2ErrorCodes.SERVER_ERROR, errorMessage + errorDetail, e);
             }
         } else {
             log.warn("JWKS URI is empty");

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/RequestObjectValidatorUtil.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/RequestObjectValidatorUtil.java
@@ -183,9 +183,7 @@ public class RequestObjectValidatorUtil {
                 return new JWKSBasedJWTValidator().validateSignature(jwtString, jwksUri, alg, MapUtils.EMPTY_MAP);
             } catch (IdentityOAuth2Exception e) {
                 String errorMessage = "Error occurred while validating request object signature using jwks endpoint";
-                String errorDetail = e.getCause() != null && StringUtils.isNotBlank(e.getCause().getMessage()) ?
-                        ": " + e.getCause().getMessage() : StringUtils.EMPTY;
-                throw new RequestObjectException(OAuth2ErrorCodes.SERVER_ERROR, errorMessage + errorDetail, e);
+                throw new RequestObjectException(OAuth2ErrorCodes.SERVER_ERROR, errorMessage, e);
             }
         } else {
             log.warn("JWKS URI is empty");


### PR DESCRIPTION
### Proposed changes in this pull request

This pr allows sending the /par request without sending duplicates of oauth2 parameters as request parameters when request object is sent.

### Related issues
https://github.com/wso2/product-is/issues/18874
