### PR TITLE
Response mode for subject token

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/responsemode/provider/SuccessResponseDTO.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/responsemode/provider/SuccessResponseDTO.java
@@ -32,6 +32,7 @@ public class SuccessResponseDTO {
     private String tokenType;
     private long validityPeriod;
     private String formPostBody;
+    private String subjectToken;
     private Set<String> scope = null;
 
     public String getAuthorizationCode() {
@@ -105,5 +106,15 @@ public class SuccessResponseDTO {
     public void setFormPostBody(String formPostBody) {
 
         this.formPostBody = formPostBody;
+    }
+
+    public String getSubjectToken() {
+
+        return subjectToken;
+    }
+
+    public void setSubjectToken(String subjectToken) {
+
+        this.subjectToken = subjectToken;
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/responsemode/provider/impl/FragmentResponseModeProvider.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/responsemode/provider/impl/FragmentResponseModeProvider.java
@@ -54,6 +54,7 @@ public class FragmentResponseModeProvider extends AbstractResponseModeProvider {
             long validityPeriod = authorizationResponseDTO.getSuccessResponseDTO().getValidityPeriod();
             String scope = authorizationResponseDTO.getSuccessResponseDTO().getScope();
             String authenticatedIdPs = authorizationResponseDTO.getAuthenticatedIDPs();
+            String subjectToken = authorizationResponseDTO.getSuccessResponseDTO().getSubjectToken();
             List<String> params = new ArrayList<>();
             if (accessToken != null) {
                 params.add(OAuthConstants.ACCESS_TOKEN_RESPONSE_PARAM + "=" + accessToken);
@@ -86,6 +87,10 @@ public class FragmentResponseModeProvider extends AbstractResponseModeProvider {
 
             if (scope != null) {
                 params.add(OAuthConstants.SCOPE + "=" + scope);
+            }
+
+            if (StringUtils.isNotBlank(subjectToken)) {
+                params.add(OAuthConstants.SUBJECT_TOKEN + "=" + subjectToken);
             }
 
             redirectUrl += "#" + String.join("&", params);

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/responsemode/provider/impl/QueryResponseModeProvider.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/responsemode/provider/impl/QueryResponseModeProvider.java
@@ -81,6 +81,7 @@ public class QueryResponseModeProvider extends AbstractResponseModeProvider {
             long validityPeriod = authorizationResponseDTO.getSuccessResponseDTO().getValidityPeriod();
             String scope = authorizationResponseDTO.getSuccessResponseDTO().getScope();
             String authenticatedIdPs = authorizationResponseDTO.getAuthenticatedIDPs();
+            String subjectToken = authorizationResponseDTO.getSuccessResponseDTO().getSubjectToken();
             List<String> queryParams = new ArrayList<>();
             if (accessToken != null) {
                 queryParams.add(OAuthConstants.ACCESS_TOKEN_RESPONSE_PARAM + "=" + accessToken);
@@ -113,6 +114,10 @@ public class QueryResponseModeProvider extends AbstractResponseModeProvider {
 
             if (scope != null) {
                 queryParams.add(OAuthConstants.SCOPE + "=" + scope);
+            }
+
+            if (StringUtils.isNotBlank(subjectToken)) {
+                queryParams.add(OAuthConstants.SUBJECT_TOKEN + "=" + subjectToken);
             }
 
             redirectUrl = FrameworkUtils.appendQueryParamsStringToUrl(redirectUrl,

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/responsemode/provider/ResponseModeProviderTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/responsemode/provider/ResponseModeProviderTest.java
@@ -30,10 +30,10 @@ public class ResponseModeProviderTest {
                         "https://www.google.com/redirects/redirect2?param1=abc&param2=xyz#access_token=access_token_1" +
                                 "&expires_in=3600&code=code3&scope=randomScope"},
                 {getAuthResponseDTO("https://www.google.com/redirects/redirect2?param1=abc&param2=xyz",
-                        "code3", null, "subject_token_1"),
+                        null, null, "subject_token_1"),
                         "https://www.google.com/redirects/redirect2?param1=abc&param2=xyz",
-                        "https://www.google.com/redirects/redirect2?param1=abc&param2=xyz#code=code3" +
-                                "&subject_token=subject_token_1"},
+                        "https://www.google.com/redirects/redirect2?param1=abc&param2=xyz#" +
+                                "subject_token=subject_token_1"},
 
         };
     }
@@ -49,7 +49,10 @@ public class ResponseModeProviderTest {
         Assert.assertTrue(redirectUrl.contains(callbackUrl), "Redirect url does not " +
                 "contain the callback url provided.");
         Assert.assertTrue(redirectUrl.contains("#"), "Redirect url does not contain a fragment part.");
-        Assert.assertTrue(redirectUrl.contains("code="), "Redirect url does not contain the authorization code.");
+        if (authorizationResponseDTO.getSuccessResponseDTO().getAuthorizationCode() != null) {
+            Assert.assertTrue(redirectUrl.contains("code="),
+                    "Redirect url does not contain the authorization code.");
+        }
         Assert.assertEquals(redirectUrl, expectedRedirectUrl, "Redirect url is not as expected.");
     }
 
@@ -72,9 +75,9 @@ public class ResponseModeProviderTest {
                         "https://www.google.com/redirects/redirect2?param1=abc&param2=xyz&access_token=access_token_1" +
                                 "&expires_in=3600&code=code3&scope=randomScope"},
                 {getAuthResponseDTO("https://www.google.com/redirects/redirect2?param1=abc&param2=xyz",
-                        "code3", null, "subject_token_1"),
+                        null, null, "subject_token_1"),
                         "https://www.google.com/redirects/redirect2?param1=abc&param2=xyz",
-                        "https://www.google.com/redirects/redirect2?param1=abc&param2=xyz&code=code3" +
+                        "https://www.google.com/redirects/redirect2?param1=abc&param2=xyz" +
                                 "&subject_token=subject_token_1"},
 
         };
@@ -91,7 +94,10 @@ public class ResponseModeProviderTest {
         Assert.assertTrue(redirectUrl.contains(callbackUrl), "Redirect url does not " +
                 "contain the callback url provided.");
         Assert.assertTrue(redirectUrl.contains("?"), "Redirect url does not contain a query part.");
-        Assert.assertTrue(redirectUrl.contains("code="), "Redirect url does not contain the authorization code.");
+        if (authorizationResponseDTO.getSuccessResponseDTO().getAuthorizationCode() != null) {
+            Assert.assertTrue(redirectUrl.contains("code="),
+                    "Redirect url does not contain the authorization code.");
+        }
         Assert.assertEquals(redirectUrl, expectedRedirectUrl, "Redirect url is not as expected.");
     }
 

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/responsemode/provider/ResponseModeProviderTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/responsemode/provider/ResponseModeProviderTest.java
@@ -16,13 +16,24 @@ public class ResponseModeProviderTest {
 
         return new Object[][] {
                 // AuthorizationResponseDTO, provided callback url, expected redirect url
-                {getAuthResponseDTO("https://www.google.com/redirects/redirect1", "code1"),
+                {getAuthResponseDTO("https://www.google.com/redirects/redirect1", "code1", null,
+                        null),
                         "https://www.google.com/redirects/redirect1",
-                        "https://www.google.com/redirects/redirect1#code=code1&scope=openid"},
+                        "https://www.google.com/redirects/redirect1#code=code1"},
                 {getAuthResponseDTO("https://www.google.com/redirects/redirect2?param1=abc&param2=xyz",
-                        "code2"),
+                        "code2", null, null),
                         "https://www.google.com/redirects/redirect2?param1=abc&param2=xyz",
-                        "https://www.google.com/redirects/redirect2?param1=abc&param2=xyz#code=code2&scope=openid"},
+                        "https://www.google.com/redirects/redirect2?param1=abc&param2=xyz#code=code2"},
+                {getAuthResponseDTO("https://www.google.com/redirects/redirect2?param1=abc&param2=xyz",
+                        "code3", "access_token_1", null),
+                        "https://www.google.com/redirects/redirect2?param1=abc&param2=xyz",
+                        "https://www.google.com/redirects/redirect2?param1=abc&param2=xyz#access_token=access_token_1" +
+                                "&expires_in=3600&code=code3&scope=randomScope"},
+                {getAuthResponseDTO("https://www.google.com/redirects/redirect2?param1=abc&param2=xyz",
+                        "code3", null, "subject_token_1"),
+                        "https://www.google.com/redirects/redirect2?param1=abc&param2=xyz",
+                        "https://www.google.com/redirects/redirect2?param1=abc&param2=xyz#code=code3" +
+                                "&subject_token=subject_token_1"},
 
         };
     }
@@ -47,13 +58,24 @@ public class ResponseModeProviderTest {
 
         return new Object[][] {
                 // AuthorizationResponseDTO, provided callback url, expected redirect url
-                {getAuthResponseDTO("https://www.google.com/redirects/redirect1", "code1"),
+                {getAuthResponseDTO("https://www.google.com/redirects/redirect1", "code1", null,
+                        null),
                         "https://www.google.com/redirects/redirect1",
-                        "https://www.google.com/redirects/redirect1?code=code1&scope=openid"},
+                        "https://www.google.com/redirects/redirect1?code=code1"},
                 {getAuthResponseDTO("https://www.google.com/redirects/redirect2?param1=abc&param2=xyz",
-                        "code2"),
+                        "code2", null, null),
                         "https://www.google.com/redirects/redirect2?param1=abc&param2=xyz",
-                        "https://www.google.com/redirects/redirect2?param1=abc&param2=xyz&code=code2&scope=openid"},
+                        "https://www.google.com/redirects/redirect2?param1=abc&param2=xyz&code=code2"},
+                {getAuthResponseDTO("https://www.google.com/redirects/redirect2?param1=abc&param2=xyz",
+                        "code3", "access_token_1", null),
+                        "https://www.google.com/redirects/redirect2?param1=abc&param2=xyz",
+                        "https://www.google.com/redirects/redirect2?param1=abc&param2=xyz&access_token=access_token_1" +
+                                "&expires_in=3600&code=code3&scope=randomScope"},
+                {getAuthResponseDTO("https://www.google.com/redirects/redirect2?param1=abc&param2=xyz",
+                        "code3", null, "subject_token_1"),
+                        "https://www.google.com/redirects/redirect2?param1=abc&param2=xyz",
+                        "https://www.google.com/redirects/redirect2?param1=abc&param2=xyz&code=code3" +
+                                "&subject_token=subject_token_1"},
 
         };
     }
@@ -77,13 +99,19 @@ public class ResponseModeProviderTest {
      * This method creates and returns dummy AuthorizationResponseDTO instance.
      * @return AuthorizationResponseDTO DTO
      */
-    private AuthorizationResponseDTO getAuthResponseDTO(String redirectURI, String code) {
+    private AuthorizationResponseDTO getAuthResponseDTO(String redirectURI, String code, String accessToken,
+                                                        String subjectToken) {
 
         AuthorizationResponseDTO authorizationResponseDTO = new AuthorizationResponseDTO();
         authorizationResponseDTO.setRedirectUrl(redirectURI);
 
         authorizationResponseDTO.getSuccessResponseDTO().setAuthorizationCode(code);
-        authorizationResponseDTO.getSuccessResponseDTO().setScope(new HashSet<>(Arrays.asList("openid")));
+        authorizationResponseDTO.getSuccessResponseDTO().setSubjectToken(subjectToken);
+        authorizationResponseDTO.getSuccessResponseDTO().setAccessToken(accessToken);
+        if (accessToken != null) {
+            authorizationResponseDTO.getSuccessResponseDTO().setScope(new HashSet<>(Arrays.asList("randomScope")));
+            authorizationResponseDTO.getSuccessResponseDTO().setValidityPeriod(3600);
+        }
 
         return authorizationResponseDTO;
     }


### PR DESCRIPTION
Related Public Issue: https://github.com/wso2/product-is/issues/20066

## Issue
To issue subject token, we need to improve query and fragment response mode providers. This fix resolve the issue.
Additionally this fix is aim to improve some existing test cases where scope is issued with code.

## Fix
Use SuccessResponseDTO to retrieve subject token from successful response if exists, then append to query or fragment

- [x] Unit test covered [link](https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2445/files#diff-f12c0d4246b326198c989d0966890fd61f20619fc8bf69f5227043109530d64e)