### PR TITLE
[6.13.x] Improve cache clearing for AppInfoCache and AuthorizationGrantCache

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuthApplicationMgtListener.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuthApplicationMgtListener.java
@@ -142,10 +142,8 @@ public class OAuthApplicationMgtListener extends AbstractApplicationMgtListener 
         revokeAccessTokensWhenSaaSDisabled(serviceProvider, tenantDomain);
         addClientSecret(serviceProvider);
         updateAuthApplication(serviceProvider);
+        removeEntriesFromCache(serviceProvider, tenantDomain);
 
-        if (threadLocalForClaimConfigUpdates.get()) {
-            removeEntriesFromCache(serviceProvider, tenantDomain);
-        }
         threadLocalForClaimConfigUpdates.remove();
         return true;
     }
@@ -463,11 +461,11 @@ public class OAuthApplicationMgtListener extends AbstractApplicationMgtListener 
                 OAuthCache.getInstance().clearCacheEntry(new OAuthCacheKey(oauthKey));
             }
 
-            if (isNotEmpty(accessTokenDOSet)) {
+            if (isNotEmpty(accessTokenDOSet) && threadLocalForClaimConfigUpdates.get()) {
                 clearCacheEntriesAgainstToken(accessTokenDOSet);
             }
 
-            if (isNotEmpty(authzCodeDOSet)) {
+            if (isNotEmpty(authzCodeDOSet) && threadLocalForClaimConfigUpdates.get()) {
                 clearCacheEntriesAgainstAuthzCode(authzCodeDOSet);
             }
         }


### PR DESCRIPTION
### Proposed changes in this pull request

Fixes an issue where the AppInfoCache was not cleared upon an update to the SP.

Related issue: https://github.com/wso2/api-manager/issues/2545

Back ported from https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2416