### PR TITLE
Add support to use legacy scopes as an alias for new scopes

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
+++ b/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
@@ -213,6 +213,7 @@ public final class OAuthConstants {
     //Constants used for multiple scopes
     public static final String OIDC_SCOPE_CONFIG_PATH = "oidc-scope-config.xml";
     public static final String OAUTH_SCOPE_BINDING_PATH = "oauth-scope-bindings.xml";
+    public static final String RESOURCE_ACCESS_CONTROL_V2_CONFIG_PATH = "resource-access-control-v2.xml";
     public static final String SCOPE_RESOURCE_PATH = "/oidc";
 
     public static final String RESTRICT_UNASSIGNED_SCOPES = "restrict.unassigned.scopes";

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2013, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2013-2024, WSO2 LLC. (http://www.wso2.com).
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -166,6 +166,7 @@ public class OAuthServerConfiguration {
     private boolean allowCrossTenantIntrospection = true;
     private boolean useClientIdAsSubClaimForAppTokens = true;
     private boolean removeUsernameFromIntrospectionResponseForAppTokens = true;
+    private boolean useLegacyScopesAsAliasForNewScopes = false;
     private String accessTokenPartitioningDomains = null;
     private TokenPersistenceProcessor persistenceProcessor = null;
     private Set<OAuthCallbackHandlerMetaData> callbackHandlerMetaData = new HashSet<>();
@@ -514,6 +515,9 @@ public class OAuthServerConfiguration {
 
         // Read config for RoleBasedScopeIssuer in GlobalScopeValidators enabled.
         parseRoleBasedScopeIssuerEnabled(oauthElem);
+
+        // Read config for using legacy scopes as alias for new scopes.
+        parseUseLegacyScopesAsAliasForNewScopes(oauthElem);
     }
 
     /**
@@ -3577,6 +3581,32 @@ public class OAuthServerConfiguration {
         return removeUsernameFromIntrospectionResponseForAppTokens;
     }
 
+    /**
+     * Parse the UseLegacyScopesAsAliasForNewScopes configuration that used to use legacy scopes as alias for
+     * new scopes.
+     *
+     * @param oauthConfigElem oauthConfigElem.
+     */
+    private void parseUseLegacyScopesAsAliasForNewScopes(OMElement oauthConfigElem) {
+
+        OMElement useLegacyScopesAsAliasForNewScopesElem = oauthConfigElem.getFirstChildWithName(
+                getQNameWithIdentityNS(ConfigElements.USE_LEGACY_SCOPES_AS_ALIAS_FOR_NEW_SCOPES));
+        if (useLegacyScopesAsAliasForNewScopesElem != null) {
+            useLegacyScopesAsAliasForNewScopes = Boolean.parseBoolean(useLegacyScopesAsAliasForNewScopesElem.getText());
+        }
+    }
+
+    /**
+     * This method returns the value of the property UseLegacyScopesAsAliasForNewScopes for the OAuth configuration in
+     * identity.xml.
+     *
+     * @return true if the UseLegacyScopesAsAliasForNewScopes is enabled.
+     */
+    public boolean isUseLegacyScopesAsAliasForNewScopesEnabled() {
+
+        return useLegacyScopesAsAliasForNewScopes;
+    }
+
     private static void setOAuthResponseJspPageAvailable() {
 
         java.nio.file.Path path = Paths.get(CarbonUtils.getCarbonHome(), "repository", "deployment",
@@ -3904,6 +3934,7 @@ public class OAuthServerConfiguration {
                 "SkipOIDCClaimsForClientCredentialGrant";
         private static final String SUPPORTED_TOKEN_ENDPOINT_SIGNING_ALGS = "SupportedTokenEndpointSigningAlgorithms";
         private static final String SUPPORTED_TOKEN_ENDPOINT_SIGNING_ALG = "SupportedTokenEndpointSigningAlgorithm";
+        private static final String USE_LEGACY_SCOPES_AS_ALIAS_FOR_NEW_SCOPES = "UseLegacyScopesAsAliasForNewScopes";
     }
 
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuth2ServiceComponentHolder.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuth2ServiceComponentHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2023, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2014-2024, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -62,6 +62,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * OAuth2 Service component data holder
@@ -110,6 +111,8 @@ public class OAuth2ServiceComponentHolder {
     private AuthorizedAPIManagementService authorizedAPIManagementService;
     private APIResourceManager apiResourceManager;
     private RoleManagementService roleManagementServiceV2;
+    private Map<String, Set<String>> legacyScopesToNewScopesMap = new HashMap<>();
+    private Map<String, Set<String>> legacyMultipleScopesToNewScopesMap = new HashMap<>();
 
     private OAuth2ServiceComponentHolder() {
 
@@ -791,5 +794,45 @@ public class OAuth2ServiceComponentHolder {
     public void setRoleManagementServiceV2(RoleManagementService roleManagementServiceV2) {
 
         this.roleManagementServiceV2 = roleManagementServiceV2;
+    }
+
+    /**
+     * Get the map of legacy scopes to new scopes.
+     *
+     * @return Map of legacy scopes to new scopes.
+     */
+    public Map<String, Set<String>> getLegacyScopesToNewScopesMap() {
+
+        return legacyScopesToNewScopesMap;
+    }
+
+    /**
+     * Set the map of legacy scopes to new scopes.
+     *
+     * @param legacyScopesToNewScopesMap Map of legacy scopes to new scopes.
+     */
+    public void setLegacyScopesToNewScopesMap(Map<String, Set<String>> legacyScopesToNewScopesMap) {
+
+        this.legacyScopesToNewScopesMap = legacyScopesToNewScopesMap;
+    }
+
+    /**
+     * Get the map of legacy multiple scopes to new scopes.
+     *
+     * @return Map of legacy multiple scopes to new scopes.
+     */
+    public Map<String, Set<String>> getLegacyMultipleScopesToNewScopesMap() {
+
+        return legacyMultipleScopesToNewScopesMap;
+    }
+
+    /**
+     * Set the map of legacy multiple scopes to new scopes.
+     *
+     * @param legacyMultipleScopesToNewScopesMap Map of legacy multiple scopes to new scopes.
+     */
+    public void setLegacyMultipleScopesToNewScopesMap(Map<String, Set<String>> legacyMultipleScopesToNewScopesMap) {
+
+        this.legacyMultipleScopesToNewScopesMap = legacyMultipleScopesToNewScopesMap;
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/model/ResourceAccessControlKey.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/model/ResourceAccessControlKey.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth2.model;
+
+import java.util.Objects;
+
+/**
+ * This class represents the key for the resource access control map.
+ */
+public class ResourceAccessControlKey {
+
+    private String endpointRegex;
+    private String httpMethod;
+
+    /**
+     * Get the endpoint regex.
+     *
+     * @return endpoint regex.
+     */
+    public String getEndpointRegex() {
+
+        return endpointRegex;
+    }
+
+    /**
+     * Set the endpoint regex.
+     *
+     * @param endpointRegex Endpoint regex.
+     */
+    public void setEndpointRegex(String endpointRegex) {
+
+        this.endpointRegex = endpointRegex;
+    }
+
+    /**
+     * Get the http method.
+     *
+     * @return Http method.
+     */
+    public String getHttpMethod() {
+
+        return httpMethod;
+    }
+
+    /**
+     * Set the http method.
+     *
+     * @param httpMethod Http method.
+     */
+    public void setHttpMethod(String httpMethod) {
+
+        this.httpMethod = httpMethod;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ResourceAccessControlKey that = (ResourceAccessControlKey) o;
+        return Objects.equals(endpointRegex, that.endpointRegex) && Objects.equals(httpMethod, that.httpMethod);
+    }
+
+    @Override
+    public int hashCode() {
+
+        return Objects.hash(endpointRegex, httpMethod);
+    }
+}


### PR DESCRIPTION
### Proposed changes in this pull request
Prior to IS 7.0.0, some of the internal scopes were used as shared scopes for multiple APIs for the access control. With the introduction of new authorization runtime with IS 7.0.0, new internal scopes were introduced for some of the APIs which previously used shared scopes. This PR will allow to use the legacy scopes as an alias to obtain new scopes corresponding to legacy scopes

Related Issues - https://github.com/wso2/product-is/issues/18826