### PR TITLE
Resolve tenantDomain in tenanted my account logout

### DIFF
--- a/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/util/OIDCSessionManagementUtil.java
+++ b/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/util/OIDCSessionManagementUtil.java
@@ -241,6 +241,11 @@ public class OIDCSessionManagementUtil {
                             String tenantDomain;
                             if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled()) {
                                 tenantDomain = IdentityTenantUtil.resolveTenantDomain();
+                                if (request.getParameter(
+                                        FrameworkConstants.RequestParams.LOGIN_TENANT_DOMAIN) != null) {
+                                    tenantDomain = request.getParameter(
+                                            FrameworkConstants.RequestParams.LOGIN_TENANT_DOMAIN);
+                                }
                             } else {
                                 tenantDomain = resolveTenantDomain(request);
                             }


### PR DESCRIPTION
### Proposed changes in this pull request
When setting the opbs cookie value for tenanted my account, path is set as `/t/<TENANT-DOMAIN>/`. When clearing the cookie, same path should be used. However, when resolving the tenant domain in [1] it's resolved as `carbon.super` resulting in obps cookie not clearing. 

[1] - https://github.com/wso2-extensions/identity-inbound-auth-oauth/blob/d1ab6c6b69d162e37659e5faad7e9da01200de07/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/util/OIDCSessionManagementUtil.java#L228

This change is introduced to resolve the correct tenant domain in this scenario
