### PR TITLE
Mask `state` and `login_hint` Params in Diagnostic Logs

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
@@ -1430,6 +1430,10 @@ public class OAuth2AuthzEndpoint {
             if (oAuthMessage.getRequest() != null && MapUtils.isNotEmpty(oAuthMessage.getRequest().getParameterMap())) {
                 oAuthMessage.getRequest().getParameterMap().forEach((key, value) -> {
                     if (ArrayUtils.isNotEmpty(value)) {
+                        if (STATE.equals(key) || LOGIN_HINT.equals(key)) {
+                            Arrays.setAll(value, i ->
+                                    LoggerUtils.isLogMaskingEnable ? LoggerUtils.getMaskedContent(value[i]) : value[i]);
+                        }
                         diagnosticLogBuilder.inputParam(key, Arrays.asList(value));
                     }
                 });

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
@@ -1431,10 +1431,14 @@ public class OAuth2AuthzEndpoint {
                 oAuthMessage.getRequest().getParameterMap().forEach((key, value) -> {
                     if (ArrayUtils.isNotEmpty(value)) {
                         if (STATE.equals(key) || LOGIN_HINT.equals(key)) {
-                            Arrays.setAll(value, i ->
-                                    LoggerUtils.isLogMaskingEnable ? LoggerUtils.getMaskedContent(value[i]) : value[i]);
+                            String[] maskedValue = Arrays.copyOf(value, value.length);
+                            Arrays.setAll(maskedValue, i ->
+                                    LoggerUtils.isLogMaskingEnable ?
+                                            LoggerUtils.getMaskedContent(maskedValue[i]) : maskedValue[i]);
+                            diagnosticLogBuilder.inputParam(key, Arrays.asList(maskedValue));
+                        } else {
+                            diagnosticLogBuilder.inputParam(key, Arrays.asList(value));
                         }
-                        diagnosticLogBuilder.inputParam(key, Arrays.asList(value));
                     }
                 });
             }


### PR DESCRIPTION
### Proposed changes in this pull request

- Mask PII content in `state` and `login_hint` params when passing them into the diagnostic logger.

