### PR TITLE
Add Config to Enable/ Disable x5t Param in JWKS Response

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/jwks/JwksEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/jwks/JwksEndpoint.java
@@ -68,6 +68,7 @@ public class JwksEndpoint {
     private static final String SECURITY_KEY_STORE_PW = "Security.KeyStore.Password";
     private static final String KEYS = "keys";
     private static final String ADD_PREVIOUS_VERSION_KID = "JWTValidatorConfigs.JWKSEndpoint.AddPreviousVersionKID";
+    private static final String ENABLE_X5T_IN_RESPONSE = "JWTValidatorConfigs.JWKSEndpoint.EnableX5TInResponse";
 
     @GET
     @Path(value = "/jwks")
@@ -168,7 +169,9 @@ public class JwksEndpoint {
         jwk.algorithm(algorithm);
         jwk.keyUse(KeyUse.parse(KEY_USE));
         jwk.x509CertChain(encodedCertList);
-        jwk.x509CertSHA256Thumbprint(new Base64URL(OAuth2Util.getThumbPrint(certificate, alias)));
+        if (Boolean.parseBoolean(IdentityUtil.getProperty(ENABLE_X5T_IN_RESPONSE))) {
+            jwk.x509CertSHA256Thumbprint(new Base64URL(OAuth2Util.getThumbPrint(certificate, alias)));
+        }
         return jwk;
     }
 

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/jwks/JwksEndpointTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/jwks/JwksEndpointTest.java
@@ -84,7 +84,6 @@ public class JwksEndpointTest extends PowerMockIdentityBaseTest {
     private static final String ALG = "RS256";
     private static final String USE = "sig";
     private static final String ENABLE_X5T_IN_RESPONSE = "JWTValidatorConfigs.JWKSEndpoint.EnableX5TInResponse";
-
     private static final JSONArray X5C_ARRAY = new JSONArray();
     private static final String X5T = "YmUwN2EzOGI3ZTI0Y2NiNTNmZWFlZjI5MmVjZjdjZTYzZjI0M2MxNDQ1YjQwNjI3NjY" +
             "yZmZlYzkwNzY0YjU4NQ";

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/jwks/JwksEndpointTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/jwks/JwksEndpointTest.java
@@ -83,6 +83,8 @@ public class JwksEndpointTest extends PowerMockIdentityBaseTest {
     private static final String CERT_THUMB_PRINT = "generatedCertThrumbPrint";
     private static final String ALG = "RS256";
     private static final String USE = "sig";
+    private static final String ENABLE_X5T_IN_RESPONSE = "JWTValidatorConfigs.JWKSEndpoint.EnableX5TInResponse";
+
     private static final JSONArray X5C_ARRAY = new JSONArray();
     private static final String X5T = "YmUwN2EzOGI3ZTI0Y2NiNTNmZWFlZjI5MmVjZjdjZTYzZjI0M2MxNDQ1YjQwNjI3NjY" +
             "yZmZlYzkwNzY0YjU4NQ";
@@ -200,6 +202,8 @@ public class JwksEndpointTest extends PowerMockIdentityBaseTest {
         if ("foo.com".equals(tenantDomain)) {
             when(OAuth2Util.mapSignatureAlgorithmForJWSAlgorithm("SHA512withRSA")).thenReturn(JWSAlgorithm.RS256);
         }
+        mockStatic(IdentityUtil.class);
+        when(IdentityUtil.getProperty(ENABLE_X5T_IN_RESPONSE)).thenReturn("true");
         when(OAuth2Util.getThumbPrint(any(), anyString())).thenReturn("YmUwN2EzOGI3ZTI0Y2NiNTNmZWFlZjI5Mm" +
                 "VjZjdjZTYzZjI0M2MxNDQ1YjQwNjI3NjYyZmZlYzkwNzY0YjU4NQ");
         mockStatic(KeyStoreManager.class);


### PR DESCRIPTION
### Purpose
- $Subject

### Note
- This config is enabled by default.
- In order to disable it, add the following lines to `deployment.toml`.
```
[oauth.jwks_endpoint]
enable_x5t_in_response=false
```

### Related Issues
- https://github.com/wso2/product-is/issues/18839

### Related PRs
- 