### PR TITLE
Revoke refresh token revoke

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/tokenprocessor/DefaultOAuth2RevocationProcessor.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/tokenprocessor/DefaultOAuth2RevocationProcessor.java
@@ -175,7 +175,7 @@ public class DefaultOAuth2RevocationProcessor implements OAuth2RevocationProcess
         if (revocationResponseDTO.isError()) {
             String msg = "Error while revoking tokens for clientId:" + clientId +
                     " Error Message:" + revocationResponseDTO.getErrorMsg();
-            if (OAuth2ErrorCodes.SERVER_ERROR.equals(revocationResponseDTO.getErrorCode())) {
+            if (StringUtils.equals(OAuth2ErrorCodes.SERVER_ERROR, revocationResponseDTO.getErrorCode())) {
                 LOG.error(msg);
             }
             if (LOG.isDebugEnabled()) {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/tokenprocessor/DefaultOAuth2RevocationProcessor.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/tokenprocessor/DefaultOAuth2RevocationProcessor.java
@@ -175,7 +175,7 @@ public class DefaultOAuth2RevocationProcessor implements OAuth2RevocationProcess
         if (revocationResponseDTO.isError()) {
             String msg = "Error while revoking tokens for clientId:" + clientId +
                     " Error Message:" + revocationResponseDTO.getErrorMsg();
-            if (revocationResponseDTO.getErrorCode().equals(OAuth2ErrorCodes.SERVER_ERROR)) {
+            if (OAuth2ErrorCodes.SERVER_ERROR.equals(revocationResponseDTO.getErrorCode())) {
                 LOG.error(msg);
             }
             if (LOG.isDebugEnabled()) {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dao/AccessTokenDAOImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dao/AccessTokenDAOImpl.java
@@ -2829,10 +2829,10 @@ public class AccessTokenDAOImpl extends AbstractOAuthDAO implements AccessTokenD
         if (log.isDebugEnabled()) {
             log.debug("Retrieving active access token set with token id of client: " + consumerKey);
         }
-        Set<AccessTokenDO> activeAccessTokenDOSet = null;
+        Set<AccessTokenDO> activeAccessTokenDOSet = new HashSet<>();
         for (String scope: scopes) {
-            activeAccessTokenDOSet = getActiveAccessTokenSetByConsumerKeyForScope(consumerKey,
-                    IdentityUtil.getPrimaryDomainName(), scope);
+            activeAccessTokenDOSet.addAll(getActiveAccessTokenSetByConsumerKeyForScope(consumerKey,
+                    IdentityUtil.getPrimaryDomainName(), scope));
 
             if (OAuth2Util.checkAccessTokenPartitioningEnabled() && OAuth2Util.checkUserNameAssertionEnabled()) {
                 Map<String, String> availableDomainMappings = OAuth2Util.getAvailableUserStoreDomainMappings();


### PR DESCRIPTION
### Proposed changes in this pull request
Related to : https://github.com/wso2/product-is/issues/19330
Handle revoking refresh token when revoking the access token.

Here we are using OAuth2Service revoke token method to revoke the access token rather manully revoke it cause OAuth2Service revoke method will handle the refresh token also.

### Test cases

Code grant while removing API Authorization

https://github.com/wso2-extensions/identity-inbound-auth-oauth/assets/25488962/9ab3618c-25be-434b-a03d-aa174078c2da



Code grant while removing scope

https://github.com/wso2-extensions/identity-inbound-auth-oauth/assets/25488962/abe683f1-7d71-435d-8d7c-8cf4f962c079



CC grant while removing API Authorization



https://github.com/wso2-extensions/identity-inbound-auth-oauth/assets/25488962/06a0a2d1-f438-40f7-ae88-34535b2ed55c



CC grant while removing scope

https://github.com/wso2-extensions/identity-inbound-auth-oauth/assets/25488962/a379d9ca-95b6-4244-81b5-21a09a737488
