### PR TITLE
Add aud parameter in introspection response for opaque tokens

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/introspection/OAuth2IntrospectionEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/introspection/OAuth2IntrospectionEndpoint.java
@@ -142,15 +142,15 @@ public class OAuth2IntrospectionEndpoint {
                 .setClientId(introspectionResponse.getClientId())
                 .setIssuedAt(introspectionResponse.getIat())
                 .setExpiration(introspectionResponse.getExp())
-                .setAuthorizedUserType(introspectionResponse.getAut());
+                .setAuthorizedUserType(introspectionResponse.getAut())
+                .setAudience(introspectionResponse.getAud());;
 
         if (introspectionResponse.getAuthorizedUser() != null) {
             respBuilder.setOrgId(introspectionResponse.getAuthorizedUser().getAccessingOrganization());
         }
 
         if (StringUtils.equalsIgnoreCase(introspectionResponse.getTokenType(), JWT_TOKEN_TYPE)) {
-            respBuilder.setAudience(introspectionResponse.getAud())
-                    .setJwtId(introspectionResponse.getJti())
+            respBuilder.setJwtId(introspectionResponse.getJti())
                     .setSubject(introspectionResponse.getSub())
                     .setTokenType(introspectionResponse.getTokenType())
                     .setIssuer(introspectionResponse.getIss());

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dao/AccessTokenDAOImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dao/AccessTokenDAOImpl.java
@@ -585,6 +585,7 @@ public class AccessTokenDAOImpl extends AbstractOAuthDAO implements AccessTokenD
                     accessTokenDO.setTokenState(tokenState);
                     accessTokenDO.setTokenId(tokenId);
                     accessTokenDO.setGrantType(grantType);
+                    accessTokenDO.setAppResidentTenantId(appTenantId);
 
                     if (StringUtils.isNotEmpty(authzUser.getAccessingOrganization())) {
                         accessTokenDO.getAuthzUser().setAccessingOrganization(authzUser.getAccessingOrganization());
@@ -1165,6 +1166,7 @@ public class AccessTokenDAOImpl extends AbstractOAuthDAO implements AccessTokenD
                     dataDO.setGrantType(grantType);
                     dataDO.setTenantID(tenantId);
                     dataDO.setIsConsentedToken(isConsentedToken);
+                    dataDO.setAppResidentTenantId(appResideTenantId);
 
                     /* For organization bound access tokens, the authenticated user should be populated considering
                     below factors. */

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/model/AccessTokenDO.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/model/AccessTokenDO.java
@@ -77,6 +77,8 @@ public class AccessTokenDO extends CacheEntry {
 
     private String authorizedOrganizationId;
 
+    private int appResidentTenantId = MultitenantConstants.INVALID_TENANT_ID;
+
     public AccessTokenDO(String consumerKey, AuthenticatedUser authzUser, String[] scope, Timestamp issuedTime,
                          Timestamp refreshTokenIssuedTime, long validityPeriodInMillis,
                          long refreshTokenValidityPeriodInMillis, String tokenType) {
@@ -143,6 +145,7 @@ public class AccessTokenDO extends CacheEntry {
         newTokenDO.setGrantType(tokenDO.getGrantType());
         newTokenDO.setTokenBinding(tokenDO.getTokenBinding());
         newTokenDO.setIsConsentedToken(tokenDO.isConsentedToken());
+        newTokenDO.setAppResidentTenantId(tokenDO.getAppResidentTenantId());
 
         return newTokenDO;
     }
@@ -344,5 +347,15 @@ public class AccessTokenDO extends CacheEntry {
     public void setAuthorizedOrganizationId(String authorizedOrganizationId) {
 
         this.authorizedOrganizationId = authorizedOrganizationId;
+    }
+
+    public int getAppResidentTenantId() {
+
+        return appResidentTenantId;
+    }
+
+    public void setAppResidentTenantId(int appResidentTenantId) {
+
+        this.appResidentTenantId = appResidentTenantId;
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AbstractAuthorizationGrantHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AbstractAuthorizationGrantHandler.java
@@ -32,6 +32,7 @@ import org.wso2.carbon.identity.base.IdentityConstants;
 import org.wso2.carbon.identity.base.IdentityException;
 import org.wso2.carbon.identity.central.log.mgt.utils.LogConstants;
 import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.oauth.OAuthUtil;
 import org.wso2.carbon.identity.oauth.cache.CacheEntry;
@@ -486,6 +487,7 @@ public abstract class AbstractAuthorizationGrantHandler implements Authorization
         newTokenBean.setTenantID(OAuth2Util.getTenantId(tenantDomain));
         newTokenBean.setTokenId(UUID.randomUUID().toString());
         newTokenBean.setGrantType(tokenReq.getGrantType());
+        newTokenBean.setAppResidentTenantId(IdentityTenantUtil.getLoginTenantId());
         /* If the existing token is available, the consented token flag will be extracted from that. Otherwise,
         from the current grant. */
         if (OAuth2ServiceComponentHolder.isConsentedTokenColumnEnabled()) {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -2406,7 +2406,7 @@ public class OAuth2Util {
     public static OAuthAppDO getAppInformationByClientId(String clientId, String tenantDomain)
             throws IdentityOAuth2Exception, InvalidOAuthClientException {
 
-        OAuthAppDO oAuthAppDO = AppInfoCache.getInstance().getValueFromCache(clientId);
+        OAuthAppDO oAuthAppDO = AppInfoCache.getInstance().getValueFromCache(clientId, tenantDomain);
         if (oAuthAppDO == null) {
             oAuthAppDO = new OAuthAppDAO().getAppInformation(clientId, IdentityTenantUtil.getTenantId(tenantDomain));
             if (oAuthAppDO != null) {
@@ -2415,7 +2415,7 @@ public class OAuth2Util {
                     AppInfoCache.getInstance().addToCache(clientId, oAuthAppDO,
                             oAuthAppDO.getAppOwner().getTenantDomain());
                 } else {
-                    AppInfoCache.getInstance().addToCache(clientId, oAuthAppDO);
+                    AppInfoCache.getInstance().addToCache(clientId, oAuthAppDO, tenantDomain);
                 }
             }
         }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/TokenValidationHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/TokenValidationHandler.java
@@ -873,18 +873,19 @@ public class TokenValidationHandler {
     private void addAudienceToIntrospectionResponse(OAuth2IntrospectionResponseDTO introResp,
                                                       AccessTokenDO accessTokenDO) throws IdentityOAuth2Exception {
 
-        OAuthAppDO oAuthAppDO;
+        String tenantDomain = null;
         try {
             int appResidentTenantId = accessTokenDO.getAppResidentTenantId();
             if (appResidentTenantId != MultitenantConstants.INVALID_TENANT_ID) {
-                String tenantDomain = IdentityTenantUtil.getTenantDomain(appResidentTenantId);
-                oAuthAppDO = OAuth2Util.getAppInformationByClientId(accessTokenDO.getConsumerKey(), tenantDomain);
+                tenantDomain = IdentityTenantUtil.getTenantDomain(appResidentTenantId);
+                OAuthAppDO oAuthAppDO = OAuth2Util.getAppInformationByClientId(accessTokenDO.getConsumerKey(),
+                        tenantDomain);
                 List<String> audience = OAuth2Util.getOIDCAudience(accessTokenDO.getConsumerKey(), oAuthAppDO);
                 introResp.setAud(String.join(",", audience));
             }
         } catch (InvalidOAuthClientException e) {
-            throw new IdentityOAuth2Exception("Error while retrieving OAuth app information for clientId: " +
-                    accessTokenDO.getConsumerKey());
+            log.warn("Unable to set the audience in the introspection response. Failed to retrieve the " +
+                    "application for client id: " + accessTokenDO.getConsumerKey() + " in tenant: " + tenantDomain);
         }
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/validators/DefaultOAuth2TokenValidatorTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/validators/DefaultOAuth2TokenValidatorTest.java
@@ -34,10 +34,12 @@ import org.wso2.carbon.identity.oauth.dao.OAuthAppDO;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2TokenValidationRequestDTO;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2TokenValidationResponseDTO;
 import org.wso2.carbon.identity.oauth2.model.AccessTokenDO;
+import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
 import java.util.HashSet;
 import java.util.Set;
 
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.powermock.api.mockito.PowerMockito.mock;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
@@ -59,6 +61,7 @@ public class DefaultOAuth2TokenValidatorTest extends PowerMockTestCase {
         //todo - match the dependencies in the originating repo
         mockStatic(IdentityTenantUtil.class);
         when(IdentityTenantUtil.getTenantId(anyString())).thenReturn(-1234);
+        when(IdentityTenantUtil.getTenantDomain(anyInt())).thenReturn(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
 
         defaultOAuth2TokenValidator = new DefaultOAuth2TokenValidator();
         oAuth2TokenValidationRequestDTO = new OAuth2TokenValidationRequestDTO();

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/validators/TokenValidationHandlerTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/validators/TokenValidationHandlerTest.java
@@ -217,6 +217,7 @@ public class TokenValidationHandlerTest extends PowerMockTestCase {
         mockRequiredObjects();
         when(realmService.getTenantManager()).thenReturn(tenantManager);
         doReturn(MultitenantConstants.SUPER_TENANT_ID).when(tenantManager).getTenantId(Mockito.anyString());
+        doReturn(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME).when(tenantManager).getDomain(Mockito.anyInt());
         OAuthComponentServiceHolder.getInstance().setRealmService(realmService);
         IdentityTenantUtil.setRealmService(realmService);
         when(realmService.getBootstrapRealmConfiguration()).thenReturn(realmConfiguration);


### PR DESCRIPTION
### Purpose

The aud parameter was added to the introspection response of opaque tokens by https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2457 but was later reverted due to cross-tenant introspection requests failing. This PR contains the changes of the above and corrects the application retrieval logic.

The consumer application is retrieved by the client ID and the tenant domain. Previously, the tenant domain was resolved from the thread local ie. it will resolve to be the tenant domain which the introspection call is made to. When the token is obtained for an application in a different domain, application retrieval failed. 

This PR retrieves the application by the client ID and the tenant domain which the application resides in. To achieve this, the new class variable `appResidentTenantId` is introduced to the Access Token model.