### PR TITLE
Add api based logout support

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
+++ b/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
@@ -127,6 +127,7 @@ public final class OAuthConstants {
 
     public static final String ENABLE_TLS_CERT_BOUND_ACCESS_TOKENS_VIA_BINDING_TYPE = "OAuth.OpenIDConnect." +
             "EnableTLSCertificateBoundAccessTokensViaBindingType";
+    public static final String IS_API_BASED_LOGOUT_WITHOUT_COOKIES = "isAPIBasedLogoutWithoutCookies";
 
     /**
      * Enum for OIDC supported subject types.

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/bindings/handlers/TokenBindingExpiryEventHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/bindings/handlers/TokenBindingExpiryEventHandler.java
@@ -254,6 +254,11 @@ public class TokenBindingExpiryEventHandler extends AbstractEventHandler {
      */
     private String getBindingRefFromCommonAuthCookie(HttpServletRequest request) {
 
+        if (Boolean.TRUE.equals(request.getAttribute(OAuthConstants.IS_API_BASED_LOGOUT_WITHOUT_COOKIES))) {
+            // The session id is a sha256Hex of the commonAuthId cookie value.
+            return request.getParameter(FrameworkConstants.RequestParams.SESSION_ID);
+        }
+
         Cookie[] cookies = request.getCookies();
 
         if (ArrayUtils.isEmpty(cookies)) {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/bindings/impl/SSOSessionBasedTokenBinder.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/bindings/impl/SSOSessionBasedTokenBinder.java
@@ -25,7 +25,9 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.oltu.oauth2.common.exception.OAuthSystemException;
 import org.wso2.carbon.identity.application.authentication.framework.context.SessionContext;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
+import org.wso2.carbon.identity.oauth.common.OAuthConstants;
 import org.wso2.carbon.identity.oauth2.OAuth2Constants;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2AccessTokenReqDTO;
 
@@ -88,6 +90,10 @@ public class SSOSessionBasedTokenBinder extends AbstractTokenBinder {
 
     private String retrieveTokenBindingValueFromRequest(HttpServletRequest request) throws OAuthSystemException {
 
+        if (Boolean.TRUE.equals(request.getAttribute(OAuthConstants.IS_API_BASED_LOGOUT_WITHOUT_COOKIES))) {
+            // The session id is a sha256Hex of the commonAuthId cookie value.
+            return request.getParameter(FrameworkConstants.RequestParams.SESSION_ID);
+        }
         Cookie[] cookies = request.getCookies();
         String commonAuthCookieValueFromRequestAttribute = (String) request.getAttribute(COMMONAUTH_COOKIE);
         if (ArrayUtils.isNotEmpty(cookies)) {

--- a/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/model/APIError.java
+++ b/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/model/APIError.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oidc.session.model;
+
+/**
+ * Class containing error data.
+ */
+public class APIError {
+
+    private String code = null;
+    private String message = null;
+    private String description = null;
+    private String traceId = null;
+
+    public APIError() {
+
+    }
+
+    public APIError(String code, String message, String description, String traceId) {
+
+        this.code = code;
+        this.message = message;
+        this.description = description;
+        this.traceId = traceId;
+    }
+
+    public String getCode() {
+
+        return code;
+    }
+
+    public void setCode(String code) {
+
+        this.code = code;
+    }
+
+    public String getMessage() {
+
+        return message;
+    }
+
+    public void setMessage(String message) {
+
+        this.message = message;
+    }
+
+    public String getDescription() {
+
+        return description;
+    }
+
+    public void setDescription(String description) {
+
+        this.description = description;
+    }
+
+    public String getTraceId() {
+
+        return traceId;
+    }
+
+    public void setTraceId(String traceId) {
+
+        this.traceId = traceId;
+    }
+}

--- a/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/model/LogoutContext.java
+++ b/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/model/LogoutContext.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oidc.session.model;
+
+/**
+ * This class holds context information required for logout.
+ */
+public class LogoutContext {
+
+    private boolean isAPIBasedLogout;
+    private boolean isAPIBasedLogoutWithoutCookies;
+    private String clientId;
+    private String sessionId;
+
+    public boolean isAPIBasedLogout() {
+
+        return isAPIBasedLogout;
+    }
+
+    public void setAPIBasedLogout(boolean isAPIBasedLogout) {
+
+        this.isAPIBasedLogout = isAPIBasedLogout;
+    }
+
+    public boolean isAPIBasedLogoutWithoutCookies() {
+
+        return isAPIBasedLogoutWithoutCookies;
+    }
+
+    public void setAPIBasedLogoutWithoutCookies(boolean isAPIBasedLogoutWithoutCookies) {
+
+        this.isAPIBasedLogoutWithoutCookies = isAPIBasedLogoutWithoutCookies;
+    }
+
+    public String getClientId() {
+
+        return clientId;
+    }
+
+    public void setClientId(String clientId) {
+
+        this.clientId = clientId;
+    }
+
+    public String getSessionId() {
+
+        return sessionId;
+    }
+
+    public void setSessionId(String sessionId) {
+
+        this.sessionId = sessionId;
+    }
+}

--- a/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/servlet/OIDCLogoutServlet.java
+++ b/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/servlet/OIDCLogoutServlet.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.oidc.session.servlet;
 
+import com.google.gson.Gson;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSVerifier;
 import com.nimbusds.jose.crypto.RSASSAVerifier;
@@ -27,16 +28,20 @@ import com.nimbusds.jwt.SignedJWT;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.slf4j.MDC;
 import org.wso2.carbon.base.MultitenantConstants;
 import org.wso2.carbon.core.util.KeyStoreManager;
 import org.wso2.carbon.identity.application.authentication.framework.AuthenticatorFlowStatus;
 import org.wso2.carbon.identity.application.authentication.framework.CommonAuthenticationHandler;
 import org.wso2.carbon.identity.application.authentication.framework.cache.AuthenticationRequestCacheEntry;
+import org.wso2.carbon.identity.application.authentication.framework.exception.auth.service.AuthServiceClientException;
+import org.wso2.carbon.identity.application.authentication.framework.exception.auth.service.AuthServiceException;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticationRequest;
 import org.wso2.carbon.identity.application.authentication.framework.model.CommonAuthRequestWrapper;
 import org.wso2.carbon.identity.application.authentication.framework.model.CommonAuthResponseWrapper;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
+import org.wso2.carbon.identity.application.authentication.framework.util.auth.service.AuthServiceConstants;
 import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
 import org.wso2.carbon.identity.application.common.model.ServiceProvider;
 import org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants;
@@ -62,10 +67,13 @@ import org.wso2.carbon.identity.oidc.session.cache.OIDCSessionDataCacheEntry;
 import org.wso2.carbon.identity.oidc.session.cache.OIDCSessionDataCacheKey;
 import org.wso2.carbon.identity.oidc.session.handler.OIDCLogoutHandler;
 import org.wso2.carbon.identity.oidc.session.internal.OIDCSessionManagementComponentServiceHolder;
+import org.wso2.carbon.identity.oidc.session.model.APIError;
+import org.wso2.carbon.identity.oidc.session.model.LogoutContext;
 import org.wso2.carbon.identity.oidc.session.util.OIDCSessionManagementUtil;
 import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
 import java.io.IOException;
+import java.io.PrintWriter;
 import java.io.UnsupportedEncodingException;
 import java.security.interfaces.RSAPublicKey;
 import java.text.ParseException;
@@ -73,6 +81,7 @@ import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -97,6 +106,7 @@ public class OIDCLogoutServlet extends HttpServlet {
 
     private static final Log log = LogFactory.getLog(OIDCLogoutServlet.class);
     private static final String REQUEST_PARAM_SP = "sp";
+    private static final String UTF_8 = "UTF-8";
     private static final long serialVersionUID = -9203934217770142011L;
 
     @Override
@@ -131,8 +141,29 @@ public class OIDCLogoutServlet extends HttpServlet {
 
         String redirectURL;
         String opBrowserState = getOPBrowserState(request);
+        LogoutContext logoutContext = new LogoutContext();
+        try {
+            boolean isAPIBasedLogout = isAPIBasedLogoutFlow(request);
+            logoutContext.setAPIBasedLogout(isAPIBasedLogout);
+            if (isAPIBasedLogout) {
+                if (log.isDebugEnabled()) {
+                    log.debug("The initiated logout flow is an API based logout flow.");
+                }
+                populateAPIBasedLogoutContext(request, logoutContext);
+            }
+        } catch (AuthServiceClientException e) {
+            if (log.isDebugEnabled()) {
+                log.debug("Error while populating logout context for api based logout.", e);
+            }
+            handleAPIBasedLogoutErrorResponse(e, response);
+            return;
+        } catch (AuthServiceException e) {
+            log.error("Error while populating logout context for api based logout.", e);
+            handleAPIBasedLogoutErrorResponse(e, response);
+            return;
+        }
 
-        if (StringUtils.isBlank(opBrowserState)) {
+        if (!logoutContext.isAPIBasedLogout() && StringUtils.isBlank(opBrowserState)) {
             String msg = OIDCSessionConstants.OPBS_COOKIE_ID + " cookie not received. Missing session state.";
             if (log.isDebugEnabled()) {
                 log.debug(msg);
@@ -152,8 +183,8 @@ public class OIDCLogoutServlet extends HttpServlet {
             }
         }
 
-        if (!OIDCSessionManagementUtil.getSessionManager().sessionExists(opBrowserState,
-                OAuth2Util.resolveTenantDomain(request))) {
+        if (!logoutContext.isAPIBasedLogout() && !OIDCSessionManagementUtil.getSessionManager().
+                sessionExists(opBrowserState, OAuth2Util.resolveTenantDomain(request))) {
             String msg = "No valid session found for the received session state.";
             if (log.isDebugEnabled()) {
                 log.debug(msg);
@@ -178,7 +209,7 @@ public class OIDCLogoutServlet extends HttpServlet {
             // User consent received for logout
             if (consent.equals(OAuthConstants.Consent.APPROVE)) {
                 // User approved logout. Logout from authentication framework
-                sendToFrameworkForLogout(request, response);
+                sendToFrameworkForLogout(request, response, logoutContext);
                 return;
             } else {
                 // User denied logout.
@@ -192,7 +223,7 @@ public class OIDCLogoutServlet extends HttpServlet {
             // OIDC Logout response
             String sessionDataKey = request.getParameter(OIDCSessionConstants.OIDC_SESSION_DATA_KEY_PARAM);
             if (sessionDataKey != null) {
-                handleLogoutResponseFromFramework(request, response);
+                handleLogoutResponseFromFramework(request, response, logoutContext);
                 return;
             }
             String idTokenHint = request.getParameter(OIDCSessionConstants.OIDC_ID_TOKEN_HINT_PARAM);
@@ -200,7 +231,7 @@ public class OIDCLogoutServlet extends HttpServlet {
             boolean skipConsent;
             // Get user consent to logout
             try {
-                skipConsent = getOpenIDConnectSkipUserConsent(request);
+                skipConsent = logoutContext.isAPIBasedLogout() || getOpenIDConnectSkipUserConsent(request);
             } catch (ParseException e) {
                 if (log.isDebugEnabled()) {
                     log.debug("Error while getting clientId from the IdTokenHint.", e);
@@ -241,7 +272,7 @@ public class OIDCLogoutServlet extends HttpServlet {
                     addSessionDataToCache(opBrowserState, cacheEntry);
                 }
 
-                sendToFrameworkForLogout(request, response);
+                sendToFrameworkForLogout(request, response, logoutContext);
                 return;
             } else {
                 sendToConsentUri(request, response);
@@ -369,17 +400,19 @@ public class OIDCLogoutServlet extends HttpServlet {
             return getRedirectURL(redirectURL, request);
         }
 
-        Map<String, String> paramMap = new HashMap<>();
-        paramMap.put(OIDCSessionConstants.OIDC_CACHE_CLIENT_ID_PARAM, clientId);
-        paramMap.put(OIDCSessionConstants.OIDC_CACHE_TENANT_DOMAIN_PARAM, appTenantDomain);
-        OIDCSessionDataCacheEntry cacheEntry = new OIDCSessionDataCacheEntry();
-        if (StringUtils.isNotBlank(idTokenHint)) {
-            cacheEntry.setIdToken(idTokenHint);
+        if (opBrowserStateCookie != null) {
+            Map<String, String> paramMap = new HashMap<>();
+            paramMap.put(OIDCSessionConstants.OIDC_CACHE_CLIENT_ID_PARAM, clientId);
+            paramMap.put(OIDCSessionConstants.OIDC_CACHE_TENANT_DOMAIN_PARAM, appTenantDomain);
+            OIDCSessionDataCacheEntry cacheEntry = new OIDCSessionDataCacheEntry();
+            if (StringUtils.isNotBlank(idTokenHint)) {
+                cacheEntry.setIdToken(idTokenHint);
+            }
+            cacheEntry.setPostLogoutRedirectUri(postLogoutRedirectUri);
+            cacheEntry.setState(state);
+            cacheEntry.setParamMap(new ConcurrentHashMap<>(paramMap));
+            addSessionDataToCache(opBrowserStateCookie.getValue(), cacheEntry);
         }
-        cacheEntry.setPostLogoutRedirectUri(postLogoutRedirectUri);
-        cacheEntry.setState(state);
-        cacheEntry.setParamMap(new ConcurrentHashMap<>(paramMap));
-        addSessionDataToCache(opBrowserStateCookie.getValue(), cacheEntry);
 
         return redirectURL;
     }
@@ -626,8 +659,8 @@ public class OIDCLogoutServlet extends HttpServlet {
         doGet(request, response);
     }
 
-    private void sendToFrameworkForLogout(HttpServletRequest request, HttpServletResponse response)
-            throws ServletException, IOException {
+    private void sendToFrameworkForLogout(HttpServletRequest request, HttpServletResponse response,
+                                          LogoutContext logoutContext) throws ServletException, IOException {
 
         try {
             triggerLogoutHandlersForPreLogout(request, response);
@@ -636,13 +669,24 @@ public class OIDCLogoutServlet extends HttpServlet {
             if (log.isDebugEnabled()) {
                 log.debug("Error executing logout handlers on pre logout.", e);
             }
-            response.sendRedirect(
-                    getRedirectURL(getErrorPageURL(OAuth2ErrorCodes.SERVER_ERROR, "User logout failed."), request));
+            if (logoutContext.isAPIBasedLogout()) {
+                handleAPIBasedLogoutErrorResponse(new AuthServiceException(
+                        getDefaultError(false).code(),
+                        getDefaultError(false).description(), e), response);
+            } else {
+                response.sendRedirect(getRedirectURL(getErrorPageURL(OAuth2ErrorCodes.SERVER_ERROR,
+                        "User logout failed."), request));
+            }
+            return;
         }
 
         // Generate a SessionDataKey. Authentication framework expects this parameter
         String sessionDataKey = UUID.randomUUID().toString();
-        String opBrowserStateCookieValue = OIDCSessionManagementUtil.getOPBrowserStateCookie(request).getValue();
+        String opBrowserStateCookieValue = null;
+        Cookie opBrowserStateCookie = OIDCSessionManagementUtil.getOPBrowserStateCookie(request);
+        if (opBrowserStateCookie != null) {
+            opBrowserStateCookieValue = opBrowserStateCookie.getValue();
+        }
 
         //Add all parameters to authentication context before sending to authentication framework
         AuthenticationRequest authenticationRequest = new AuthenticationRequest();
@@ -655,19 +699,31 @@ public class OIDCLogoutServlet extends HttpServlet {
                     ServiceURLBuilder.create().addPath(OIDC_LOGOUT_ENDPOINT).build().getRelativeInternalURL());
         } catch (URLBuilderException e) {
             log.error("Error building commonauth caller path to send logout request to framework.", e);
-            response.sendRedirect(
-                    getRedirectURL(getErrorPageURL(OAuth2ErrorCodes.SERVER_ERROR, "User logout failed."), request));
+            if (logoutContext.isAPIBasedLogout()) {
+                handleAPIBasedLogoutErrorResponse(new AuthServiceException(
+                        getDefaultError(false).code(),
+                        getDefaultError(false).description(), e), response);
+            } else {
+                response.sendRedirect(getRedirectURL(getErrorPageURL(OAuth2ErrorCodes.SERVER_ERROR,
+                        "User logout failed."), request));
+            }
+            return;
         }
         authenticationRequest.setPost(true);
 
-        OIDCSessionDataCacheEntry cacheEntry = getSessionDataFromCache(opBrowserStateCookieValue);
-        if (cacheEntry != null) {
-            authenticationRequest
-                    .setRelyingParty(cacheEntry.getParamMap().get(OIDCSessionConstants.OIDC_CACHE_CLIENT_ID_PARAM));
-            authenticationRequest
-                    .setTenantDomain(cacheEntry.getParamMap().get(OIDCSessionConstants.OIDC_CACHE_TENANT_DOMAIN_PARAM));
-            addOPBSCookieValueToCacheEntry(opBrowserStateCookieValue, cacheEntry);
-            addSessionDataToCache(sessionDataKey, cacheEntry);
+        if (StringUtils.isNotBlank(opBrowserStateCookieValue)) {
+            OIDCSessionDataCacheEntry cacheEntry = getSessionDataFromCache(opBrowserStateCookieValue);
+            if (cacheEntry != null) {
+                authenticationRequest.setRelyingParty(
+                        cacheEntry.getParamMap().get(OIDCSessionConstants.OIDC_CACHE_CLIENT_ID_PARAM));
+                authenticationRequest.setTenantDomain(
+                        cacheEntry.getParamMap().get(OIDCSessionConstants.OIDC_CACHE_TENANT_DOMAIN_PARAM));
+                addOPBSCookieValueToCacheEntry(opBrowserStateCookieValue, cacheEntry);
+                addSessionDataToCache(sessionDataKey, cacheEntry);
+            }
+        } else if (logoutContext.isAPIBasedLogout()) {
+            authenticationRequest.setRelyingParty(logoutContext.getClientId());
+            map.put(FrameworkConstants.RequestParams.SESSION_ID, new String[]{logoutContext.getSessionId()});
         }
 
         //Add headers to AuthenticationRequestContext
@@ -680,7 +736,8 @@ public class OIDCLogoutServlet extends HttpServlet {
                 new AuthenticationRequestCacheEntry(authenticationRequest);
         addAuthenticationRequestToRequest(request, authenticationRequestCacheEntry);
         OIDCSessionManagementUtil.removeOPBrowserStateCookie(request, response);
-        sendRequestToFramework(request, response, sessionDataKey, FrameworkConstants.RequestType.CLAIM_TYPE_OIDC);
+        sendRequestToFramework(request, response, sessionDataKey, FrameworkConstants.RequestType.CLAIM_TYPE_OIDC,
+                logoutContext);
     }
 
     private void addOPBSCookieValueToCacheEntry(String opBrowserStateCookieValue,
@@ -694,15 +751,22 @@ public class OIDCLogoutServlet extends HttpServlet {
         cacheEntry.setParamMap(paramMap);
     }
 
-    private void handleLogoutResponseFromFramework(HttpServletRequest request, HttpServletResponse response)
+    private void handleLogoutResponseFromFramework(HttpServletRequest request, HttpServletResponse response,
+                                                   LogoutContext logoutContext)
             throws IOException {
+
+        if (logoutContext.isAPIBasedLogout() && logoutContext.isAPIBasedLogoutWithoutCookies()) {
+            clearTokenBindingElements(logoutContext.getClientId(), request, response);
+            response.setStatus(HttpServletResponse.SC_OK);
+            return;
+        }
 
         String sessionDataKey = request.getParameter(FrameworkConstants.SESSION_DATA_KEY);
         OIDCSessionDataCacheEntry cacheEntry = getSessionDataFromCache(sessionDataKey);
-        String obpsCookieValue = getOPBrowserState(request);
-        String tenantDomain = OAuth2Util.resolveTenantDomain(request);
 
         if (cacheEntry != null) {
+            String obpsCookieValue = getOPBrowserState(request);
+            String tenantDomain = OAuth2Util.resolveTenantDomain(request);
             if (log.isDebugEnabled()) {
                 String clientId = cacheEntry.getParamMap().get(OIDCSessionConstants.OIDC_CACHE_CLIENT_ID_PARAM);
                 String sidClaim;
@@ -731,8 +795,15 @@ public class OIDCLogoutServlet extends HttpServlet {
                 if (log.isDebugEnabled()) {
                     log.debug("Error executing logout handlers on post logout.", e);
                 }
-                response.sendRedirect(
-                        getRedirectURL(getErrorPageURL(OAuth2ErrorCodes.SERVER_ERROR, "User logout failed."), request));
+                if (logoutContext.isAPIBasedLogout()) {
+                    handleAPIBasedLogoutErrorResponse(new AuthServiceException(
+                            getDefaultError(false).code(),
+                            getDefaultError(false).description(), e), response);
+                } else {
+                    response.sendRedirect(getRedirectURL(getErrorPageURL(OAuth2ErrorCodes.SERVER_ERROR,
+                            "User logout failed."), request));
+                }
+                return;
             }
 
             redirectURL = appendStateQueryParam(redirectURL, cacheEntry.getState());
@@ -741,10 +812,20 @@ public class OIDCLogoutServlet extends HttpServlet {
             // Clear binding elements from the response.
             clearTokenBindingElements(cacheEntry.getParamMap().get(OIDCSessionConstants.OIDC_CACHE_CLIENT_ID_PARAM),
                     request, response);
-            response.sendRedirect(buildRedirectURLAfterLogout(redirectURL, request));
+            if (logoutContext.isAPIBasedLogout()) {
+                response.setStatus(HttpServletResponse.SC_OK);
+            } else {
+                response.sendRedirect(buildRedirectURLAfterLogout(redirectURL, request));
+            }
         } else {
-            response.sendRedirect(
-                    getRedirectURL(getErrorPageURL(OAuth2ErrorCodes.SERVER_ERROR, "User logout failed"), request));
+            if (logoutContext.isAPIBasedLogout()) {
+                handleAPIBasedLogoutErrorResponse(new AuthServiceException(
+                        getDefaultError(false).code(),
+                        getDefaultError(false).description()), response);
+            } else {
+                response.sendRedirect(getRedirectURL(getErrorPageURL(OAuth2ErrorCodes.SERVER_ERROR,
+                        "User logout failed"), request));
+            }
         }
     }
 
@@ -777,11 +858,16 @@ public class OIDCLogoutServlet extends HttpServlet {
     }
 
     private void sendRequestToFramework(HttpServletRequest request, HttpServletResponse response, String sessionDataKey,
-                                        String type) throws ServletException, IOException {
+                                        String type, LogoutContext logoutContext) throws ServletException, IOException {
 
         CommonAuthenticationHandler commonAuthenticationHandler = new CommonAuthenticationHandler();
 
         CommonAuthRequestWrapper requestWrapper = new CommonAuthRequestWrapper(request);
+        if (logoutContext.isAPIBasedLogout() && logoutContext.isAPIBasedLogoutWithoutCookies()) {
+            // Setting this attribute as the framework checks for it to obtain the session id in an api based flow.
+            request.setAttribute(FrameworkConstants.IS_API_BASED_AUTH_FLOW, true);
+            requestWrapper.setParameter(FrameworkConstants.RequestParams.SESSION_ID, logoutContext.getSessionId());
+        }
         requestWrapper.setParameter(FrameworkConstants.SESSION_DATA_KEY, sessionDataKey);
         requestWrapper.setParameter(FrameworkConstants.RequestParams.TYPE, type);
 
@@ -799,10 +885,10 @@ public class OIDCLogoutServlet extends HttpServlet {
                     responseWrapper.write();
                 }
             } else {
-                handleLogoutResponseFromFramework(requestWrapper, response);
+                handleLogoutResponseFromFramework(requestWrapper, response, logoutContext);
             }
         } else {
-            handleLogoutResponseFromFramework(requestWrapper, response);
+            handleLogoutResponseFromFramework(requestWrapper, response, logoutContext);
         }
     }
 
@@ -1009,6 +1095,9 @@ public class OIDCLogoutServlet extends HttpServlet {
 
         if (OIDCSessionManagementUtil.isIDTokenEncrypted(idToken)) {
             String appTenantDomain = request.getParameter(OIDCSessionConstants.OIDC_TENANT_DOMAIN_PARAM);
+            if (StringUtils.isBlank(appTenantDomain)) {
+                appTenantDomain = IdentityTenantUtil.resolveTenantDomain();
+            }
             JWT decryptedIDToken = OIDCSessionManagementUtil.decryptWithRSA(appTenantDomain, idToken);
             return OIDCSessionManagementUtil.extractClientIDFromDecryptedIDToken(decryptedIDToken);
         } else {
@@ -1018,5 +1107,190 @@ public class OIDCLogoutServlet extends HttpServlet {
             }
             return extractClientFromIdToken(idToken);
         }
+    }
+
+    private String getSessionIdFromIdToken(HttpServletRequest request, String idToken)
+            throws IdentityOAuth2Exception, ParseException {
+
+        if (OIDCSessionManagementUtil.isIDTokenEncrypted(idToken)) {
+            String appTenantDomain = request.getParameter(OIDCSessionConstants.OIDC_TENANT_DOMAIN_PARAM);
+            if (StringUtils.isBlank(appTenantDomain)) {
+                appTenantDomain = IdentityTenantUtil.resolveTenantDomain();
+            }
+            JWT decryptedIDToken = OIDCSessionManagementUtil.decryptWithRSA(appTenantDomain, idToken);
+            return (String) decryptedIDToken.getJWTClaimsSet().getClaims()
+                    .get(OAuthConstants.OIDCClaims.IDP_SESSION_KEY);
+        } else {
+            if (!validateIdToken(idToken)) {
+                throw new IdentityOAuth2Exception(OAuth2ErrorCodes.OAuth2SubErrorCodes.INVALID_ID_TOKEN,
+                        "ID token signature validation failed.");
+            }
+            return (String) SignedJWT.parse(idToken).getJWTClaimsSet()
+                    .getClaims().get(OAuthConstants.OIDCClaims.IDP_SESSION_KEY);
+        }
+    }
+
+    private boolean canHandleAPIBasedLogoutFromCookies(HttpServletRequest request) {
+
+        String opBrowserState = getOPBrowserState(request);
+        if (StringUtils.isNotBlank(opBrowserState)) {
+            return OIDCSessionManagementUtil.getSessionManager().sessionExists(opBrowserState,
+                    OAuth2Util.resolveTenantDomain(request));
+        }
+        return false;
+    }
+
+    private boolean isAPIBasedLogoutFlow(HttpServletRequest request) throws AuthServiceException {
+
+        boolean isAPIBasedRequest = OAuth2Util.isApiBasedAuthenticationFlow(request);
+        if (isAPIBasedRequest) {
+            String idTokenHint = request.getParameter(OIDCSessionConstants.OIDC_ID_TOKEN_HINT_PARAM);
+            String clientId = request.getParameter(OIDCSessionConstants.OIDC_CLIENT_ID_PARAM);
+
+            if (StringUtils.isBlank(clientId) && StringUtils.isNotBlank(idTokenHint)) {
+                try {
+                    clientId = getClientIdFromIdToken(request, idTokenHint);
+                } catch (IdentityOAuth2Exception | ParseException e) {
+                    throw new AuthServiceException(
+                            AuthServiceConstants.ErrorMessage.ERROR_UNABLE_TO_PROCEED_LOGOUT.code(),
+                            AuthServiceConstants.ErrorMessage.ERROR_UNABLE_TO_PROCEED_LOGOUT.description(), e);
+                }
+            }
+            if (StringUtils.isNotBlank(clientId)) {
+                ServiceProvider serviceProvider;
+                try {
+                    serviceProvider = OAuth2Util.getServiceProvider(clientId);
+                } catch (IdentityOAuth2Exception e) {
+                    throw new AuthServiceException(
+                            AuthServiceConstants.ErrorMessage.ERROR_UNABLE_TO_PROCEED_LOGOUT.code(),
+                            AuthServiceConstants.ErrorMessage.ERROR_UNABLE_TO_PROCEED_LOGOUT.description(), e);
+                }
+                if (serviceProvider != null) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Checking if API based authentication is enabled in the app: " + clientId);
+                    }
+                    if (serviceProvider.isAPIBasedAuthenticationEnabled()) {
+                        return true;
+                    } else {
+                        throw new AuthServiceClientException(
+                                AuthServiceConstants.ErrorMessage.ERROR_API_BASED_AUTH_NOT_ENABLED.code(),
+                                "App native authentication should be enabled in the app to perform app native logout.");
+                    }
+                }
+            } else {
+                throw new AuthServiceClientException(
+                        AuthServiceConstants.ErrorMessage.ERROR_INVALID_LOGOUT_REQUEST.code(),
+                        "Unable to resolve client_id to perform app native logout.");
+            }
+        }
+
+        return false;
+    }
+
+    private void populateAPIBasedLogoutContext(HttpServletRequest request, LogoutContext context)
+            throws AuthServiceException {
+
+        context.setAPIBasedLogout(true);
+        boolean isAPIBasedLogoutWithCookies = canHandleAPIBasedLogoutFromCookies(request);
+        if (isAPIBasedLogoutWithCookies) {
+            context.setAPIBasedLogoutWithoutCookies(false);
+        } else {
+            String idTokenHint = request.getParameter(OIDCSessionConstants.OIDC_ID_TOKEN_HINT_PARAM);
+            if (StringUtils.isBlank(idTokenHint)) {
+                throw new AuthServiceClientException(
+                        AuthServiceConstants.ErrorMessage.ERROR_INVALID_LOGOUT_REQUEST.code(),
+                        "App native logout required the session cookies or the id_token.");
+            }
+            try {
+                String isk = getSessionIdFromIdToken(request, idTokenHint);
+                context.setSessionId(isk);
+                String clientId = getClientIdFromIdToken(request, idTokenHint);
+                context.setClientId(clientId);
+            } catch (IdentityOAuth2Exception | ParseException e) {
+                throw new AuthServiceException(
+                        AuthServiceConstants.ErrorMessage.ERROR_UNABLE_TO_PROCEED_LOGOUT.code(),
+                        AuthServiceConstants.ErrorMessage.ERROR_UNABLE_TO_PROCEED_LOGOUT.description(), e);
+            }
+            context.setAPIBasedLogoutWithoutCookies(true);
+            request.setAttribute(OAuthConstants.IS_API_BASED_LOGOUT_WITHOUT_COOKIES, true);
+        }
+    }
+
+    private void handleAPIBasedLogoutErrorResponse(AuthServiceException exception, HttpServletResponse response)
+            throws IOException {
+
+        if (log.isDebugEnabled()) {
+            log.debug("Error while handling logout request.", exception);
+        }
+
+        boolean isClientError = exception instanceof AuthServiceClientException;
+        APIError apiError = new APIError();
+        Optional<AuthServiceConstants.ErrorMessage> error =
+                AuthServiceConstants.ErrorMessage.fromCode(exception.getErrorCode());
+
+        String errorCode = exception.getErrorCode() != null ?
+                exception.getErrorCode() : getDefaultError(isClientError).code();
+
+        String errorMessage;
+        if (error.isPresent()) {
+            errorMessage = error.get().message();
+        } else {
+            errorMessage = getDefaultError(isClientError).message();
+        }
+
+        String errorDescription;
+        if (StringUtils.isNotBlank(exception.getMessage())) {
+            errorDescription = exception.getMessage();
+        } else {
+            if (error.isPresent()) {
+                errorDescription = error.get().description();
+            } else {
+                errorDescription = getDefaultError(isClientError).description();
+            }
+        }
+
+        apiError.setCode(errorCode);
+        apiError.setMessage(errorMessage);
+        apiError.setDescription(errorDescription);
+        apiError.setTraceId(getCorrelationId());
+        String jsonString = new Gson().toJson(apiError);
+
+        int statusCode = isClientError ? HttpServletResponse.SC_BAD_REQUEST :
+                HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
+
+        response.setStatus(statusCode);
+        response.setContentType(OAuthConstants.HTTP_RESP_CONTENT_TYPE_JSON);
+        response.setCharacterEncoding(UTF_8);
+        PrintWriter writer = response.getWriter();
+        writer.write(jsonString);
+        writer.flush();
+        writer.close();
+    }
+
+    private static String getCorrelationId() {
+
+        String ref;
+        if (isCorrelationIDPresent()) {
+            ref = MDC.get(FrameworkUtils.CORRELATION_ID_MDC);
+        } else {
+            if (log.isDebugEnabled()) {
+                log.debug("Correlation id is not present in the log MDC.");
+            }
+            ref = StringUtils.EMPTY;
+        }
+        return ref;
+    }
+
+    private static boolean isCorrelationIDPresent() {
+
+        return MDC.get(FrameworkUtils.CORRELATION_ID_MDC) != null;
+    }
+
+    private static AuthServiceConstants.ErrorMessage getDefaultError(boolean isClientError) {
+
+        if (isClientError) {
+            return AuthServiceConstants.ErrorMessage.ERROR_INVALID_LOGOUT_REQUEST;
+        }
+        return AuthServiceConstants.ErrorMessage.ERROR_UNABLE_TO_PROCEED_LOGOUT;
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -890,7 +890,7 @@
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!-- Carbon Identity Framework version -->
-        <carbon.identity.framework.version>5.25.669</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.25.673</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.25.234, 7.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 


### PR DESCRIPTION
This PR provides the support for API based logout. The logout request can be initiated as a normal OIDC logout. If the app doesn't send cookies then the id_token is required to perform the logout else the request will fail. Additionally, SLO is not supported when cookies are not sent.

To revoke the tokens during logout use sso-session binding with token revocation enabling config.

Resolves https://github.com/wso2/product-is/issues/18004
related to https://github.com/wso2/product-is/issues/15684