### PR TITLE
Remove session termination by userID to restrict token revocation of applications not associated for app Role 

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/listener/IdentityOauthEventHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/listener/IdentityOauthEventHandler.java
@@ -23,7 +23,6 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.context.CarbonContext;
 import org.wso2.carbon.identity.application.authentication.framework.exception.UserSessionException;
-import org.wso2.carbon.identity.application.authentication.framework.exception.session.mgt.SessionManagementException;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
 import org.wso2.carbon.identity.base.IdentityRuntimeException;
 import org.wso2.carbon.identity.core.bean.context.MessageContext;

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/listener/IdentityOauthEventHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/listener/IdentityOauthEventHandler.java
@@ -336,14 +336,8 @@ public class IdentityOauthEventHandler extends AbstractEventHandler {
                                 .getRevocationProcessor()
                                 .revokeTokens(userName, userStoreManager, roleId);
                         OAuthUtil.removeUserClaimsFromCache(userName, userStoreManager);
-                        OAuth2ServiceComponentHolder.getUserSessionManagementService()
-                                .terminateSessionsByUserId(userId);
                     } catch (UserSessionException e) {
                         String errorMsg = "Error occurred while revoking access token for user Id: " + userId;
-                        log.error(errorMsg, e);
-                        throw new IdentityEventException(errorMsg, e);
-                    } catch (SessionManagementException e) {
-                        String errorMsg = "Failed to terminate active sessions of user Id: " + userId;
                         log.error(errorMsg, e);
                         throw new IdentityEventException(errorMsg, e);
                     }


### PR DESCRIPTION
- According to the previous implementation, if role update related events are triggered, the tokens and sessions belongs to the user are revoked and terminated. 
- With the new application role concept, we restricted the token revocation logic to revoke only the tokens generated for the associated app of the specific app role. 
- But, the session termination happens based on the userID where all active session of the relevant user will be terminated and the tokens are revoked.
- If multiple application tokens shares the same session, when the session is terminated, irrelevant tokens will also be revoked.
- Since we are anyway revoking the relevant tokens, avoiding the session termination will not be an issue. Because, anyhow when an API call is made through the application with the revoked token, authentication will fail and in that time, the session will get expired.

Related issue:
- https://github.com/wso2/product-is/issues/18815