### PR TITLE
Improve error logging

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.client.authn.filter/src/main/java/org/wso2/carbon/identity/oauth/client/authn/filter/OAuthClientAuthenticatorProxy.java
+++ b/components/org.wso2.carbon.identity.oauth.client.authn.filter/src/main/java/org/wso2/carbon/identity/oauth/client/authn/filter/OAuthClientAuthenticatorProxy.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.oauth.client.authn.filter;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.cxf.jaxrs.impl.MetadataMap;
@@ -84,8 +85,15 @@ public class OAuthClientAuthenticatorProxy extends AbstractPhaseInterceptor<Mess
                 OAuthClientAuthnContext oAuthClientAuthnContext = oAuthClientAuthnService
                         .authenticateClient(request, bodyContentParams);
                 if (!oAuthClientAuthnContext.isPreviousAuthenticatorEngaged()) {
-                    oAuthClientAuthnContext.setErrorCode(OAuth2ErrorCodes.INVALID_CLIENT);
-                    oAuthClientAuthnContext.setErrorMessage("Unsupported client authentication mechanism");
+                    /* If the previous authenticator is not engaged it means that either client authentication
+                    flow failed or no supported authenticaiton mechanism was found.If the error details are already
+                    not set in the context, set the default error details. */
+                    if (StringUtils.isBlank(oAuthClientAuthnContext.getErrorCode())) {
+                        oAuthClientAuthnContext.setErrorCode(OAuth2ErrorCodes.INVALID_CLIENT);
+                    }
+                    if (StringUtils.isBlank(oAuthClientAuthnContext.getErrorMessage())) {
+                        oAuthClientAuthnContext.setErrorMessage("Unsupported client authentication mechanism");
+                    }
                 }
                 setContextToRequest(request, oAuthClientAuthnContext);
             } catch (DBConnectionException e) {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/client/authentication/OAuthClientAuthnService.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/client/authentication/OAuthClientAuthnService.java
@@ -185,8 +185,11 @@ public class OAuthClientAuthnService {
                     executeAuthenticator(oAuthClientAuthenticator, oAuthClientAuthnContext, request, bodyContentMap);
                 });
             } catch (InvalidOAuthClientException e) {
-                throw new OAuthClientAuthnException("Could not find an existing app for client_id: " + clientId,
-                        OAuth2ErrorCodes.INVALID_CLIENT);
+                String errorMessage = "A valid OAuth client could not be found for client_id: " + clientId;
+                if (log.isDebugEnabled()) {
+                    log.debug(errorMessage, e);
+                }
+                setErrorToContext(OAuth2ErrorCodes.INVALID_CLIENT, errorMessage, oAuthClientAuthnContext);
             } catch (IdentityOAuth2Exception e) {
                 throw new OAuthClientAuthnException("Error while obtaining the service provider for client_id: " +
                         clientId, OAuth2ErrorCodes.SERVER_ERROR);
@@ -315,7 +318,7 @@ public class OAuthClientAuthnService {
      * @throws OAuthClientAuthnException OAuth Client Authentication Exception.
      */
     private List<OAuthClientAuthenticator> getConfiguredClientAuthMethods(String clientId)
-            throws OAuthClientAuthnException {
+            throws OAuthClientAuthnException, InvalidOAuthClientException {
 
         String tenantDomain = IdentityTenantUtil.resolveTenantDomain();
         List<String> configuredClientAuthMethods = new ArrayList<>();
@@ -325,7 +328,7 @@ public class OAuthClientAuthnService {
             if (StringUtils.isNotBlank(tokenEndpointAuthMethod)) {
                 configuredClientAuthMethods = Arrays.asList(tokenEndpointAuthMethod);
             }
-        } catch (IdentityOAuth2Exception | InvalidOAuthClientException e) {
+        } catch (IdentityOAuth2Exception e) {
             throw new OAuthClientAuthnException("Error occurred while retrieving app information for client id: " +
                     clientId + " of tenantDomain: " + tenantDomain, OAuth2ErrorCodes.INVALID_REQUEST, e);
         }


### PR DESCRIPTION
This PR fixes an issue where an error log is printed when an invalid client id is sent in the token request.