### PR TITLE
DPoP Authorization Code Binding For PAR Requests

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/par/OAuth2ParEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/par/OAuth2ParEndpoint.java
@@ -132,8 +132,8 @@ public class OAuth2ParEndpoint {
             }
 
             handleValidation(httpRequest, params);
-            ParAuthData parAuthData =
-                    getParAuthService().handleParAuthRequest(parameters);
+            EndpointUtil.preHandleParRequest(httpRequest, parameters);
+            ParAuthData parAuthData = getParAuthService().handleParAuthRequest(parameters);
             return createAuthResponse(response, parAuthData);
         } catch (ParClientException e) {
             return handleParClientException(e);

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/par/OAuth2ParEndpointTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/par/OAuth2ParEndpointTest.java
@@ -423,6 +423,9 @@ public class OAuth2ParEndpointTest extends TestOAuthEndpointBase {
             return null;
         }).when(httpServletRequest).setAttribute(anyString(), any());
 
+        Map<String, String[]> headers = new HashMap<>();
+        headers.put("Content-Type", new String[]{"application/x-www-form-urlencoded"});
+        when(httpServletRequest.getHeaderNames()).thenReturn(Collections.enumeration(headers.keySet()));
         when(httpServletRequest.getParameterMap()).thenReturn(requestParams);
         when(httpServletRequest.getParameterNames()).thenReturn(Collections.enumeration(requestParams.keySet()));
         when(httpServletRequest.getMethod()).thenReturn(HttpMethod.POST);

--- a/components/org.wso2.carbon.identity.oauth.par/src/main/java/org/wso2/carbon/identity/oauth/par/common/ParConstants.java
+++ b/components/org.wso2.carbon.identity.oauth.par/src/main/java/org/wso2/carbon/identity/oauth/par/common/ParConstants.java
@@ -27,6 +27,9 @@ public class ParConstants {
     public static final long SEC_TO_MILLISEC_FACTOR = 1000;
     public static final String UTC = "UTC";
     public static final String EXPIRES_IN = "expires_in";
+    public static final String REQUEST_PARAMETERS = "request_parameters";
+    public static final String REQUEST_HEADERS = "request_headers";
+    public static final String PRE_HANDLE_PAR_REQUEST = "PRE_HANDLE_PAR_REQUEST";
     public static final String REQUEST_URI_PREFIX = "urn:ietf:params:oauth:par:request_uri:";
     public static final String CACHE_NAME = "ParCache";
     public static final String COL_LBL_PARAMETERS = "PARAMETERS";


### PR DESCRIPTION
#parent issue : https://github.com/wso2/product-is/issues/16606

When Pushed Authorization Requests (PARs) are used in conjunction with DPoP, there are two ways in which the public key of the key pair used for DPoP proof generation can be communicated in the PAR request:

1. The `dpop_jkt` parameter can be included alongside other authorization request parameters in the POST body of the PAR request.

2. Alternatively, the DPoP header can be added to the PAR request. In this case, the authorization server MUST check the provided DPoP proof JWT as defined in [Section 4.3](https://datatracker.ietf.org/doc/html/rfc9449#checking). It MUST further behave as if the contained public key's thumbprint was provided using dpop_jkt, i.e., reject the subsequent token request unless a DPoP proof for the same key is provided. 

This PR implements the above mechanism as follows:
 
The persistance of authorization request parameters sent with par requests is handled inside `handleParAuthRequest(parameters)` method .
https://github.com/wso2-extensions/identity-inbound-auth-oauth/blob/dd1475b94127a00e7cfa103d4f798b612ab555db/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/par/OAuth2ParEndpoint.java#L136

if we use the first method, which is sending `dpop_jkt` parameter alongside other request parameters, the `dpop_jkt` parameter will be persisted and retrieved at the time of authorization endpoint call and the dpop authorization code binding will be handled by the implementation of authorization code binding in authorization end point.This means there is no additional work needs to be done here regarding the first method.

However for the second method, the DPoP proof header needs to be validated and if the header is valid, the hash of the public key contained in the DPoP proof should be calculated &  added to the request parameters map before they get persisted.
This is done by introducing a new Event named `PRE_HANDLE_PAR_REQUEST` which takes the request headers and the refference of the `parameters` variable as its properties.This event is triggered right before `handleParAuthRequest(parameters)` method .
This event is handled in dpop code base, and hash calculated from a valid DPoP proof will be added to the  `parameters`
before getting persisted.