### PR TITLE
Sync token issuance logic to resolve user attributes missing in the subsequent Id tokens for concurrent requests

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AuthorizationCodeGrantHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AuthorizationCodeGrantHandler.java
@@ -103,6 +103,21 @@ public class AuthorizationCodeGrantHandler extends AbstractAuthorizationGrantHan
         return tokenResp;
     }
 
+    /**
+     * Build and return a string to be used as a lock for synchronous token issuance for refresh token grant type.
+     *
+     * @param tokReqMsgCtx        OAuthTokenReqMessageContext
+     * @return A string to be used as a lock for synchronous token issuance for refresh token grant type.
+     */
+    public String buildSyncLockString(OAuthTokenReqMessageContext tokReqMsgCtx) {
+
+        String clientId = tokReqMsgCtx.getOauth2AccessTokenReqDTO().getClientId();
+        String authzCode = tokReqMsgCtx.getOauth2AccessTokenReqDTO().getAuthorizationCode();
+        String tokenBindingReference = OAuth2Util.getTokenBindingReferenceString(tokReqMsgCtx);
+
+        return AUTHZ_CODE + ":" + clientId + ":" + authzCode + ":" + tokenBindingReference;
+    }
+
     private void setPropertiesForTokenGeneration(OAuthTokenReqMessageContext tokReqMsgCtx,
                                                  OAuth2AccessTokenReqDTO tokenReq, AuthzCodeDO authzCodeBean) {
         tokReqMsgCtx.setAuthorizedUser(authzCodeBean.getAuthorizedUser());

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AuthorizationCodeGrantHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AuthorizationCodeGrantHandler.java
@@ -114,8 +114,9 @@ public class AuthorizationCodeGrantHandler extends AbstractAuthorizationGrantHan
         String clientId = tokReqMsgCtx.getOauth2AccessTokenReqDTO().getClientId();
         String authzCode = tokReqMsgCtx.getOauth2AccessTokenReqDTO().getAuthorizationCode();
         String tokenBindingReference = OAuth2Util.getTokenBindingReferenceString(tokReqMsgCtx);
+        String scope = OAuth2Util.buildScopeString(tokReqMsgCtx.getScope());
 
-        return AUTHZ_CODE + ":" + clientId + ":" + authzCode + ":" + tokenBindingReference;
+        return AUTHZ_CODE + ":" + clientId + ":" + authzCode + ":" + tokenBindingReference + ":" + scope;
     }
 
     private void setPropertiesForTokenGeneration(OAuthTokenReqMessageContext tokReqMsgCtx,

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AuthorizationGrantHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AuthorizationGrantHandler.java
@@ -111,4 +111,15 @@ public interface AuthorizationGrantHandler {
      * @throws IdentityOAuth2Exception
      */
     boolean isAuthorizedClient(OAuthTokenReqMessageContext tokReqMsgCtx) throws IdentityOAuth2Exception;
+
+    /**
+     * Build the string to be used for the sync lock for synchoronized token issuance.
+     *
+     * @param tokReqMsgCtx Token request message context.
+     * @return String to be used as the key for the sync lock
+     */
+    default String buildSyncLockString(OAuthTokenReqMessageContext tokReqMsgCtx) {
+
+        return null;
+    }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/RefreshGrantHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/RefreshGrantHandler.java
@@ -61,6 +61,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.GrantTypes.REFRESH_TOKEN;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.TokenBindings.NONE;
 import static org.wso2.carbon.identity.oauth2.util.OAuth2Util.buildCacheKeyStringForTokenWithUserId;
 import static org.wso2.carbon.identity.oauth2.util.OAuth2Util.buildCacheKeyStringForTokenWithUserIdOrgId;
@@ -184,6 +185,21 @@ public class RefreshGrantHandler extends AbstractAuthorizationGrantHandler {
             tokReqMsgCtx.setScope(requestedScopes);
         }
         return true;
+    }
+
+    /**
+     * Build and return a string to be used as a lock for synchronous token issuance for refresh token grant type.
+     *
+     * @param tokReqMsgCtx        OAuthTokenReqMessageContext
+     * @return A string to be used as a lock for synchronous token issuance for refresh token grant type.
+     */
+    public String buildSyncLockString(OAuthTokenReqMessageContext tokReqMsgCtx) {
+
+        String clientId = tokReqMsgCtx.getOauth2AccessTokenReqDTO().getClientId();
+        String refreshToken = tokReqMsgCtx.getOauth2AccessTokenReqDTO().getRefreshToken();
+        String tokenBindingReference = OAuth2Util.getTokenBindingReferenceString(tokReqMsgCtx);
+
+        return REFRESH_TOKEN + ":" + clientId + ":" + refreshToken + ":" + tokenBindingReference;
     }
 
     private void setPropertiesForTokenGeneration(OAuthTokenReqMessageContext tokReqMsgCtx,

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/RefreshGrantHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/RefreshGrantHandler.java
@@ -198,8 +198,9 @@ public class RefreshGrantHandler extends AbstractAuthorizationGrantHandler {
         String clientId = tokReqMsgCtx.getOauth2AccessTokenReqDTO().getClientId();
         String refreshToken = tokReqMsgCtx.getOauth2AccessTokenReqDTO().getRefreshToken();
         String tokenBindingReference = OAuth2Util.getTokenBindingReferenceString(tokReqMsgCtx);
+        String scope = OAuth2Util.buildScopeString(tokReqMsgCtx.getScope());
 
-        return REFRESH_TOKEN + ":" + clientId + ":" + refreshToken + ":" + tokenBindingReference;
+        return REFRESH_TOKEN + ":" + clientId + ":" + refreshToken + ":" + tokenBindingReference + ":" + scope;
     }
 
     private void setPropertiesForTokenGeneration(OAuthTokenReqMessageContext tokReqMsgCtx,

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -902,6 +902,27 @@ public class OAuth2Util {
         return DigestUtils.md5Hex(tokenBindingValue);
     }
 
+    /**
+     * Get token binding reference string from OAuthTokenReqMessageContext.
+     * Returns NONE if token binding is not enabled or token binding reference is not available.
+     *
+     * @param tokReqMsgCtx OAuthTokenReqMessageContext.
+     * @return token binding reference.
+     */
+    public static String getTokenBindingReferenceString(OAuthTokenReqMessageContext tokReqMsgCtx) {
+
+        if (tokReqMsgCtx.getTokenBinding() == null) {
+            if (log.isDebugEnabled()) {
+                log.debug("Token binding data is null.");
+            }
+            return NONE;
+        }
+        if (StringUtils.isBlank(tokReqMsgCtx.getTokenBinding().getBindingReference())) {
+            return NONE;
+        }
+        return tokReqMsgCtx.getTokenBinding().getBindingReference();
+    }
+
     public static AccessTokenDO validateAccessTokenDO(AccessTokenDO accessTokenDO) {
 
         long validityPeriodMillis = accessTokenDO.getValidityPeriodInMillis();


### PR DESCRIPTION
### Purpose
- When there are concurrent refresh token requests, only the first Id token issued has the user attributes
- This PR resolves the issue by syncing the token issuance logic

### Related Issue
- https://github.com/wso2/product-is/issues/18890