### PR TITLE
Improve response type method in AbstractResponseModeProvider

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/responsemode/provider/AbstractResponseModeProvider.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/responsemode/provider/AbstractResponseModeProvider.java
@@ -28,7 +28,7 @@ import java.util.Arrays;
  */
 public abstract class AbstractResponseModeProvider implements ResponseModeProvider {
 
-    public static final String SPACE_SEPARATOR = " ";
+    private static final String SPACE_SEPARATOR = " ";
 
     /**
      * Checks if the given response type contains either "id_token" or "token".

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/responsemode/provider/AbstractResponseModeProvider.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/responsemode/provider/AbstractResponseModeProvider.java
@@ -21,21 +21,42 @@ package org.wso2.carbon.identity.oauth2.responsemode.provider;
 import org.apache.commons.lang.StringUtils;
 import org.wso2.carbon.identity.oauth.common.OAuthConstants;
 
+import java.util.Arrays;
+
 /**
  * Abstract class for response mode provider classes
  */
 public abstract class AbstractResponseModeProvider implements ResponseModeProvider {
 
+    public static final String SPACE_SEPARATOR = " ";
+
     /**
-     * Check whether the response type is "token" or "id_token"
-     * @param responseType response_type passed
-     * @return true if response_type is "token" or "id_token"
+     * Checks if the given response type contains either "id_token" or "token".
+     *
+     * @param responseType The response type to check.
+     * @return {@code true} if "id_token" or "token" is present in the response type, {@code false} otherwise.
      */
     protected boolean hasIDTokenOrTokenInResponseType(String responseType) {
 
-        return StringUtils.isNotBlank(responseType)
-                && (responseType.toLowerCase().contains(OAuthConstants.ID_TOKEN)
-                || responseType.toLowerCase().contains(OAuthConstants.TOKEN));
+        return hasResponseType(responseType, OAuthConstants.ID_TOKEN)
+                || hasResponseType(responseType, OAuthConstants.TOKEN);
+    }
+
+    /**
+     * Checks if the given response type contains the specified OAuth response type.
+     *
+     * @param responseType      The response type to check.
+     * @param oauthResponseType The OAuth response type to look for.
+     * @return {@code true} if the specified OAuth response type is present in the response type,
+     * {@code false} otherwise.
+     */
+    private boolean hasResponseType(String responseType, String oauthResponseType) {
+
+        if (StringUtils.isNotBlank(responseType)) {
+            String[] responseTypes = responseType.split(SPACE_SEPARATOR);
+            return Arrays.asList(responseTypes).contains(oauthResponseType);
+        }
+        return false;
     }
 
     /**


### PR DESCRIPTION
Related Public Issue: https://github.com/wso2/product-is/issues/20066

## Issue
Current response type check in AbstractResponseModeProvider use String.contains which may not give expected result in all scenarios.

For ex:
custom response type "subject_token" contain "token" string but that doesn't mean it represents token response type.

## Fix
Hence we use SPACE SEPARATOR to seperate given response type then the expression Arrays.asList(responseTypes).contains(oauthResponseType) checks whether the oauthResponseType is present in the array responseTypes.