### PR TITLE
Select DPoP Token Validator for DPoP Type JWT Access Tokens

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/TokenValidationHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/TokenValidationHandler.java
@@ -64,6 +64,7 @@ public class TokenValidationHandler {
     private Map<String, OAuth2TokenValidator> tokenValidators = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
     private TokenProvider tokenValidationProcessor;
     private static final String BEARER_TOKEN_TYPE = "Bearer";
+    private static final String DPOP_TOKEN_TYPE = "DPoP";
     private static final String BEARER_TOKEN_TYPE_JWT = "jwt";
     private static final String BUILD_FQU_FROM_SP_CONFIG = "OAuth.BuildSubjectIdentifierFromSPConfig";
     private static final String ENABLE_JWT_TOKEN_VALIDATION = "OAuth.EnableJWTTokenValidationDuringIntrospection";
@@ -748,7 +749,8 @@ public class TokenValidationHandler {
         }
 
         OAuth2TokenValidator tokenValidator;
-        if (isJWTTokenValidation(accessToken.getIdentifier())) {
+        if (!StringUtils.equalsIgnoreCase(accessToken.getTokenType(), DPOP_TOKEN_TYPE) &&
+                isJWTTokenValidation(accessToken.getIdentifier())) {
             /*
             If the token is a self-contained JWT based access token and the
             config EnableJWTTokenValidationDuringIntrospection is set to true


### PR DESCRIPTION
## Purpose
When selecting token validators for access tokens, both opaque and JWT tokens with the identifier `DPoP` should utilize the dpop token validator. However, due to a bug in the existing implementation, when the token type is JWT and its identifier is `DPoP`, the token is mistakenly validated using the bearer JWT token validator instead of the intended dpop token validator.

## Fix 
an additional condition has been introduced to ensure that the bearer JWT token validator is chosen only when the token identifier is not `DPoP`. Consequently, this modification ensures that the dpop token validator is appropriately selected for both JWT and opaque tokens with the `DPoP` token identifier.

## Related Issues
- https://github.com/wso2/product-is/issues/16606
