### PR TITLE
Implement token revocation specific for application roles

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthUtil.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthUtil.java
@@ -30,7 +30,10 @@ import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.application.authentication.framework.exception.UserIdNotFoundException;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
 import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
+import org.wso2.carbon.identity.application.common.model.ServiceProvider;
 import org.wso2.carbon.identity.application.common.model.User;
+import org.wso2.carbon.identity.application.mgt.ApplicationConstants;
+import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.base.IdentityConstants;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
@@ -51,6 +54,11 @@ import org.wso2.carbon.identity.oauth2.model.AccessTokenDO;
 import org.wso2.carbon.identity.oauth2.model.AuthzCodeDO;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
+import org.wso2.carbon.identity.role.v2.mgt.core.RoleConstants;
+import org.wso2.carbon.identity.role.v2.mgt.core.RoleManagementService;
+import org.wso2.carbon.identity.role.v2.mgt.core.exception.IdentityRoleManagementException;
+import org.wso2.carbon.identity.role.v2.mgt.core.model.AssociatedApplication;
+import org.wso2.carbon.identity.role.v2.mgt.core.model.Role;
 import org.wso2.carbon.user.api.Tenant;
 import org.wso2.carbon.user.core.UserStoreException;
 import org.wso2.carbon.user.core.UserStoreManager;
@@ -59,6 +67,7 @@ import org.wso2.carbon.user.core.util.UserCoreUtil;
 import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -664,42 +673,67 @@ public final class OAuthUtil {
     }
 
     /**
-     * This method will revoke the accesstokens of user.
-     * @param username username.
-     * @param userStoreManager userStoreManager.
-     * @return true if revocation is successfull. Else return false
-     * @throws UserStoreException
+     * This method can be used to build the AuthenticatedUser object.
+     * @param username          username.
+     * @param userStoreDomain   userStoreDomain.
+     * @return AuthenticatedUser.
      */
-    public static boolean revokeTokens(String username, UserStoreManager userStoreManager) throws UserStoreException {
+    private static AuthenticatedUser buildAuthenticatedUser(String username, String userStoreDomain,
+                                                            String tenantDomain) {
 
-        String userStoreDomain = UserCoreUtil.getDomainName(userStoreManager.getRealmConfiguration());
-        String tenantDomain = IdentityTenantUtil.getTenantDomain(userStoreManager.getTenantId());
         AuthenticatedUser authenticatedUser = new AuthenticatedUser();
         authenticatedUser.setUserStoreDomain(userStoreDomain);
         authenticatedUser.setTenantDomain(tenantDomain);
         authenticatedUser.setUserName(username);
+        return authenticatedUser;
+    }
 
-        /* This userStoreDomain variable is used for access token table partitioning. So it is set to null when access
-        token table partitioning is not enabled.*/
-        userStoreDomain = null;
-        if (OAuth2Util.checkAccessTokenPartitioningEnabled() && OAuth2Util.checkUserNameAssertionEnabled()) {
+    /**
+     * Get clientIds of associated application of an application role.
+     * @param role          Role object.
+     * @param tenantDomain  Tenant domain.
+     * @return Set of clientIds of associated applications.
+     */
+    private static Set<String> getClientIdsOfAssociatedApplications(Role role, String tenantDomain) {
+
+        ApplicationManagementService applicationManagementService =
+                OAuthComponentServiceHolder.getInstance().getApplicationManagementService();
+        List<AssociatedApplication> associatedApplications = role.getAssociatedApplications();
+        Set<String> clientIds = new HashSet<>();
+        associatedApplications.forEach(associatedApplication -> {
             try {
-                userStoreDomain = OAuth2Util.getUserStoreForFederatedUser(authenticatedUser);
-            } catch (IdentityOAuth2Exception e) {
-                LOG.error("Error occurred while getting user store domain for User ID : " + authenticatedUser, e);
-                throw new UserStoreException(e);
+                ServiceProvider application = applicationManagementService
+                        .getApplicationByResourceId(associatedApplication.getId(), tenantDomain);
+                if (application == null || application.getInboundAuthenticationConfig() == null) {
+                    return;
+                }
+                Arrays.stream(application.getInboundAuthenticationConfig().getInboundAuthenticationRequestConfigs())
+                        .forEach(inboundAuthenticationRequestConfig -> {
+                            if (ApplicationConstants.StandardInboundProtocols.OAUTH2.equals(
+                                    inboundAuthenticationRequestConfig.getInboundAuthType())) {
+                                clientIds.add(inboundAuthenticationRequestConfig.getInboundAuthKey());
+                            }
+                        });
+            } catch (IdentityApplicationManagementException e) {
+                String errorMessage = "Error occurred while retrieving application of id : " +
+                        associatedApplication.getId();
+                LOG.error(errorMessage);
             }
-        }
+        });
+        return clientIds;
+    }
 
-        Set<String> clientIds;
-        try {
-            // get all the distinct client Ids authorized by this user
-            clientIds = OAuthTokenPersistenceFactory.getInstance()
-                    .getTokenManagementDAO().getAllTimeAuthorizedClientIds(authenticatedUser);
-        } catch (IdentityOAuth2Exception e) {
-            LOG.error("Error occurred while retrieving apps authorized by User ID : " + authenticatedUser, e);
-            throw new UserStoreException(e);
-        }
+    /**
+     * Initiate token revocation process for the associated clientIds for the given user.
+     * @param clientIds          Set of clientIds
+     * @param authenticatedUser  Authenticated User object of the user.
+     * @param userStoreDomain    User store domain of the user.
+     * @param username           Username.
+     * @return True if token revocation is successful. Else return false.
+     */
+    private static boolean processTokenRevocation(Set<String> clientIds, AuthenticatedUser authenticatedUser,
+                                                  String userStoreDomain, String username) {
+
         boolean isErrorOnRevokingTokens = false;
         for (String clientId : clientIds) {
             try {
@@ -789,6 +823,109 @@ public final class OAuthUtil {
                 isErrorOnRevokingTokens = true;
             }
         }
+
+        return isErrorOnRevokingTokens;
+    }
+
+    /**
+     * This method will revoke the access tokens of user.
+     * @param username username.
+     * @param userStoreManager userStoreManager.
+     * @param roleId roleId.
+     * @return true if revocation is successful. Else return false.
+     */
+    public static boolean revokeTokens(String username, UserStoreManager userStoreManager, String roleId)
+            throws UserStoreException {
+
+        String userStoreDomain = UserCoreUtil.getDomainName(userStoreManager.getRealmConfiguration());
+        String tenantDomain = IdentityTenantUtil.getTenantDomain(userStoreManager.getTenantId());
+        AuthenticatedUser authenticatedUser = buildAuthenticatedUser(username, userStoreDomain, tenantDomain);
+
+        /* This userStoreDomain variable is used for access token table partitioning. So it is set to null when access
+        token table partitioning is not enabled.*/
+        userStoreDomain = null;
+        if (OAuth2Util.checkAccessTokenPartitioningEnabled() && OAuth2Util.checkUserNameAssertionEnabled()) {
+            try {
+                userStoreDomain = OAuth2Util.getUserStoreForFederatedUser(authenticatedUser);
+            } catch (IdentityOAuth2Exception e) {
+                LOG.error("Error occurred while getting user store domain for User ID : " + authenticatedUser, e);
+                throw new UserStoreException(e);
+            }
+        }
+
+        // Get details about the role to identify the audience and associated applications.
+        Role role;
+        try {
+            RoleManagementService roleV2ManagementService =
+                    OAuthComponentServiceHolder.getInstance().getRoleV2ManagementService();
+            role = roleV2ManagementService.getRole(roleId, tenantDomain);
+        } catch (IdentityRoleManagementException e) {
+            String errorMessage = "Error occurred while retrieving role of id : " + roleId;
+            throw new UserStoreException(errorMessage, e);
+        }
+
+        Set<String> clientIds;
+        if (role != null && RoleConstants.APPLICATION.equals(role.getAudience())) {
+            // Get clientIds of associated applications for the specific application role.
+            clientIds = getClientIdsOfAssociatedApplications(role, tenantDomain);
+        } else {
+            try {
+                // Get all the distinct client Ids authorized by this user.
+                // This is applicable for organization roles as well.
+                clientIds = OAuthTokenPersistenceFactory.getInstance()
+                        .getTokenManagementDAO().getAllTimeAuthorizedClientIds(authenticatedUser);
+            } catch (IdentityOAuth2Exception e) {
+                LOG.error("Error occurred while retrieving apps authorized by User ID : " + authenticatedUser, e);
+                throw new UserStoreException(e);
+            }
+        }
+
+        boolean isErrorOnRevokingTokens;
+        isErrorOnRevokingTokens = processTokenRevocation(clientIds, authenticatedUser, userStoreDomain, username);
+
+        // Throw exception if there was any error found in revoking tokens.
+        if (isErrorOnRevokingTokens) {
+            throw new UserStoreException("Error occurred while revoking Access Tokens of the user " + username);
+        }
+        return true;
+    }
+
+    /**
+     * This method will revoke the accesstokens of user.
+     * @param username username.
+     * @param userStoreManager userStoreManager.
+     * @return true if revocation is successfull. Else return false
+     * @throws UserStoreException
+     */
+    public static boolean revokeTokens(String username, UserStoreManager userStoreManager) throws UserStoreException {
+
+        String userStoreDomain = UserCoreUtil.getDomainName(userStoreManager.getRealmConfiguration());
+        String tenantDomain = IdentityTenantUtil.getTenantDomain(userStoreManager.getTenantId());
+        AuthenticatedUser authenticatedUser = buildAuthenticatedUser(username, userStoreDomain, tenantDomain);
+
+        /* This userStoreDomain variable is used for access token table partitioning. So it is set to null when access
+        token table partitioning is not enabled.*/
+        userStoreDomain = null;
+        if (OAuth2Util.checkAccessTokenPartitioningEnabled() && OAuth2Util.checkUserNameAssertionEnabled()) {
+            try {
+                userStoreDomain = OAuth2Util.getUserStoreForFederatedUser(authenticatedUser);
+            } catch (IdentityOAuth2Exception e) {
+                LOG.error("Error occurred while getting user store domain for User ID : " + authenticatedUser, e);
+                throw new UserStoreException(e);
+            }
+        }
+
+        Set<String> clientIds;
+        try {
+            // get all the distinct client Ids authorized by this user
+            clientIds = OAuthTokenPersistenceFactory.getInstance()
+                    .getTokenManagementDAO().getAllTimeAuthorizedClientIds(authenticatedUser);
+        } catch (IdentityOAuth2Exception e) {
+            LOG.error("Error occurred while retrieving apps authorized by User ID : " + authenticatedUser, e);
+            throw new UserStoreException(e);
+        }
+        boolean isErrorOnRevokingTokens;
+        isErrorOnRevokingTokens = processTokenRevocation(clientIds, authenticatedUser, userStoreDomain, username);
 
         // Throw exception if there was any error found in revoking tokens.
         if (isErrorOnRevokingTokens) {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/internal/OAuthComponentServiceHolder.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/internal/OAuthComponentServiceHolder.java
@@ -20,6 +20,7 @@ package org.wso2.carbon.identity.oauth.internal;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.oauth.OAuthAdminServiceImpl;
 import org.wso2.carbon.identity.oauth.common.token.bindings.TokenBinderInfo;
 import org.wso2.carbon.identity.oauth.dto.TokenBindingMetaDataDTO;
@@ -61,11 +62,13 @@ public class OAuthComponentServiceHolder {
     private List<ScopeValidationHandler> scopeValidationHandlers = new ArrayList<>();
     private Map<Integer, OAuthApplicationMgtListener> oAuthApplicationMgtListeners = new TreeMap<>();
     private RoleManagementService roleManagementService;
+    private org.wso2.carbon.identity.role.v2.mgt.core.RoleManagementService roleV2ManagementService;
     private OrganizationUserResidentResolverService organizationUserResidentResolverService;
     private OrganizationManager organizationManager;
     private List<AccessTokenResponseHandler> accessTokenResponseHandlers = new ArrayList<>();
     private AccessTokenDAO accessTokenDAOService;
     private TokenManagementDAO tokenManagementDAOService;
+    private ApplicationManagementService applicationManagementService;
 
     /**
      * Get the list of scope validator implementations available.
@@ -261,6 +264,27 @@ public class OAuthComponentServiceHolder {
     }
 
     /**
+     * Set RoleManagementService instance.
+     *
+     * @param roleManagementService RoleManagementService instance.
+     */
+    public void setRoleV2ManagementService(
+            org.wso2.carbon.identity.role.v2.mgt.core.RoleManagementService roleManagementService) {
+
+        this.roleV2ManagementService = roleManagementService;
+    }
+
+    /**
+     * Get RoleManagementService instance.
+     *
+     * @return RoleManagementService instance.
+     */
+    public org.wso2.carbon.identity.role.v2.mgt.core.RoleManagementService getRoleV2ManagementService() {
+
+        return roleV2ManagementService;
+    }
+
+    /**
      * Get OrganizationUserResidentResolverService instance.
      *
      * @return OrganizationUserResidentResolverService instance.
@@ -369,5 +393,25 @@ public class OAuthComponentServiceHolder {
     public void setTokenManagementDAOService(TokenManagementDAO tokenManagementDAOService) {
 
         this.tokenManagementDAOService = tokenManagementDAOService;
+    }
+
+    /**
+     * Get ApplicationManagementService instance.
+     *
+     * @return ApplicationManagementService {@link ApplicationManagementService} instance.
+     */
+    public ApplicationManagementService getApplicationManagementService() {
+
+        return applicationManagementService;
+    }
+
+    /**
+     * Set ApplicationManagementService instance.
+     *
+     * @param applicationManagementService {@link ApplicationManagementService} instance.
+     */
+    public void setApplicationManagementService(ApplicationManagementService applicationManagementService) {
+
+        this.applicationManagementService = applicationManagementService;
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/internal/OAuthServiceComponent.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/internal/OAuthServiceComponent.java
@@ -27,6 +27,7 @@ import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
 import org.wso2.carbon.identity.application.authentication.framework.UserSessionManagementService;
+import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.core.util.IdentityCoreInitializedEvent;
 import org.wso2.carbon.identity.event.handler.AbstractEventHandler;
 import org.wso2.carbon.identity.oauth.OAuthAdminServiceImpl;
@@ -333,6 +334,25 @@ public class OAuthServiceComponent {
     }
 
     @Reference(
+            name = "org.wso2.carbon.identity.role.v2.mgt.core.internal.RoleManagementServiceComponent",
+            service = org.wso2.carbon.identity.role.v2.mgt.core.RoleManagementService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetRoleV2ManagementService"
+    )
+    private void setRoleV2ManagementService(
+            org.wso2.carbon.identity.role.v2.mgt.core.RoleManagementService roleV2ManagementService) {
+
+        OAuthComponentServiceHolder.getInstance().setRoleV2ManagementService(roleV2ManagementService);
+    }
+
+    private void unsetRoleV2ManagementService(
+            org.wso2.carbon.identity.role.v2.mgt.core.RoleManagementService roleV2ManagementService) {
+
+        OAuthComponentServiceHolder.getInstance().setRoleV2ManagementService(null);
+    }
+
+    @Reference(
             name = "organization.user.resident.resolver.service",
             service = OrganizationUserResidentResolverService.class,
             cardinality = ReferenceCardinality.MANDATORY,
@@ -375,5 +395,34 @@ public class OAuthServiceComponent {
 
         OAuthComponentServiceHolder.getInstance().setOrganizationManager(null);
         log.debug("Unset organization management service.");
+    }
+
+    @Reference(
+            name = "application.mgt.service",
+            service = ApplicationManagementService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetApplicationManagementService"
+    )
+    protected void setApplicationManagementService(ApplicationManagementService applicationManagementService) {
+
+        if (log.isDebugEnabled()) {
+            log.debug("Setting ApplicationManagement Service");
+        }
+        OAuthComponentServiceHolder.getInstance().
+                setApplicationManagementService(applicationManagementService);
+    }
+
+    /**
+     * Unsets ApplicationManagement Service.
+     *
+     * @param applicationManagementService An instance of ApplicationManagementService
+     */
+    protected void unsetApplicationManagementService(ApplicationManagementService applicationManagementService) {
+
+        if (log.isDebugEnabled()) {
+            log.debug("Unsetting ApplicationManagement.");
+        }
+        OAuthComponentServiceHolder.getInstance().setApplicationManagementService(null);
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/tokenprocessor/DefaultOAuth2RevocationProcessor.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/tokenprocessor/DefaultOAuth2RevocationProcessor.java
@@ -56,4 +56,11 @@ public class DefaultOAuth2RevocationProcessor implements OAuth2RevocationProcess
 
         return OAuthUtil.revokeTokens(username, userStoreManager);
     }
+
+    @Override
+    public boolean revokeTokens(String username, UserStoreManager userStoreManager, String roleId)
+            throws UserStoreException {
+
+        return OAuthUtil.revokeTokens(username, userStoreManager, roleId);
+    }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/tokenprocessor/OAuth2RevocationProcessor.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/tokenprocessor/OAuth2RevocationProcessor.java
@@ -62,4 +62,15 @@ public interface OAuth2RevocationProcessor {
      * @throws UserStoreException If an error occurs while revoking tokens for users.
      */
     boolean revokeTokens(String username, UserStoreManager userStoreManager) throws UserStoreException;
+
+    /**
+     * Handle indirect token revocation for internal user events.
+     *
+     * @param username         User on which the event occurred.
+     * @param userStoreManager User store manager.
+     * @param roleId           Role id of the relevant role.
+     * @return true if revocation is successful. Else return false.
+     * @throws UserStoreException If an error occurs while revoking tokens for users.
+     */
+    boolean revokeTokens(String username, UserStoreManager userStoreManager, String roleId) throws UserStoreException;
 }


### PR DESCRIPTION
When a user is removed from a specific application role, all tokens generated for that user is revokes irrespective of the application. With this implementation, only the tokens related to the applications associated with that specific app role will be revoked.

Related issue:
- https://github.com/wso2/product-is/issues/18815
