### PR TITLE
Add org_id param to introspection response of sub orgs

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/introspection/IntrospectionResponse.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/introspection/IntrospectionResponse.java
@@ -38,6 +38,10 @@ public final class IntrospectionResponse {
     public static final String USERNAME = "username";
 
     // OPTIONAL
+    // organization for which the token was issued
+    public static final String ORG_ID = "org_id";
+
+    // OPTIONAL
     // token type
     public static final String TOKEN_TYPE = "token_type";
 

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/introspection/IntrospectionResponseBuilder.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/introspection/IntrospectionResponseBuilder.java
@@ -130,6 +130,18 @@ public class IntrospectionResponseBuilder {
     }
 
     /**
+     * @param orgId Organization ID
+     * @return IntrospectionResponseBuilder
+     */
+    public IntrospectionResponseBuilder setOrgId(String orgId) {
+
+        if (StringUtils.isNotBlank(orgId)) {
+            parameters.put(IntrospectionResponse.ORG_ID, orgId);
+        }
+        return this;
+    }
+
+    /**
      * @param tokenType Token type
      * @return IntrospectionResponseBuilder
      */

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/introspection/OAuth2IntrospectionEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/introspection/OAuth2IntrospectionEndpoint.java
@@ -144,6 +144,10 @@ public class OAuth2IntrospectionEndpoint {
                 .setExpiration(introspectionResponse.getExp())
                 .setAuthorizedUserType(introspectionResponse.getAut());
 
+        if (introspectionResponse.getAuthorizedUser() != null) {
+            respBuilder.setOrgId(introspectionResponse.getAuthorizedUser().getAccessingOrganization());
+        }
+
         if (StringUtils.equalsIgnoreCase(introspectionResponse.getTokenType(), JWT_TOKEN_TYPE)) {
             respBuilder.setAudience(introspectionResponse.getAud())
                     .setJwtId(introspectionResponse.getJti())


### PR DESCRIPTION
### Proposed changes in this pull request

With new implementations, there has been a behavioural change in the tenant domain of the username parameter of the introspection response, where it is set to the tenant domain of the tenant where the console app resides, and not the sub org for which the token was issued for. With this, there is no way to identify the org for which the token was issued for, if it is a suborg. Microservices such as the Feature Gate used the tenant domain from the username parameter to validate whether the token has been issued for the tenant for which the services are requested. With this change, the validation breaks and currently there is no other way to validate this. Thus, for suborgs a new parameter `org_id` is introduced to the introspection response so that this can be used for the validations instead. 

### When should this PR be merged

**After IS 7.0 release**

### Related issues
- https://github.com/wso2-enterprise/asgardeo-product/issues/22200

### Related PRs
- https://github.com/wso2-enterprise/asgardeo-feature-gate/pull/77
