### PR TITLE
Fix callback URL not properly set in the cache when portal app creation

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImpl.java
@@ -515,7 +515,12 @@ public class OAuthAdminServiceImpl {
                     }
                     dao.addOAuthApplication(app);
                     if (ApplicationMgtUtil.isConsoleOrMyAccount(app.getApplicationName())) {
-                        String callbackURL = OAuth2Util.getConsoleCallbackFromServerConfig(tenantDomain);
+                        String callbackURL;
+                        if (ApplicationMgtUtil.isConsole(app.getApplicationName())) {
+                            callbackURL = OAuth2Util.getConsoleCallbackFromServerConfig(tenantDomain);
+                        } else {
+                            callbackURL = OAuth2Util.getMyAccountCallbackFromServerConfig(tenantDomain);
+                        }
                         if (StringUtils.isEmpty(callbackURL)) {
                             callbackURL = ApplicationMgtUtil.resolveOriginUrlFromPlaceholders(callbackURL);
                         }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImpl.java
@@ -524,8 +524,9 @@ public class OAuthAdminServiceImpl {
                             callbackURL = OAuth2Util.getMyAccountCallbackFromServerConfig(tenantDomain);
                         }
                         if (StringUtils.isEmpty(callbackURL)) {
-                            callbackURL = ApplicationMgtUtil.resolveOriginUrlFromPlaceholders(callbackURL);
+                            callbackURL = app.getCallbackUrl();
                         }
+                        callbackURL = ApplicationMgtUtil.resolveOriginUrlFromPlaceholders(callbackURL);
                         app.setCallbackUrl(callbackURL);
                     }
                     AppInfoCache.getInstance().addToCache(app.getOauthConsumerKey(), app, tenantDomain);

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImpl.java
@@ -1,17 +1,19 @@
 /*
- * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2019-2024, WSO2 LLC. (http://www.wso2.com).
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
  * You may obtain a copy of the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.wso2.carbon.identity.oauth;


### PR DESCRIPTION
### Proposed changes in this pull request

$subject

When the oauth app is registered, the oauth app get cached. But when caching, if the oauth app is a portal application like Console or MyAccount, it should build the callback URL properly.