### PR TITLE
Improve cache clearing for AppInfoCache and AuthorizationGrantCache

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuthApplicationMgtListener.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuthApplicationMgtListener.java
@@ -143,9 +143,7 @@ public class OAuthApplicationMgtListener extends AbstractApplicationMgtListener 
         addClientSecret(serviceProvider, tenantDomain);
         updateAuthApplication(serviceProvider);
 
-        if (threadLocalForClaimConfigUpdates.get()) {
-            removeEntriesFromCache(serviceProvider, tenantDomain);
-        }
+        removeEntriesFromCache(serviceProvider, tenantDomain);
         threadLocalForClaimConfigUpdates.remove();
         return true;
     }
@@ -481,11 +479,11 @@ public class OAuthApplicationMgtListener extends AbstractApplicationMgtListener 
                 OAuthCache.getInstance().clearCacheEntry(new OAuthCacheKey(oauthKey));
             }
 
-            if (isNotEmpty(accessTokenDOSet)) {
+            if (isNotEmpty(accessTokenDOSet) && threadLocalForClaimConfigUpdates.get()) {
                 clearCacheEntriesAgainstToken(accessTokenDOSet);
             }
 
-            if (isNotEmpty(authzCodeDOSet)) {
+            if (isNotEmpty(authzCodeDOSet) && threadLocalForClaimConfigUpdates.get()) {
                 clearCacheEntriesAgainstAuthzCode(authzCodeDOSet);
             }
         }


### PR DESCRIPTION
In an update done for [1], the requirement was to clear the AuthorizationGrantCache only on cases like disabling the OAuth app, removing the OAuth config, changing the claims configurations, etc. But the validation done restricts the AppInfoCache also to be cleared only on claim updates. 

In this PR, the if condition is added only to validate clearing the AuthorizationGrantCache. 

[1] https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/1963/files

Related issue 
https://github.com/wso2-enterprise/asgardeo-product/issues/22964
https://github.com/wso2/product-is/issues/20085