### PR TITLE
Add tenant domain to jwt payload

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
@@ -3202,6 +3202,7 @@ public class OAuthServerConfiguration {
     }
     
     private void isAddTenantDomainToAccessTokenEnabled(OMElement oauthConfigElem) {
+
         OMElement enableAddDomainElem = oauthConfigElem.getFirstChildWithName(getQNameWithIdentityNS(
                 ConfigElements.ADD_DOMAIN_TO_ACCESS_TOKEN));
         if (enableAddDomainElem != null) {
@@ -3369,7 +3370,7 @@ public class OAuthServerConfiguration {
         private static final String OPENID_CONNECT_ADD_TENANT_DOMAIN_TO_ID_TOKEN = "AddTenantDomainToIdToken";
         // Property to decide whether to add userstore domain to id_token.
         private static final String OPENID_CONNECT_ADD_USERSTORE_DOMAIN_TO_ID_TOKEN = "AddUserstoreDomainToIdToken";
-        // Enable/Disable adding domain information to the token
+        // Enable/Disable adding domain information to the token.
         private static final String ADD_DOMAIN_TO_ACCESS_TOKEN = "AddTenantDomainToAccessToken";
         private static final String REQUEST_OBJECT_ENABLED = "RequestObjectEnabled";
         private static final String ENABLE_FAPI_CIBA_PROFILE = "EnableCibaProfile";

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
@@ -3204,7 +3204,7 @@ public class OAuthServerConfiguration {
     private void isAddTenantDomainToAccessTokenEnabled(OMElement oauthConfigElem) {
 
         OMElement enableAddDomainElem = oauthConfigElem.getFirstChildWithName(getQNameWithIdentityNS(
-                ConfigElements.ADD_DOMAIN_TO_ACCESS_TOKEN));
+                ConfigElements.ADD_TENANT_DOMAIN_TO_ACCESS_TOKEN));
         if (enableAddDomainElem != null) {
             addTenantDomainToAccessTokenEnabled  = Boolean.parseBoolean(enableAddDomainElem.getText());
         }
@@ -3371,7 +3371,7 @@ public class OAuthServerConfiguration {
         // Property to decide whether to add userstore domain to id_token.
         private static final String OPENID_CONNECT_ADD_USERSTORE_DOMAIN_TO_ID_TOKEN = "AddUserstoreDomainToIdToken";
         // Enable/Disable adding domain information to the token.
-        private static final String ADD_DOMAIN_TO_ACCESS_TOKEN = "AddTenantDomainToAccessToken";
+        private static final String ADD_TENANT_DOMAIN_TO_ACCESS_TOKEN = "AddTenantDomainToAccessToken";
         private static final String REQUEST_OBJECT_ENABLED = "RequestObjectEnabled";
         private static final String ENABLE_FAPI_CIBA_PROFILE = "EnableCibaProfile";
         private static final String ENABLE_FAPI_SECURITY_PROFILE = "EnableSecurityProfile";

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
@@ -294,7 +294,7 @@ public class OAuthServerConfiguration {
     private int deviceCodePollingInterval = 5000;
     private String deviceCodeKeySet = "BCDFGHJKLMNPQRSTVWXYZbcdfghjklmnpqrstvwxyz23456789";
     private String deviceAuthzEPUrl = null;
-    private boolean addTenantDomainToTokenEnabled = false;
+    private boolean addTenantDomainToAccessTokenEnabled = false;
 
     private OAuthServerConfiguration() {
         buildOAuthServerConfiguration();
@@ -469,7 +469,7 @@ public class OAuthServerConfiguration {
         setOAuthResponseJspPageAvailable();
         
         // read domain information setting config.
-        isAddTenantDomainToTokenEnabled(oauthElem);
+        isAddTenantDomainToAccessTokenEnabled(oauthElem);
     }
 
     /**
@@ -646,9 +646,9 @@ public class OAuthServerConfiguration {
         return deviceAuthzEPUrl;
     }
     
-    public boolean isAddTenantDomainToTokenEnabled() {
+    public boolean isAddTenantDomainToAccessTokenEnabled() {
 
-        return addTenantDomainToTokenEnabled;
+        return addTenantDomainToAccessTokenEnabled;
     }
     
     /**
@@ -3201,14 +3201,14 @@ public class OAuthServerConfiguration {
         }
     }
     
-    private void isAddTenantDomainToTokenEnabled(OMElement oauthConfigElem) {
+    private void isAddTenantDomainToAccessTokenEnabled(OMElement oauthConfigElem) {
         OMElement enableAddDomainElem = oauthConfigElem.getFirstChildWithName(getQNameWithIdentityNS(
-                ConfigElements.ADD_DOMAIN_TO_TOKEN));
+                ConfigElements.ADD_DOMAIN_TO_ACCESS_TOKEN));
         if (enableAddDomainElem != null) {
-            addTenantDomainToTokenEnabled  = Boolean.parseBoolean(enableAddDomainElem.getText());
+            addTenantDomainToAccessTokenEnabled  = Boolean.parseBoolean(enableAddDomainElem.getText());
         }
         if (log.isDebugEnabled()) {
-            log.debug("AddTenantDomainToTokenEnabled was set to : " + addTenantDomainToTokenEnabled);
+            log.debug("AddTenantDomainToAccessTokenEnabled was set to : " + addTenantDomainToAccessTokenEnabled);
         }
     }
 
@@ -3370,7 +3370,7 @@ public class OAuthServerConfiguration {
         // Property to decide whether to add userstore domain to id_token.
         private static final String OPENID_CONNECT_ADD_USERSTORE_DOMAIN_TO_ID_TOKEN = "AddUserstoreDomainToIdToken";
         // Enable/Disable adding domain information to the token
-        private static final String ADD_DOMAIN_TO_TOKEN = "AddTenantDomainToAccessToken";
+        private static final String ADD_DOMAIN_TO_ACCESS_TOKEN = "AddTenantDomainToAccessToken";
         private static final String REQUEST_OBJECT_ENABLED = "RequestObjectEnabled";
         private static final String ENABLE_FAPI_CIBA_PROFILE = "EnableCibaProfile";
         private static final String ENABLE_FAPI_SECURITY_PROFILE = "EnableSecurityProfile";

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
@@ -647,6 +647,7 @@ public class OAuthServerConfiguration {
     }
     
     public boolean isAddTenantDomainToTokenEnabled() {
+
         return addTenantDomainToTokenEnabled;
     }
     
@@ -3369,7 +3370,7 @@ public class OAuthServerConfiguration {
         // Property to decide whether to add userstore domain to id_token.
         private static final String OPENID_CONNECT_ADD_USERSTORE_DOMAIN_TO_ID_TOKEN = "AddUserstoreDomainToIdToken";
         // Enable/Disable adding domain information to the token
-        private static final String ADD_DOMAIN_TO_TOKEN = "AddTenantDomainToToken";
+        private static final String ADD_DOMAIN_TO_TOKEN = "AddTenantDomainToAccessToken";
         private static final String REQUEST_OBJECT_ENABLED = "RequestObjectEnabled";
         private static final String ENABLE_FAPI_CIBA_PROFILE = "EnableCibaProfile";
         private static final String ENABLE_FAPI_SECURITY_PROFILE = "EnableSecurityProfile";

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
@@ -294,6 +294,7 @@ public class OAuthServerConfiguration {
     private int deviceCodePollingInterval = 5000;
     private String deviceCodeKeySet = "BCDFGHJKLMNPQRSTVWXYZbcdfghjklmnpqrstvwxyz23456789";
     private String deviceAuthzEPUrl = null;
+    private boolean addTenantDomainToTokenEnabled = false;
 
     private OAuthServerConfiguration() {
         buildOAuthServerConfiguration();
@@ -466,6 +467,9 @@ public class OAuthServerConfiguration {
 
         // Set the availability of oauth_response.jsp page.
         setOAuthResponseJspPageAvailable();
+        
+        // read domain information setting config.
+        isAddTenantDomainToTokenEnabled(oauthElem);
     }
 
     /**
@@ -641,6 +645,11 @@ public class OAuthServerConfiguration {
 
         return deviceAuthzEPUrl;
     }
+    
+    public boolean isAddTenantDomainToTokenEnabled() {
+        return addTenantDomainToTokenEnabled;
+    }
+    
     /**
      * instantiate the OAuth token generator. to override the default implementation, one can specify the custom class
      * in the identity.xml.
@@ -3190,6 +3199,17 @@ public class OAuthServerConfiguration {
             log.debug("RenewTokenPerRequest was set to : " + isTokenRenewalPerRequestEnabled);
         }
     }
+    
+    private void isAddTenantDomainToTokenEnabled(OMElement oauthConfigElem) {
+        OMElement enableAddDomainElem = oauthConfigElem.getFirstChildWithName(getQNameWithIdentityNS(
+                ConfigElements.ADD_DOMAIN_TO_TOKEN));
+        if (enableAddDomainElem != null) {
+            addTenantDomainToTokenEnabled  = Boolean.parseBoolean(enableAddDomainElem.getText());
+        }
+        if (log.isDebugEnabled()) {
+            log.debug("AddTenantDomainToTokenEnabled was set to : " + addTenantDomainToTokenEnabled);
+        }
+    }
 
     /**
      * This method populates oauthTokenIssuerMap by reading the supportedTokenIssuers map. Earlier we only
@@ -3348,6 +3368,8 @@ public class OAuthServerConfiguration {
         private static final String OPENID_CONNECT_ADD_TENANT_DOMAIN_TO_ID_TOKEN = "AddTenantDomainToIdToken";
         // Property to decide whether to add userstore domain to id_token.
         private static final String OPENID_CONNECT_ADD_USERSTORE_DOMAIN_TO_ID_TOKEN = "AddUserstoreDomainToIdToken";
+        // Enable/Disable adding domain information to the token
+        private static final String ADD_DOMAIN_TO_TOKEN = "AddTenantDomainToToken";
         private static final String REQUEST_OBJECT_ENABLED = "RequestObjectEnabled";
         private static final String ENABLE_FAPI_CIBA_PROFILE = "EnableCibaProfile";
         private static final String ENABLE_FAPI_SECURITY_PROFILE = "EnableSecurityProfile";

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuer.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuer.java
@@ -102,8 +102,8 @@ public class JWTTokenIssuer extends OauthTokenIssuerImpl {
 
     private static final String AUTHORIZATION_PARTY = "azp";
     private static final String CLIENT_ID = "client_id";
-    private static final String APP_DOMAIN = "app_td";
-    private static final String USER_DOMAIN = "user_td";
+    private static final String APP_TENANT_DOMAIN = "app_td";
+    private static final String USER_TENANT_DOMAIN = "user_td";
     private static final String AUDIENCE = "aud";
     private static final String SCOPE = "scope";
     private static final String TOKEN_BINDING_REF = "binding_ref";
@@ -482,8 +482,8 @@ public class JWTTokenIssuer extends OauthTokenIssuerImpl {
         jwtClaimsSetBuilder.claim(CLIENT_ID, consumerKey);
 
         if (OAuthServerConfiguration.getInstance().isAddTenantDomainToAccessTokenEnabled()) {
-            jwtClaimsSetBuilder.claim(APP_DOMAIN, oAuthAppDO.getAppOwner().getTenantDomain());
-            jwtClaimsSetBuilder.claim(USER_DOMAIN, authenticatedUser.getTenantDomain());
+            jwtClaimsSetBuilder.claim(APP_TENANT_DOMAIN, spTenantDomain);
+            jwtClaimsSetBuilder.claim(USER_TENANT_DOMAIN, authenticatedUser.getTenantDomain());
         }
 
         setClaimsForNonPersistence(jwtClaimsSetBuilder, authAuthzReqMessageContext, tokenReqMessageContext,

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuer.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuer.java
@@ -481,7 +481,7 @@ public class JWTTokenIssuer extends OauthTokenIssuerImpl {
         jwtClaimsSetBuilder.notBeforeTime(new Date(curTimeInMillis));
         jwtClaimsSetBuilder.claim(CLIENT_ID, consumerKey);
 
-        if (OAuthServerConfiguration.getInstance().isAddTenantDomainToTokenEnabled()) {
+        if (OAuthServerConfiguration.getInstance().isAddTenantDomainToAccessTokenEnabled()) {
             jwtClaimsSetBuilder.claim(APP_DOMAIN, oAuthAppDO.getAppOwner().getTenantDomain());
             jwtClaimsSetBuilder.claim(USER_DOMAIN, authenticatedUser.getTenantDomain());
         }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuer.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuer.java
@@ -102,6 +102,8 @@ public class JWTTokenIssuer extends OauthTokenIssuerImpl {
 
     private static final String AUTHORIZATION_PARTY = "azp";
     private static final String CLIENT_ID = "client_id";
+    private static final String APP_DOMAIN = "app_domain";
+    private static final String USER_DOMAIN = "user_domain";
     private static final String AUDIENCE = "aud";
     private static final String SCOPE = "scope";
     private static final String TOKEN_BINDING_REF = "binding_ref";
@@ -478,6 +480,11 @@ public class JWTTokenIssuer extends OauthTokenIssuerImpl {
         jwtClaimsSetBuilder.jwtID(UUID.randomUUID().toString());
         jwtClaimsSetBuilder.notBeforeTime(new Date(curTimeInMillis));
         jwtClaimsSetBuilder.claim(CLIENT_ID, consumerKey);
+
+        if (OAuthServerConfiguration.getInstance().isAddTenantDomainToTokenEnabled()) {
+            jwtClaimsSetBuilder.claim(APP_DOMAIN, oAuthAppDO.getAppOwner().getTenantDomain());
+            jwtClaimsSetBuilder.claim(USER_DOMAIN, authenticatedUser.getTenantDomain());
+        }
 
         setClaimsForNonPersistence(jwtClaimsSetBuilder, authAuthzReqMessageContext, tokenReqMessageContext,
                 authenticatedUser, oAuthAppDO);

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuer.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuer.java
@@ -102,8 +102,8 @@ public class JWTTokenIssuer extends OauthTokenIssuerImpl {
 
     private static final String AUTHORIZATION_PARTY = "azp";
     private static final String CLIENT_ID = "client_id";
-    private static final String APP_DOMAIN = "app_domain";
-    private static final String USER_DOMAIN = "user_domain";
+    private static final String APP_DOMAIN = "app_td";
+    private static final String USER_DOMAIN = "user_td";
     private static final String AUDIENCE = "aud";
     private static final String SCOPE = "scope";
     private static final String TOKEN_BINDING_REF = "binding_ref";


### PR DESCRIPTION
### Proposed changes in this pull request

When SP is created with saas app enabled, it is not possible to identify the tenant domain of the user. Also, it is not possible to identify the SP's tenant domain as well.  For that had a chat with @janakamarasena and decided to introduce two new custom fields to the JWT token (`user_domain` and `app_domain`). It was decided to introduce a flag to enable this to the jwt. 

This will be enabled only if the following config is added

    [oauth]
    add_tenant_domain_to_access_token = true

PR related to the config https://github.com/wso2/carbon-identity-framework/pull/5547
