### PR TITLE
Remove userID check for revoking tokens based on token binding reference

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/bindings/handlers/TokenBindingExpiryEventHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/bindings/handlers/TokenBindingExpiryEventHandler.java
@@ -204,13 +204,13 @@ public class TokenBindingExpiryEventHandler extends AbstractEventHandler {
                                             String bindingType) throws IdentityOAuth2Exception,
             InvalidOAuthClientException, OAuthSystemException {
 
-        revokeTokensOfBindingRef(user, getBindingRefFromType(request, consumerKey, bindingType));
+        revokeTokensOfBindingRef(user, getBindingRefFromType(request, consumerKey, bindingType), bindingType);
     }
 
     private void revokeTokensForCommonAuthCookie(HttpServletRequest request, AuthenticatedUser user) throws
             IdentityOAuth2Exception, InvalidOAuthClientException {
 
-        revokeTokensOfBindingRef(user, getBindingRefFromCommonAuthCookie(request));
+        revokeTokensOfBindingRef(user, getBindingRefFromCommonAuthCookie(request), null);
     }
 
     /**
@@ -288,11 +288,12 @@ public class TokenBindingExpiryEventHandler extends AbstractEventHandler {
      *
      * @param user                  authenticated user
      * @param tokenBindingReference token binding reference
+     * @param tokenBindingType      token binding type for the current binding reference
      * @throws IdentityOAuth2Exception     if an exception occurs while revoking tokens
      * @throws InvalidOAuthClientException if an exception occurs while revoking tokens
      */
-    private void revokeTokensOfBindingRef(AuthenticatedUser user, String tokenBindingReference) throws
-            IdentityOAuth2Exception, InvalidOAuthClientException {
+    private void revokeTokensOfBindingRef(AuthenticatedUser user, String tokenBindingReference, String tokenBindingType)
+            throws IdentityOAuth2Exception, InvalidOAuthClientException {
 
         if (StringUtils.isBlank(tokenBindingReference) || user == null) {
             return;
@@ -330,7 +331,7 @@ public class TokenBindingExpiryEventHandler extends AbstractEventHandler {
                             && StringUtils.equalsIgnoreCase(user.getUserName(), authenticatedUser.getUserName())) {
                         revokeFederatedTokens(consumerKey, user, accessTokenDO, tokenBindingReference);
                     } else if (
-                            StringUtils.equalsIgnoreCase(accessTokenDO.getTokenBinding().getBindingType(),
+                            StringUtils.equalsIgnoreCase(tokenBindingType,
                                     OAuth2Constants.TokenBinderType.SSO_SESSION_BASED_TOKEN_BINDER) ||
                                     StringUtils.equalsIgnoreCase(userId, authenticatedUser.getUserId())) {
                         revokeTokens(consumerKey, accessTokenDO, tokenBindingReference);

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/bindings/handlers/TokenBindingExpiryEventHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/bindings/handlers/TokenBindingExpiryEventHandler.java
@@ -329,7 +329,10 @@ public class TokenBindingExpiryEventHandler extends AbstractEventHandler {
                                     user.getFederatedIdPName(), authenticatedUser.getFederatedIdPName())
                             && StringUtils.equalsIgnoreCase(user.getUserName(), authenticatedUser.getUserName())) {
                         revokeFederatedTokens(consumerKey, user, accessTokenDO, tokenBindingReference);
-                    } else if (StringUtils.equalsIgnoreCase(userId, authenticatedUser.getUserId())) {
+                    } else if (
+                            StringUtils.equalsIgnoreCase(accessTokenDO.getTokenBinding().getBindingType(),
+                                    OAuth2Constants.TokenBinderType.SSO_SESSION_BASED_TOKEN_BINDER) ||
+                                    StringUtils.equalsIgnoreCase(userId, authenticatedUser.getUserId())) {
                         revokeTokens(consumerKey, accessTokenDO, tokenBindingReference);
                     }
                 } catch (UserIdNotFoundException e) {


### PR DESCRIPTION
### Purpose
All access tokens of SSO-session based token binding reference should be revoked when a user logs out when
- SSO-session based token binding is enabled
- Revoke tokens when the IDP session terminates config is enabled

Other binding references need to check for user ID as it was intentionally added.
- https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/1676

### Related Issue
- https://github.com/wso2/product-is/issues/20459
