### PR TITLE
Fix b2b user token revocation issue

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dao/AccessTokenDAOImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dao/AccessTokenDAOImpl.java
@@ -503,6 +503,8 @@ public class AccessTokenDAOImpl extends AbstractOAuthDAO implements AccessTokenD
             int appTenantId = IdentityTenantUtil.getLoginTenantId();
             if (rootTenantDomain != null) {
                 appTenantId = OAuth2Util.getTenantId(rootTenantDomain);
+            } else if (authzUser.isOrganizationUser()) {
+                appTenantId = OAuth2Util.getTenantId(authzUser.getTenantDomain());
             }
             prepStmt.setInt(2, appTenantId);
             if (isUsernameCaseSensitive) {


### PR DESCRIPTION
### Proposed changes in this pull request
Check if the user is an organization user and change the appTenantDomain to the parent organization tenantId as tokens for B2B users are issued against the shared parent application