### PR TITLE
Fix super tenant system apps get overridden from the newly created tenanted system app when tenant creation for IDaaS deployments

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImpl.java
@@ -478,7 +478,7 @@ public class OAuthAdminServiceImpl {
                         app.setFapiConformanceEnabled(application.isFapiConformanceEnabled());
                     }
                     dao.addOAuthApplication(app);
-                    AppInfoCache.getInstance().addToCache(app.getOauthConsumerKey(), app);
+                    AppInfoCache.getInstance().addToCache(app.getOauthConsumerKey(), app, tenantDomain);
                     if (LOG.isDebugEnabled()) {
                         LOG.debug("Oauth Application registration success : " + application.getApplicationName() +
                                 " in tenant domain: " + tenantDomain);

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dao/OAuthAppDAO.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dao/OAuthAppDAO.java
@@ -1161,6 +1161,12 @@ public class OAuthAppDAO {
     public void updateOAuthConsumerApp(ServiceProvider serviceProvider, String consumerKey)
             throws IdentityApplicationManagementException, IdentityOAuthAdminException {
 
+        int tenantId;
+        if (StringUtils.isNotEmpty(serviceProvider.getTenantDomain())) {
+            tenantId = IdentityTenantUtil.getTenantId(serviceProvider.getTenantDomain());
+        } else {
+            tenantId = IdentityTenantUtil.getLoginTenantId();
+        }
         if (validateUserForOwnerUpdate(serviceProvider)) {
             try (Connection connection = IdentityDatabaseUtil.getDBConnection(true)) {
                  try (PreparedStatement statement = connection.prepareStatement(
@@ -1169,7 +1175,7 @@ public class OAuthAppDAO {
                      statement.setString(2, serviceProvider.getOwner().getUserName());
                      statement.setString(3, serviceProvider.getOwner().getUserStoreDomain());
                      statement.setString(4, consumerKey);
-                     statement.setInt(5, IdentityTenantUtil.getLoginTenantId());
+                     statement.setInt(5, tenantId);
                      statement.execute();
                      IdentityDatabaseUtil.commitTransaction(connection);
                  } catch (SQLException e1) {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -2346,9 +2346,10 @@ public class OAuth2Util {
         if (oAuthAppDO == null) {
             oAuthAppDO = new OAuthAppDAO().getAppInformation(clientId, accessTokenDO);
             if (oAuthAppDO != null) {
-                String tenantDomain = oAuthAppDO.getAppOwner().getTenantDomain();
-                if (StringUtils.isNotEmpty(tenantDomain)) {
-                    AppInfoCache.getInstance().addToCache(clientId, oAuthAppDO, tenantDomain);
+                if (oAuthAppDO.getAppOwner() != null &&
+                        StringUtils.isNotEmpty(oAuthAppDO.getAppOwner().getTenantDomain())) {
+                    AppInfoCache.getInstance().addToCache(clientId, oAuthAppDO,
+                            oAuthAppDO.getAppOwner().getTenantDomain());
                 } else {
                     AppInfoCache.getInstance().addToCache(clientId, oAuthAppDO);
                 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -2346,7 +2346,12 @@ public class OAuth2Util {
         if (oAuthAppDO == null) {
             oAuthAppDO = new OAuthAppDAO().getAppInformation(clientId, accessTokenDO);
             if (oAuthAppDO != null) {
-                AppInfoCache.getInstance().addToCache(clientId, oAuthAppDO);
+                String tenantDomain = oAuthAppDO.getAppOwner().getTenantDomain();
+                if (StringUtils.isNotEmpty(tenantDomain)) {
+                    AppInfoCache.getInstance().addToCache(clientId, oAuthAppDO, tenantDomain);
+                } else {
+                    AppInfoCache.getInstance().addToCache(clientId, oAuthAppDO);
+                }
             }
         }
         return oAuthAppDO;


### PR DESCRIPTION
$subject

Without this fix, when tenant creation, the super tenant console and my account configurations get overridden by the configs of the newly created console app and my Account.

Ex: The app owner which was super tenant admin was changed to the owner of the tenanted console app.
