### PR TITLE
Fix x5t incompatibility issue of JWT token

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/pom.xml
+++ b/components/org.wso2.carbon.identity.oauth/pom.xml
@@ -345,6 +345,11 @@
             <groupId>org.wso2.carbon.identity.framework</groupId>
             <artifactId>org.wso2.carbon.identity.cors.mgt.core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.bitbucket.b_c</groupId>
+            <artifactId>jose4j</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuer.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuer.java
@@ -371,13 +371,8 @@ public class JWTTokenIssuer extends OauthTokenIssuerImpl {
             Key privateKey = getPrivateKey(tenantDomain, tenantId);
             JWSSigner signer = OAuth2Util.createJWSSigner((RSAPrivateKey) privateKey);
             JWSHeader.Builder headerBuilder = new JWSHeader.Builder((JWSAlgorithm) signatureAlgorithm);
-            String certThumbPrint;
-            if (!Boolean.parseBoolean(IdentityUtil.getProperty(OAuth2Util.JWT_X5T_HEXIFY_REQUIRED))) {
-                Certificate certificate = OAuth2Util.getCertificate(tenantDomain, tenantId);
-                certThumbPrint = OAuth2Util.getThumbPrintWithPrevAlgorithm(certificate, false);
-            } else {
-                certThumbPrint = OAuth2Util.getThumbPrint(tenantDomain, tenantId);
-            }
+            Certificate certificate = OAuth2Util.getCertificate(tenantDomain, tenantId);
+            String certThumbPrint = OAuth2Util.getThumbPrintWithPrevAlgorithm(certificate, false);
             headerBuilder.keyID(OAuth2Util.getKID(OAuth2Util.getCertificate(tenantDomain, tenantId),
                     (JWSAlgorithm) signatureAlgorithm, tenantDomain));
             // Set the required "typ" header "at+jwt" for access tokens issued by the issuer

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuer.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuer.java
@@ -56,6 +56,7 @@ import org.wso2.carbon.identity.openidconnect.CustomClaimsCallbackHandler;
 import org.wso2.carbon.identity.openidconnect.OIDCClaimUtil;
 
 import java.security.Key;
+import java.security.cert.Certificate;
 import java.security.interfaces.RSAPrivateKey;
 import java.text.ParseException;
 import java.util.Arrays;
@@ -370,7 +371,13 @@ public class JWTTokenIssuer extends OauthTokenIssuerImpl {
             Key privateKey = getPrivateKey(tenantDomain, tenantId);
             JWSSigner signer = OAuth2Util.createJWSSigner((RSAPrivateKey) privateKey);
             JWSHeader.Builder headerBuilder = new JWSHeader.Builder((JWSAlgorithm) signatureAlgorithm);
-            String certThumbPrint = OAuth2Util.getThumbPrint(tenantDomain, tenantId);
+            String certThumbPrint;
+            if (!Boolean.parseBoolean(IdentityUtil.getProperty(OAuth2Util.JWT_X5T_HEXIFY_REQUIRED))) {
+                Certificate certificate = OAuth2Util.getCertificate(tenantDomain, tenantId);
+                certThumbPrint = OAuth2Util.getThumbPrintWithPrevAlgorithm(certificate, false);
+            } else {
+                certThumbPrint = OAuth2Util.getThumbPrint(tenantDomain, tenantId);
+            }
             headerBuilder.keyID(OAuth2Util.getKID(OAuth2Util.getCertificate(tenantDomain, tenantId),
                     (JWSAlgorithm) signatureAlgorithm, tenantDomain));
             // Set the required "typ" header "at+jwt" for access tokens issued by the issuer

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -342,7 +342,6 @@ public class OAuth2Util {
     private static Pattern pkceCodeVerifierPattern = Pattern.compile("[\\w\\-\\._~]+");
     // System flag to allow the weak keys (key length less than 2048) to be used for the signing.
     private static final String ALLOW_WEAK_RSA_SIGNER_KEY = "allow_weak_rsa_signer_key";
-    public static final String JWT_X5T_HEXIFY_REQUIRED = "OAuth.JWTX5tHexifyingRequired";
 
     private static Map<Integer, Certificate> publicCerts = new ConcurrentHashMap<Integer, Certificate>();
     private static Map<Integer, Key> privateKeys = new ConcurrentHashMap<Integer, Key>();
@@ -3127,12 +3126,8 @@ public class OAuth2Util {
             JWSSigner signer = OAuth2Util.createJWSSigner((RSAPrivateKey) privateKey);
             JWSHeader.Builder headerBuilder = new JWSHeader.Builder((JWSAlgorithm) signatureAlgorithm);
             headerBuilder.keyID(getKID(getCertificate(tenantDomain, tenantId), signatureAlgorithm, tenantDomain));
-            if (!Boolean.parseBoolean(IdentityUtil.getProperty(JWT_X5T_HEXIFY_REQUIRED))) {
-                Certificate certificate = getCertificate(tenantDomain, tenantId);
-                headerBuilder.x509CertThumbprint(new Base64URL(getThumbPrintWithPrevAlgorithm(certificate, false)));
-            } else {
-                headerBuilder.x509CertThumbprint(new Base64URL(getThumbPrint(tenantDomain, tenantId)));
-            }
+            Certificate certificate = getCertificate(tenantDomain, tenantId);
+            headerBuilder.x509CertThumbprint(new Base64URL(getThumbPrintWithPrevAlgorithm(certificate, false)));
             SignedJWT signedJWT = new SignedJWT(headerBuilder.build(), jwtClaimsSet);
             signedJWT.sign(signer);
             return signedJWT;

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuerTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuerTest.java
@@ -70,6 +70,7 @@ import java.util.Map;
 import java.util.UUID;
 
 import static org.junit.Assert.assertNull;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyObject;
@@ -444,7 +445,7 @@ public class JWTTokenIssuerTest extends PowerMockIdentityBaseTest {
             mockCustomClaimsCallbackHandler();
             mockStatic(OAuth2Util.class);
             when(OAuth2Util.getAppInformationByClientId(anyString())).thenReturn(appDO);
-            when(OAuth2Util.getThumbPrint(anyString(), anyInt())).thenReturn(THUMBPRINT);
+            when(OAuth2Util.getThumbPrintWithPrevAlgorithm(any(), anyBoolean())).thenReturn(THUMBPRINT);
             when(OAuth2Util.isTokenPersistenceEnabled()).thenReturn(true);
 
             System.setProperty(CarbonBaseConstants.CARBON_HOME,

--- a/pom.xml
+++ b/pom.xml
@@ -644,6 +644,12 @@
                 <version>${commons-codec.test.version}</version>
                 <scope>test</scope>
             </dependency>
+            <dependency>
+                <groupId>org.bitbucket.b_c</groupId>
+                <artifactId>jose4j</artifactId>
+                <version>${jose4j.version}</version>
+                <scope>test</scope>
+            </dependency>
 
             <!--
                 See https://github.com/wso2-extensions/identity-inbound-auth-oauth/issues/543 for the requirement to
@@ -1012,6 +1018,7 @@
         <commons-codec.test.version>1.4</commons-codec.test.version>
         <org.wso2.carbon.identity.testutil.version>5.23.18</org.wso2.carbon.identity.testutil.version>
         <jaxp-ri.version>1.4.5</jaxp-ri.version>
+        <jose4j.version>0.9.5</jose4j.version>
         <!--SAML component version for test-->
         <carbon.identity.sso.saml.version>5.7.0</carbon.identity.sso.saml.version>
         <spring-context.version>5.1.1.RELEASE</spring-context.version>


### PR DESCRIPTION
Related issue: https://github.com/wso2-enterprise/wso2-iam-internal/issues/1325

The x5t value returned in the JWT token is not correct as per the specification. 
- The x5t#256 (sha-256 thumbprint) value is added instead of the x5t (sha-1 thumbprint) value as reported in [[1]](https://github.com/wso2/product-is/issues/11736).
- There is an additional hexifying step as reported in [[2](https://github.com/wso2/product-is/issues/19876)].

Due to this JWT token validation using a library such as jose4j (which will validate this x5t value) will fail. 

With this PR, the [fix](https://github.com/wso2-support/identity-inbound-auth-oauth/pull/867) for [1] will be front ported and additionally the certificate thumprint will not be hexified before encoding, and therefore the x5t value will be in the correct format as per the specification.

[1] https://github.com/wso2/product-is/issues/11736
[2] https://github.com/wso2/product-is/issues/19876