### PR TITLE
Optimize OAuth scope validation before global scope validation

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
@@ -1196,7 +1196,9 @@ public class EndpointUtil {
                     if (log.isDebugEnabled()) {
                         log.debug("DropUnregisteredScopes config is enabled. Attempting to drop unregistered scopes.");
                     }
-                    allowedScopes = dropUnregisteredScopes(params);
+                    if (AuthzUtil.isLegacyAuthzRuntime()) {
+                        allowedScopes = dropUnregisteredScopes(params);
+                    }
                 }
                 for (String scope : allowedScopes) {
                     allowedRegisteredScopes.add(scope);

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/AuthorizationHandlerManager.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/AuthorizationHandlerManager.java
@@ -302,6 +302,7 @@ public class AuthorizationHandlerManager {
             // Engage new scope validator
             authorizedScopes = getAuthorizedScopes(authzReqMsgCtx);
             removeAuthorizedScopesFromRequestedScopes(authzReqMsgCtx, authorizedScopes);
+            authzReqMsgCtx.getAuthorizationReqDTO().setScopes(new String[0]);
         }
         //Validate scopes using global scope validators.
         boolean isValid = validateScopes(authzReqMsgCtx, authzHandler);

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/AuthorizationHandlerManager.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/AuthorizationHandlerManager.java
@@ -290,17 +290,18 @@ public class AuthorizationHandlerManager {
             removeInternalScopesFromRequestedScopes(authzReqMsgCtx);
             // Adding the authorized internal scopes to tokReqMsgCtx for any special validators to use.
             authzReqMsgCtx.setAuthorizedInternalScopes(authorizedInternalScopes);
+            // Drop unregistered scopes before global scope validators.
+            boolean isDropUnregisteredScopes = OAuthServerConfiguration.getInstance().isDropUnregisteredScopes();
+            if (isDropUnregisteredScopes) {
+                if (log.isDebugEnabled()) {
+                    log.debug("DropUnregisteredScopes config is enabled. Attempting to drop unregistered scopes.");
+                }
+                dropUnregisteredScopeFromRequestedScopes(authzReqMsgCtx);
+            }
         } else {
             // Engage new scope validator
             authorizedScopes = getAuthorizedScopes(authzReqMsgCtx);
             removeAuthorizedScopesFromRequestedScopes(authzReqMsgCtx, authorizedScopes);
-        }
-        boolean isDropUnregisteredScopes = OAuthServerConfiguration.getInstance().isDropUnregisteredScopes();
-        if (isDropUnregisteredScopes) {
-            if (log.isDebugEnabled()) {
-                log.debug("DropUnregisteredScopes config is enabled. Attempting to drop unregistered scopes.");
-            }
-            dropUnregisteredScopeFromRequestedScopes(authzReqMsgCtx);
         }
         //Validate scopes using global scope validators.
         boolean isValid = validateScopes(authzReqMsgCtx, authzHandler);

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/AuthorizationHandlerManager.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/AuthorizationHandlerManager.java
@@ -280,6 +280,7 @@ public class AuthorizationHandlerManager {
         removeAllowedScopesFromRequestedScopes(authzReqMsgCtx, requestedAllowedScopes);
         List<String> authorizedScopes = null;
         // Switch the scope validators dynamically based on the authorization runtime.
+        boolean isDropUnregisteredScopes = OAuthServerConfiguration.getInstance().isDropUnregisteredScopes();
         if (AuthzUtil.isLegacyAuthzRuntime()) {
             // If it is management app, we validate internal scopes in the requested scopes.
             String[] authorizedInternalScopes = new String[0];
@@ -291,7 +292,6 @@ public class AuthorizationHandlerManager {
             // Adding the authorized internal scopes to tokReqMsgCtx for any special validators to use.
             authzReqMsgCtx.setAuthorizedInternalScopes(authorizedInternalScopes);
             // Drop unregistered scopes before global scope validators.
-            boolean isDropUnregisteredScopes = OAuthServerConfiguration.getInstance().isDropUnregisteredScopes();
             if (isDropUnregisteredScopes) {
                 if (log.isDebugEnabled()) {
                     log.debug("DropUnregisteredScopes config is enabled. Attempting to drop unregistered scopes.");
@@ -302,7 +302,14 @@ public class AuthorizationHandlerManager {
             // Engage new scope validator
             authorizedScopes = getAuthorizedScopes(authzReqMsgCtx);
             removeAuthorizedScopesFromRequestedScopes(authzReqMsgCtx, authorizedScopes);
-            authzReqMsgCtx.getAuthorizationReqDTO().setScopes(new String[0]);
+            // Drop unregistered scopes before global scope validators.
+            if (isDropUnregisteredScopes) {
+                if (log.isDebugEnabled()) {
+                    log.debug("DropUnregisteredScopes config is enabled. Drop all the scopes left as they did not " +
+                            "get validated from any of validators.");
+                }
+                authzReqMsgCtx.getAuthorizationReqDTO().setScopes(new String[0]);
+            }
         }
         //Validate scopes using global scope validators.
         boolean isValid = validateScopes(authzReqMsgCtx, authzHandler);


### PR DESCRIPTION
### Proposed changes in this pull request
- The OAuth Scope validation happens before the global scope validation is not needed for the new runtime. In this effort we move the logic to the legacy runtime.

### Related Issues
- https://github.com/wso2/product-is/issues/18860