### PR TITLE
Remove OIDC scope feature

### DIFF
--- a/features/org.wso2.carbon.identity.oauth.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.oauth.feature/pom.xml
@@ -40,11 +40,6 @@
         </dependency>
         <dependency>
             <groupId>org.wso2.carbon.identity.inbound.auth.oauth2</groupId>
-            <artifactId>org.wso2.carbon.identity.oauth.ui.feature</artifactId>
-            <type>zip</type>
-        </dependency>
-        <dependency>
-            <groupId>org.wso2.carbon.identity.inbound.auth.oauth2</groupId>
             <artifactId>org.wso2.carbon.identity.oauth.common.feature</artifactId>
             <type>zip</type>
         </dependency>
@@ -74,8 +69,6 @@
                             <includedFeatures>
                                 <includedFeatureDef>
                                     org.wso2.carbon.identity.inbound.auth.oauth2:org.wso2.carbon.identity.oauth.server.feature
-                                </includedFeatureDef>
-                                <includedFeatureDef>org.wso2.carbon.identity.inbound.auth.oauth2:org.wso2.carbon.identity.oauth.ui.feature
                                 </includedFeatureDef>
                                 <includedFeatureDef>
                                     org.wso2.carbon.identity.inbound.auth.oauth2:org.wso2.carbon.identity.oauth.common.feature


### PR DESCRIPTION
### Proposed changes in this pull request

Remove OAuth UI feature from the aggregated pom. This will hide the OIDC Scope section from the management console.

### Issue

https://github.com/wso2/product-is/issues/18950