### PR TITLE
Use the access token tenant ID when fetching the client app by tenant domain

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/introspection/OAuth2IntrospectionEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/introspection/OAuth2IntrospectionEndpoint.java
@@ -142,15 +142,15 @@ public class OAuth2IntrospectionEndpoint {
                 .setClientId(introspectionResponse.getClientId())
                 .setIssuedAt(introspectionResponse.getIat())
                 .setExpiration(introspectionResponse.getExp())
-                .setAuthorizedUserType(introspectionResponse.getAut());
+                .setAuthorizedUserType(introspectionResponse.getAut())
+                .setAudience(introspectionResponse.getAud());;
 
         if (introspectionResponse.getAuthorizedUser() != null) {
             respBuilder.setOrgId(introspectionResponse.getAuthorizedUser().getAccessingOrganization());
         }
 
         if (StringUtils.equalsIgnoreCase(introspectionResponse.getTokenType(), JWT_TOKEN_TYPE)) {
-            respBuilder.setAudience(introspectionResponse.getAud())
-                    .setJwtId(introspectionResponse.getJti())
+            respBuilder.setJwtId(introspectionResponse.getJti())
                     .setSubject(introspectionResponse.getSub())
                     .setTokenType(introspectionResponse.getTokenType())
                     .setIssuer(introspectionResponse.getIss());

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -2389,7 +2389,7 @@ public class OAuth2Util {
         if (oAuthAppDO == null) {
             oAuthAppDO = new OAuthAppDAO().getAppInformation(clientId, IdentityTenantUtil.getTenantId(tenantDomain));
             if (oAuthAppDO != null) {
-                if (!AuthzUtil.isLegacyAuthzRuntime() && oAuthAppDO.getAppOwner() != null &&
+                if (oAuthAppDO.getAppOwner() != null &&
                         StringUtils.isNotEmpty(oAuthAppDO.getAppOwner().getTenantDomain())) {
                     AppInfoCache.getInstance().addToCache(clientId, oAuthAppDO,
                             oAuthAppDO.getAppOwner().getTenantDomain());

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/TokenValidationHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/TokenValidationHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2019-2024, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/TokenValidationHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/TokenValidationHandler.java
@@ -28,6 +28,7 @@ import org.wso2.carbon.identity.application.common.IdentityApplicationManagement
 import org.wso2.carbon.identity.application.common.model.ServiceProvider;
 import org.wso2.carbon.identity.central.log.mgt.utils.LogConstants;
 import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.oauth.common.OAuthConstants;
 import org.wso2.carbon.identity.oauth.common.exception.InvalidOAuthClientException;
@@ -603,7 +604,7 @@ public class TokenValidationHandler {
             if (!OAuth2Util.isJWT(validationRequest.getAccessToken().getIdentifier())) {
                 OAuthAppDO oAuthAppDO;
                 try {
-                    String tenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
+                    String tenantDomain = IdentityTenantUtil.getTenantDomain(accessTokenDO.getTenantID());
                     oAuthAppDO = OAuth2Util.getAppInformationByClientId(accessTokenDO.getConsumerKey(), tenantDomain);
                 } catch (InvalidOAuthClientException e) {
                     throw new IdentityOAuth2Exception("Error while retrieving OAuth app information for clientId: " +

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/validators/TokenValidationHandlerTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/validators/TokenValidationHandlerTest.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2017-2024, WSO2 LLC. (http://www.wso2.com).
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -11,7 +11,7 @@
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the
+ * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
  */
@@ -99,7 +99,7 @@ import static org.wso2.carbon.identity.organization.management.service.constant.
         IdentityApplicationManagementUtil.class, IdentityProviderManager.class, RealmService.class, LoggerUtils.class,
         FederatedAuthenticatorConfig.class, OAuth2ServiceComponentHolder.class, OAuth2JWTTokenValidator.class,
         OrganizationManagementConfigUtil.class, IdentityUtil.class, OAuthTokenPersistenceFactory.class,
-        OAuth2Util.class, JWTUtils.class})
+        OAuth2Util.class, JWTUtils.class, IdentityTenantUtil.class})
 public class TokenValidationHandlerTest extends PowerMockTestCase {
 
     private String[] scopeArraySorted = new String[]{"scope1", "scope2", "scope3"};
@@ -221,6 +221,9 @@ public class TokenValidationHandlerTest extends PowerMockTestCase {
         IdentityTenantUtil.setRealmService(realmService);
         when(realmService.getBootstrapRealmConfiguration()).thenReturn(realmConfiguration);
         when(IdentityUtil.getPrimaryDomainName()).thenReturn("PRIMARY");
+        mockStatic(IdentityTenantUtil.class);
+        when(IdentityTenantUtil.getTenantDomain(MultitenantConstants.SUPER_TENANT_ID))
+                .thenReturn(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
 
         OAuth2TokenValidationRequestDTO oAuth2TokenValidationRequestDTO = new OAuth2TokenValidationRequestDTO();
         OAuth2TokenValidationRequestDTO.OAuth2AccessToken accessToken = oAuth2TokenValidationRequestDTO.new


### PR DESCRIPTION
### Proposed changes in this pull request

$subject

The oauth application needs to be fetched using client ID & tenant domain. But the tenant domain resolved from the context is not reliable as there can be custom grant types which were used to get tokens for different tenants where the corresponding oauth app belongs to another tenant (mostly super tenant).

Therefore, rely on the tenant ID of the token makes less issues.