### PR TITLE
Add userId to authzUser object for local users when retrieving tokenDO from DB

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dao/AccessTokenDAOImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dao/AccessTokenDAOImpl.java
@@ -556,8 +556,8 @@ public class AccessTokenDAOImpl extends AbstractOAuthDAO implements AccessTokenD
                         isConsentedToken = resultSet.getString(12);
                     }
                     // data loss at dividing the validity period but can be neglected
-                    AuthenticatedUser user = OAuth2Util.createAuthenticatedUser(tenantAwareUsernameWithNoUserDomain,
-                            userDomain, tenantDomain, authenticatedIDP);
+                    AuthenticatedUser user = OAuth2Util.createAuthenticatedUser(authzUser, userDomain,
+                            tenantDomain, authenticatedIDP);
 
                     user.setAuthenticatedSubjectIdentifier(subjectIdentifier);
                     AccessTokenDO accessTokenDO = new AccessTokenDO(consumerKey, user, OAuth2Util.buildScopeArray

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -3928,6 +3928,33 @@ public class OAuth2Util {
     /**
      * Creates an instance of AuthenticatedUser{@link AuthenticatedUser} for the given parameters.
      *
+     * @param authzUser       authenticated user object
+     * @param userStoreDomain user store domain
+     * @param tenantDomain    tenent domain
+     * @param idpName         idp name
+     * @return an instance of AuthenticatedUser{@link AuthenticatedUser}
+     */
+    public static AuthenticatedUser createAuthenticatedUser(AuthenticatedUser authzUser, String userStoreDomain,
+                                                            String tenantDomain, String idpName)
+            throws IdentityOAuth2Exception {
+
+        String username = authzUser.getUserName();
+        AuthenticatedUser authenticatedUser = createAuthenticatedUser(username, userStoreDomain, tenantDomain, idpName);
+        if (!authenticatedUser.isFederatedUser()) {
+            try {
+                String userId = authzUser.getUserId();
+                authenticatedUser.setUserId(userId);
+            } catch (UserIdNotFoundException e) {
+                throw new IdentityOAuth2Exception(
+                        "User id is not available for user: " + authzUser.getLoggableUserId(), e);
+            }
+        }
+        return authenticatedUser;
+    }
+
+    /**
+     * Creates an instance of AuthenticatedUser{@link AuthenticatedUser} for the given parameters.
+     *
      * @param username        username of the user
      * @param userStoreDomain user store domain
      * @param tenantDomain    tenent domain


### PR DESCRIPTION
This will add the userId of the local user to the authenticatedUser object which will avoid userId being null and causing issues on generaring cache keys and on cache clearance tasks.

Related issue:
- https://github.com/wso2/product-is/issues/18992