### PR TITLE
Remove root org tokens when revoking tokens during application un-share

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImpl.java
@@ -1780,6 +1780,9 @@ public class OAuthAdminServiceImpl {
         }
 
         List<AccessTokenDO> accessTokenDOs = getActiveAccessTokensByConsumerKey(consumerKey);
+        accessTokenDOs.removeIf(token -> OAuthConstants.AuthorizedOrganization.NONE.equals(
+                token.getAuthorizedOrganizationId()));
+
         if (!accessTokenDOs.isEmpty()) {
             List<String> accessTokens = new ArrayList<>();
             for (AccessTokenDO accessTokenDO : accessTokenDOs) {


### PR DESCRIPTION
### Purpose

When un-sharing sub organizations, root organization tokens should not be checked.