### PR TITLE
[Impersonation] Add Config Mgt support to impersonation tenant settings 

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/pom.xml
+++ b/components/org.wso2.carbon.identity.oauth/pom.xml
@@ -346,6 +346,10 @@
             <artifactId>org.wso2.carbon.identity.cors.mgt.core</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.configuration.mgt.core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.bitbucket.b_c</groupId>
             <artifactId>jose4j</artifactId>
             <scope>test</scope>
@@ -447,7 +451,8 @@
                             org.wso2.carbon.identity.multi.attribute.login.mgt.*;
                             version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.api.resource.mgt; version="${carbon.identity.framework.imp.pkg.version.range}",
-                            org.wso2.carbon.identity.role.v2.mgt.core; version="${carbon.identity.framework.imp.pkg.version.range}"
+                            org.wso2.carbon.identity.role.v2.mgt.core; version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.configuration.mgt.core; version="${carbon.identity.framework.imp.pkg.version.range}"
                         </Import-Package>
                         <Export-Package>
                             !org.wso2.carbon.identity.oauth.internal,

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/impersonation/exceptions/ImpersonationConfigMgtClientException.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/impersonation/exceptions/ImpersonationConfigMgtClientException.java
@@ -1,0 +1,46 @@
+/*
+ *  Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+
+package org.wso2.carbon.identity.oauth2.impersonation.exceptions;
+
+/**
+ * Exception class for handling impersonation configuration management client errors.
+ */
+public class ImpersonationConfigMgtClientException extends ImpersonationConfigMgtException {
+
+    /**
+     * The default constructor.
+     */
+    public ImpersonationConfigMgtClientException() {
+
+        super();
+    }
+
+    /**
+     * Constructor with {@code message}, {@code errorCode} and {@code cause} parameters.
+     *
+     * @param message   Message to be included in the exception.
+     * @param errorCode Error code of the exception.
+     * @param cause     Exception to be wrapped.
+     */
+    public ImpersonationConfigMgtClientException(String message, String errorCode, Throwable cause) {
+
+        super(message, errorCode, cause);
+    }
+}

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/impersonation/exceptions/ImpersonationConfigMgtException.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/impersonation/exceptions/ImpersonationConfigMgtException.java
@@ -1,0 +1,59 @@
+/*
+ *  Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+
+package org.wso2.carbon.identity.oauth2.impersonation.exceptions;
+
+/**
+ * Exception class for handling impersonation configuration management errors.
+ */
+public class ImpersonationConfigMgtException extends Exception {
+
+    private String errorCode;
+
+    /**
+     * The default constructor.
+     */
+    public ImpersonationConfigMgtException() {
+
+        super();
+    }
+
+    /**
+     * Constructor with {@code message}, {@code errorCode} and {@code cause} parameters.
+     *
+     * @param message   Message to be included in the exception.
+     * @param errorCode Error code of the exception.
+     * @param cause     Exception to be wrapped.
+     */
+    public ImpersonationConfigMgtException(String message, String errorCode, Throwable cause) {
+
+        super(message, cause);
+        this.errorCode = errorCode;
+    }
+
+    /**
+     * Get the {@code errorCode}.
+     *
+     * @return Returns the {@code errorCode}.
+     */
+    public String getErrorCode() {
+
+        return errorCode;
+    }
+}

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/impersonation/exceptions/ImpersonationConfigMgtServerException.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/impersonation/exceptions/ImpersonationConfigMgtServerException.java
@@ -1,0 +1,46 @@
+/*
+ *  Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+
+package org.wso2.carbon.identity.oauth2.impersonation.exceptions;
+
+/**
+ * Exception class for handling impersonation configuration management server errors.
+ */
+public class ImpersonationConfigMgtServerException extends ImpersonationConfigMgtException {
+
+    /**
+     * The default constructor.
+     */
+    public ImpersonationConfigMgtServerException() {
+
+        super();
+    }
+
+    /**
+     * Constructor with {@code message}, {@code errorCode} and {@code cause} parameters.
+     *
+     * @param message   Message to be included in the exception.
+     * @param errorCode Error code of the exception.
+     * @param cause     Exception to be wrapped.
+     */
+    public ImpersonationConfigMgtServerException(String message, String errorCode, Throwable cause) {
+
+        super(message, errorCode, cause);
+    }
+}

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/impersonation/models/ImpersonationConfig.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/impersonation/models/ImpersonationConfig.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth2.impersonation.models;
+
+/**
+ * The ImpersonationConfig class handles the configuration for impersonation settings.
+ */
+public class ImpersonationConfig {
+
+    // A flag to enable or disable email notifications for impersonation actions.
+    private boolean enableEmailNotification;
+
+    /**
+     * Gets the current status of email notifications.
+     *
+     * @return true if email notifications are enabled, false otherwise.
+     */
+    public boolean isEnableEmailNotification() {
+
+        return enableEmailNotification;
+    }
+
+    /**
+     * Sets the status of email notifications.
+     *
+     * @param enableEmailNotification true to enable email notifications, false to disable them.
+     */
+    public void setEnableEmailNotification(boolean enableEmailNotification) {
+
+        this.enableEmailNotification = enableEmailNotification;
+    }
+}
+

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/impersonation/services/ImpersonationConfigMgtService.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/impersonation/services/ImpersonationConfigMgtService.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth2.impersonation.services;
+
+import org.wso2.carbon.identity.oauth2.impersonation.exceptions.ImpersonationConfigMgtException;
+import org.wso2.carbon.identity.oauth2.impersonation.models.ImpersonationConfig;
+
+/**
+ * Service interface for managing impersonation configurations.
+ */
+public interface ImpersonationConfigMgtService {
+
+    /**
+     * Retrieves the impersonation configuration for a given tenant domain.
+     *
+     * @param tenantDomain The domain of the tenant whose impersonation configuration is to be retrieved.
+     * @return The impersonation configuration of the specified tenant.
+     * @throws ImpersonationConfigMgtException If there is an error in retrieving the configuration.
+     */
+    public ImpersonationConfig getImpersonationConfig(String tenantDomain) throws ImpersonationConfigMgtException;
+
+    /**
+     * Sets the impersonation configuration for a given tenant domain.
+     *
+     * @param impersonationConfig The impersonation configuration to be set.
+     * @param tenantDomain        The domain of the tenant for which the configuration is to be set.
+     * @throws ImpersonationConfigMgtException If there is an error in setting the configuration.
+     */
+    public void setImpersonationConfig(ImpersonationConfig impersonationConfig, String tenantDomain)
+            throws ImpersonationConfigMgtException;
+}
+

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/impersonation/services/ImpersonationConfigMgtServiceImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/impersonation/services/ImpersonationConfigMgtServiceImpl.java
@@ -128,7 +128,10 @@ public class ImpersonationConfigMgtServiceImpl implements ImpersonationConfigMgt
     private Resource getResource(String resourceTypeName, String resourceName) throws ConfigurationManagementException {
 
         try {
-            return getConfigurationManager().getResource(resourceTypeName, resourceName);
+            if (getConfigurationManager() != null) {
+                return getConfigurationManager().getResource(resourceTypeName, resourceName);
+            }
+            return null;
         } catch (ConfigurationManagementException e) {
             if (ERROR_CODE_RESOURCE_DOES_NOT_EXISTS.getCode().equals(e.getErrorCode())) {
                 return null;

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/impersonation/services/ImpersonationConfigMgtServiceImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/impersonation/services/ImpersonationConfigMgtServiceImpl.java
@@ -1,0 +1,140 @@
+/*
+ *  Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+
+package org.wso2.carbon.identity.oauth2.impersonation.services;
+
+import org.wso2.carbon.identity.base.IdentityRuntimeException;
+import org.wso2.carbon.identity.configuration.mgt.core.ConfigurationManager;
+import org.wso2.carbon.identity.configuration.mgt.core.exception.ConfigurationManagementException;
+import org.wso2.carbon.identity.configuration.mgt.core.model.Resource;
+import org.wso2.carbon.identity.configuration.mgt.core.model.ResourceAdd;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.oauth2.impersonation.exceptions.ImpersonationConfigMgtException;
+import org.wso2.carbon.identity.oauth2.impersonation.models.ImpersonationConfig;
+import org.wso2.carbon.identity.oauth2.impersonation.utils.ErrorMessage;
+import org.wso2.carbon.identity.oauth2.impersonation.utils.Util;
+import org.wso2.carbon.identity.oauth2.internal.OAuth2ServiceComponentHolder;
+
+import static org.wso2.carbon.identity.configuration.mgt.core.constant.ConfigurationConstants.ErrorMessages.ERROR_CODE_RESOURCE_DOES_NOT_EXISTS;
+import static org.wso2.carbon.identity.oauth2.impersonation.utils.Constants.IMPERSONATION_RESOURCE_NAME;
+import static org.wso2.carbon.identity.oauth2.impersonation.utils.Constants.IMPERSONATION_RESOURCE_TYPE_NAME;
+import static org.wso2.carbon.identity.oauth2.impersonation.utils.Util.handleClientException;
+import static org.wso2.carbon.identity.oauth2.impersonation.utils.Util.handleServerException;
+
+/**
+ * Implementation class for managing impersonation configurations.
+ */
+public class ImpersonationConfigMgtServiceImpl implements ImpersonationConfigMgtService {
+
+    /**
+     * Retrieves the impersonation configuration for a given tenant domain.
+     *
+     * @param tenantDomain The domain of the tenant whose impersonation configuration is to be retrieved.
+     * @return The impersonation configuration of the specified tenant.
+     * @throws ImpersonationConfigMgtException If there is an error in retrieving the configuration.
+     */
+    @Override
+    public ImpersonationConfig getImpersonationConfig(String tenantDomain) throws ImpersonationConfigMgtException {
+
+        try {
+            // Attempt to retrieve the resource containing impersonation configuration.
+            Resource resource = getResource(IMPERSONATION_RESOURCE_TYPE_NAME, IMPERSONATION_RESOURCE_NAME);
+            ImpersonationConfig impersonationConfig;
+            // If the resource is null, use the default configuration, otherwise parse the resource.
+            if (resource == null) {
+                impersonationConfig = Util.getDefaultConfiguration();
+            } else {
+                impersonationConfig = Util.parseResource(resource);
+            }
+            return impersonationConfig;
+        } catch (ConfigurationManagementException e) {
+            // If there is an error in retrieving the configuration, handle it as a server exception.
+            throw handleServerException(ErrorMessage.ERROR_CODE_IMP_CONFIG_RETRIEVE, e, tenantDomain);
+        }
+    }
+
+    /**
+     * Sets the impersonation configuration for a given tenant domain.
+     *
+     * @param impersonationConfig The impersonation configuration to be set.
+     * @param tenantDomain        The domain of the tenant for which the configuration is to be set.
+     * @throws ImpersonationConfigMgtException If there is an error in setting the configuration.
+     */
+    @Override
+    public void setImpersonationConfig(ImpersonationConfig impersonationConfig, String tenantDomain)
+            throws ImpersonationConfigMgtException {
+
+        // Validate the tenant domain before proceeding.
+        validateTenantDomain(tenantDomain);
+        try {
+            // Parse the impersonation configuration and replace the existing resource with the updated configuration.
+            ResourceAdd resourceAdd = Util.parseConfig(impersonationConfig);
+            getConfigurationManager().replaceResource(IMPERSONATION_RESOURCE_TYPE_NAME, resourceAdd);
+        } catch (ConfigurationManagementException e) {
+            // If there is an error in setting the configuration, handle it as a server exception.
+            throw handleServerException(ErrorMessage.ERROR_CODE_IMP_CONFIG_UPDATE, e, tenantDomain);
+        }
+    }
+
+    /**
+     * Validates the given tenant domain.
+     *
+     * @param tenantDomain The tenant domain to validate.
+     * @throws ImpersonationConfigMgtException If the tenant domain is invalid.
+     */
+    private void validateTenantDomain(String tenantDomain) throws ImpersonationConfigMgtException {
+
+        try {
+            IdentityTenantUtil.getTenantId(tenantDomain);
+        } catch (IdentityRuntimeException e) {
+            throw handleClientException(ErrorMessage.ERROR_CODE_INVALID_TENANT_DOMAIN, e, tenantDomain);
+        }
+    }
+
+    /**
+     * Retrieve the ConfigurationManager instance from the OAuth2ServiceComponentHolder.
+     *
+     * @return ConfigurationManager The ConfigurationManager instance.
+     */
+    private ConfigurationManager getConfigurationManager() {
+
+        return OAuth2ServiceComponentHolder.getInstance().getConfigurationManager();
+    }
+
+    /**
+     * Retrieves a resource based on the given resource type name and resource name.
+     *
+     * @param resourceTypeName The type name of the resource.
+     * @param resourceName     The name of the resource.
+     * @return The resource if found, or null if the resource does not exist.
+     * @throws ConfigurationManagementException If there is an error in the configuration management process.
+     */
+    private Resource getResource(String resourceTypeName, String resourceName) throws ConfigurationManagementException {
+
+        try {
+            return getConfigurationManager().getResource(resourceTypeName, resourceName);
+        } catch (ConfigurationManagementException e) {
+            if (ERROR_CODE_RESOURCE_DOES_NOT_EXISTS.getCode().equals(e.getErrorCode())) {
+                return null;
+            } else {
+                throw e;
+            }
+        }
+    }
+}

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/impersonation/utils/Constants.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/impersonation/utils/Constants.java
@@ -25,4 +25,7 @@ package org.wso2.carbon.identity.oauth2.impersonation.utils;
 public class Constants {
 
     public static final String OAUTH_2 = "oauth2";
+    public static final String ENABLE_EMAIL_NOTIFICATION = "EnableEmailNotification";
+    public static final String IMPERSONATION_RESOURCE_TYPE_NAME = "IMPERSONATION_CONFIGURATION";
+    public static final String IMPERSONATION_RESOURCE_NAME = "TENANT_IMPERSONATION_CONFIGURATION";
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/impersonation/utils/ErrorMessage.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/impersonation/utils/ErrorMessage.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth2.impersonation.utils;
+
+/**
+ * Error message enum for Impersonation Config Mgt Exceptions.
+ */
+public enum ErrorMessage {
+
+    ERROR_CODE_INVALID_TENANT_DOMAIN("60004",
+            "Invalid input.",
+            "%s is not a valid tenant domain."),
+
+    ERROR_CODE_IMP_CONFIG_RETRIEVE("65018",
+            "Unable to retrieve Impersonation configuration.",
+            "Server encountered an error while retrieving the Impersonation configuration of %s."),
+
+    ERROR_CODE_IMP_CONFIG_UPDATE("65019",
+            "Unable to update Impersonation configuration.",
+            "Server encountered an error while updating the Impersonation configuration of %s.");
+
+    /**
+     * The error code.
+     */
+    private final String code;
+
+    /**
+     * The error message.
+     */
+    private final String message;
+
+    /**
+     * The error description.
+     */
+    private final String description;
+
+
+    ErrorMessage(String code, String message, String description) {
+        this.code = code;
+        this.message = message;
+        this.description = description;
+    }
+
+    /**
+     * Get the {@code code}.
+     *
+     * @return Returns the {@code code} to be set.
+     */
+    public String getCode() {
+
+        return code;
+    }
+
+    /**
+     * Get the {@code message}.
+     *
+     * @return Returns the {@code message} to be set.
+     */
+    public String getMessage() {
+
+        return message;
+    }
+
+    /**
+     * Get the {@code description}.
+     *
+     * @return Returns the {@code description} to be set.
+     */
+    public String getDescription() {
+
+        return description;
+    }
+
+    @Override
+    public String toString() {
+
+        return code + ":" + message;
+    }
+}
+

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/impersonation/utils/Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/impersonation/utils/Util.java
@@ -1,0 +1,134 @@
+/*
+ *  Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+
+package org.wso2.carbon.identity.oauth2.impersonation.utils;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang.StringUtils;
+import org.wso2.carbon.identity.configuration.mgt.core.model.Attribute;
+import org.wso2.carbon.identity.configuration.mgt.core.model.Resource;
+import org.wso2.carbon.identity.configuration.mgt.core.model.ResourceAdd;
+import org.wso2.carbon.identity.oauth2.impersonation.exceptions.ImpersonationConfigMgtClientException;
+import org.wso2.carbon.identity.oauth2.impersonation.exceptions.ImpersonationConfigMgtException;
+import org.wso2.carbon.identity.oauth2.impersonation.exceptions.ImpersonationConfigMgtServerException;
+import org.wso2.carbon.identity.oauth2.impersonation.models.ImpersonationConfig;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.wso2.carbon.identity.oauth2.impersonation.utils.Constants.ENABLE_EMAIL_NOTIFICATION;
+import static org.wso2.carbon.identity.oauth2.impersonation.utils.Constants.IMPERSONATION_RESOURCE_NAME;
+
+/**
+ * Utility class providing helper methods for managing impersonation configurations.
+ */
+public class Util {
+
+    /**
+     * Handles server exceptions by creating an instance of ImpersonationConfigMgtServerException.
+     *
+     * @param error The error message and code associated with the server exception.
+     * @param e     The underlying cause of the server exception.
+     * @param data  Additional data to be included in the error message.
+     * @return An instance of ImpersonationConfigMgtServerException.
+     */
+    public static ImpersonationConfigMgtException handleServerException(ErrorMessage error, Throwable e,
+                                                                        String... data) {
+        return new ImpersonationConfigMgtServerException(String.format(error.getDescription(), data),
+                error.getCode(), e);
+    }
+
+    /**
+     * Handles client exceptions by creating an instance of ImpersonationConfigMgtClientException.
+     *
+     * @param error The error message and code associated with the client exception.
+     * @param e     The underlying cause of the client exception.
+     * @param data  Additional data to be included in the error message.
+     * @return An instance of ImpersonationConfigMgtClientException.
+     */
+    public static ImpersonationConfigMgtException handleClientException(ErrorMessage error, Throwable e,
+                                                                        String... data) {
+        return new ImpersonationConfigMgtClientException(String.format(error.getDescription(), data),
+                error.getCode(), e);
+    }
+
+    /**
+     * Parses an ImpersonationConfig object into a ResourceAdd object.
+     *
+     * @param impersonationConfig The impersonation configuration to be parsed.
+     * @return A ResourceAdd object representing the parsed configuration.
+     */
+    public static ResourceAdd parseConfig(ImpersonationConfig impersonationConfig) {
+        ResourceAdd resourceAdd = new ResourceAdd();
+        resourceAdd.setName(IMPERSONATION_RESOURCE_NAME);
+        List<Attribute> attributes = new ArrayList<>();
+        addAttribute(attributes, impersonationConfig);
+        resourceAdd.setAttributes(attributes);
+        return resourceAdd;
+    }
+
+    private static void addAttribute(List<Attribute> attributeList, ImpersonationConfig impersonationConfig) {
+        String value = String.valueOf(impersonationConfig.isEnableEmailNotification());
+        if (StringUtils.isNotBlank(value)) {
+            Attribute attribute = new Attribute();
+            attribute.setKey(ENABLE_EMAIL_NOTIFICATION);
+            attribute.setValue(value);
+            attributeList.add(attribute);
+        }
+    }
+
+    /**
+     * Parses a Resource object into an ImpersonationConfig object.
+     *
+     * @param resource The resource to be parsed.
+     * @return An ImpersonationConfig object representing the parsed resource.
+     */
+    public static ImpersonationConfig parseResource(Resource resource) {
+        ImpersonationConfig impersonationConfig = new ImpersonationConfig();
+        if (resource.isHasAttribute()) {
+            List<Attribute> attributes = resource.getAttributes();
+            Map<String, String> attributeMap = getAttributeMap(attributes);
+            impersonationConfig.setEnableEmailNotification(
+                    Boolean.parseBoolean(attributeMap.get(ENABLE_EMAIL_NOTIFICATION)));
+        }
+        return impersonationConfig;
+    }
+
+    private static Map<String, String> getAttributeMap(List<Attribute> attributes) {
+        if (CollectionUtils.isNotEmpty(attributes)) {
+            return attributes.stream().collect(Collectors.toMap(Attribute::getKey, Attribute::getValue));
+        }
+        return Collections.emptyMap();
+    }
+
+    /**
+     * Retrieves the default impersonation configuration.
+     *
+     * @return The default ImpersonationConfig object.
+     */
+    public static ImpersonationConfig getDefaultConfiguration() {
+        ImpersonationConfig impersonationConfig = new ImpersonationConfig();
+        impersonationConfig.setEnableEmailNotification(true);
+        return impersonationConfig;
+    }
+}
+

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/impersonation/utils/Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/impersonation/utils/Util.java
@@ -53,6 +53,7 @@ public class Util {
      */
     public static ImpersonationConfigMgtException handleServerException(ErrorMessage error, Throwable e,
                                                                         String... data) {
+
         return new ImpersonationConfigMgtServerException(String.format(error.getDescription(), data),
                 error.getCode(), e);
     }
@@ -67,6 +68,7 @@ public class Util {
      */
     public static ImpersonationConfigMgtException handleClientException(ErrorMessage error, Throwable e,
                                                                         String... data) {
+
         return new ImpersonationConfigMgtClientException(String.format(error.getDescription(), data),
                 error.getCode(), e);
     }
@@ -78,6 +80,7 @@ public class Util {
      * @return A ResourceAdd object representing the parsed configuration.
      */
     public static ResourceAdd parseConfig(ImpersonationConfig impersonationConfig) {
+
         ResourceAdd resourceAdd = new ResourceAdd();
         resourceAdd.setName(IMPERSONATION_RESOURCE_NAME);
         List<Attribute> attributes = new ArrayList<>();
@@ -87,6 +90,7 @@ public class Util {
     }
 
     private static void addAttribute(List<Attribute> attributeList, ImpersonationConfig impersonationConfig) {
+
         String value = String.valueOf(impersonationConfig.isEnableEmailNotification());
         if (StringUtils.isNotBlank(value)) {
             Attribute attribute = new Attribute();
@@ -103,6 +107,7 @@ public class Util {
      * @return An ImpersonationConfig object representing the parsed resource.
      */
     public static ImpersonationConfig parseResource(Resource resource) {
+
         ImpersonationConfig impersonationConfig = new ImpersonationConfig();
         if (resource.isHasAttribute()) {
             List<Attribute> attributes = resource.getAttributes();
@@ -114,6 +119,7 @@ public class Util {
     }
 
     private static Map<String, String> getAttributeMap(List<Attribute> attributes) {
+
         if (CollectionUtils.isNotEmpty(attributes)) {
             return attributes.stream().collect(Collectors.toMap(Attribute::getKey, Attribute::getValue));
         }
@@ -126,6 +132,7 @@ public class Util {
      * @return The default ImpersonationConfig object.
      */
     public static ImpersonationConfig getDefaultConfiguration() {
+
         ImpersonationConfig impersonationConfig = new ImpersonationConfig();
         impersonationConfig.setEnableEmailNotification(true);
         return impersonationConfig;

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuth2ServiceComponent.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuth2ServiceComponent.java
@@ -40,6 +40,7 @@ import org.wso2.carbon.identity.application.authentication.framework.util.Framew
 import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.application.mgt.AuthorizedAPIManagementService;
 import org.wso2.carbon.identity.application.mgt.listener.ApplicationMgtListener;
+import org.wso2.carbon.identity.configuration.mgt.core.ConfigurationManager;
 import org.wso2.carbon.identity.consent.server.configs.mgt.services.ConsentServerConfigsManagementService;
 import org.wso2.carbon.identity.core.SAMLSSOServiceProviderManager;
 import org.wso2.carbon.identity.core.util.IdentityCoreConstants;
@@ -72,6 +73,8 @@ import org.wso2.carbon.identity.oauth2.dao.TokenManagementDAO;
 import org.wso2.carbon.identity.oauth2.device.api.DeviceAuthService;
 import org.wso2.carbon.identity.oauth2.device.api.DeviceAuthServiceImpl;
 import org.wso2.carbon.identity.oauth2.device.response.DeviceFlowResponseTypeRequestValidator;
+import org.wso2.carbon.identity.oauth2.impersonation.services.ImpersonationConfigMgtService;
+import org.wso2.carbon.identity.oauth2.impersonation.services.ImpersonationConfigMgtServiceImpl;
 import org.wso2.carbon.identity.oauth2.impersonation.services.ImpersonationMgtServiceImpl;
 import org.wso2.carbon.identity.oauth2.impersonation.validators.ImpersonationValidator;
 import org.wso2.carbon.identity.oauth2.impersonation.validators.SubjectScopeValidator;
@@ -395,6 +398,8 @@ public class OAuth2ServiceComponent {
 
             OAuth2ServiceComponentHolder.getInstance().setImpersonationMgtService(new ImpersonationMgtServiceImpl());
             bundleContext.registerService(ImpersonationValidator.class, new SubjectScopeValidator(), null);
+            bundleContext.registerService(ImpersonationConfigMgtService.class, new ImpersonationConfigMgtServiceImpl(),
+                    null);
 
             // Note : DO NOT add any activation related code below this point,
             // to make sure the server doesn't start up if any activation failures occur
@@ -1570,5 +1575,39 @@ public class OAuth2ServiceComponent {
     protected void unsetImpersonationValidator(ImpersonationValidator impersonationValidator) {
 
         OAuth2ServiceComponentHolder.getInstance().removeImpersonationValidator(impersonationValidator);
+    }
+
+    /**
+     * Set the ConfigurationManager.
+     *
+     * @param configurationManager The {@code ConfigurationManager} instance.
+     */
+    @Reference(
+            name = "resource.configuration.manager",
+            service = ConfigurationManager.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unregisterConfigurationManager"
+    )
+    protected void registerConfigurationManager(ConfigurationManager configurationManager) {
+
+        if (log.isDebugEnabled()) {
+            log.debug("Registering the ConfigurationManager in JWT Client Authenticator ManagementService.");
+        }
+        OAuth2ServiceComponentHolder.getInstance().setConfigurationManager(configurationManager);
+    }
+
+
+    /**
+     * Unset the ConfigurationManager.
+     *
+     * @param configurationManager The {@code ConfigurationManager} instance.
+     */
+    protected void unregisterConfigurationManager(ConfigurationManager configurationManager) {
+
+        if (log.isDebugEnabled()) {
+            log.debug("Unregistering the ConfigurationManager in JWT Client Authenticator ManagementService.");
+        }
+        OAuth2ServiceComponentHolder.getInstance().setConfigurationManager(null);
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuth2ServiceComponentHolder.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuth2ServiceComponentHolder.java
@@ -24,6 +24,7 @@ import org.wso2.carbon.identity.application.authentication.framework.Authenticat
 import org.wso2.carbon.identity.application.authentication.framework.UserSessionManagementService;
 import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.application.mgt.AuthorizedAPIManagementService;
+import org.wso2.carbon.identity.configuration.mgt.core.ConfigurationManager;
 import org.wso2.carbon.identity.consent.server.configs.mgt.services.ConsentServerConfigsManagementService;
 import org.wso2.carbon.identity.core.SAMLSSOServiceProviderManager;
 import org.wso2.carbon.identity.core.handler.HandlerComparator;
@@ -120,6 +121,8 @@ public class OAuth2ServiceComponentHolder {
     private ImpersonationMgtService impersonationMgtService;
 
     private List<ImpersonationValidator> impersonationValidators = new ArrayList<>();
+    private ConfigurationManager configurationManager;
+
 
     private OAuth2ServiceComponentHolder() {
 
@@ -875,5 +878,15 @@ public class OAuth2ServiceComponentHolder {
 
         // Sort based on priority in descending order, ie. the highest priority comes to the first element of the list.
         return Comparator.comparingInt(ImpersonationValidator::getPriority).reversed();
+    }
+
+    public ConfigurationManager getConfigurationManager() {
+
+        return configurationManager;
+    }
+
+    public void setConfigurationManager(ConfigurationManager configurationManager) {
+
+        this.configurationManager = configurationManager;
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/impersonation/ImpersonationConfigMgtTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/impersonation/ImpersonationConfigMgtTest.java
@@ -1,0 +1,174 @@
+/*
+ *  Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+
+package org.wso2.carbon.identity.oauth2.impersonation;
+
+import org.mockito.Mock;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.configuration.mgt.core.ConfigurationManager;
+import org.wso2.carbon.identity.configuration.mgt.core.exception.ConfigurationManagementException;
+import org.wso2.carbon.identity.configuration.mgt.core.model.Attribute;
+import org.wso2.carbon.identity.configuration.mgt.core.model.Resource;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.oauth2.impersonation.exceptions.ImpersonationConfigMgtException;
+import org.wso2.carbon.identity.oauth2.impersonation.models.ImpersonationConfig;
+import org.wso2.carbon.identity.oauth2.impersonation.services.ImpersonationConfigMgtServiceImpl;
+import org.wso2.carbon.identity.oauth2.internal.OAuth2ServiceComponentHolder;
+import org.wso2.carbon.identity.testutil.powermock.PowerMockIdentityBaseTest;
+
+import java.util.Collections;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.FileAssert.fail;
+import static org.wso2.carbon.identity.configuration.mgt.core.constant.ConfigurationConstants.ErrorMessages.ERROR_CODE_RESOURCE_DOES_NOT_EXISTS;
+import static org.wso2.carbon.identity.configuration.mgt.core.constant.ConfigurationConstants.ErrorMessages.ERROR_CODE_RETRIEVE_RESOURCE_TYPE;
+import static org.wso2.carbon.identity.oauth2.impersonation.utils.Constants.ENABLE_EMAIL_NOTIFICATION;
+import static org.wso2.carbon.identity.oauth2.impersonation.utils.Constants.IMPERSONATION_RESOURCE_NAME;
+import static org.wso2.carbon.identity.oauth2.impersonation.utils.Constants.IMPERSONATION_RESOURCE_TYPE_NAME;
+import static org.wso2.carbon.identity.oauth2.impersonation.utils.ErrorMessage.ERROR_CODE_IMP_CONFIG_RETRIEVE;
+import static org.wso2.carbon.identity.oauth2.impersonation.utils.ErrorMessage.ERROR_CODE_IMP_CONFIG_UPDATE;
+
+/**
+ * Unit test cases for ImpersonationConfigMgtService clas..
+ */
+@PrepareForTest({
+        IdentityTenantUtil.class
+        })
+public class ImpersonationConfigMgtTest extends PowerMockIdentityBaseTest {
+    @Mock
+    private ConfigurationManager configurationManager;
+
+    private ImpersonationConfigMgtServiceImpl impersonationConfigMgtService
+                = new ImpersonationConfigMgtServiceImpl();
+    private static final String tenantDomain = "carbon.super";
+
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+
+        OAuth2ServiceComponentHolder.getInstance().setConfigurationManager(configurationManager);
+        mockStatic(IdentityTenantUtil.class);
+
+    }
+
+    @DataProvider(name = "GetImpersonationConfigData")
+    public Object[][] getImpersonationConfigData() {
+
+            Attribute attributeEnabled = new Attribute(ENABLE_EMAIL_NOTIFICATION, "true");
+            Resource resourceEnabled = new Resource(IMPERSONATION_RESOURCE_NAME, IMPERSONATION_RESOURCE_TYPE_NAME);
+            resourceEnabled.setHasAttribute(true);
+            resourceEnabled.setAttributes(Collections.singletonList(attributeEnabled));
+
+            Attribute attributeDisabled = new Attribute(ENABLE_EMAIL_NOTIFICATION, "false");
+            Resource resourceDisabled = new Resource(IMPERSONATION_RESOURCE_NAME, IMPERSONATION_RESOURCE_TYPE_NAME);
+            resourceDisabled.setHasAttribute(true);
+            resourceDisabled.setAttributes(Collections.singletonList(attributeDisabled));
+
+            return new Object[][]{
+                 // Resource to be return
+                 // isEmailNotificationEnabled
+                {resourceEnabled, true},
+                {resourceDisabled, false},
+                {null, true}
+            };
+    }
+
+    @Test(dataProvider = "GetImpersonationConfigData")
+    public void testGetImpersonationConfig(Object resource, boolean isEmailNotificationEnabled)
+            throws Exception {
+
+        Resource tenantResource = (Resource) resource;
+         if (resource != null) {
+              when(configurationManager.getResource(IMPERSONATION_RESOURCE_TYPE_NAME, IMPERSONATION_RESOURCE_NAME))
+                      .thenReturn(tenantResource);
+         }  else {
+             ConfigurationManagementException configurationManagementException = new ConfigurationManagementException
+                     (ERROR_CODE_RESOURCE_DOES_NOT_EXISTS.getMessage(), ERROR_CODE_RESOURCE_DOES_NOT_EXISTS.getCode());
+              when(configurationManager.getResource(IMPERSONATION_RESOURCE_TYPE_NAME, IMPERSONATION_RESOURCE_NAME))
+                      .thenThrow(configurationManagementException);
+         }
+
+        try {
+            ImpersonationConfig impersonationConfig = impersonationConfigMgtService
+                    .getImpersonationConfig(tenantDomain);
+            assertEquals(isEmailNotificationEnabled, impersonationConfig.isEnableEmailNotification());
+
+        } catch (ImpersonationConfigMgtException e) {
+            fail("Unexpected Exception");
+        }
+//        assertTrue(true);
+    }
+
+    @Test
+    public void testGetImpersonationConfigException() throws ConfigurationManagementException {
+
+
+        ConfigurationManagementException configurationManagementException = new ConfigurationManagementException
+                (ERROR_CODE_RETRIEVE_RESOURCE_TYPE.getMessage(), ERROR_CODE_RETRIEVE_RESOURCE_TYPE.getCode());
+        when(configurationManager.getResource(IMPERSONATION_RESOURCE_TYPE_NAME, IMPERSONATION_RESOURCE_NAME))
+                    .thenThrow(configurationManagementException);
+
+        try {
+            impersonationConfigMgtService.getImpersonationConfig(tenantDomain);
+        } catch (ImpersonationConfigMgtException e) {
+            assertEquals(e.getErrorCode(), ERROR_CODE_IMP_CONFIG_RETRIEVE.getCode());
+            assertEquals(e.getMessage(), String.format(ERROR_CODE_IMP_CONFIG_RETRIEVE.getDescription(), tenantDomain));
+        }
+    }
+
+    @Test
+    public void testSetImpersonationConfig() throws ConfigurationManagementException {
+
+        when(IdentityTenantUtil.getTenantId(tenantDomain)).thenReturn(-1234);
+        when(configurationManager.replaceResource(eq(IMPERSONATION_RESOURCE_TYPE_NAME), any(Resource.class)))
+                .thenReturn(new Resource());
+        ImpersonationConfig impersonationConfig = new ImpersonationConfig();
+        impersonationConfig.setEnableEmailNotification(true);
+        try {
+            impersonationConfigMgtService.setImpersonationConfig(impersonationConfig, tenantDomain);
+        } catch (ImpersonationConfigMgtException e) {
+            fail("Unexpected Exception");
+        }
+    }
+
+    @Test
+    public void testSetImpersonationConfigException() throws ConfigurationManagementException {
+
+        when(IdentityTenantUtil.getTenantId(tenantDomain)).thenReturn(-1234);
+        ConfigurationManagementException configurationManagementException = new ConfigurationManagementException
+                (ERROR_CODE_RESOURCE_DOES_NOT_EXISTS.getMessage(), ERROR_CODE_RESOURCE_DOES_NOT_EXISTS.getCode());
+        when(configurationManager.replaceResource(eq(IMPERSONATION_RESOURCE_TYPE_NAME), any(Resource.class)))
+                .thenThrow(configurationManagementException);
+        ImpersonationConfig impersonationConfig = new ImpersonationConfig();
+        impersonationConfig.setEnableEmailNotification(true);
+        try {
+            impersonationConfigMgtService.setImpersonationConfig(impersonationConfig, tenantDomain);
+        } catch (ImpersonationConfigMgtException e) {
+            assertEquals(e.getErrorCode(), ERROR_CODE_IMP_CONFIG_UPDATE.getCode());
+            assertEquals(e.getMessage(), String.format(ERROR_CODE_IMP_CONFIG_UPDATE.getDescription(), tenantDomain));
+        }
+    }
+}

--- a/components/org.wso2.carbon.identity.oauth/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.identity.oauth/src/test/resources/testng.xml
@@ -38,6 +38,7 @@
             <class name="org.wso2.carbon.identity.oauth2.authcontext.JWTTokenGeneratorTest"/>
             <class name="org.wso2.carbon.identity.oauth2.token.SubjectTokenIssuerTest"/>
             <class name="org.wso2.carbon.identity.oauth2.impersonation.SubjectScopeValidatorTest"/>
+            <class name="org.wso2.carbon.identity.oauth2.impersonation.ImpersonationConfigMgtTest"/>
             <class name="org.wso2.carbon.identity.openidconnect.RememberMeStoreTest"/>
             <class name="org.wso2.carbon.identity.openidconnect.RequestObjectValidatorImplTest"/>
             <class name="org.wso2.carbon.identity.openidconnect.RequestParamRequestObjectBuilderTest"/>
@@ -182,6 +183,7 @@
             <class name="org.wso2.carbon.identity.oauth2.token.JWTTokenIssuerTest"/>
             <class name="org.wso2.carbon.identity.oauth2.token.SubjectTokenIssuerTest"/>
             <class name="org.wso2.carbon.identity.oauth2.impersonation.SubjectScopeValidatorTest"/>
+            <class name="org.wso2.carbon.identity.oauth2.impersonation.ImpersonationConfigMgtTest"/>
             <class name="org.wso2.carbon.identity.oauth2.token.OauthTokenIssuerImplTest"/>
             <class name="org.wso2.carbon.identity.oauth2.util.OAuth2UtilTest"/>
             <class name="org.wso2.carbon.identity.openidconnect.DefaultIDTokenBuilderTest"/>

--- a/pom.xml
+++ b/pom.xml
@@ -729,6 +729,11 @@
                 <artifactId>org.wso2.carbon.identity.role.v2.mgt.core</artifactId>
                 <version>${carbon.identity.framework.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.framework</groupId>
+                <artifactId>org.wso2.carbon.identity.configuration.mgt.core</artifactId>
+                <version>${carbon.identity.framework.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
Public Issue: https://github.com/wso2/product-is/issues/20066

## Purpose
With this PR we are adding BE support for impersonation tenant wise configuration. Currently it used to configure enableEmail notification.

## Approach
We used configuration mgt to manage tenant wise configuration.

- [x] Unit Test [link](https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2482/files#diff-f166c7b44293f099a990b9bfa37d3e075e064bc1feabfdd5950fc797dbc31650)