### PR TITLE
Fix keystore issue.

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/model/Constants.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/model/Constants.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.openidconnect.model;
 
+import org.wso2.carbon.base.MultitenantConstants;
 import org.wso2.carbon.utils.security.KeystoreUtils;
 
 /**
@@ -59,7 +60,8 @@ public class Constants {
 
     public static final String FULL_STOP_DELIMITER = ".";
     public static final String DASH_DELIMITER = "-";
-    public static final String KEYSTORE_FILE_EXTENSION = KeystoreUtils.getExtensionByFileType(
-            KeystoreUtils.StoreFileType.defaultFileType());
+    @Deprecated
+    public static final String KEYSTORE_FILE_EXTENSION = KeystoreUtils.getKeyStoreFileExtension(
+            MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
     public static final String REQUEST_OBJECT_SIGNING_ALG = "request_object_signing_alg";
 }


### PR DESCRIPTION
Previously we kept the KEYSTORE_FILE_EXTENSION as follows. With the https://github.com/wso2/product-is/issues/18466 effort, we need to pass the tenant domain to get the relevent file extension to support backward compatibility. 
`public static final String KEYSTORE_FILE_EXTENSION = ".jks";`

Hence, make `KEYSTORE_FILE_EXTENSION` deprecated and keep the same value