### PR TITLE
Add subject token response type handler

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/OAuthAuthzReqMessageContext.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/OAuthAuthzReqMessageContext.java
@@ -52,7 +52,7 @@ public class OAuthAuthzReqMessageContext implements Serializable {
 
     private boolean isConsentedToken;
 
-    private boolean isSubjectTokenFLow;
+    private boolean isSubjectTokenFlow;
 
     private Properties properties = new Properties();
 
@@ -203,13 +203,13 @@ public class OAuthAuthzReqMessageContext implements Serializable {
         isConsentedToken = consentedToken;
     }
 
-    public boolean isSubjectTokenFLow() {
+    public boolean isSubjectTokenFlow() {
 
-        return isSubjectTokenFLow;
+        return isSubjectTokenFlow;
     }
 
-    public void setSubjectTokenFLow(boolean subjectTokenFLow) {
+    public void setSubjectTokenFlow(boolean subjectTokenFlow) {
 
-        isSubjectTokenFLow = subjectTokenFLow;
+        isSubjectTokenFlow = subjectTokenFlow;
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/OAuthAuthzReqMessageContext.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/OAuthAuthzReqMessageContext.java
@@ -52,6 +52,8 @@ public class OAuthAuthzReqMessageContext implements Serializable {
 
     private boolean isConsentedToken;
 
+    private boolean isSubjectTokenFLow;
+
     private Properties properties = new Properties();
 
     public OAuthAuthzReqMessageContext(OAuth2AuthorizeReqDTO authorizationReqDTO) {
@@ -199,5 +201,15 @@ public class OAuthAuthzReqMessageContext implements Serializable {
     public void setConsentedToken(boolean consentedToken) {
 
         isConsentedToken = consentedToken;
+    }
+
+    public boolean isSubjectTokenFLow() {
+
+        return isSubjectTokenFLow;
+    }
+
+    public void setSubjectTokenFLow(boolean subjectTokenFLow) {
+
+        isSubjectTokenFLow = subjectTokenFLow;
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/handlers/SubjectTokenResponseTypeHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/handlers/SubjectTokenResponseTypeHandler.java
@@ -1,0 +1,90 @@
+/*
+ *  Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+
+package org.wso2.carbon.identity.oauth2.authz.handlers;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.oauth.common.OAuthConstants;
+import org.wso2.carbon.identity.oauth.dao.OAuthAppDO;
+import org.wso2.carbon.identity.oauth.internal.OAuthComponentServiceHolder;
+import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
+import org.wso2.carbon.identity.oauth2.authz.OAuthAuthzReqMessageContext;
+import org.wso2.carbon.identity.oauth2.authz.handlers.util.ResponseTypeHandlerUtil;
+import org.wso2.carbon.identity.oauth2.dto.OAuth2AuthorizeReqDTO;
+import org.wso2.carbon.identity.oauth2.dto.OAuth2AuthorizeRespDTO;
+import org.wso2.carbon.identity.oauth2.model.SubjectTokenDO;
+
+/**
+ * Device response type handler.
+ */
+public class SubjectTokenResponseTypeHandler extends AbstractResponseTypeHandler {
+
+    private static final Log LOG = LogFactory.getLog(SubjectTokenResponseTypeHandler.class);
+    private static final String SUBJECT_TOKEN = "subject_token";
+    private static final String OAUTH_APP_DO = "OAuthAppDO";
+
+    /**
+     * This method is used to handle the response type. After authentication process finish this will redirect to the
+     * constant page.
+     *
+     * @param oauthAuthzMsgCtx Authorization message context.
+     * @return Response DTO.
+     * @throws IdentityOAuth2Exception Error at device response type handler.
+     */
+    @Override
+    public OAuth2AuthorizeRespDTO issue(OAuthAuthzReqMessageContext oauthAuthzMsgCtx) throws IdentityOAuth2Exception {
+
+        OAuth2AuthorizeRespDTO respDTO = initResponse(oauthAuthzMsgCtx);
+        SubjectTokenDO subjectTokenDO = OAuthComponentServiceHolder.getInstance().getOauth2Service()
+                    .issueSubjectToken(oauthAuthzMsgCtx);
+        String responseType = oauthAuthzMsgCtx.getAuthorizationReqDTO().getResponseType();
+
+        // Generating id_token and generating response for id_token flow.
+        if (isIDTokenIssued(responseType)) {
+            ResponseTypeHandlerUtil.buildIDTokenResponseDTO(respDTO, null, oauthAuthzMsgCtx);
+        }
+        respDTO.setSubjectToken(subjectTokenDO.getSubjectToken());
+        return respDTO;
+    }
+
+    @Override
+    public boolean isAuthorizedClient(OAuthAuthzReqMessageContext authzReqMsgCtx) throws IdentityOAuth2Exception {
+
+        OAuth2AuthorizeReqDTO authzReqDTO = authzReqMsgCtx.getAuthorizationReqDTO();
+
+        OAuthAppDO oAuthAppDO = (OAuthAppDO) authzReqMsgCtx.getProperty(OAUTH_APP_DO);
+        if (!oAuthAppDO.isImpersonationEnabled()) {
+            return false;
+        }
+
+        String responseType = authzReqDTO.getResponseType();
+        if (StringUtils.contains(responseType, SUBJECT_TOKEN)) {
+            authzReqMsgCtx.setSubjectTokenFLow(true);
+            return true;
+        }
+        return false;
+    }
+
+    private boolean isIDTokenIssued(String responseType) {
+
+        return StringUtils.contains(responseType, OAuthConstants.ID_TOKEN);
+    }
+}

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/handlers/SubjectTokenResponseTypeHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/handlers/SubjectTokenResponseTypeHandler.java
@@ -76,7 +76,7 @@ public class SubjectTokenResponseTypeHandler extends AbstractResponseTypeHandler
 
         String responseType = authzReqDTO.getResponseType();
         if (oAuthAppDO.isSubjectTokenEnabled() && StringUtils.contains(responseType, SUBJECT_TOKEN)) {
-            authzReqMsgCtx.setSubjectTokenFLow(true);
+            authzReqMsgCtx.setSubjectTokenFlow(true);
             return true;
         }
         return false;

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/handlers/SubjectTokenResponseTypeHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/handlers/SubjectTokenResponseTypeHandler.java
@@ -33,7 +33,9 @@ import org.wso2.carbon.identity.oauth2.dto.OAuth2AuthorizeRespDTO;
 import org.wso2.carbon.identity.oauth2.model.SubjectTokenDO;
 
 /**
- * Device response type handler.
+ * The {@code SubjectTokenResponseTypeHandler} class is responsible for handling the "subject_token" response type
+ * in OAuth authorization requests. It extends the {@link AbstractResponseTypeHandler} class and implements the logic
+ * to issue subject tokens and build responses accordingly.
  */
 public class SubjectTokenResponseTypeHandler extends AbstractResponseTypeHandler {
 
@@ -71,12 +73,9 @@ public class SubjectTokenResponseTypeHandler extends AbstractResponseTypeHandler
         OAuth2AuthorizeReqDTO authzReqDTO = authzReqMsgCtx.getAuthorizationReqDTO();
 
         OAuthAppDO oAuthAppDO = (OAuthAppDO) authzReqMsgCtx.getProperty(OAUTH_APP_DO);
-        if (!oAuthAppDO.isImpersonationEnabled()) {
-            return false;
-        }
 
         String responseType = authzReqDTO.getResponseType();
-        if (StringUtils.contains(responseType, SUBJECT_TOKEN)) {
+        if (oAuthAppDO.isSubjectTokenEnabled() && StringUtils.contains(responseType, SUBJECT_TOKEN)) {
             authzReqMsgCtx.setSubjectTokenFLow(true);
             return true;
         }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dto/OAuth2AuthorizeRespDTO.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dto/OAuth2AuthorizeRespDTO.java
@@ -40,6 +40,7 @@ public class OAuth2AuthorizeRespDTO {
     private String pkceCodeChallengeMethod;
     private String oidcSessionId;
 
+    private String subjectToken;
     public String getAuthorizationCode() {
 
         return authorizationCode;
@@ -188,5 +189,15 @@ public class OAuth2AuthorizeRespDTO {
     public String getOidcSessionId() {
 
         return oidcSessionId;
+    }
+
+    public String getSubjectToken() {
+
+        return subjectToken;
+    }
+
+    public void setSubjectToken(String subjectToken) {
+
+        this.subjectToken = subjectToken;
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/authz/handlers/SubjectTokenResponseTypeHandlerTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/authz/handlers/SubjectTokenResponseTypeHandlerTest.java
@@ -1,0 +1,168 @@
+/*
+ *  Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+
+package org.wso2.carbon.identity.oauth2.authz.handlers;
+
+import org.apache.commons.lang.StringUtils;
+import org.mockito.Mock;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.testng.PowerMockTestCase;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
+import org.wso2.carbon.identity.common.testng.WithCarbonHome;
+import org.wso2.carbon.identity.common.testng.WithRealmService;
+import org.wso2.carbon.identity.oauth.common.OAuthConstants;
+import org.wso2.carbon.identity.oauth.dao.OAuthAppDO;
+import org.wso2.carbon.identity.oauth.internal.OAuthComponentServiceHolder;
+import org.wso2.carbon.identity.oauth2.OAuth2Service;
+import org.wso2.carbon.identity.oauth2.TestConstants;
+import org.wso2.carbon.identity.oauth2.authz.OAuthAuthzReqMessageContext;
+import org.wso2.carbon.identity.oauth2.authz.handlers.util.ResponseTypeHandlerUtil;
+import org.wso2.carbon.identity.oauth2.dto.OAuth2AuthorizeReqDTO;
+import org.wso2.carbon.identity.oauth2.dto.OAuth2AuthorizeRespDTO;
+import org.wso2.carbon.identity.oauth2.model.SubjectTokenDO;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.powermock.api.mockito.PowerMockito.doAnswer;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+/**
+ * Test class covering SubjectTokenResponseTypeHandler.
+ */
+
+@WithCarbonHome
+@WithRealmService(tenantId = TestConstants.TENANT_ID,
+        tenantDomain = TestConstants.TENANT_DOMAIN,
+        initUserStoreManager = true,
+        injectToSingletons = {OAuthComponentServiceHolder.class})
+@PrepareForTest(ResponseTypeHandlerUtil.class)
+public class SubjectTokenResponseTypeHandlerTest extends PowerMockTestCase {
+
+    private static final String TEST_CONSUMER_KEY =  "testconsumenrkey";
+    private static final String TEST_CALLBACK_URL = "https://localhost:8000/callback";
+    OAuthAuthzReqMessageContext authAuthzReqMessageContext;
+    OAuth2AuthorizeReqDTO authorizationReqDTO;
+    @Mock
+    OAuth2Service oAuth2Service;
+
+    @DataProvider(name = "IsAuthorizedDataProvider")
+    public Object[][] isAuthorizedDataProvider() {
+        return new Object[][]{
+                {true, "subject_token", true},
+                {false, "subject_token", false},
+                {true, "id_token subject_token", true},
+                {true, "code id_token", false},
+        };
+    }
+
+    @Test(dataProvider = "IsAuthorizedDataProvider")
+    public void isAuthorizedTest(boolean isImpersonationEnabled, String responseType, boolean isAuthorized)
+            throws Exception {
+
+        authorizationReqDTO = new OAuth2AuthorizeReqDTO();
+        authorizationReqDTO.setCallbackUrl(TEST_CALLBACK_URL);
+        authorizationReqDTO.setConsumerKey(TEST_CONSUMER_KEY);
+        authorizationReqDTO.setResponseType(responseType);
+        authAuthzReqMessageContext = new OAuthAuthzReqMessageContext(authorizationReqDTO);
+        authAuthzReqMessageContext.setApprovedScope(new String[]{"scope1", "scope2", OAuthConstants.Scope.OPENID});
+
+        OAuthAppDO oAuthAppDO = new OAuthAppDO();
+        oAuthAppDO.setGrantTypes("code");
+        oAuthAppDO.setOauthConsumerKey(TEST_CONSUMER_KEY);
+        oAuthAppDO.setState("active");
+        oAuthAppDO.setApplicationName("testApp");
+        oAuthAppDO.setImpersonationEnabled(isImpersonationEnabled);
+        authAuthzReqMessageContext.addProperty("OAuthAppDO", oAuthAppDO);
+
+        SubjectTokenResponseTypeHandler subjectTokenResponseTypeHandler = new SubjectTokenResponseTypeHandler();
+        subjectTokenResponseTypeHandler.init();
+        boolean actualResult = subjectTokenResponseTypeHandler.isAuthorizedClient(authAuthzReqMessageContext);
+        Assert.assertEquals(actualResult, isAuthorized, " mismatch client authorization " +
+                "for impersonation flow");
+    }
+
+    @DataProvider(name = "IssueSubjectTokenDataProvider")
+    public Object[][] issueSubjectTokenDataProvider() {
+        return new Object[][]{
+                {"subject_token"},
+                {"id_token subject_token"},
+        };
+    }
+
+    @Test(dataProvider = "IssueSubjectTokenDataProvider")
+    public void issueSubjectTokenTest(String responseType) throws Exception {
+
+        OAuthComponentServiceHolder.getInstance().setOauth2Service(oAuth2Service);
+        mockStatic(ResponseTypeHandlerUtil.class);
+        OAuth2AuthorizeRespDTO authorizeRespDTO = new OAuth2AuthorizeRespDTO();
+        authorizeRespDTO.setIdToken("dummy_id_token");
+
+        doAnswer(new Answer<Object>() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+
+                OAuth2AuthorizeRespDTO respDTO = (OAuth2AuthorizeRespDTO) invocation.getArguments()[0];
+                respDTO.setIdToken("dummy_id_token");
+                return respDTO;
+            }
+        }).when(ResponseTypeHandlerUtil.class, "buildIDTokenResponseDTO", any(OAuth2AuthorizeRespDTO.class),
+                isNull(),any(OAuthAuthzReqMessageContext.class));
+
+        AuthenticatedUser user = new AuthenticatedUser();
+        user.setUserStoreDomain("PRIMARY");
+        user.setUserName("testUser");
+        user.setFederatedIdPName(TestConstants.LOCAL_IDP);
+
+        authorizationReqDTO = new OAuth2AuthorizeReqDTO();
+        authorizationReqDTO.setCallbackUrl(TEST_CALLBACK_URL);
+        authorizationReqDTO.setConsumerKey(TEST_CONSUMER_KEY);
+        authorizationReqDTO.setResponseType(responseType);
+        authorizationReqDTO.setUser(user);
+        authAuthzReqMessageContext = new OAuthAuthzReqMessageContext(authorizationReqDTO);
+        authAuthzReqMessageContext.setApprovedScope(new String[]{"scope1", "scope2", OAuthConstants.Scope.OPENID});
+
+        OAuthAppDO oAuthAppDO = new OAuthAppDO();
+        oAuthAppDO.setGrantTypes("code");
+        oAuthAppDO.setOauthConsumerKey(TEST_CONSUMER_KEY);
+        oAuthAppDO.setState("active");
+        oAuthAppDO.setApplicationName("testApp");
+        oAuthAppDO.setImpersonationEnabled(true);
+
+        oAuthAppDO.setAppOwner(user);
+        authAuthzReqMessageContext.addProperty("OAuthAppDO", oAuthAppDO);
+
+        SubjectTokenDO subjectTokenDO = new SubjectTokenDO();
+        subjectTokenDO.setSubjectToken("dummy_subject_token");
+        when(oAuth2Service.issueSubjectToken(authAuthzReqMessageContext)).thenReturn(subjectTokenDO);
+
+        SubjectTokenResponseTypeHandler subjectTokenResponseTypeHandler = new SubjectTokenResponseTypeHandler();
+        subjectTokenResponseTypeHandler.init();
+        OAuth2AuthorizeRespDTO respDTO = subjectTokenResponseTypeHandler.issue(authAuthzReqMessageContext);
+        Assert.assertNotNull(respDTO.getSubjectToken(), "Subject token is null");
+        if (StringUtils.contains(responseType, "id_token")) {
+            Assert.assertNotNull(respDTO.getIdToken(), "Id token is null");
+        }
+    }
+}

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/authz/handlers/SubjectTokenResponseTypeHandlerTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/authz/handlers/SubjectTokenResponseTypeHandlerTest.java
@@ -128,7 +128,7 @@ public class SubjectTokenResponseTypeHandlerTest extends PowerMockTestCase {
                 return respDTO;
             }
         }).when(ResponseTypeHandlerUtil.class, "buildIDTokenResponseDTO", any(OAuth2AuthorizeRespDTO.class),
-                isNull(),any(OAuthAuthzReqMessageContext.class));
+                isNull(), any(OAuthAuthzReqMessageContext.class));
 
         AuthenticatedUser user = new AuthenticatedUser();
         user.setUserStoreDomain("PRIMARY");

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/authz/handlers/SubjectTokenResponseTypeHandlerTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/authz/handlers/SubjectTokenResponseTypeHandlerTest.java
@@ -78,7 +78,7 @@ public class SubjectTokenResponseTypeHandlerTest extends PowerMockTestCase {
     }
 
     @Test(dataProvider = "IsAuthorizedDataProvider")
-    public void isAuthorizedTest(boolean isImpersonationEnabled, String responseType, boolean isAuthorized)
+    public void isAuthorizedTest(boolean isSubjectTokenEnabled, String responseType, boolean isAuthorized)
             throws Exception {
 
         authorizationReqDTO = new OAuth2AuthorizeReqDTO();
@@ -93,7 +93,7 @@ public class SubjectTokenResponseTypeHandlerTest extends PowerMockTestCase {
         oAuthAppDO.setOauthConsumerKey(TEST_CONSUMER_KEY);
         oAuthAppDO.setState("active");
         oAuthAppDO.setApplicationName("testApp");
-        oAuthAppDO.setImpersonationEnabled(isImpersonationEnabled);
+        oAuthAppDO.setSubjectTokenEnabled(isSubjectTokenEnabled);
         authAuthzReqMessageContext.addProperty("OAuthAppDO", oAuthAppDO);
 
         SubjectTokenResponseTypeHandler subjectTokenResponseTypeHandler = new SubjectTokenResponseTypeHandler();
@@ -148,7 +148,7 @@ public class SubjectTokenResponseTypeHandlerTest extends PowerMockTestCase {
         oAuthAppDO.setOauthConsumerKey(TEST_CONSUMER_KEY);
         oAuthAppDO.setState("active");
         oAuthAppDO.setApplicationName("testApp");
-        oAuthAppDO.setImpersonationEnabled(true);
+        oAuthAppDO.setSubjectTokenEnabled(true);
 
         oAuthAppDO.setAppOwner(user);
         authAuthzReqMessageContext.addProperty("OAuthAppDO", oAuthAppDO);


### PR DESCRIPTION
Public Issue: https://github.com/wso2/product-is/issues/20066

## Purpose
For Subject Token response type, it requires a handler to issue subject token. 

## Approach
Here we are introducing new class to issue subject token and introducing two response types/
'subject_token' and 'id_token subject_token'.

- [x] Unit Tests Covered [Link](https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2448/files#diff-045f36596bcb1b50c95e44de35ec6adf40eee4c5c515c693be4f8dd3250c2644)