### PR TITLE
Fix masking data from error logs when user id not found exception

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthUtil.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthUtil.java
@@ -210,9 +210,7 @@ public final class OAuthUtil {
             userId = resolveUserIdFromUsername(authorizedUser);
             if (StringUtils.isEmpty(userId)) {
                 // Masking getLoggableUserId as it will return the username because the user id is not available.
-                LOG.error("User id cannot be found for user: " + (LoggerUtils.isLogMaskingEnable ?
-                        LoggerUtils.getMaskedContent(authorizedUser.getLoggableUserId()) :
-                        authorizedUser.getLoggableUserId()));
+                LOG.error("User id cannot be found for user: " + authorizedUser.getLoggableMaskedUserId());
                 return;
             }
         }
@@ -243,9 +241,7 @@ public final class OAuthUtil {
                 userId = authenticatedUser.getUserId();
             } catch (UserIdNotFoundException e) {
                 // Masking getLoggableUserId as it will return the username because the user id is not available.
-                LOG.error("User id cannot be found for user: " + (LoggerUtils.isLogMaskingEnable ?
-                        LoggerUtils.getMaskedContent(authenticatedUser.getLoggableUserId()) :
-                        authenticatedUser.getLoggableUserId()));
+                LOG.error("User id cannot be found for user: " + authorizedUser.getLoggableMaskedUserId());
                 return;
             }
             clearOAuthCache(consumerKey, userId, scope);
@@ -272,9 +268,7 @@ public final class OAuthUtil {
             userId = resolveUserIdFromUsername(authorizedUser);
             if (StringUtils.isEmpty(userId)) {
                 // Masking getLoggableUserId as it will return the username because the user id is not available.
-                LOG.error("User id cannot be found for user: " + (LoggerUtils.isLogMaskingEnable ?
-                        LoggerUtils.getMaskedContent(authorizedUser.getLoggableUserId()) :
-                        authorizedUser.getLoggableUserId()));
+                LOG.error("User id cannot be found for user: " + authorizedUser.getLoggableMaskedUserId());
                 return;
             }
         }
@@ -308,9 +302,7 @@ public final class OAuthUtil {
                 userId = authenticatedUser.getUserId();
             } catch (UserIdNotFoundException e) {
                 // Masking getLoggableUserId as it will return the username because the user id is not available.
-                LOG.error("User id cannot be found for user: " + (LoggerUtils.isLogMaskingEnable ?
-                        LoggerUtils.getMaskedContent(authenticatedUser.getLoggableUserId()) :
-                        authenticatedUser.getLoggableUserId()));
+                LOG.error("User id cannot be found for user: " + authorizedUser.getLoggableMaskedUserId());
                 return;
             }
             clearOAuthCache(consumerKey, userId, scope);
@@ -356,10 +348,7 @@ public final class OAuthUtil {
             tenantDomain = authorizedUser.getTenantDomain();
 
         } catch (UserIdNotFoundException e) {
-            // Masking getLoggableUserId as it will return the username because the user id is not available.
-            LOG.error("User id cannot be found for user: " + (LoggerUtils.isLogMaskingEnable ?
-                    LoggerUtils.getMaskedContent(authorizedUser.getLoggableUserId()) :
-                    authorizedUser.getLoggableUserId()));
+            LOG.error("User id cannot be found for user: " + authorizedUser.getLoggableMaskedUserId());
             return;
         }
         if (authorizedUser.getAccessingOrganization() != null) {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/bindings/handlers/TokenBindingExpiryEventHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/bindings/handlers/TokenBindingExpiryEventHandler.java
@@ -303,8 +303,7 @@ public class TokenBindingExpiryEventHandler extends AbstractEventHandler {
             userId = user.getUserId();
         } catch (UserIdNotFoundException e) {
             // Masking getLoggableUserId as it will return the username because the user id is not available.
-            log.error("User id cannot be found for user: " + (LoggerUtils.isLogMaskingEnable ?
-                    LoggerUtils.getMaskedContent(user.getLoggableUserId()) :  user.getLoggableUserId()) +
+            log.error("User id cannot be found for user: " + user.getLoggableMaskedUserId() +
                     ". Hence skip revoking relevant tokens");
             throw new IdentityOAuth2Exception("Unable to revoke tokens for the token binding reference: "
                     + tokenBindingReference);
@@ -336,9 +335,7 @@ public class TokenBindingExpiryEventHandler extends AbstractEventHandler {
                     }
                 } catch (UserIdNotFoundException e) {
                     // Masking getLoggableUserId as it will return the username because the user id is not available.
-                    log.error("User id cannot be found for user: " + (LoggerUtils.isLogMaskingEnable ?
-                            LoggerUtils.getMaskedContent(authenticatedUser.getLoggableUserId()) :
-                            authenticatedUser.getLoggableUserId()));
+                    log.error("User id cannot be found for user: " + user.getLoggableMaskedUserId());
                     throw new IdentityOAuth2Exception("Unable to revoke tokens of the app: " + consumerKey +
                             " for the token binding reference: " + tokenBindingReference);
                 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/bindings/handlers/TokenBindingExpiryEventHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/bindings/handlers/TokenBindingExpiryEventHandler.java
@@ -30,7 +30,6 @@ import org.wso2.carbon.identity.application.authentication.framework.context.Ses
 import org.wso2.carbon.identity.application.authentication.framework.exception.UserIdNotFoundException;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
-import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
 import org.wso2.carbon.identity.event.IdentityEventConstants;
 import org.wso2.carbon.identity.event.IdentityEventException;
 import org.wso2.carbon.identity.event.event.Event;

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AbstractAuthorizationGrantHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AbstractAuthorizationGrantHandler.java
@@ -134,7 +134,8 @@ public abstract class AbstractAuthorizationGrantHandler implements Authorization
             authorizedUserId = tokReqMsgCtx.getAuthorizedUser().getUserId();
         } catch (UserIdNotFoundException e) {
             throw new IdentityOAuth2Exception(
-                    "User id is not available for user: " + tokReqMsgCtx.getAuthorizedUser().getLoggableUserId(), e);
+                    "User id is not available for user: " +
+                            tokReqMsgCtx.getAuthorizedUser().getLoggableMaskedUserId(), e);
         }
         String authenticatedIDP = OAuth2Util.getAuthenticatedIDP(tokReqMsgCtx.getAuthorizedUser());
         String tokenBindingReference = getTokenBindingReference(tokReqMsgCtx);
@@ -581,7 +582,8 @@ public abstract class AbstractAuthorizationGrantHandler implements Authorization
                     }
                 } catch (UserIdNotFoundException e) {
                     throw new IdentityOAuth2Exception(
-                            "User id is not available for user: " + tokenToCache.getAuthzUser().getLoggableUserId(), e);
+                            "User id is not available for user: " +
+                                    tokenToCache.getAuthzUser().getLoggableMaskedUserId(), e);
                 }
 
                 String authenticatedIDP = OAuth2Util.getAuthenticatedIDP(tokenToCache.getAuthzUser());

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/RefreshGrantHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/RefreshGrantHandler.java
@@ -26,7 +26,6 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.oltu.oauth2.common.exception.OAuthSystemException;
 import org.wso2.carbon.identity.application.authentication.framework.exception.UserIdNotFoundException;
 import org.wso2.carbon.identity.base.IdentityConstants;
-import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.oauth.cache.AuthorizationGrantCache;
 import org.wso2.carbon.identity.oauth.cache.AuthorizationGrantCacheEntry;

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/RefreshGrantHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/RefreshGrantHandler.java
@@ -305,9 +305,7 @@ public class RefreshGrantHandler extends AbstractAuthorizationGrantHandler {
             } catch (UserIdNotFoundException e) {
                 // Masking getLoggableUserId as it will return the username because the user id is not available.
                 throw new IdentityOAuth2Exception("User id is not available for user: " +
-                        (LoggerUtils.isLogMaskingEnable ?
-                                LoggerUtils.getMaskedContent(tokReqMsgCtx.getAuthorizedUser().getLoggableUserId()) :
-                                tokReqMsgCtx.getAuthorizedUser().getLoggableUserId()), e);
+                        tokReqMsgCtx.getAuthorizedUser().getLoggableMaskedUserId(), e);
             }
             String authenticatedIDP = tokReqMsgCtx.getAuthorizedUser().getFederatedIdPName();
             String accessingOrganization = OAuthConstants.AuthorizedOrganization.NONE;

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -3967,7 +3967,7 @@ public class OAuth2Util {
                 authenticatedUser.setUserId(userId);
             } catch (UserIdNotFoundException e) {
                 throw new IdentityOAuth2Exception(
-                        "User id is not available for user: " + authzUser.getLoggableUserId(), e);
+                        "User id is not available for user: " + authzUser.getLoggableMaskedUserId(), e);
             }
         }
         return authenticatedUser;


### PR DESCRIPTION
### Proposed changes in this pull request

- Fix the data is not masking issue when user id not found exception
- instead of using the deprecated method  `getLoggableUserId()` , Use the method `getLoggableMaskedUserId()` to masked the data when user id not found exception
    - https://github.com/wso2/carbon-identity-framework/blob/65e8b217a28db39610d687f5fbb35c63c6866b44/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/model/AuthenticatedUser.java#L395

