### PR TITLE
DTO improvement for impersonation consumer app properties

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
+++ b/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
@@ -623,6 +623,9 @@ public final class OAuthConstants {
         public static final String REQUEST_OBJECT_ENCRYPTION_ALGORITHM = "requestObjectEncryptionAlgorithm";
         public static final String REQUEST_OBJECT_ENCRYPTION_METHOD = "requestObjectEncryptionMethod";
         public static final String IS_FAPI_CONFORMANT_APP = "isFAPIConformant";
+        public static final String IS_SUBJECT_TOKEN_ENABLED = "isSubjectTokenEnabled";
+        public static final String SUBJECT_TOKEN_EXPIRY_TIME = "subjectTokenExpiryTime";
+        public static final int SUBJECT_TOKEN_EXPIRY_TIME_VALUE = 180;
 
         private OIDCConfigProperties() {
 

--- a/components/org.wso2.carbon.identity.oauth.stub/src/main/resources/OAuthAdminService.wsdl
+++ b/components/org.wso2.carbon.identity.oauth.stub/src/main/resources/OAuthAdminService.wsdl
@@ -409,6 +409,8 @@
                     <xs:element minOccurs="0" name="idTokenEncryptionMethod" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="idTokenExpiryTime" type="xs:long"/>
                     <xs:element minOccurs="0" name="idTokenSignatureAlgorithm" nillable="true" type="xs:string"/>
+                    <xs:element minOccurs="0" name="impersonationEmailNotificationEnabled" type="xs:boolean"/>
+                    <xs:element minOccurs="0" name="impersonationEnabled" type="xs:boolean"/>
                     <xs:element minOccurs="0" name="jwksURI" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="oauthConsumerKey" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="oauthConsumerSecret" nillable="true" type="xs:string"/>
@@ -424,6 +426,8 @@
                     <xs:element maxOccurs="unbounded" minOccurs="0" name="scopeValidators" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="sectorIdentifierURI" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="state" nillable="true" type="xs:string"/>
+                    <xs:element minOccurs="0" name="subjectTokenEnabled" type="xs:boolean"/>
+                    <xs:element minOccurs="0" name="subjectTokenExpiryTime" type="xs:int"/>
                     <xs:element minOccurs="0" name="subjectType" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="tlsClientAuthSubjectDN" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="tokenBindingType" nillable="true" type="xs:string"/>

--- a/components/org.wso2.carbon.identity.oauth.stub/src/main/resources/OAuthAdminService.wsdl
+++ b/components/org.wso2.carbon.identity.oauth.stub/src/main/resources/OAuthAdminService.wsdl
@@ -409,8 +409,6 @@
                     <xs:element minOccurs="0" name="idTokenEncryptionMethod" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="idTokenExpiryTime" type="xs:long"/>
                     <xs:element minOccurs="0" name="idTokenSignatureAlgorithm" nillable="true" type="xs:string"/>
-                    <xs:element minOccurs="0" name="impersonationEmailNotificationEnabled" type="xs:boolean"/>
-                    <xs:element minOccurs="0" name="impersonationEnabled" type="xs:boolean"/>
                     <xs:element minOccurs="0" name="jwksURI" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="oauthConsumerKey" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="oauthConsumerSecret" nillable="true" type="xs:string"/>

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImpl.java
@@ -494,6 +494,8 @@ public class OAuthAdminServiceImpl {
                         }
                         app.setRequirePushedAuthorizationRequests(application.getRequirePushedAuthorizationRequests());
                         app.setFapiConformanceEnabled(application.isFapiConformanceEnabled());
+                        app.setSubjectTokenEnabled(application.isSubjectTokenEnabled());
+                        app.setSubjectTokenExpiryTime(application.getSubjectTokenExpiryTime());
                     }
                     dao.addOAuthApplication(app);
                     if (ApplicationConstants.CONSOLE_APPLICATION_NAME.equals(app.getApplicationName())) {
@@ -917,6 +919,8 @@ public class OAuthAdminServiceImpl {
             }
             oauthappdo.setRequestObjectEncryptionMethod(requestObjectEncryptionMethod);
             oauthappdo.setRequirePushedAuthorizationRequests(consumerAppDTO.getRequirePushedAuthorizationRequests());
+            oauthappdo.setSubjectTokenEnabled(consumerAppDTO.isSubjectTokenEnabled());
+            oauthappdo.setSubjectTokenExpiryTime(consumerAppDTO.getSubjectTokenExpiryTime());;
         }
         dao.updateConsumerApplication(oauthappdo);
         AppInfoCache.getInstance().addToCache(oauthappdo.getOauthConsumerKey(), oauthappdo, tenantDomain);

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthUtil.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthUtil.java
@@ -552,6 +552,8 @@ public final class OAuthUtil {
         dto.setRequestObjectEncryptionMethod(appDO.getRequestObjectEncryptionMethod());
         dto.setRequirePushedAuthorizationRequests(appDO.isRequirePushedAuthorizationRequests());
         dto.setFapiConformanceEnabled(appDO.isFapiConformanceEnabled());
+        dto.setSubjectTokenEnabled(appDO.isSubjectTokenEnabled());
+        dto.setSubjectTokenExpiryTime(appDO.getSubjectTokenExpiryTime());
         return dto;
     }
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dao/OAuthAppDAO.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dao/OAuthAppDAO.java
@@ -84,12 +84,15 @@ import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCConfigPro
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCConfigProperties.IS_CERTIFICATE_BOUND_ACCESS_TOKEN;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCConfigProperties.IS_FAPI_CONFORMANT_APP;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCConfigProperties.IS_PUSH_AUTH;
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCConfigProperties.IS_SUBJECT_TOKEN_ENABLED;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCConfigProperties.RENEW_REFRESH_TOKEN;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCConfigProperties.REQUEST_OBJECT_ENCRYPTION_ALGORITHM;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCConfigProperties.REQUEST_OBJECT_ENCRYPTION_METHOD;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCConfigProperties.REQUEST_OBJECT_SIGNATURE_ALGORITHM;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCConfigProperties.REQUEST_OBJECT_SIGNED;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCConfigProperties.SECTOR_IDENTIFIER_URI;
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCConfigProperties.SUBJECT_TOKEN_EXPIRY_TIME;
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCConfigProperties.SUBJECT_TOKEN_EXPIRY_TIME_VALUE;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCConfigProperties.SUBJECT_TYPE;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCConfigProperties.TLS_SUBJECT_DN;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCConfigProperties.TOKEN_AUTH_METHOD;
@@ -1016,6 +1019,17 @@ public class OAuthAppDAO {
                 SUBJECT_TYPE, oauthAppDO.getSubjectType(),
                 prepStatementForPropertyAdd, preparedStatementForPropertyUpdate);
 
+        addOrUpdateOIDCSpProperty(preprocessedClientId, spTenantId, spOIDCProperties,
+                IS_SUBJECT_TOKEN_ENABLED, String.valueOf(oauthAppDO.isSubjectTokenEnabled()),
+                prepStatementForPropertyAdd, preparedStatementForPropertyUpdate);
+
+        if (oauthAppDO.getSubjectTokenExpiryTime() <= 0) {
+            oauthAppDO.setSubjectTokenExpiryTime(SUBJECT_TOKEN_EXPIRY_TIME_VALUE);
+        }
+        addOrUpdateOIDCSpProperty(preprocessedClientId, spTenantId, spOIDCProperties,
+                SUBJECT_TOKEN_EXPIRY_TIME, String.valueOf(oauthAppDO.getSubjectTokenExpiryTime()),
+                prepStatementForPropertyAdd, preparedStatementForPropertyUpdate);
+
         // Execute batched add/update/delete.
         prepStatementForPropertyAdd.executeBatch();
         preparedStatementForPropertyUpdate.executeBatch();
@@ -1644,6 +1658,11 @@ public class OAuthAppDAO {
             addToBatchForOIDCPropertyAdd(processedClientId, spTenantId, prepStmtAddOIDCProperty,
                     IS_FAPI_CONFORMANT_APP, String.valueOf(consumerAppDO.isFapiConformanceEnabled()));
 
+            addToBatchForOIDCPropertyAdd(processedClientId, spTenantId, prepStmtAddOIDCProperty,
+                    IS_SUBJECT_TOKEN_ENABLED, String.valueOf(consumerAppDO.isSubjectTokenEnabled()));
+            addToBatchForOIDCPropertyAdd(processedClientId, spTenantId, prepStmtAddOIDCProperty,
+                    SUBJECT_TOKEN_EXPIRY_TIME, String.valueOf(consumerAppDO.getSubjectTokenExpiryTime()));
+
             prepStmtAddOIDCProperty.executeBatch();
         }
     }
@@ -1799,6 +1818,15 @@ public class OAuthAppDAO {
         String isFAPI = getFirstPropertyValue(spOIDCProperties, IS_FAPI_CONFORMANT_APP);
         if (isFAPI != null) {
             oauthApp.setFapiConformanceEnabled(Boolean.parseBoolean(isFAPI));
+        }
+
+        String isSubjectTokenEnabled = getFirstPropertyValue(spOIDCProperties, IS_SUBJECT_TOKEN_ENABLED);
+        if (isSubjectTokenEnabled != null) {
+            oauthApp.setSubjectTokenEnabled(Boolean.parseBoolean(isSubjectTokenEnabled));
+        }
+        String subjectTokenExpiryTime = getFirstPropertyValue(spOIDCProperties, SUBJECT_TOKEN_EXPIRY_TIME);
+        if (subjectTokenExpiryTime != null) {
+            oauthApp.setSubjectTokenExpiryTime(Integer.parseInt(subjectTokenExpiryTime));
         }
     }
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dao/OAuthAppDAO.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dao/OAuthAppDAO.java
@@ -1660,6 +1660,10 @@ public class OAuthAppDAO {
 
             addToBatchForOIDCPropertyAdd(processedClientId, spTenantId, prepStmtAddOIDCProperty,
                     IS_SUBJECT_TOKEN_ENABLED, String.valueOf(consumerAppDO.isSubjectTokenEnabled()));
+
+            if (consumerAppDO.getSubjectTokenExpiryTime() <= 0) {
+                consumerAppDO.setSubjectTokenExpiryTime(SUBJECT_TOKEN_EXPIRY_TIME_VALUE);
+            }
             addToBatchForOIDCPropertyAdd(processedClientId, spTenantId, prepStmtAddOIDCProperty,
                     SUBJECT_TOKEN_EXPIRY_TIME, String.valueOf(consumerAppDO.getSubjectTokenExpiryTime()));
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dao/OAuthAppDO.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dao/OAuthAppDO.java
@@ -90,6 +90,8 @@ public class OAuthAppDO extends InboundConfigurationProtocol implements Serializ
     private String requestObjectEncryptionAlgorithm;
     private String requestObjectEncryptionMethod;
     private boolean fapiConformanceEnabled;
+    private boolean subjectTokenEnabled;
+    private int subjectTokenExpiryTime;
 
     public AuthenticatedUser getAppOwner() {
 
@@ -470,5 +472,26 @@ public class OAuthAppDO extends InboundConfigurationProtocol implements Serializ
     public void setFapiConformanceEnabled(boolean fapiConformant) {
 
         fapiConformanceEnabled = fapiConformant;
+    }
+
+
+    public boolean isSubjectTokenEnabled() {
+
+        return subjectTokenEnabled;
+    }
+
+    public void setSubjectTokenEnabled(boolean subjectTokenEnabled) {
+
+        this.subjectTokenEnabled = subjectTokenEnabled;
+    }
+
+    public int getSubjectTokenExpiryTime() {
+
+        return subjectTokenExpiryTime;
+    }
+
+    public void setSubjectTokenExpiryTime(int subjectTokenExpiryTime) {
+
+        this.subjectTokenExpiryTime = subjectTokenExpiryTime;
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dto/OAuthConsumerAppDTO.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dto/OAuthConsumerAppDTO.java
@@ -75,6 +75,8 @@ public class OAuthConsumerAppDTO implements InboundProtocolConfigurationDTO {
     private String requestObjectEncryptionMethod;
     private String jwksURI;
     private boolean fapiConformanceEnabled;
+    private boolean subjectTokenEnabled;
+    private int subjectTokenExpiryTime;
 
     // CORS origin related properties. This will be used by the CORS management service
     @IgnoreNullElement
@@ -476,6 +478,26 @@ public class OAuthConsumerAppDTO implements InboundProtocolConfigurationDTO {
     public void setAuditLogData(Map<String, Object> auditLogData) {
         
         this.auditLogData = auditLogData;
+    }
+
+    public boolean isSubjectTokenEnabled() {
+
+        return subjectTokenEnabled;
+    }
+
+    public void setSubjectTokenEnabled(boolean subjectTokenEnabled) {
+
+        this.subjectTokenEnabled = subjectTokenEnabled;
+    }
+
+    public int getSubjectTokenExpiryTime() {
+
+        return subjectTokenExpiryTime;
+    }
+
+    public void setSubjectTokenExpiryTime(int subjectTokenExpiryTime) {
+
+        this.subjectTokenExpiryTime = subjectTokenExpiryTime;
     }
 }
 


### PR DESCRIPTION
Public Issue: https://github.com/wso2/product-is/issues/20066

## Purpose
Each application should have 2 properties to store following configurations
- subject token enabled or not.
- subject token expiration time.

## Approach
We decided to use inbound protocol properties to store it. in this way, these properties will be stored in IDN_OIDC_PROPERTY table. Properties are
- isSubjectTokenEnabled
- subjectTokenExpiryTime

I also updated the WSDL file of admin services for backward compatibility.
REST API PR: https://github.com/wso2/identity-api-server/pull/609

- [x] Unit Tests Covered [Link](https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2447/files#diff-3893c5865829d317d9b5b19c3b44ea5571e5e7455b40aa3cec8adc4b5f03bfad)