### PR TITLE
Revocation for Application Authorized API 

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/internal/OAuthComponentServiceHolder.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/internal/OAuthComponentServiceHolder.java
@@ -21,6 +21,7 @@ package org.wso2.carbon.identity.oauth.internal;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
+import org.wso2.carbon.identity.application.mgt.AuthorizedAPIManagementService;
 import org.wso2.carbon.identity.cors.mgt.core.CORSManagementService;
 import org.wso2.carbon.identity.oauth.OAuthAdminServiceImpl;
 import org.wso2.carbon.identity.oauth.OauthInboundAuthConfigHandler;
@@ -74,6 +75,7 @@ public class OAuthComponentServiceHolder {
     private OauthInboundAuthConfigHandler oauthInboundAuthConfigHandler;
     private CORSManagementService corsManagementService;
 
+    private AuthorizedAPIManagementService authorizedAPIManagementService;
 
     /**
      * Get the list of scope validator implementations available.
@@ -444,5 +446,25 @@ public class OAuthComponentServiceHolder {
     public void setCorsManagementService(CORSManagementService corsManagementService) {
 
         this.corsManagementService = corsManagementService;
+    }
+
+    /**
+     * Returns the authorized API management service.
+     *
+     * @return The authorized API management service.
+     */
+    public AuthorizedAPIManagementService getAuthorizedAPIManagementService() {
+
+        return authorizedAPIManagementService;
+    }
+
+    /**
+     * Sets the authorized API management service.
+     *
+     * @param authorizedAPIManagementService The authorized API management service to set.
+     */
+    public void setAuthorizedAPIManagementService(AuthorizedAPIManagementService authorizedAPIManagementService) {
+
+        this.authorizedAPIManagementService = authorizedAPIManagementService;
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/internal/OAuthServiceComponent.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/internal/OAuthServiceComponent.java
@@ -24,10 +24,11 @@ import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
-import org.osgi.service.component.annotations.ReferenceCardinality;
+    import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
 import org.wso2.carbon.identity.application.authentication.framework.UserSessionManagementService;
 import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
+import org.wso2.carbon.identity.application.mgt.AuthorizedAPIManagementService;
 import org.wso2.carbon.identity.application.mgt.inbound.protocol.ApplicationInboundAuthConfigHandler;
 import org.wso2.carbon.identity.core.util.IdentityCoreInitializedEvent;
 import org.wso2.carbon.identity.cors.mgt.core.CORSManagementService;
@@ -449,5 +450,34 @@ public class OAuthServiceComponent {
     protected void unsetApplicationCORSManagementService(CORSManagementService corsManagementService) {
 
         OAuthComponentServiceHolder.getInstance().setCorsManagementService(null);
+    }
+
+    @Reference(
+            name = "identity.authorized.api.management.component",
+            service = AuthorizedAPIManagementService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetAuthorizedAPIManagementService"
+    )
+    protected void setAuthorizedAPIManagementService(AuthorizedAPIManagementService authorizedAPIManagementService) {
+
+        if (log.isDebugEnabled()) {
+            log.debug("Setting AuthorizedAPIManagementService Service");
+        }
+        OAuthComponentServiceHolder.getInstance().
+                setAuthorizedAPIManagementService(authorizedAPIManagementService);
+    }
+
+    /**
+     * Unsets AuthorizedAPIManagementService Service.
+     *
+     * @param authorizedAPIManagementService An instance of AuthorizedAPIManagementService
+     */
+    protected void unsetAuthorizedAPIManagementService(AuthorizedAPIManagementService authorizedAPIManagementService) {
+
+        if (log.isDebugEnabled()) {
+            log.debug("Unsetting AuthorizedAPIManagementService.");
+        }
+        OAuthComponentServiceHolder.getInstance().setAuthorizedAPIManagementService(null);
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/tokenprocessor/DefaultOAuth2RevocationProcessor.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/tokenprocessor/DefaultOAuth2RevocationProcessor.java
@@ -18,14 +18,30 @@
 
 package org.wso2.carbon.identity.oauth.tokenprocessor;
 
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
+import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
+import org.wso2.carbon.identity.application.common.model.InboundAuthenticationRequestConfig;
+import org.wso2.carbon.identity.application.common.model.ServiceProvider;
+import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.oauth.OAuthUtil;
+import org.wso2.carbon.identity.oauth.internal.OAuthComponentServiceHolder;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.dao.OAuthTokenPersistenceFactory;
 import org.wso2.carbon.identity.oauth2.dto.OAuthRevocationRequestDTO;
 import org.wso2.carbon.identity.oauth2.model.AccessTokenDO;
 import org.wso2.carbon.identity.oauth2.model.RefreshTokenValidationDataDO;
+import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 import org.wso2.carbon.user.core.UserStoreException;
 import org.wso2.carbon.user.core.UserStoreManager;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.Scope.OAUTH2;
 
 /**
  * DefaultOAuth2RevocationProcessor is responsible for handling OAuth2 token revocation
@@ -33,6 +49,8 @@ import org.wso2.carbon.user.core.UserStoreManager;
  * refresh tokens, as well as a mechanism to revoke tokens associated with a specific user.
  */
 public class DefaultOAuth2RevocationProcessor implements OAuth2RevocationProcessor {
+
+    public static final Log LOG = LogFactory.getLog(DefaultOAuth2RevocationProcessor.class);
 
     @Override
     public void revokeAccessToken(OAuthRevocationRequestDTO revokeRequestDTO, AccessTokenDO accessTokenDO)
@@ -62,5 +80,91 @@ public class DefaultOAuth2RevocationProcessor implements OAuth2RevocationProcess
             throws UserStoreException {
 
         return OAuthUtil.revokeTokens(username, userStoreManager, roleId);
+    }
+
+    /**
+     * Revoke tokens associated with the specified application ID, API ID, removed scopes, and tenant domain.
+     *
+     * @param appId           The ID of the application.
+     * @param apiId           The ID of the API.
+     * @param removedScopes   The list of removed scopes.
+     * @param tenantDomain    The tenant domain.
+     * @throws IdentityOAuth2Exception If an error occurs while revoking tokens.
+     */
+    @Override
+    public void revokeTokens(String appId, String apiId, List<String> removedScopes,
+                             String tenantDomain) throws IdentityOAuth2Exception {
+
+        // Calling ApplicationManagementService to get client Id for the app Id.
+        ApplicationManagementService applicationManagementService =
+                OAuthComponentServiceHolder.getInstance().getApplicationManagementService();
+        String clientId = null;
+        try {
+            // Retrieving application by resource ID.
+            ServiceProvider application = applicationManagementService.getApplicationByResourceId(appId, tenantDomain);
+            if (application == null ||
+                    application.getInboundAuthenticationConfig() == null ||
+                    application.getInboundAuthenticationConfig().getInboundAuthenticationRequestConfigs() == null) {
+                // If application or authentication configurations are null, do nothing.
+                return;
+            }
+
+            // Retrieving client ID from inbound authentication configurations.
+            for (InboundAuthenticationRequestConfig oauth2config :
+                    application.getInboundAuthenticationConfig().getInboundAuthenticationRequestConfigs()) {
+                if (StringUtils.equals(OAUTH2, oauth2config.getInboundAuthType())) {
+                    clientId = oauth2config.getInboundAuthKey();
+                    break;
+                }
+            }
+            if (clientId == null) {
+                // If client ID is not found, log error and throw exception.
+                LOG.error(String.format("Invalid client of application : %s , ", application.getApplicationName()));
+                throw new IdentityOAuth2Exception(String.format("Invalid client of application : %s , "
+                        , application.getApplicationName()));
+            }
+
+            // Retrieve active access tokens for the given client ID and removed scopes.
+            Set<AccessTokenDO> accessTokenDOSet = OAuthTokenPersistenceFactory.getInstance()
+                    .getAccessTokenDAO().getActiveTokenSetWithTokenIdByConsumerKeyAndScope(clientId, removedScopes);
+
+            // Iterate through the retrieved access tokens and revoke them.
+            for (AccessTokenDO accessTokenDO: accessTokenDOSet) {
+                revokeTokens(clientId, accessTokenDO.getAuthzUser(), accessTokenDO,
+                        accessTokenDO.getTokenBinding().getBindingReference());
+            }
+        } catch (IdentityApplicationManagementException e) {
+            LOG.error("Error occurred while retrieving app by app ID : " + appId, e);
+            throw new IdentityOAuth2Exception("Error occurred while retrieving app by app ID : " + appId, e);
+        }
+    }
+
+    /**
+     * Revokes access tokens associated with the specified consumer key, user, access token data object,
+     * and token binding reference.
+     *
+     * @param consumerKey             The consumer key of the application.
+     * @param user                    The authenticated user.
+     * @param accessTokenDO           The access token data object.
+     * @param tokenBindingReference   The token binding reference.
+     * @throws IdentityOAuth2Exception If an error occurs while revoking access tokens.
+     */
+    private void revokeTokens(String consumerKey, AuthenticatedUser user, AccessTokenDO accessTokenDO,
+                                       String tokenBindingReference) throws IdentityOAuth2Exception {
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Revoking tokens for the application with consumerKey:" + consumerKey + " for the user: "
+                    + user.getLoggableUserId());
+        }
+        OAuthUtil.clearOAuthCache(consumerKey, user, OAuth2Util.buildScopeString
+                (accessTokenDO.getScope()), tokenBindingReference);
+        OAuthUtil.clearOAuthCache(consumerKey, user, OAuth2Util.buildScopeString
+                (accessTokenDO.getScope()));
+        OAuthUtil.clearOAuthCache(consumerKey, user);
+        OAuthUtil.clearOAuthCache(accessTokenDO);
+        OAuthUtil.invokePreRevocationBySystemListeners(accessTokenDO, Collections.emptyMap());
+        OAuthTokenPersistenceFactory.getInstance().getAccessTokenDAO()
+                .revokeAccessTokens(new String[]{accessTokenDO.getAccessToken()}, OAuth2Util.isHashEnabled());
+        OAuthUtil.invokePostRevocationBySystemListeners(accessTokenDO, Collections.emptyMap());
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/tokenprocessor/OAuth2RevocationProcessor.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/tokenprocessor/OAuth2RevocationProcessor.java
@@ -26,6 +26,8 @@ import org.wso2.carbon.identity.oauth2.model.RefreshTokenValidationDataDO;
 import org.wso2.carbon.user.core.UserStoreException;
 import org.wso2.carbon.user.core.UserStoreManager;
 
+import java.util.List;
+
 /**
  * Abstraction layer between OAuth2Service and persistence layer to handle revocation logic during token persistence
  * and non-persistence scenarios.
@@ -73,4 +75,19 @@ public interface OAuth2RevocationProcessor {
      * @throws UserStoreException If an error occurs while revoking tokens for users.
      */
     boolean revokeTokens(String username, UserStoreManager userStoreManager, String roleId) throws UserStoreException;
+
+    /**
+     * Revoke tokens associated with the specified application ID, API ID, removed scopes, and tenant domain.
+     *
+     * @param appId           The ID of the application.
+     * @param apiId           The ID of the API.
+     * @param removedScopes   The list of removed scopes.
+     * @param tenantDomain    The tenant domain.
+     * @throws IdentityOAuth2Exception If an error occurs while revoking tokens.
+     */
+    default void revokeTokens(String appId, String apiId,
+                         List<String> removedScopes,
+                         String tenantDomain) throws IdentityOAuth2Exception {
+
+    }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/OAuth2Constants.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/OAuth2Constants.java
@@ -84,4 +84,27 @@ public class OAuth2Constants {
 
         public static final String APIM_SERVICE_CATALOG_PREFIX = "service_catalog:";
     }
+
+    /**
+     * This class define static variables for column names in db.
+     */
+    public static class OAuthColumnName {
+
+        public static final String ACCESS_TOKEN = "ACCESS_TOKEN";
+        public static final String TOKEN_SCOPE = "TOKEN_SCOPE";
+        public static final String REFRESH_TOKEN = "REFRESH_TOKEN";
+        public static final String TOKEN_ID = "TOKEN_ID";
+        public static final String TENANT_ID = "TENANT_ID";
+        public static final String AUTHZ_USER = "AUTHZ_USER";
+        public static final String SUBJECT_IDENTIFIER = "SUBJECT_IDENTIFIER";
+        public static final String USER_DOMAIN = "USER_DOMAIN";
+        public static final String AUTHENTICATED_IDP_NAME = "NAME";
+        public static final String AUTHORIZED_ORGANIZATION = "AUTHORIZED_ORGANIZATION";
+        public static final String TOKEN_BINDING_REF = "TOKEN_BINDING_REF";
+        public static final String TIME_CREATED = "TIME_CREATED";
+        public static final String REFRESH_TOKEN_TIME_CREATED = "REFRESH_TOKEN_TIME_CREATED";
+        public static final String VALIDITY_PERIOD = "VALIDITY_PERIOD";
+        public static final String REFRESH_TOKEN_VALIDITY_PERIOD = "REFRESH_TOKEN_VALIDITY_PERIOD";
+        public static final String USER_TYPE = "USER_TYPE";
+    }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dao/AccessTokenDAO.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dao/AccessTokenDAO.java
@@ -225,6 +225,13 @@ public interface AccessTokenDAO {
         return Collections.emptySet();
     }
 
+    default Set<AccessTokenDO> getActiveTokenSetWithTokenIdByConsumerKeyAndScope(String consumerKey,
+                                                                                  List<String> scopes)
+            throws IdentityOAuth2Exception {
+
+        return Collections.emptySet();
+    }
+
     /**
      * Retrieve the active access tokens of a given user with a given access token binding reference.
      *

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dao/SQLQueries.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dao/SQLQueries.java
@@ -500,6 +500,31 @@ public class SQLQueries {
             "JOIN IDN_OAUTH2_ACCESS_TOKEN_SCOPE ON ACCESS_TOKEN_TABLE.TOKEN_ID = " +
             "IDN_OAUTH2_ACCESS_TOKEN_SCOPE.TOKEN_ID";
 
+    /**
+     * SQL query to retrieve access tokens for a given consumer key and scope.
+     * It selects various attributes of access tokens from the IDN_OAUTH2_ACCESS_TOKEN table.
+     * The query involves joining multiple tables:
+     * - It selects access tokens from a subquery filtering by consumer key ID and token state.
+     * - It joins the resulting access token table with the IDP table based on the IDP ID.
+     * - It left joins the access token scope table to retrieve token scope information.
+     * The query parameters are placeholders for the consumer key, tenant ID, token state, and token scope.
+     */
+    public static final String  GET_ACCESS_TOKENS_FOR_CONSUMER_KEY_AND_SCOPE =
+            "SELECT " +
+                    "ACCESS_TOKEN, TOKEN_SCOPE, REFRESH_TOKEN, ACCESS_TOKEN_TABLE.TOKEN_ID, TIME_CREATED, " +
+                    "REFRESH_TOKEN_TIME_CREATED, GRANT_TYPE, VALIDITY_PERIOD, REFRESH_TOKEN_VALIDITY_PERIOD, " +
+                    "USER_TYPE, ACCESS_TOKEN_TABLE.TENANT_ID, AUTHZ_USER, ACCESS_TOKEN_TABLE.USER_DOMAIN, " +
+                    "SUBJECT_IDENTIFIER, AUTHORIZED_ORGANIZATION, TOKEN_BINDING_REF, IDP_ID, IDP_TABLE.NAME " +
+            "FROM (SELECT " +
+                    "ACCESS_TOKEN, REFRESH_TOKEN, TOKEN_ID, TIME_CREATED, REFRESH_TOKEN_TIME_CREATED, " +
+                    "GRANT_TYPE, VALIDITY_PERIOD, USER_TYPE, REFRESH_TOKEN_VALIDITY_PERIOD, TENANT_ID, AUTHZ_USER, " +
+                    "SUBJECT_IDENTIFIER, USER_DOMAIN, AUTHORIZED_ORGANIZATION, IDP_ID, TOKEN_BINDING_REF " +
+            "FROM IDN_OAUTH2_ACCESS_TOKEN WHERE CONSUMER_KEY_ID IN (" +
+                    "SELECT ID FROM IDN_OAUTH_CONSUMER_APPS WHERE CONSUMER_KEY = ? AND TENANT_ID = ? ) " +
+            "AND TOKEN_STATE = ?) ACCESS_TOKEN_TABLE JOIN IDP IDP_TABLE ON IDP_TABLE.ID = IDP_ID " +
+            "LEFT JOIN IDN_OAUTH2_ACCESS_TOKEN_SCOPE ON " +
+                    "ACCESS_TOKEN_TABLE.TOKEN_ID = IDN_OAUTH2_ACCESS_TOKEN_SCOPE.TOKEN_ID WHERE TOKEN_SCOPE = ?";
+
     public static final String GET_ACCESS_TOKENS_BY_BINDING_REFERENCE = "SELECT ACCESS_TOKEN, CONSUMER_KEY, " +
             "TOKEN_SCOPE, REFRESH_TOKEN, ACCESS_TOKEN_TABLE.TOKEN_ID, TIME_CREATED, REFRESH_TOKEN_TIME_CREATED, " +
             "VALIDITY_PERIOD, REFRESH_TOKEN_VALIDITY_PERIOD, USER_TYPE, ACCESS_TOKEN_TABLE.TENANT_ID, AUTHZ_USER, " +

--- a/pom.xml
+++ b/pom.xml
@@ -895,7 +895,7 @@
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!-- Carbon Identity Framework version -->
-        <carbon.identity.framework.version>7.0.12</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.0.43</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.25.234, 8.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 


### PR DESCRIPTION
### Proposed changes in this pull request

Related Issue: https://github.com/wso2/product-is/issues/19330

With this PR, we are listening to following 2 events.
- "PRE_UPDATE_AUTHORIZED_API_FOR_APPLICATION_EVENT",
- "PRE_DELETE_AUTHORIZED_API_FOR_APPLICATION_EVENT"

After collecting data from the event, we retrive active access token for removed scopes and application.

Once found the access tokens, we revoke it.

Following test cases are tested.


**Test steps** 

1. Create application **POSTMAN_1**
2. Subscribe to SCIM2 Users API with all available scopes.
3. Get access token and get details from **https://localhost:9444/scim2/Users**
4. Remove  the **List_User** scope from application  or usubscribe  SCIM2 Users  API
5. Try get details from **https://localhost:9444/scim2/Users** with same access token.
6. The expected behavior in this scenario should result in an "Authorization failure."

- Using Client Credentials grant to get access token and delete the scope from authorized scopes.

https://github.com/wso2-extensions/identity-inbound-auth-oauth/assets/25488962/30c15bd9-27d2-4122-98b3-c6fb9f55190d

- Using Client Credentials grant to get access token and remove API from authorized api.

https://github.com/wso2-extensions/identity-inbound-auth-oauth/assets/25488962/60b3a9c5-7822-491a-b773-90a72becbfd3

- Using Code grant to get access token and delete the scope from authorized scopes.

https://github.com/wso2-extensions/identity-inbound-auth-oauth/assets/25488962/eb4898c1-0686-4e74-8551-94f002e316e9

- Using Code grant to get access token and remove API from authorized api.


https://github.com/wso2-extensions/identity-inbound-auth-oauth/assets/25488962/eead2d0d-87fb-47ba-9658-6592e58b45c9


An application named **POSTMAN_2** was developed and subscribed to the SCIM2 Users API with all available scopes. In each test case, we retrieved the scopes and attempted to access **GET https://localhost:9444/scim2/Users**. Even after removing scope from **POSTMAN_1** it should not affect access control of  **POSTMAN_2** .

**Test steps** 

1. Create application **POSTMAN_1**
2. Create application **POSTMAN_2**
3. Subscribe to SCIM2 Users API with all available scopes in both application
4. Get access token and get details from **https://localhost:9444/scim2/Users** using both application
5. Remove  the **List_User** scope from application  or usubscribe  SCIM2 Users  API in application **POSTMAN_1**
6. Try get details from **https://localhost:9444/scim2/Users** with same access token from application **POSTMAN_1**
7. The expected behavior in this scenario should result in an "Authorization failure."
8. Try get details from **https://localhost:9444/scim2/Users** with same access token from application **POSTMAN_2**
9. Able to get the details

- Using Client Credentials grant to get access token and delete the scope from authorized scopes.

https://github.com/wso2-extensions/identity-inbound-auth-oauth/assets/25488962/613de2ee-2efb-42dd-89b9-eb5dbc8aa45d

- Using Code grant to get access token and delete the scope from authorized scopes.

https://github.com/wso2-extensions/identity-inbound-auth-oauth/assets/25488962/761c2872-e0a3-49ea-ae8c-023858d4b52c


