### PR TITLE
Improv jwt token issuer for subject token

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuer.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuer.java
@@ -123,7 +123,7 @@ public class JWTTokenIssuer extends OauthTokenIssuerImpl {
      * {@inheritDoc}
      */
     @Override
-    public String subjectToken(OAuthAuthzReqMessageContext oauthAuthzMsgCtx) throws IdentityOAuth2Exception {
+    public String issueSubjectToken(OAuthAuthzReqMessageContext oauthAuthzMsgCtx) throws IdentityOAuth2Exception {
 
         if (log.isDebugEnabled()) {
             log.debug("Subject token request with authorization request message context message context. " +

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuer.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuer.java
@@ -119,19 +119,18 @@ public class JWTTokenIssuer extends OauthTokenIssuerImpl {
         signatureAlgorithm = mapSignatureAlgorithm(config.getSignatureAlgorithm());
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
-    public String subjectToken(OAuthAuthzReqMessageContext oauthAuthzMsgCtx) throws OAuthSystemException {
+    public String subjectToken(OAuthAuthzReqMessageContext oauthAuthzMsgCtx) throws IdentityOAuth2Exception {
 
         if (log.isDebugEnabled()) {
             log.debug("Subject token request with authorization request message context message context. " +
                     "Authorized user " + oauthAuthzMsgCtx.getAuthorizationReqDTO().getUser().getLoggableUserId());
         }
 
-        try {
-            return this.buildSubjectJWTToken(oauthAuthzMsgCtx);
-        } catch (IdentityOAuth2Exception e) {
-            throw new OAuthSystemException(e);
-        }
+        return this.buildSubjectJWTToken(oauthAuthzMsgCtx);
     }
 
     private String buildSubjectJWTToken(OAuthAuthzReqMessageContext oauthAuthzMsgCtx) throws IdentityOAuth2Exception {
@@ -467,7 +466,7 @@ public class JWTTokenIssuer extends OauthTokenIssuerImpl {
             headerBuilder.keyID(OAuth2Util.getKID(OAuth2Util.getCertificate(tenantDomain, tenantId),
                     (JWSAlgorithm) signatureAlgorithm, tenantDomain));
 
-            if (authorizationContext != null && authorizationContext.isSubjectTokenFLow()) {
+            if (authorizationContext != null && authorizationContext.isSubjectTokenFlow()) {
                 headerBuilder.type(new JOSEObjectType(JWT_TYP_HEADER_VALUE));
             } else {
                 // Set the required "typ" header "at+jwt" for access tokens issued by the issuer

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/OauthTokenIssuer.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/OauthTokenIssuer.java
@@ -96,7 +96,7 @@ public interface OauthTokenIssuer {
      * @return the subject token generated for the OAuth authorization request
      * @throws IdentityOAuth2Exception if an error occurs while generating the subject token
      */
-    default String subjectToken(OAuthAuthzReqMessageContext oauthAuthzMsgCtx) throws IdentityOAuth2Exception {
+    default String issueSubjectToken(OAuthAuthzReqMessageContext oauthAuthzMsgCtx) throws IdentityOAuth2Exception {
         return StringUtils.EMPTY;
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/SubjectTokenIssuer.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/SubjectTokenIssuer.java
@@ -74,7 +74,7 @@ public class SubjectTokenIssuer {
         OauthTokenIssuer oauthTokenIssuer = OAuthServerConfiguration.getInstance().getOauthTokenIssuerMap()
                 .get(JWT_TOKEN_TYPE);
         SubjectTokenDO subjectTokenDO = new SubjectTokenDO();
-        subjectTokenDO.setSubjectToken(oauthTokenIssuer.subjectToken(oauthAuthzMsgCtx));
+        subjectTokenDO.setSubjectToken(oauthTokenIssuer.issueSubjectToken(oauthAuthzMsgCtx));
         return subjectTokenDO;
     }
 

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuerTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuerTest.java
@@ -819,7 +819,7 @@ public class JWTTokenIssuerTest extends PowerMockIdentityBaseTest {
         authorizeReqDTO.setTenantDomain("carbon.super");
         OAuthAuthzReqMessageContext authzReqMessageContext = new OAuthAuthzReqMessageContext(authorizeReqDTO);
         authzReqMessageContext.setApprovedScope(new String[]{"scope1", "scope2"});
-        authzReqMessageContext.setSubjectTokenFLow(true);
+        authzReqMessageContext.setSubjectTokenFlow(true);
 
         OAuthAppDO appDO = spy(new OAuthAppDO());
         mockStatic(OAuth2Util.class);
@@ -829,7 +829,6 @@ public class JWTTokenIssuerTest extends PowerMockIdentityBaseTest {
                 ("dummyConsumerKey"));
         when(OAuth2Util.buildScopeString(any(String[].class))).thenReturn("scope1 scope2");
 
-        when(OAuth2Util.getAppInformationByClientId(anyString())).thenReturn(appDO);
         when(OAuth2Util.getThumbPrint(anyString(), anyInt())).thenReturn(THUMBPRINT);
         when(OAuth2Util.isTokenPersistenceEnabled()).thenReturn(true);
 
@@ -838,6 +837,12 @@ public class JWTTokenIssuerTest extends PowerMockIdentityBaseTest {
         KeyStore wso2KeyStore = getKeyStoreFromFile("wso2carbon.jks", "wso2carbon",
                 System.getProperty(CarbonBaseConstants.CARBON_HOME));
         RSAPrivateKey rsaPrivateKey = (RSAPrivateKey) wso2KeyStore.getKey("wso2carbon", "wso2carbon".toCharArray());
+        Certificate cert = wso2KeyStore.getCertificate("wso2carbon");
+        when(OAuth2Util.getCertificate(anyString(), anyInt())).thenReturn(cert);
+        when(OAuth2Util.class, "getThumbPrintWithPrevAlgorithm",
+                any(), anyBoolean()).thenCallRealMethod();
+        when(OAuth2Util.class, "getThumbPrintWithAlgorithm",
+                any(), anyString(), anyBoolean()).thenCallRealMethod();
 
         when((OAuth2Util.getPrivateKey(anyString(), anyInt()))).thenReturn(rsaPrivateKey);
         JWSSigner signer = new RSASSASigner(rsaPrivateKey);

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuerTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuerTest.java
@@ -853,7 +853,7 @@ public class JWTTokenIssuerTest extends PowerMockIdentityBaseTest {
         when(IdentityTenantUtil.getTenantId(anyString())).thenReturn(-1234);
 
         JWTTokenIssuer jwtTokenIssuer = new JWTTokenIssuer();
-        String jwtToken = jwtTokenIssuer.subjectToken(authzReqMessageContext);
+        String jwtToken = jwtTokenIssuer.issueSubjectToken(authzReqMessageContext);
         assertNotNull(jwtToken);
         SignedJWT signedJWT = SignedJWT.parse(jwtToken);
         assertNotNull(signedJWT.getHeader());

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuerTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuerTest.java
@@ -799,4 +799,69 @@ public class JWTTokenIssuerTest extends PowerMockIdentityBaseTest {
             return null;
         }
     }
+
+    @Test
+    public void testIssueSubjectToken() throws Exception {
+
+        when(oAuthServerConfiguration.getSignatureAlgorithm()).thenReturn(SHA256_WITH_RSA);
+        AuthenticatedUser impersonator = new AuthenticatedUser();
+        impersonator.setUserId("dummyUserId");
+        impersonator.setUserName("dummyUserName");
+        impersonator.setUserStoreDomain("dummyUserStoreDomain");
+        impersonator.setTenantDomain("carbon.super");
+        impersonator.setAuthenticatedSubjectIdentifier("dummyUserId");
+
+        OAuth2AuthorizeReqDTO authorizeReqDTO = new OAuth2AuthorizeReqDTO();
+        authorizeReqDTO.setUser(impersonator);
+        authorizeReqDTO.setResponseType("subject_token");
+        authorizeReqDTO.setRequestedSubjectId("dummySubjectId");
+        authorizeReqDTO.setConsumerKey("dummyConsumerKey");
+        authorizeReqDTO.setTenantDomain("carbon.super");
+        OAuthAuthzReqMessageContext authzReqMessageContext = new OAuthAuthzReqMessageContext(authorizeReqDTO);
+        authzReqMessageContext.setApprovedScope(new String[]{"scope1", "scope2"});
+        authzReqMessageContext.setSubjectTokenFLow(true);
+
+        OAuthAppDO appDO = spy(new OAuthAppDO());
+        mockStatic(OAuth2Util.class);
+        when(OAuth2Util.getAppInformationByClientId(anyString())).thenReturn(appDO);
+        when(OAuth2Util.getIdTokenIssuer("carbon.super")).thenReturn(ID_TOKEN_ISSUER);
+        when(OAuth2Util.getOIDCAudience("dummyConsumerKey", appDO)).thenReturn(Collections.singletonList
+                ("dummyConsumerKey"));
+        when(OAuth2Util.buildScopeString(any(String[].class))).thenReturn("scope1 scope2");
+
+        when(OAuth2Util.getAppInformationByClientId(anyString())).thenReturn(appDO);
+        when(OAuth2Util.getThumbPrint(anyString(), anyInt())).thenReturn(THUMBPRINT);
+        when(OAuth2Util.isTokenPersistenceEnabled()).thenReturn(true);
+
+        System.setProperty(CarbonBaseConstants.CARBON_HOME,
+                Paths.get(System.getProperty("user.dir"), "src", "test", "resources").toString());
+        KeyStore wso2KeyStore = getKeyStoreFromFile("wso2carbon.jks", "wso2carbon",
+                System.getProperty(CarbonBaseConstants.CARBON_HOME));
+        RSAPrivateKey rsaPrivateKey = (RSAPrivateKey) wso2KeyStore.getKey("wso2carbon", "wso2carbon".toCharArray());
+
+        when((OAuth2Util.getPrivateKey(anyString(), anyInt()))).thenReturn(rsaPrivateKey);
+        JWSSigner signer = new RSASSASigner(rsaPrivateKey);
+        when(OAuth2Util.createJWSSigner(any())).thenReturn(signer);
+        when(oAuthServerConfiguration.getSignatureAlgorithm()).thenReturn(SHA256_WITH_RSA);
+
+        mockStatic(IdentityTenantUtil.class);
+        when(IdentityTenantUtil.getTenantId(anyString())).thenReturn(-1234);
+
+        JWTTokenIssuer jwtTokenIssuer = new JWTTokenIssuer();
+        String jwtToken = jwtTokenIssuer.subjectToken(authzReqMessageContext);
+        assertNotNull(jwtToken);
+        SignedJWT signedJWT = SignedJWT.parse(jwtToken);
+        assertNotNull(signedJWT.getHeader());
+        assertNotNull(signedJWT.getHeader().getType());
+        assertEquals(signedJWT.getHeader().getType().toString(), "jwt");
+        JWTClaimsSet jwtClaimsSet = signedJWT.getJWTClaimsSet();
+        assertNotNull(jwtClaimsSet);
+        assertEquals(jwtClaimsSet.getSubject(), "dummySubjectId");
+        assertEquals(jwtClaimsSet.getAudience().get(0), "dummyConsumerKey");
+        assertEquals(jwtClaimsSet.getIssuer(), ID_TOKEN_ISSUER);
+        Map<String, String> map = (Map<String, String>) jwtClaimsSet.getClaim("may_act");
+        assertNotNull(map);
+        assertNotNull(map.get("sub"));
+        assertEquals(map.get("sub"), "dummyUserId");
+    }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/SubjectTokenIssuerTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/SubjectTokenIssuerTest.java
@@ -79,7 +79,7 @@ public class SubjectTokenIssuerTest extends PowerMockIdentityBaseTest {
         when(oAuth2AuthorizeReqDTO.getScopes()).thenReturn(SCOPES_WITHOUT_OPENID);
         when(oAuth2AuthorizeReqDTO.getTenantDomain()).thenReturn("carbon.super");
 
-        when(jwtTokenIssuer.subjectToken(oAuthAuthzReqMessageContext)).thenReturn("dummySubjectToken");
+        when(jwtTokenIssuer.issueSubjectToken(oAuthAuthzReqMessageContext)).thenReturn("dummySubjectToken");
         Map<String, OauthTokenIssuer> oauthTokenIssuerMap = new HashMap<>();
         oauthTokenIssuerMap.put(JWT_TOKEN_TYPE, jwtTokenIssuer);
         when(OAuthServerConfiguration.getInstance().getOauthTokenIssuerMap()).thenReturn(oauthTokenIssuerMap);


### PR DESCRIPTION
Public Issue: https://github.com/wso2/product-is/issues/20066

## Purpose
Since subject token is a JWT token we need to improve JWT token issuer to issue subject token

## Approach
Here we are exposing a api to create subject token via oauthTokenIssuer. Implementation is in JWT Token issuer. JWT Token Issuer will add required claims and generate jwt subject token.


- [x] Unit Tests Covered [Link](https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2460/files#diff-4348b218081bc3e04e2be6be31d0d7e52e3320a148ff4b33e73c6418adeaaff4R802)