### PR TITLE
Modify scope validation for impersonated access token

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
+++ b/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
@@ -298,6 +298,7 @@ public final class OAuthConstants {
         public static final String REFRESH_TOKEN = "refresh_token";
         public static final String DEVICE_CODE = "device_code";
         public static final String ORGANIZATION_SWITCH = "organization_switch";
+        public static final String TOKEN_EXCHANGE = "urn:ietf:params:oauth:grant-type:token-exchange";
 
         private GrantTypes() {
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuer.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuer.java
@@ -629,6 +629,20 @@ public class AccessTokenIssuer {
 
         OAuth2AccessTokenReqDTO tokenReqDTO = tokReqMsgCtx.getOauth2AccessTokenReqDTO();
         String grantType = tokenReqDTO.getGrantType();
+        if (tokReqMsgCtx.isImpersonationRequest() && OAuthConstants.GrantTypes.TOKEN_EXCHANGE.equals(grantType)) {
+            /*
+             In the impersonation flow, we have already completed scope validation during the /authorize call and
+             issued a subject token with the authorized scopes. During the token flow we only consider the
+             scopes bound to the issued subject token and simply ignore any 'scope' parameter sent in the
+             subsequent token request. Therefore, it does not make sense to go through scope validation again as
+             there won't be any new scopes to validate.
+            */
+            if (log.isDebugEnabled()) {
+                log.debug("Skipping scope validation for impersonation flow as scope validation has already " +
+                        "happened in the authorize flow.");
+            }
+            return true;
+        }
         if (GrantType.AUTHORIZATION_CODE.toString().equals(grantType)) {
             /*
              In the authorization code flow, we have already completed scope validation during the /authorize call and

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuer.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuer.java
@@ -632,10 +632,9 @@ public class AccessTokenIssuer {
         if (tokReqMsgCtx.isImpersonationRequest() && OAuthConstants.GrantTypes.TOKEN_EXCHANGE.equals(grantType)) {
             /*
              In the impersonation flow, we have already completed scope validation during the /authorize call and
-             issued a subject token with the authorized scopes. During the token flow we only consider the
-             scopes bound to the issued subject token and simply ignore any 'scope' parameter sent in the
-             subsequent token request. Therefore, it does not make sense to go through scope validation again as
-             there won't be any new scopes to validate.
+             issued a subject token with the authorized scopes. During the token flow, if the scope body param presented
+             then we will take the intersection of scope. This also handled in the token exchange handler. Therefore,
+             it does not make sense to go through scope validation again as there won't be any new scopes to validate.
             */
             if (log.isDebugEnabled()) {
                 log.debug("Skipping scope validation for impersonation flow as scope validation has already " +


### PR DESCRIPTION
Public Issue: https://github.com/wso2/product-is/issues/20066

## Purpose
Like authorization code, scope validation will happen for impersonation in subject token request flow. Hence when exchanging the token we don't need to validate the scope again for token exchange grant type. 

In the impersonation flow, we have already completed scope validation during the /authorize call and issued a subject token with the authorized scopes. During the token flow we only consider the scopes bound to the issued subject token and simply ignore any 'scope' parameter sent in the subsequent token request. Therefore, it does not make sense to go through scope validation again as there won't be any new scopes to validate.

 But we should validate scope for org switch grant because the request can have scope as body param.

