### PR TITLE
Remove SHA1 Default Usage

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImpl.java
@@ -273,11 +273,11 @@ public class OAuthAdminServiceImpl {
                     app.setState(APP_STATE_ACTIVE);
                     if (StringUtils.isEmpty(application.getOauthConsumerKey())) {
                         app.setOauthConsumerKey(OAuthUtil.getRandomNumber());
-                        app.setOauthConsumerSecret(OAuthUtil.getRandomNumber());
+                        app.setOauthConsumerSecret(OAuthUtil.getRandomNumberSecure());
                     } else {
                         app.setOauthConsumerKey(application.getOauthConsumerKey());
                         if (StringUtils.isEmpty(application.getOauthConsumerSecret())) {
-                            app.setOauthConsumerSecret(OAuthUtil.getRandomNumber());
+                            app.setOauthConsumerSecret(OAuthUtil.getRandomNumberSecure());
                         } else {
                             app.setOauthConsumerSecret(application.getOauthConsumerSecret());
                         }
@@ -849,7 +849,7 @@ public class OAuthAdminServiceImpl {
     public OAuthConsumerAppDTO updateAndRetrieveOauthSecretKey(String consumerKey) throws IdentityOAuthAdminException {
 
         Properties properties = new Properties();
-        String newSecret = OAuthUtil.getRandomNumber();
+        String newSecret = OAuthUtil.getRandomNumberSecure();
         properties.setProperty(OAuthConstants.OAUTH_APP_NEW_SECRET_KEY, newSecret);
         properties.setProperty(OAuthConstants.ACTION_PROPERTY_KEY, OAuthConstants.ACTION_REGENERATE);
         properties.setProperty(OAuthConstants.OAUTH_APP_NEW_STATE, APP_STATE_ACTIVE);

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthUtil.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthUtil.java
@@ -96,6 +96,31 @@ public final class OAuthUtil {
         try {
             String secretKey = UUIDGenerator.generateUUID();
             String baseString = UUIDGenerator.generateUUID();
+            SecretKeySpec key = new SecretKeySpec(secretKey.getBytes(Charsets.UTF_8), ALGORITHM_SHA1);
+            Mac mac = Mac.getInstance(ALGORITHM_SHA1);
+            mac.init(key);
+            byte[] rawHmac = mac.doFinal(baseString.getBytes(Charsets.UTF_8));
+            String random = Base64.encode(rawHmac);
+            // Registry doesn't have support for these character.
+            random = random.replace("/", "_");
+            random = random.replace("=", "a");
+            random = random.replace("+", "f");
+            return random;
+        } catch (Exception e) {
+            throw new IdentityOAuthAdminException("Error when generating a random number.", e);
+        }
+    }
+
+    /**
+     * Generates a securer random number using two UUIDs and HMAC-SHA256
+     *
+     * @return generated secure random number
+     * @throws IdentityOAuthAdminException Invalid Algorithm or Invalid Key
+     */
+    public static String getRandomNumberSecure() throws IdentityOAuthAdminException {
+        try {
+            String secretKey = UUIDGenerator.generateUUID();
+            String baseString = UUIDGenerator.generateUUID();
 
             String hmacAlgorithm;
             if (Boolean.parseBoolean(IdentityUtil.getProperty(IdentityConstants.OAuth.ENABLE_SHA256_PARAMS))) {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthUtil.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthUtil.java
@@ -78,14 +78,14 @@ import static org.wso2.carbon.identity.oauth.common.OAuthConstants.TokenBindings
 public final class OAuthUtil {
 
     public static final Log LOG = LogFactory.getLog(OAuthUtil.class);
-    private static final String ALGORITHM = "HmacSHA1";
+    private static final String ALGORITHM = "HmacSHA256";
 
     private OAuthUtil() {
 
     }
 
     /**
-     * Generates a random number using two UUIDs and HMAC-SHA1
+     * Generates a random number using two UUIDs and HMAC-SHA256
      *
      * @return generated secure random number
      * @throws IdentityOAuthAdminException Invalid Algorithm or Invalid Key

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dao/OAuthAppDAO.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dao/OAuthAppDAO.java
@@ -196,7 +196,7 @@ public class OAuthAppDAO {
     public String[] addOAuthConsumer(String username, int tenantId, String userDomain) throws
             IdentityOAuthAdminException {
         String consumerKey;
-        String consumerSecret = OAuthUtil.getRandomNumber();
+        String consumerSecret = OAuthUtil.getRandomNumberSecure();
         long userAccessTokenExpireTime = OAuthServerConfiguration.getInstance()
                 .getUserAccessTokenValidityPeriodInSeconds();
         long applicationAccessTokenExpireTime = OAuthServerConfiguration.getInstance()

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuthApplicationMgtListener.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuthApplicationMgtListener.java
@@ -260,7 +260,7 @@ public class OAuthApplicationMgtListener extends AbstractApplicationMgtListener 
                                 OAuthAppDO app = OAuth2Util.getAppInformationByClientId(oauthConsumerKey);
                                 oAuthConsumerAppDTO.setOauthConsumerSecret(app.getOauthConsumerSecret());
                             } else {
-                                oAuthConsumerAppDTO.setOauthConsumerSecret(OAuthUtil.getRandomNumber());
+                                oAuthConsumerAppDTO.setOauthConsumerSecret(OAuthUtil.getRandomNumberSecure());
                             }
                         }
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -4359,7 +4359,7 @@ public class OAuth2Util {
             X509Certificate x509 = (X509Certificate) cf.generateCertificate(bais);
             Base64URL jwkThumbprint;
             // check config to maintain backward compatibility with SHA-1 thumbprint
-            if (!Boolean.parseBoolean(IdentityUtil.getProperty(
+            if (Boolean.parseBoolean(IdentityUtil.getProperty(
                     IdentityConstants.OAuth.ENABLE_SHA256_JWK_THUMBPRINT))) {
                 jwkThumbprint = RSAKey.parse(x509).computeThumbprint(Constants.SHA256);
             } else {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/model/Constants.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/model/Constants.java
@@ -45,6 +45,7 @@ public class Constants {
     public static final String JWKS_URI = "jwksURI";
     public static final String X509 = "X.509";
     public static final String SHA1 = "SHA-1";
+    public static final String SHA256 = "SHA-256";
 
 
     //JWS is consists of three parts seperated by 2 '.'s as JOSE header, JWS payload, JWS signature

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImplTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImplTest.java
@@ -560,7 +560,7 @@ public class OAuthAdminServiceImplTest extends PowerMockIdentityBaseTest {
     public void testUpdateOauthSecretKey() throws Exception {
 
         mockStatic(OAuthUtil.class);
-        when(OAuthUtil.getRandomNumber()).thenReturn(UPDATED_CONSUMER_SECRET);
+        when(OAuthUtil.getRandomNumberSecure()).thenReturn(UPDATED_CONSUMER_SECRET);
         when(OAuthUtil.buildConsumerAppDTO(any())).thenCallRealMethod();
 
         OAuthAdminServiceImpl oAuthAdminServiceImpl = spy(new OAuthAdminServiceImpl());
@@ -589,7 +589,7 @@ public class OAuthAdminServiceImplTest extends PowerMockIdentityBaseTest {
     public void testUpdateOauthSecretKeyWithException() throws Exception {
 
         mockStatic(OAuthUtil.class);
-        when(OAuthUtil.getRandomNumber()).thenReturn(UPDATED_CONSUMER_SECRET);
+        when(OAuthUtil.getRandomNumberSecure()).thenReturn(UPDATED_CONSUMER_SECRET);
         OAuthAdminServiceImpl oAuthAdminServiceImpl = spy(new OAuthAdminServiceImpl());
         doThrow(new IdentityOAuthAdminException("Error while regenerating consumer secret")).when(oAuthAdminServiceImpl,
                 "updateAppAndRevokeTokensAndAuthzCodes", anyString(), Matchers.any(Properties.class));

--- a/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/DefaultOIDCSessionStateManager.java
+++ b/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/DefaultOIDCSessionStateManager.java
@@ -43,7 +43,7 @@ import static org.wso2.carbon.identity.oidc.session.util.OIDCSessionManagementUt
  */
 public class DefaultOIDCSessionStateManager implements OIDCSessionStateManager {
 
-    private static final String RANDOM_ALG_SHA1 = "SHA1PRNG";
+    private static final String RANDOM_ALG_DRBG = "DRBG";
     private static final String DIGEST_ALG_SHA256 = "SHA-256";
 
     private static final Log log = LogFactory.getLog(OIDCSessionStateManager.class);
@@ -164,7 +164,7 @@ public class DefaultOIDCSessionStateManager implements OIDCSessionStateManager {
     private static String generateSaltValue() throws NoSuchAlgorithmException {
 
         byte[] bytes = new byte[16];
-        SecureRandom secureRandom = SecureRandom.getInstance(RANDOM_ALG_SHA1);
+        SecureRandom secureRandom = SecureRandom.getInstance(RANDOM_ALG_DRBG);
         secureRandom.nextBytes(bytes);
         return Base64.encodeBase64URLSafeString(bytes);
     }

--- a/pom.xml
+++ b/pom.xml
@@ -839,7 +839,7 @@
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!-- Carbon Identity Framework version -->
-        <carbon.identity.framework.version>5.25.92</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.25.711</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.17.5, 6.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 


### PR DESCRIPTION
### Purpose
- Removing SHA1 default usages
- Porting https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2076

## Important
- This PR should be merged after merging [1] and bumping the framework version after the framework release

[1] https://github.com/wso2/carbon-identity-framework/pull/5604