### PR TITLE
Fix shared console app callback URL is set with URL origin with placeholders

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dao/OAuthAppDAO.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dao/OAuthAppDAO.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2013, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2013-2024, WSO2 LLC. (http://www.wso2.com).
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -11,7 +11,7 @@
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the
+ * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
  */

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dao/OAuthAppDAO.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dao/OAuthAppDAO.java
@@ -164,7 +164,8 @@ public class OAuthAppDAO {
                             persistenceProcessor.getProcessedClientSecret(consumerAppDO.getOauthConsumerSecret());
 
                     String templatedCallbackUrl = consumerAppDO.getCallbackUrl();
-                    if (ApplicationMgtUtil.isConsoleOrMyAccount(consumerAppDO.getApplicationName())) {
+                    if (ApplicationMgtUtil.isConsoleOrMyAccount(consumerAppDO.getApplicationName()) &&
+                            isRootOrganization(spTenantId)) {
                         templatedCallbackUrl = ApplicationMgtUtil.replaceUrlOriginWithPlaceholders(
                                 templatedCallbackUrl);
                     }


### PR DESCRIPTION
### Proposed changes in this pull request

The shared console/MyAccount callback URL is set with URL origin placeholders as its app name is Console/MyAccount.
But when retrieving the callback URL, the placeholder values will be replaced with the hostname (console.xyz.io) defined for corresponding origin instead API path (api.xyz.io). 

This fix is sent to resolve that by persisting the generated callback URL for the shared app, instead of persisting the placeholders same as it is done for the other shared apps (except console & myaccount).