### PR TITLE
[APIM] Introduces `null` Checks for Array Variables

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuer.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuer.java
@@ -745,6 +745,15 @@ public class AccessTokenIssuer {
                                              String[] authorizedInternalScopes) {
 
         String[] scopes = tokReqMsgCtx.getScope();
+        // If scopes is null, initialize it as an empty array
+        if (scopes == null) {
+            scopes = new String[0];
+        }
+        // If authorizedInternalScopes is null, initialize it as an empty array
+        if (authorizedInternalScopes == null) {
+            authorizedInternalScopes = new String[0];
+        }
+
         tokReqMsgCtx.setScope(Stream.concat(Arrays.stream(scopes), Arrays.stream(authorizedInternalScopes))
                 .distinct().toArray(String[]::new));
     }


### PR DESCRIPTION
## Purpose

- Fixes https://github.com/wso2/api-manager/issues/2699 for APIM 4.3.0
- Introduces `null` checks for array variables in `addAuthorizedInternalScopes` method
