### PR TITLE
Add config supported response type validators

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
+++ b/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
@@ -187,6 +187,8 @@ public final class OAuthConstants {
     public static final String CODE_IDTOKEN = "code id_token";
     public static final String CODE_IDTOKEN_TOKEN = "code id_token token";
     public static final String SUBJECT_TOKEN = "subject_token";
+    public static final String ID_TOKEN_SUBJECT_TOKEN = "id_token subject_token";
+
     public static final String IMPERSONATED_SUBJECT = "IMPERSONATED_SUBJECT";
     public static final String IMPERSONATING_ACTOR = "IMPERSONATING_ACTOR";
     public static final String IDTOKEN_TOKEN = "id_token token";

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
@@ -42,6 +42,7 @@ import org.wso2.carbon.identity.oauth.common.IDTokenResponseValidator;
 import org.wso2.carbon.identity.oauth.common.IDTokenTokenResponseValidator;
 import org.wso2.carbon.identity.oauth.common.OAuthConstants;
 import org.wso2.carbon.identity.oauth.common.SAML2GrantValidator;
+import org.wso2.carbon.identity.oauth.common.SubjectTokenResponseValidator;
 import org.wso2.carbon.identity.oauth.tokenprocessor.HashingPersistenceProcessor;
 import org.wso2.carbon.identity.oauth.tokenprocessor.PlainTextPersistenceProcessor;
 import org.wso2.carbon.identity.oauth.tokenprocessor.TokenPersistenceProcessor;

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
@@ -1066,6 +1066,8 @@ public class OAuthServerConfiguration {
                             CodeTokenResponseValidator.class);
                     supportedResponseTypeValidatorsTemp.put(OAuthConstants.SUBJECT_TOKEN,
                             SubjectTokenResponseValidator.class);
+                    supportedResponseTypeValidatorsTemp.put(OAuthConstants.ID_TOKEN_SUBJECT_TOKEN,
+                            SubjectTokenResponseValidator.class);
                     if (supportedResponseTypeValidatorNames != null) {
                         // Load configured grant type validators
                         for (Map.Entry<String, String> entry : supportedResponseTypeValidatorNames

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
@@ -1063,6 +1063,8 @@ public class OAuthServerConfiguration {
                             CodeTokenResponseValidator.class);
                     supportedResponseTypeValidatorsTemp.put(OAuthConstants.CODE_IDTOKEN_TOKEN,
                             CodeTokenResponseValidator.class);
+                    supportedResponseTypeValidatorsTemp.put(OAuthConstants.SUBJECT_TOKEN,
+                            SubjectTokenResponseValidator.class);
                     if (supportedResponseTypeValidatorNames != null) {
                         // Load configured grant type validators
                         for (Map.Entry<String, String> entry : supportedResponseTypeValidatorNames

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfigurationTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfigurationTest.java
@@ -373,7 +373,7 @@ public class OAuthServerConfigurationTest extends PowerMockIdentityBaseTest {
     public void testGetSupportedResponseTypeValidators() throws Exception {
 
         Assert.assertTrue(OAuthServerConfiguration.getInstance()
-                .getSupportedResponseTypeValidators().size() == 7, "Expected value not returned from getter");
+                .getSupportedResponseTypeValidators().size() == 8, "Expected value not returned from getter");
     }
 
     @Test

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfigurationTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfigurationTest.java
@@ -373,7 +373,7 @@ public class OAuthServerConfigurationTest extends PowerMockIdentityBaseTest {
     public void testGetSupportedResponseTypeValidators() throws Exception {
 
         Assert.assertTrue(OAuthServerConfiguration.getInstance()
-                .getSupportedResponseTypeValidators().size() == 8, "Expected value not returned from getter");
+                .getSupportedResponseTypeValidators().size() == 9, "Expected value not returned from getter");
     }
 
     @Test


### PR DESCRIPTION
Public Issue: https://github.com/wso2/product-is/issues/20066

## Purpose
With https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2435, we added subject token response type validator. With this PR, we are enabling the validator as valid response type.

- [x] Unit Tests Covered [Link](https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2441/files#diff-06876dbbae19d854ca869b261405d9cc3dee101cfdce85d33ae525d0757465c8R376)
