### PR TITLE
Ask consent for essential claims added through claims parameter

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
@@ -203,6 +203,7 @@ import static org.wso2.carbon.identity.client.attestation.mgt.utils.Constants.CL
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.LogConstants.InputKeys.RESPONSE_TYPE;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OAuth20Params.CLIENT_ID;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OAuth20Params.REDIRECT_URI;
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OAuth20Params.USERINFO;
 import static org.wso2.carbon.identity.oauth.endpoint.state.OAuthAuthorizeState.AUTHENTICATION_RESPONSE;
 import static org.wso2.carbon.identity.oauth.endpoint.state.OAuthAuthorizeState.INITIAL_REQUEST;
 import static org.wso2.carbon.identity.oauth.endpoint.state.OAuthAuthorizeState.PASSTHROUGH_TO_COMMONAUTH;
@@ -3362,6 +3363,13 @@ public class OAuth2AuthzEndpoint {
                     essentialRequestedClaims.add(requestedClaim.getName());
                 }
             }
+        }
+
+        // Add user info's essential claims requested using claims parameter. Claims for id_token are skipped
+        // since claims parameter does not support id_token yet.
+        if (oauth2Params.getEssentialClaims() != null) {
+            essentialRequestedClaims.addAll(OAuth2Util.getEssentialClaims(oauth2Params.getEssentialClaims(),
+                    USERINFO));
         }
 
         if (CollectionUtils.isNotEmpty(claimListOfScopes)) {

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
@@ -971,21 +971,11 @@ public class OAuth2AuthzEndpoint {
                                                        OAuth2Parameters oAuth2Parameters)
             throws SSOConsentServiceException {
 
-        List<String> claimsListOfScopes =
-                openIDConnectClaimFilter.getClaimsFilteredByOIDCScopes(oAuth2Parameters.getScopes(),
-                        oAuth2Parameters.getTenantDomain());
-        // Add essential claims requested through the claims parameter.
-        if (oAuth2Parameters.getEssentialClaims() != null) {
-            claimsListOfScopes.addAll(OAuth2Util.getEssentialClaims(oAuth2Parameters.getEssentialClaims(),
-                    USERINFO));
-        }
         if (hasPromptContainsConsent(oAuth2Parameters)) {
             // Ignore all previous consents and get consent required claims
-            return getSSOConsentService().getConsentRequiredClaimsWithoutExistingConsents(serviceProvider, user,
-                    claimsListOfScopes);
+            return getSSOConsentService().getConsentRequiredClaimsWithoutExistingConsents(serviceProvider, user);
         } else {
-            return getSSOConsentService().getConsentRequiredClaimsWithExistingConsents(serviceProvider, user,
-                    claimsListOfScopes);
+            return getSSOConsentService().getConsentRequiredClaimsWithExistingConsents(serviceProvider, user);
         }
     }
 
@@ -3221,8 +3211,7 @@ public class OAuth2AuthzEndpoint {
                     .logDetailLevel(DiagnosticLog.LogDetailLevel.APPLICATION);
         }
         try {
-            ConsentClaimsData claimsForApproval = getConsentRequiredClaims(user, serviceProvider, useExistingConsents,
-                    oauth2Params);
+            ConsentClaimsData claimsForApproval = getConsentRequiredClaims(user, serviceProvider, useExistingConsents);
             if (claimsForApproval != null) {
                 String requestClaimsQueryParam = null;
                 // Get the mandatory claims and append as query param.
@@ -3420,23 +3409,12 @@ public class OAuth2AuthzEndpoint {
 
     private ConsentClaimsData getConsentRequiredClaims(AuthenticatedUser user,
                                                        ServiceProvider serviceProvider,
-                                                       boolean useExistingConsents, OAuth2Parameters oAuth2Parameters)
-            throws SSOConsentServiceException {
+                                                       boolean useExistingConsents) throws SSOConsentServiceException {
 
-        List<String> claimsListOfScopes =
-                openIDConnectClaimFilter.getClaimsFilteredByOIDCScopes(oAuth2Parameters.getScopes(),
-                        oAuth2Parameters.getTenantDomain());
-        // Add essential claims requested through the claims parameter.
-        if (oAuth2Parameters.getEssentialClaims() != null) {
-            claimsListOfScopes.addAll(OAuth2Util.getEssentialClaims(oAuth2Parameters.getEssentialClaims(),
-                    USERINFO));
-        }
         if (useExistingConsents) {
-            return getSSOConsentService().getConsentRequiredClaimsWithExistingConsents(serviceProvider, user,
-                    claimsListOfScopes);
+            return getSSOConsentService().getConsentRequiredClaimsWithExistingConsents(serviceProvider, user);
         } else {
-            return getSSOConsentService().getConsentRequiredClaimsWithoutExistingConsents(serviceProvider, user,
-                    claimsListOfScopes);
+            return getSSOConsentService().getConsentRequiredClaimsWithoutExistingConsents(serviceProvider, user);
         }
     }
 

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
@@ -974,6 +974,11 @@ public class OAuth2AuthzEndpoint {
         List<String> claimsListOfScopes =
                 openIDConnectClaimFilter.getClaimsFilteredByOIDCScopes(oAuth2Parameters.getScopes(),
                         oAuth2Parameters.getTenantDomain());
+        // Add essential claims requested through the claims parameter.
+        if (oAuth2Parameters.getEssentialClaims() != null) {
+            claimsListOfScopes.addAll(OAuth2Util.getEssentialClaims(oAuth2Parameters.getEssentialClaims(),
+                    USERINFO));
+        }
         if (hasPromptContainsConsent(oAuth2Parameters)) {
             // Ignore all previous consents and get consent required claims
             return getSSOConsentService().getConsentRequiredClaimsWithoutExistingConsents(serviceProvider, user,
@@ -3421,6 +3426,11 @@ public class OAuth2AuthzEndpoint {
         List<String> claimsListOfScopes =
                 openIDConnectClaimFilter.getClaimsFilteredByOIDCScopes(oAuth2Parameters.getScopes(),
                         oAuth2Parameters.getTenantDomain());
+        // Add essential claims requested through the claims parameter.
+        if (oAuth2Parameters.getEssentialClaims() != null) {
+            claimsListOfScopes.addAll(OAuth2Util.getEssentialClaims(oAuth2Parameters.getEssentialClaims(),
+                    USERINFO));
+        }
         if (useExistingConsents) {
             return getSSOConsentService().getConsentRequiredClaimsWithExistingConsents(serviceProvider, user,
                     claimsListOfScopes);


### PR DESCRIPTION
Related issue: https://github.com/wso2/product-is/issues/19817
Related internal: https://github.com/wso2-enterprise/wso2-iam-internal/issues/1312

This PR adds essential claims requested for the user info response from the claims parameter in the auth flow, to the set of claims that needs consent from the user. The claims requested for the id token are not considered at this point since, requesting claims through the claims parameter for the id token is not supported in the product.

Additionally, this PR reverts the changes added by https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/1698 to do an additional filtering based on scopes when getting the claims requested by the SP. Due to this essential claims requested by the claims parameter or request object will not be considered for consent and therefore if consent prompting is enabled those flows related to requesting essential claims will be broken. 