### PR TITLE
Add Impersonated Access Token Claim Provider

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuth2ServiceComponent.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuth2ServiceComponent.java
@@ -85,6 +85,7 @@ import org.wso2.carbon.identity.oauth2.token.bindings.impl.ClientRequestTokenBin
 import org.wso2.carbon.identity.oauth2.token.bindings.impl.CookieBasedTokenBinder;
 import org.wso2.carbon.identity.oauth2.token.bindings.impl.DeviceFlowTokenBinder;
 import org.wso2.carbon.identity.oauth2.token.bindings.impl.SSOSessionBasedTokenBinder;
+import org.wso2.carbon.identity.oauth2.token.handlers.claims.ImpersonatedAccessTokenClaimProvider;
 import org.wso2.carbon.identity.oauth2.token.handlers.claims.JWTAccessTokenClaimProvider;
 import org.wso2.carbon.identity.oauth2.token.handlers.response.AccessTokenResponseHandler;
 import org.wso2.carbon.identity.oauth2.token.handlers.response.FederatedTokenResponseHandler;
@@ -261,6 +262,8 @@ public class OAuth2ServiceComponent {
             PublicClientAuthenticator publicClientAuthenticator = new PublicClientAuthenticator();
             bundleContext.registerService(OAuthClientAuthenticator.class.getName(), publicClientAuthenticator,
                     null);
+            bundleContext.registerService(JWTAccessTokenClaimProvider.class.getName(),
+                    new ImpersonatedAccessTokenClaimProvider(), null);
 
             // Register cookie based access token binder.
             CookieBasedTokenBinder cookieBasedTokenBinder = new CookieBasedTokenBinder();

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/OAuthTokenReqMessageContext.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/OAuthTokenReqMessageContext.java
@@ -54,6 +54,8 @@ public class OAuthTokenReqMessageContext {
 
     private boolean isConsentedToken;
 
+    private boolean isImpersonationRequest;
+
     public OAuthTokenReqMessageContext(OAuth2AccessTokenReqDTO oauth2AccessTokenReqDTO) {
 
         this.oauth2AccessTokenReqDTO = oauth2AccessTokenReqDTO;
@@ -170,5 +172,15 @@ public class OAuthTokenReqMessageContext {
     public void setConsentedToken(boolean consentedToken) {
 
         isConsentedToken = consentedToken;
+    }
+
+    public boolean isImpersonationRequest() {
+
+        return isImpersonationRequest;
+    }
+
+    public void setImpersonationRequest(boolean impersonationRequest) {
+
+        isImpersonationRequest = impersonationRequest;
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/claims/ImpersonatedAccessTokenClaimProvider.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/claims/ImpersonatedAccessTokenClaimProvider.java
@@ -31,12 +31,13 @@ import java.util.Map;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.IMPERSONATING_ACTOR;
 
 /**
- * Adds new claims into JWT Access Tokens.
+ * A class that provides additional claims for JWT access tokens when impersonation is requested.
  */
 public class ImpersonatedAccessTokenClaimProvider implements JWTAccessTokenClaimProvider {
 
     private static final String ACT = "act";
     private static final String SUB = "SUB";
+
     @Override
     public Map<String, Object> getAdditionalClaims(OAuthAuthzReqMessageContext context) throws IdentityOAuth2Exception {
 
@@ -47,6 +48,7 @@ public class ImpersonatedAccessTokenClaimProvider implements JWTAccessTokenClaim
     public Map<String, Object> getAdditionalClaims(OAuthTokenReqMessageContext context) throws IdentityOAuth2Exception {
 
         if (context.isImpersonationRequest()
+                && (context.getProperty(IMPERSONATING_ACTOR) != null)
                 && StringUtils.isNotBlank(context.getProperty(IMPERSONATING_ACTOR).toString())) {
 
             Map<String, Object> actorMap = new HashMap<>();

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/claims/ImpersonatedAccessTokenClaimProvider.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/claims/ImpersonatedAccessTokenClaimProvider.java
@@ -1,0 +1,58 @@
+/*
+ *  Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+
+package org.wso2.carbon.identity.oauth2.token.handlers.claims;
+
+import org.apache.commons.lang.StringUtils;
+import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
+import org.wso2.carbon.identity.oauth2.authz.OAuthAuthzReqMessageContext;
+import org.wso2.carbon.identity.oauth2.token.OAuthTokenReqMessageContext;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.IMPERSONATING_ACTOR;
+
+/**
+ * Adds new claims into JWT Access Tokens.
+ */
+public class ImpersonatedAccessTokenClaimProvider implements JWTAccessTokenClaimProvider {
+
+    private static final String ACT = "act";
+    private static final String SUB = "SUB";
+    @Override
+    public Map<String, Object> getAdditionalClaims(OAuthAuthzReqMessageContext context) throws IdentityOAuth2Exception {
+
+        return null;
+    }
+
+    @Override
+    public Map<String, Object> getAdditionalClaims(OAuthTokenReqMessageContext context) throws IdentityOAuth2Exception {
+
+        if (context.isImpersonationRequest()
+                && StringUtils.isNotBlank(context.getProperty(IMPERSONATING_ACTOR).toString())) {
+
+            Map<String, Object> actorMap = new HashMap<>();
+            actorMap.put(ACT, Collections.singletonMap(SUB, context.getProperty(IMPERSONATING_ACTOR).toString()));
+            return actorMap;
+        }
+        return null;
+    }
+}

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/claims/ImpersonatedAccessTokenClaimProvider.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/claims/ImpersonatedAccessTokenClaimProvider.java
@@ -36,7 +36,7 @@ import static org.wso2.carbon.identity.oauth.common.OAuthConstants.IMPERSONATING
 public class ImpersonatedAccessTokenClaimProvider implements JWTAccessTokenClaimProvider {
 
     private static final String ACT = "act";
-    private static final String SUB = "SUB";
+    private static final String SUB = "sub";
 
     @Override
     public Map<String, Object> getAdditionalClaims(OAuthAuthzReqMessageContext context) throws IdentityOAuth2Exception {

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/handlers/claims/ImpersonatedAccessTokenClaimProviderTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/handlers/claims/ImpersonatedAccessTokenClaimProviderTest.java
@@ -1,0 +1,87 @@
+/*
+ *  Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+
+package org.wso2.carbon.identity.oauth2.token.handlers.claims;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.oauth2.token.OAuthTokenReqMessageContext;
+import org.wso2.carbon.identity.testutil.powermock.PowerMockIdentityBaseTest;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+public class ImpersonatedAccessTokenClaimProviderTest extends PowerMockIdentityBaseTest {
+
+    private OAuthTokenReqMessageContext tokReqMsgCtx;
+    public static final String IMPERSONATING_ACTOR = "IMPERSONATING_ACTOR";
+    private static final String ACT = "act";
+    private static final String SUB = "SUB";
+
+
+    @BeforeMethod
+    public void init() {
+
+        tokReqMsgCtx = mock(OAuthTokenReqMessageContext.class);
+    }
+
+    @DataProvider(name = "GetAdditionalClaimsDataProvider")
+    public Object[][] getAdditionalClaimsDataProvider() {
+
+        Map<String, Object> validActorMap = new HashMap<>();
+        validActorMap.put(ACT, Collections.singletonMap(SUB, IMPERSONATING_ACTOR));
+        return new Object[][]{
+                {true, IMPERSONATING_ACTOR, validActorMap},
+                {true, null, null},
+                {true, "", null},
+                {true, " ", null},
+                {false, IMPERSONATING_ACTOR, null},
+        };
+    }
+
+    @Test(dataProvider = "GetAdditionalClaimsDataProvider")
+    public void testGetAdditionalClaimsData(boolean isImpersonationRequest, String impersonator,
+                                            Map<String, Object> claimMapping)
+            throws Exception {
+
+        JWTAccessTokenClaimProvider claimProvider = new ImpersonatedAccessTokenClaimProvider();
+        when(tokReqMsgCtx.isImpersonationRequest()).thenReturn(isImpersonationRequest);
+        when(tokReqMsgCtx.getProperty(IMPERSONATING_ACTOR)).thenReturn(impersonator);
+
+        Map<String, Object> actorMap;
+        actorMap = claimProvider.getAdditionalClaims(tokReqMsgCtx);
+
+        if (claimMapping != null) {
+
+            assertTrue(actorMap.containsKey(ACT), "Expected 'act' claim in the claim mapping");
+            assertEquals(IMPERSONATING_ACTOR, ((Map<String, Object>) actorMap.get(ACT)).get(SUB),
+                    "Expected 'act' claim in the claim mapping has 'sub' claim.");
+        } else {
+            assertNull(actorMap, " Expected Null mapping but retrieved non null object.");
+        }
+    }
+}

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/handlers/claims/ImpersonatedAccessTokenClaimProviderTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/handlers/claims/ImpersonatedAccessTokenClaimProviderTest.java
@@ -40,7 +40,7 @@ public class ImpersonatedAccessTokenClaimProviderTest extends PowerMockIdentityB
     private OAuthTokenReqMessageContext tokReqMsgCtx;
     public static final String IMPERSONATING_ACTOR = "IMPERSONATING_ACTOR";
     private static final String ACT = "act";
-    private static final String SUB = "SUB";
+    private static final String SUB = "sub";
 
 
     @BeforeMethod

--- a/components/org.wso2.carbon.identity.oauth/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.identity.oauth/src/test/resources/testng.xml
@@ -114,6 +114,7 @@
             <class name="org.wso2.carbon.identity.oauth2.validators.jwt.JWKSBasedJWTValidatorTest"/>
             <class name="org.wso2.carbon.identity.oauth2.device.codegenerator.GenerateKeysTest"/>
             <class name="org.wso2.carbon.identity.oauth2.responsemode.provider.ResponseModeProviderTest"/>
+            <class name="org.wso2.carbon.identity.oauth2.token.handlers.claims.ImpersonatedAccessTokenClaimProviderTest"></class>
         </classes>
     </test>
 


### PR DESCRIPTION
Public Issue: https://github.com/wso2/product-is/issues/20066

## Purpose
Once subject token is received it can be used to exchange for impersonated Access token. This access token should contain 
'act' claim which indicates the subject of impersonator.

## Approach
Here we are extending JWT Access Token Claim Provider and introducing ImpersonatedAccessTokenClaimProvider class. When issuing jwt access tokens, it will help to add 'act' claim to Impersonated access token.


- [x] Unit Tests Covered [Link](https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2443/files#diff-9bdaecc96fafaba48f03695c72198afce0c55ea1369e6236a99d95fda42f85c5R38)