### PR TITLE
[Impersonation] Add token exchange grant type validation in subject token response type

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/authz/handlers/SubjectTokenResponseTypeHandlerTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/authz/handlers/SubjectTokenResponseTypeHandlerTest.java
@@ -89,7 +89,7 @@ public class SubjectTokenResponseTypeHandlerTest extends PowerMockTestCase {
         authAuthzReqMessageContext.setApprovedScope(new String[]{"scope1", "scope2", OAuthConstants.Scope.OPENID});
 
         OAuthAppDO oAuthAppDO = new OAuthAppDO();
-        oAuthAppDO.setGrantTypes("code");
+        oAuthAppDO.setGrantTypes("code urn:ietf:params:oauth:grant-type:token-exchange");
         oAuthAppDO.setOauthConsumerKey(TEST_CONSUMER_KEY);
         oAuthAppDO.setState("active");
         oAuthAppDO.setApplicationName("testApp");


### PR DESCRIPTION
Public Issue: https://github.com/wso2/product-is/issues/20066

## Purpose
Add token exchange grant type validation in subject token response type

## Approach
Add the validation in the subejct token response type handler when checking for authorized client