### PR TITLE
Onboard app level pvtkeyjwt reuse config

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.dcr/src/gen/java/org/wso2/carbon/identity/oauth2/dcr/endpoint/dto/ApplicationDTO.java
+++ b/components/org.wso2.carbon.identity.api.server.dcr/src/gen/java/org/wso2/carbon/identity/oauth2/dcr/endpoint/dto/ApplicationDTO.java
@@ -62,6 +62,7 @@ public class ApplicationDTO  {
 
     private String jwksUri = null;
     private String tokenEndpointAuthMethod = null;
+    private Boolean tokenEndpointAllowReusePvtKeyJwt = null;
     private String tokenEndpointAuthSigningAlg = null;
     private String sectorIdentifierUri = null;
     private String idTokenSignedResponseAlg = null;
@@ -289,6 +290,17 @@ public class ApplicationDTO  {
     this.tokenEndpointAuthMethod = tokenEndpointAuthMethod;
   }
 
+  @ApiModelProperty(value = "")
+  @JsonProperty("token_endpoint_allow_reuse_pvt_key_jwt")
+  public Boolean isTokenEndpointAllowReusePvtKeyJwt() {
+
+      return tokenEndpointAllowReusePvtKeyJwt;
+  }
+
+  public void setTokenEndpointAllowReusePvtKeyJwt(Boolean tokenEndpointAllowReusePvtKeyJwt) {
+
+      this.tokenEndpointAllowReusePvtKeyJwt = tokenEndpointAllowReusePvtKeyJwt;
+  }
 
   @ApiModelProperty(value = "")
   @JsonProperty("token_endpoint_auth_signing_alg")

--- a/components/org.wso2.carbon.identity.api.server.dcr/src/gen/java/org/wso2/carbon/identity/oauth2/dcr/endpoint/dto/RegistrationRequestDTO.java
+++ b/components/org.wso2.carbon.identity.api.server.dcr/src/gen/java/org/wso2/carbon/identity/oauth2/dcr/endpoint/dto/RegistrationRequestDTO.java
@@ -44,6 +44,7 @@ public class RegistrationRequestDTO  {
   private String extTokenType = null;
   private String tokenEndpointAuthMethod = null;
   private String tokenEndpointAuthSigningAlg = null;
+  private Boolean tokenEndpointAllowReusePvtKeyJwt;
   private String sectorIdentifierUri = null;
   private String idTokenSignedResponseAlg = null;
   private String idTokenEncryptedResponseAlg = null;
@@ -324,6 +325,18 @@ public class RegistrationRequestDTO  {
   }
   public void setTokenEndpointAuthMethod(String tokenEndpointAuthMethod) {
     this.tokenEndpointAuthMethod = tokenEndpointAuthMethod;
+  }
+
+  @ApiModelProperty(value = "")
+  @JsonProperty("token_endpoint_allow_reuse_pvt_key_jwt")
+  public Boolean isTokenEndpointAllowReusePvtKeyJwt() {
+
+      return tokenEndpointAllowReusePvtKeyJwt;
+  }
+
+  public void setTokenEndpointAllowReusePvtKeyJwt(Boolean tokenEndpointAllowReusePvtKeyJwt) {
+
+    this.tokenEndpointAllowReusePvtKeyJwt = tokenEndpointAllowReusePvtKeyJwt;
   }
 
 

--- a/components/org.wso2.carbon.identity.api.server.dcr/src/gen/java/org/wso2/carbon/identity/oauth2/dcr/endpoint/dto/UpdateRequestDTO.java
+++ b/components/org.wso2.carbon.identity.api.server.dcr/src/gen/java/org/wso2/carbon/identity/oauth2/dcr/endpoint/dto/UpdateRequestDTO.java
@@ -33,6 +33,7 @@ public class UpdateRequestDTO {
     private boolean extPublicClient;
     private String extTokenType = null;
     private String tokenEndpointAuthMethod = null;
+    private Boolean tokenEndpointAllowReusePvtKeyJwt;
     private String tokenEndpointAuthSigningAlg = null;
     private String sectorIdentifierUri = null;
     private String idTokenSignedResponseAlg = null;
@@ -235,6 +236,18 @@ public class UpdateRequestDTO {
 
     public void setTokenEndpointAuthMethod(String tokenEndpointAuthMethod) {
         this.tokenEndpointAuthMethod = tokenEndpointAuthMethod;
+    }
+
+    @ApiModelProperty(value = "")
+    @JsonProperty("token_endpoint_allow_reuse_pvt_key_jwt")
+    public Boolean isTokenEndpointAllowReusePvtKeyJwt() {
+
+        return tokenEndpointAllowReusePvtKeyJwt;
+    }
+
+    public void setTokenEndpointAllowReusePvtKeyJwt(Boolean tokenEndpointAllowReusePvtKeyJwt) {
+
+        this.tokenEndpointAllowReusePvtKeyJwt = tokenEndpointAllowReusePvtKeyJwt;
     }
 
     @ApiModelProperty(value = "")

--- a/components/org.wso2.carbon.identity.api.server.dcr/src/main/java/org/wso2/carbon/identity/oauth2/dcr/endpoint/util/DCRMUtils.java
+++ b/components/org.wso2.carbon.identity.api.server.dcr/src/main/java/org/wso2/carbon/identity/oauth2/dcr/endpoint/util/DCRMUtils.java
@@ -81,6 +81,8 @@ public class DCRMUtils {
         appRegistrationRequest.setExtTokenType(registrationRequestDTO.getExtTokenType());
         appRegistrationRequest.setJwksURI(registrationRequestDTO.getJwksUri());
         appRegistrationRequest.setTokenEndpointAuthMethod(registrationRequestDTO.getTokenEndpointAuthMethod());
+        appRegistrationRequest.setTokenEndpointAllowReusePvtKeyJwt(registrationRequestDTO
+                .isTokenEndpointAllowReusePvtKeyJwt());
         appRegistrationRequest.setTokenEndpointAuthSignatureAlgorithm
                 (registrationRequestDTO.getTokenEndpointAuthSigningAlg());
         appRegistrationRequest.setSectorIdentifierURI(registrationRequestDTO.getSectorIdentifierUri());
@@ -124,6 +126,8 @@ public class DCRMUtils {
         applicationUpdateRequest.setExtTokenType(updateRequestDTO.getExtTokenType());
         applicationUpdateRequest.setJwksURI(updateRequestDTO.getJwksUri());
         applicationUpdateRequest.setTokenEndpointAuthMethod(updateRequestDTO.getTokenEndpointAuthMethod());
+        applicationUpdateRequest.setTokenEndpointAllowReusePvtKeyJwt(
+                updateRequestDTO.isTokenEndpointAllowReusePvtKeyJwt());
         applicationUpdateRequest.setTokenEndpointAuthSignatureAlgorithm
                 (updateRequestDTO.getTokenEndpointAuthSigningAlg());
         applicationUpdateRequest.setSectorIdentifierURI(updateRequestDTO.getSectorIdentifierUri());
@@ -233,6 +237,7 @@ public class DCRMUtils {
         applicationDTO.setExtTokenType(application.getExtTokenType());
         applicationDTO.setJwksUri(application.getJwksURI());
         applicationDTO.setTokenEndpointAuthMethod(application.getTokenEndpointAuthMethod());
+        applicationDTO.setTokenEndpointAllowReusePvtKeyJwt(application.isTokenEndpointAllowReusePvtKeyJwt());
         applicationDTO.setTokenEndpointAuthSigningAlg(application.getTokenEndpointAuthSignatureAlgorithm());
         applicationDTO.setSectorIdentifierUri(application.getSectorIdentifierURI());
         applicationDTO.setIdTokenSignedResponseAlg(application.getIdTokenSignatureAlgorithm());

--- a/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
+++ b/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
@@ -621,6 +621,7 @@ public final class OAuthConstants {
         public static final String TOKEN_BINDING_VALIDATION = "tokenBindingValidation";
         public static final String TOKEN_BINDING_TYPE_NONE = "None";
         public static final String TOKEN_AUTH_METHOD =  "tokenEndpointAuthMethod";
+        public static final String TOKEN_EP_ALLOW_REUSE_PVT_KEY_JWT =  "tokenEndpointAllowReusePvtKeyJwt";
         public static final String TOKEN_AUTH_SIGNATURE_ALGORITHM = "tokenEndpointAuthSigningAlg";
         public static final String SECTOR_IDENTIFIER_URI = "sectorIdentifierUri";
         public static final String ID_TOKEN_SIGNATURE_ALGORITHM = "idTokenSignedResponseAlg";
@@ -635,7 +636,14 @@ public final class OAuthConstants {
         public static final String IS_SUBJECT_TOKEN_ENABLED = "isSubjectTokenEnabled";
         public static final String SUBJECT_TOKEN_EXPIRY_TIME = "subjectTokenExpiryTime";
         public static final int SUBJECT_TOKEN_EXPIRY_TIME_VALUE = 180;
-
+        public static final String PREVENT_TOKEN_REUSE = "PreventTokenReuse";
+        public static final boolean DEFAULT_VALUE_FOR_PREVENT_TOKEN_REUSE = true;
+        // Name of the {@code  JWTClientAuthenticatorConfig} resource type in the Configuration Management API.
+        public static final String JWT_CONFIGURATION_RESOURCE_TYPE_NAME = "PK_JWT_CONFIGURATION";
+        // Name of the {@code JWTClientAuthenticatorConfig} resource (per tenant) in the Configuration Management API.
+        public static final String JWT_CONFIGURATION_RESOURCE_NAME = "TENANT_PK_JWT_CONFIGURATION";
+        public static final String PVT_KEY_JWT_CLIENT_AUTHENTICATOR_CLASS_NAME = "PrivateKeyJWTClientAuthenticator";
+        public static final String ENABLE_TOKEN_REUSE = "EnableTokenReuse";
         private OIDCConfigProperties() {
 
         }

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/bean/Application.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/bean/Application.java
@@ -45,6 +45,7 @@ public class Application implements Serializable {
     private String extTokenType = null;
     private String jwksURI = null;
     private String tokenEndpointAuthMethod = null;
+    private Boolean tokenEndpointAllowReusePvtKeyJwt;
     private String tokenEndpointAuthSignatureAlgorithm = null;
     private String sectorIdentifierURI = null;
     private String idTokenSignatureAlgorithm = null;
@@ -238,6 +239,16 @@ public class Application implements Serializable {
     public void setTokenEndpointAuthMethod(String tokenEndpointAuthMethod) {
 
         this.tokenEndpointAuthMethod = tokenEndpointAuthMethod;
+    }
+
+    public Boolean isTokenEndpointAllowReusePvtKeyJwt() {
+
+        return tokenEndpointAllowReusePvtKeyJwt;
+    }
+
+    public void setTokenEndpointAllowReusePvtKeyJwt(Boolean tokenEndpointAllowReusePvtKeyJwt) {
+
+        this.tokenEndpointAllowReusePvtKeyJwt = tokenEndpointAllowReusePvtKeyJwt;
     }
 
     public String getTokenEndpointAuthSignatureAlgorithm() {

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/bean/ApplicationRegistrationRequest.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/bean/ApplicationRegistrationRequest.java
@@ -51,6 +51,7 @@ public class ApplicationRegistrationRequest implements Serializable {
     private String jwksURI;
     private String softwareStatement;
     private String tokenEndpointAuthMethod;
+    private Boolean tokenEndpointAllowReusePvtKeyJwt;
     private String tokenEndpointAuthSignatureAlgorithm;
     private String sectorIdentifierURI;
     private String idTokenSignatureAlgorithm;
@@ -366,6 +367,16 @@ public class ApplicationRegistrationRequest implements Serializable {
     public void setTokenEndpointAuthMethod(String tokenEndpointAuthMethod) {
 
         this.tokenEndpointAuthMethod = tokenEndpointAuthMethod;
+    }
+
+    public Boolean isTokenEndpointAllowReusePvtKeyJwt() {
+
+        return tokenEndpointAllowReusePvtKeyJwt;
+    }
+
+    public void setTokenEndpointAllowReusePvtKeyJwt(Boolean tokenEndpointAllowReusePvtKeyJwt) {
+
+        this.tokenEndpointAllowReusePvtKeyJwt = tokenEndpointAllowReusePvtKeyJwt;
     }
 
     public String getTokenEndpointAuthSignatureAlgorithm() {

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/bean/ApplicationUpdateRequest.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/bean/ApplicationUpdateRequest.java
@@ -47,6 +47,7 @@ public class ApplicationUpdateRequest implements Serializable {
     private String jwksURI = null;
     private String softwareStatement;
     private String tokenEndpointAuthMethod;
+    private Boolean tokenEndpointAllowReusePvtKeyJwt;
     private String tokenEndpointAuthSignatureAlgorithm;
     private String sectorIdentifierURI;
     private String idTokenSignatureAlgorithm;
@@ -291,6 +292,16 @@ public class ApplicationUpdateRequest implements Serializable {
     public void setTokenEndpointAuthMethod(String tokenEndpointAuthMethod) {
 
         this.tokenEndpointAuthMethod = tokenEndpointAuthMethod;
+    }
+
+    public Boolean isTokenEndpointAllowReusePvtKeyJwt() {
+
+        return tokenEndpointAllowReusePvtKeyJwt;
+    }
+
+    public void setTokenEndpointAllowReusePvtKeyJwt(Boolean tokenEndpointAllowReusePvtKeyJwt) {
+
+        this.tokenEndpointAllowReusePvtKeyJwt = tokenEndpointAllowReusePvtKeyJwt;
     }
 
     public String getTokenEndpointAuthSignatureAlgorithm() {

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/service/DCRMService.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/service/DCRMService.java
@@ -302,6 +302,7 @@ public class DCRMService {
             if (updateRequest.getTokenEndpointAuthMethod() != null) {
                 appDTO.setTokenEndpointAuthMethod(updateRequest.getTokenEndpointAuthMethod());
             }
+            appDTO.setTokenEndpointAllowReusePvtKeyJwt(updateRequest.isTokenEndpointAllowReusePvtKeyJwt());
             if (updateRequest.getTokenEndpointAuthSignatureAlgorithm() != null) {
                 appDTO.setTokenEndpointAuthSignatureAlgorithm
                         (updateRequest.getTokenEndpointAuthSignatureAlgorithm());
@@ -584,6 +585,7 @@ public class DCRMService {
         application.setExtTokenType(createdApp.getTokenType());
         application.setJwksURI(createdApp.getJwksURI());
         application.setTokenEndpointAuthMethod(createdApp.getTokenEndpointAuthMethod());
+        application.setTokenEndpointAllowReusePvtKeyJwt(createdApp.isTokenEndpointAllowReusePvtKeyJwt());
         application.setTokenEndpointAuthSignatureAlgorithm(createdApp.getTokenEndpointAuthSignatureAlgorithm());
         application.setSectorIdentifierURI(createdApp.getSectorIdentifierURI());
         application.setIdTokenSignatureAlgorithm(createdApp.getIdTokenSignatureAlgorithm());
@@ -678,6 +680,7 @@ public class DCRMService {
         if (registrationRequest.getTokenEndpointAuthMethod() != null) {
             oAuthConsumerApp.setTokenEndpointAuthMethod(registrationRequest.getTokenEndpointAuthMethod());
         }
+        oAuthConsumerApp.setTokenEndpointAllowReusePvtKeyJwt(registrationRequest.isTokenEndpointAllowReusePvtKeyJwt());
         if (registrationRequest.getTokenEndpointAuthSignatureAlgorithm() != null) {
             oAuthConsumerApp.setTokenEndpointAuthSignatureAlgorithm
                     (registrationRequest.getTokenEndpointAuthSignatureAlgorithm());

--- a/components/org.wso2.carbon.identity.oauth.stub/src/main/resources/OAuthAdminService.wsdl
+++ b/components/org.wso2.carbon.identity.oauth.stub/src/main/resources/OAuthAdminService.wsdl
@@ -432,9 +432,8 @@
                     <xs:element minOccurs="0" name="tlsClientAuthSubjectDN" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="tokenBindingType" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="tokenBindingValidationEnabled" type="xs:boolean"/>
+                    <xs:element minOccurs="0" name="tokenEndpointAllowReusePvtKeyJwt" nillable="true" type="xs:boolean"/>
                     <xs:element minOccurs="0" name="tokenEndpointAuthMethod" nillable="true" type="xs:string"/>
-                    <xs:element minOccurs="0" name="tokenEndpointAllowReusePvtKeyJwt" nillable="true"
-                                type="xs:boolean"/>
                     <xs:element minOccurs="0" name="tokenEndpointAuthSignatureAlgorithm" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="tokenRevocationWithIDPSessionTerminationEnabled" type="xs:boolean"/>
                     <xs:element minOccurs="0" name="tokenType" nillable="true" type="xs:string"/>

--- a/components/org.wso2.carbon.identity.oauth.stub/src/main/resources/OAuthAdminService.wsdl
+++ b/components/org.wso2.carbon.identity.oauth.stub/src/main/resources/OAuthAdminService.wsdl
@@ -433,6 +433,8 @@
                     <xs:element minOccurs="0" name="tokenBindingType" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="tokenBindingValidationEnabled" type="xs:boolean"/>
                     <xs:element minOccurs="0" name="tokenEndpointAuthMethod" nillable="true" type="xs:string"/>
+                    <xs:element minOccurs="0" name="tokenEndpointAllowReusePvtKeyJwt" nillable="true"
+                                type="xs:boolean"/>
                     <xs:element minOccurs="0" name="tokenEndpointAuthSignatureAlgorithm" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="tokenRevocationWithIDPSessionTerminationEnabled" type="xs:boolean"/>
                     <xs:element minOccurs="0" name="tokenType" nillable="true" type="xs:string"/>

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImpl.java
@@ -433,8 +433,8 @@ public class OAuthAdminServiceImpl {
                         Boolean tokenEndpointAllowReusePvtKeyJwt = application.isTokenEndpointAllowReusePvtKeyJwt();
                         if (isInvalidTokenEPReusePvtKeyJwtRequest(tokenEndpointAuthMethod,
                                 tokenEndpointAllowReusePvtKeyJwt)) {
-                            throw handleClientError(INVALID_REQUEST,
-                                    "Invalid token endpoint authentication method requested.");
+                            throw handleClientError(INVALID_REQUEST, "Requested client authentication method " +
+                                    "incompatible with the Private Key JWT Reuse config value.");
                         }
                         app.setTokenEndpointAllowReusePvtKeyJwt(tokenEndpointAllowReusePvtKeyJwt);
                         String tokenEndpointAuthSigningAlgorithm = application.getTokenEndpointAuthSignatureAlgorithm();
@@ -865,8 +865,8 @@ public class OAuthAdminServiceImpl {
 
             Boolean tokenEndpointAllowReusePvtKeyJwt = consumerAppDTO.isTokenEndpointAllowReusePvtKeyJwt();
             if (isInvalidTokenEPReusePvtKeyJwtRequest(tokenEndpointAuthMethod, tokenEndpointAllowReusePvtKeyJwt)) {
-                throw handleClientError(INVALID_REQUEST,
-                        "Invalid token endpoint authentication method requested.");
+                throw handleClientError(INVALID_REQUEST, "Requested client authentication method " +
+                        "incompatible with the Private Key JWT Reuse config value.");
             }
             oAuthAppDO.setTokenEndpointAllowReusePvtKeyJwt(tokenEndpointAllowReusePvtKeyJwt);
 
@@ -2520,12 +2520,9 @@ public class OAuthAdminServiceImpl {
         if (StringUtils.isNotBlank(tokenEndpointAuthMethod)) {
             if (tokenEndpointAuthMethod.equals(PRIVATE_KEY_JWT)) {
                 return tokenEndpointAllowReusePvtKeyJwt == null;
-            } else {
-                return tokenEndpointAllowReusePvtKeyJwt != null;
             }
-        } else {
-            return tokenEndpointAllowReusePvtKeyJwt != null;
         }
+        return tokenEndpointAllowReusePvtKeyJwt != null;
     }
 
     /**

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImpl.java
@@ -430,13 +430,13 @@ public class OAuthAdminServiceImpl {
                             }
                             app.setTokenEndpointAuthMethod(tokenEndpointAuthMethod);
                         }
-                        Boolean tokenEndpointReusePvtKeyJWT = application.isTokenEndpointAllowReusePvtKeyJwt();
-                        if (isInvalidTokenEPReusePvtKeyJWTRequest(tokenEndpointAuthMethod,
-                                tokenEndpointReusePvtKeyJWT)) {
+                        Boolean tokenEndpointAllowReusePvtKeyJwt = application.isTokenEndpointAllowReusePvtKeyJwt();
+                        if (isInvalidTokenEPReusePvtKeyJwtRequest(tokenEndpointAuthMethod,
+                                tokenEndpointAllowReusePvtKeyJwt)) {
                             throw handleClientError(INVALID_REQUEST,
                                     "Invalid token endpoint authentication method requested.");
                         }
-                        application.setTokenEndpointAllowReusePvtKeyJwt(tokenEndpointReusePvtKeyJWT);
+                        app.setTokenEndpointAllowReusePvtKeyJwt(tokenEndpointAllowReusePvtKeyJwt);
                         String tokenEndpointAuthSigningAlgorithm = application.getTokenEndpointAuthSignatureAlgorithm();
                         if (StringUtils.isNotEmpty(tokenEndpointAuthSigningAlgorithm)) {
                             if (isFAPIConformanceEnabled) {
@@ -863,12 +863,12 @@ public class OAuthAdminServiceImpl {
             }
             oAuthAppDO.setTokenEndpointAuthMethod(tokenEndpointAuthMethod);
 
-            Boolean tokenEndpointReusePvtKeyJWT = consumerAppDTO.isTokenEndpointAllowReusePvtKeyJwt();
-            if (isInvalidTokenEPReusePvtKeyJWTRequest(tokenEndpointAuthMethod, tokenEndpointReusePvtKeyJWT)) {
+            Boolean tokenEndpointAllowReusePvtKeyJwt = consumerAppDTO.isTokenEndpointAllowReusePvtKeyJwt();
+            if (isInvalidTokenEPReusePvtKeyJwtRequest(tokenEndpointAuthMethod, tokenEndpointAllowReusePvtKeyJwt)) {
                 throw handleClientError(INVALID_REQUEST,
                         "Invalid token endpoint authentication method requested.");
             }
-            oAuthAppDO.setTokenEndpointAllowReusePvtKeyJwt(tokenEndpointReusePvtKeyJWT);
+            oAuthAppDO.setTokenEndpointAllowReusePvtKeyJwt(tokenEndpointAllowReusePvtKeyJwt);
 
             String tokenEndpointAuthSignatureAlgorithm = consumerAppDTO.getTokenEndpointAuthSignatureAlgorithm();
             if (StringUtils.isNotEmpty(tokenEndpointAuthSignatureAlgorithm)) {
@@ -2508,23 +2508,23 @@ public class OAuthAdminServiceImpl {
     }
 
     /**
-     * Return whether the request of updating the tokenEndpointReusePvtKeyJWT is valid.
+     * Return whether the request of updating the tokenEndpointAllowReusePvtKeyJwt is valid.
      *
      * @param tokenEndpointAuthMethod     token endpoint client authentication method.
-     * @param tokenEndpointReusePvtKeyJWT During client authentication whether to reuse private key JWT.
-     * @return True if tokenEndpointAuthMethod and tokenEndpointReusePvtKeyJWT is NOT in the correct format.
+     * @param tokenEndpointAllowReusePvtKeyJwt During client authentication whether to reuse private key JWT.
+     * @return True if tokenEndpointAuthMethod and tokenEndpointAllowReusePvtKeyJwt is NOT in the correct format.
      */
-    private boolean isInvalidTokenEPReusePvtKeyJWTRequest(String tokenEndpointAuthMethod,
-                                                          Boolean tokenEndpointReusePvtKeyJWT) {
+    private boolean isInvalidTokenEPReusePvtKeyJwtRequest(String tokenEndpointAuthMethod,
+                                                          Boolean tokenEndpointAllowReusePvtKeyJwt) {
 
         if (StringUtils.isNotBlank(tokenEndpointAuthMethod)) {
             if (tokenEndpointAuthMethod.equals(PRIVATE_KEY_JWT)) {
-                return tokenEndpointReusePvtKeyJWT == null;
+                return tokenEndpointAllowReusePvtKeyJwt == null;
             } else {
-                return tokenEndpointReusePvtKeyJWT != null;
+                return tokenEndpointAllowReusePvtKeyJwt != null;
             }
         } else {
-            return tokenEndpointReusePvtKeyJWT != null;
+            return tokenEndpointAllowReusePvtKeyJwt != null;
         }
     }
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthUtil.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthUtil.java
@@ -37,6 +37,11 @@ import org.wso2.carbon.identity.application.mgt.ApplicationConstants;
 import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.base.IdentityConstants;
 import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
+import org.wso2.carbon.identity.configuration.mgt.core.exception.ConfigurationManagementException;
+import org.wso2.carbon.identity.configuration.mgt.core.model.Attribute;
+import org.wso2.carbon.identity.configuration.mgt.core.model.Resource;
+import org.wso2.carbon.identity.core.handler.AbstractIdentityHandler;
+import org.wso2.carbon.identity.core.model.IdentityEventListenerConfig;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.oauth.cache.OAuthCache;
@@ -77,6 +82,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -89,6 +95,12 @@ import static org.wso2.carbon.identity.application.authentication.framework.util
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.CURRENT_TOKEN_IDENTIFIER;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.Config.PRESERVE_LOGGED_IN_SESSION_AT_PASSWORD_UPDATE;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.ORGANIZATION_LOGIN_HOME_REALM_IDENTIFIER;
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCConfigProperties.DEFAULT_VALUE_FOR_PREVENT_TOKEN_REUSE;
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCConfigProperties.ENABLE_TOKEN_REUSE;
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCConfigProperties.JWT_CONFIGURATION_RESOURCE_NAME;
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCConfigProperties.JWT_CONFIGURATION_RESOURCE_TYPE_NAME;
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCConfigProperties.PREVENT_TOKEN_REUSE;
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCConfigProperties.PVT_KEY_JWT_CLIENT_AUTHENTICATOR_CLASS_NAME;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.TokenBindings.NONE;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.UserType.FEDERATED_USER_DOMAIN_PREFIX;
 
@@ -544,6 +556,7 @@ public final class OAuthUtil {
                 .isTokenRevocationWithIDPSessionTerminationEnabled());
         dto.setTokenBindingValidationEnabled(appDO.isTokenBindingValidationEnabled());
         dto.setTokenEndpointAuthMethod(appDO.getTokenEndpointAuthMethod());
+        dto.setTokenEndpointAllowReusePvtKeyJwt(appDO.isTokenEndpointAllowReusePvtKeyJwt());
         dto.setTokenEndpointAuthSignatureAlgorithm(appDO.getTokenEndpointAuthSignatureAlgorithm());
         dto.setSectorIdentifierURI(appDO.getSectorIdentifierURI());
         dto.setIdTokenSignatureAlgorithm(appDO.getIdTokenSignatureAlgorithm());
@@ -1230,5 +1243,73 @@ public final class OAuthUtil {
         if (orgSsoIdp != null) {
             authenticatedUser.setFederatedIdPName(orgSsoIdp.getIdentityProviderName());
         }
+    }
+
+    /**
+     * Get the value of the Tenant configuration of Reuse Private key JWT from the tenant configuration.
+     *
+     * @param tokenEPAllowReusePvtKeyJWTValue   Value of the tokenEPAllowReusePvtKeyJWT configuration.
+     * @param tokenAuthMethod                   Token authentication method.
+     * @return Value of the tokenEPAllowReusePvtKeyJWT configuration.
+     * @throws IdentityOAuth2ServerException IdentityOAuth2ServerException exception.
+     */
+    public static String getValueOfTokenEPAllowReusePvtKeyJWT(String tokenEPAllowReusePvtKeyJWTValue,
+                                                              String tokenAuthMethod)
+            throws IdentityOAuth2ServerException {
+
+        if (tokenEPAllowReusePvtKeyJWTValue == null && tokenAuthMethod != null) {
+            try {
+                tokenEPAllowReusePvtKeyJWTValue = readTenantConfigurationPvtKeyJWTReuse();
+            } catch (ConfigurationManagementException e) {
+                throw new IdentityOAuth2ServerException("Unable to retrieve JWT Authenticator tenant configuration.",
+                        e);
+            }
+            if (tokenEPAllowReusePvtKeyJWTValue == null) {
+                tokenEPAllowReusePvtKeyJWTValue = readServerConfigurationPvtKeyJWTReuse();
+                if (tokenEPAllowReusePvtKeyJWTValue == null) {
+                    tokenEPAllowReusePvtKeyJWTValue = String.valueOf(DEFAULT_VALUE_FOR_PREVENT_TOKEN_REUSE);
+                }
+            }
+        }
+        return tokenEPAllowReusePvtKeyJWTValue;
+    }
+
+    private static String readTenantConfigurationPvtKeyJWTReuse() throws ConfigurationManagementException {
+
+        String tokenEPAllowReusePvtKeyJWTTenantConfig = null;
+        Resource resource = OAuthComponentServiceHolder.getInstance().getConfigurationManager()
+                .getResource(JWT_CONFIGURATION_RESOURCE_TYPE_NAME, JWT_CONFIGURATION_RESOURCE_NAME);
+
+        if (resource != null) {
+            tokenEPAllowReusePvtKeyJWTTenantConfig = resource.getAttributes().stream()
+                    .filter(attribute -> ENABLE_TOKEN_REUSE.equals(attribute.getKey()))
+                    .map(Attribute::getValue)
+                    .findFirst()
+                    .orElse(null);
+        }
+        return tokenEPAllowReusePvtKeyJWTTenantConfig;
+    }
+
+    private static String readServerConfigurationPvtKeyJWTReuse() {
+
+        String tokenEPAllowReusePvtKeyJWTTenantConfig = null;
+        IdentityEventListenerConfig identityEventListenerConfig = IdentityUtil.readEventListenerProperty(
+                AbstractIdentityHandler.class.getName(), PVT_KEY_JWT_CLIENT_AUTHENTICATOR_CLASS_NAME);
+
+        if (identityEventListenerConfig != null
+                && Boolean.parseBoolean(identityEventListenerConfig.getEnable())) {
+            if (identityEventListenerConfig.getProperties() != null) {
+                for (Map.Entry<Object, Object> property : identityEventListenerConfig.getProperties().entrySet()) {
+                    String key = (String) property.getKey();
+                    String value = (String) property.getValue();
+                    if (Objects.equals(key, PREVENT_TOKEN_REUSE)) {
+                        boolean preventTokenReuse = Boolean.parseBoolean(value);
+                        tokenEPAllowReusePvtKeyJWTTenantConfig = String.valueOf(!preventTokenReuse);
+                        break;
+                    }
+                }
+            }
+        }
+        return tokenEPAllowReusePvtKeyJWTTenantConfig;
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthUtil.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthUtil.java
@@ -1248,51 +1248,52 @@ public final class OAuthUtil {
     /**
      * Get the value of the Tenant configuration of Reuse Private key JWT from the tenant configuration.
      *
-     * @param tokenEPAllowReusePvtKeyJWTValue   Value of the tokenEPAllowReusePvtKeyJWT configuration.
+     * @param tokenEPAllowReusePvtKeyJwtValue   Value of the tokenEPAllowReusePvtKeyJwt configuration.
      * @param tokenAuthMethod                   Token authentication method.
-     * @return Value of the tokenEPAllowReusePvtKeyJWT configuration.
+     * @return Value of the tokenEPAllowReusePvtKeyJwt configuration.
      * @throws IdentityOAuth2ServerException IdentityOAuth2ServerException exception.
      */
-    public static String getValueOfTokenEPAllowReusePvtKeyJWT(String tokenEPAllowReusePvtKeyJWTValue,
+    public static String getValueOfTokenEPAllowReusePvtKeyJwt(String tokenEPAllowReusePvtKeyJwtValue,
                                                               String tokenAuthMethod)
             throws IdentityOAuth2ServerException {
 
-        if (tokenEPAllowReusePvtKeyJWTValue == null && tokenAuthMethod != null) {
+        if (tokenEPAllowReusePvtKeyJwtValue == null && StringUtils.isNotBlank(tokenAuthMethod)
+                && OAuthConstants.PRIVATE_KEY_JWT.equals(tokenAuthMethod)) {
             try {
-                tokenEPAllowReusePvtKeyJWTValue = readTenantConfigurationPvtKeyJWTReuse();
+                tokenEPAllowReusePvtKeyJwtValue = readTenantConfigurationPvtKeyJWTReuse();
             } catch (ConfigurationManagementException e) {
                 throw new IdentityOAuth2ServerException("Unable to retrieve JWT Authenticator tenant configuration.",
                         e);
             }
-            if (tokenEPAllowReusePvtKeyJWTValue == null) {
-                tokenEPAllowReusePvtKeyJWTValue = readServerConfigurationPvtKeyJWTReuse();
-                if (tokenEPAllowReusePvtKeyJWTValue == null) {
-                    tokenEPAllowReusePvtKeyJWTValue = String.valueOf(DEFAULT_VALUE_FOR_PREVENT_TOKEN_REUSE);
+            if (tokenEPAllowReusePvtKeyJwtValue == null) {
+                tokenEPAllowReusePvtKeyJwtValue = readServerConfigurationPvtKeyJWTReuse();
+                if (tokenEPAllowReusePvtKeyJwtValue == null) {
+                    tokenEPAllowReusePvtKeyJwtValue = String.valueOf(DEFAULT_VALUE_FOR_PREVENT_TOKEN_REUSE);
                 }
             }
         }
-        return tokenEPAllowReusePvtKeyJWTValue;
+        return tokenEPAllowReusePvtKeyJwtValue;
     }
 
     private static String readTenantConfigurationPvtKeyJWTReuse() throws ConfigurationManagementException {
 
-        String tokenEPAllowReusePvtKeyJWTTenantConfig = null;
+        String tokenEPAllowReusePvtKeyJwtTenantConfig = null;
         Resource resource = OAuthComponentServiceHolder.getInstance().getConfigurationManager()
                 .getResource(JWT_CONFIGURATION_RESOURCE_TYPE_NAME, JWT_CONFIGURATION_RESOURCE_NAME);
 
         if (resource != null) {
-            tokenEPAllowReusePvtKeyJWTTenantConfig = resource.getAttributes().stream()
+            tokenEPAllowReusePvtKeyJwtTenantConfig = resource.getAttributes().stream()
                     .filter(attribute -> ENABLE_TOKEN_REUSE.equals(attribute.getKey()))
                     .map(Attribute::getValue)
                     .findFirst()
                     .orElse(null);
         }
-        return tokenEPAllowReusePvtKeyJWTTenantConfig;
+        return tokenEPAllowReusePvtKeyJwtTenantConfig;
     }
 
     private static String readServerConfigurationPvtKeyJWTReuse() {
 
-        String tokenEPAllowReusePvtKeyJWTTenantConfig = null;
+        String tokenEPAllowReusePvtKeyJwtTenantConfig = null;
         IdentityEventListenerConfig identityEventListenerConfig = IdentityUtil.readEventListenerProperty(
                 AbstractIdentityHandler.class.getName(), PVT_KEY_JWT_CLIENT_AUTHENTICATOR_CLASS_NAME);
 
@@ -1304,12 +1305,12 @@ public final class OAuthUtil {
                     String value = (String) property.getValue();
                     if (Objects.equals(key, PREVENT_TOKEN_REUSE)) {
                         boolean preventTokenReuse = Boolean.parseBoolean(value);
-                        tokenEPAllowReusePvtKeyJWTTenantConfig = String.valueOf(!preventTokenReuse);
+                        tokenEPAllowReusePvtKeyJwtTenantConfig = String.valueOf(!preventTokenReuse);
                         break;
                     }
                 }
             }
         }
-        return tokenEPAllowReusePvtKeyJWTTenantConfig;
+        return tokenEPAllowReusePvtKeyJwtTenantConfig;
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dao/OAuthAppDAO.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dao/OAuthAppDAO.java
@@ -1642,9 +1642,11 @@ public class OAuthAppDAO {
             addToBatchForOIDCPropertyAdd(processedClientId, spTenantId, prepStmtAddOIDCProperty,
                     TOKEN_AUTH_METHOD, consumerAppDO.getTokenEndpointAuthMethod());
 
-            addToBatchForOIDCPropertyAdd(processedClientId, spTenantId, prepStmtAddOIDCProperty,
-                    TOKEN_EP_ALLOW_REUSE_PVT_KEY_JWT,
-                    String.valueOf(consumerAppDO.isTokenEndpointAllowReusePvtKeyJwt()));
+            if (consumerAppDO.isTokenEndpointAllowReusePvtKeyJwt() != null) {
+                addToBatchForOIDCPropertyAdd(processedClientId, spTenantId, prepStmtAddOIDCProperty,
+                        TOKEN_EP_ALLOW_REUSE_PVT_KEY_JWT,
+                        String.valueOf(consumerAppDO.isTokenEndpointAllowReusePvtKeyJwt()));
+            }
 
             addToBatchForOIDCPropertyAdd(processedClientId, spTenantId, prepStmtAddOIDCProperty,
                     TOKEN_AUTH_SIGNATURE_ALGORITHM, consumerAppDO.getTokenEndpointAuthSignatureAlgorithm());
@@ -1806,10 +1808,10 @@ public class OAuthAppDAO {
         if (tokenAuthMethod != null) {
             oauthApp.setTokenEndpointAuthMethod(tokenAuthMethod);
         }
-        String tokenEPAllowReusePvtKeyJWT = OAuthUtil.getValueOfTokenEPAllowReusePvtKeyJWT(
+        String tokenEPAllowReusePvtKeyJwt = OAuthUtil.getValueOfTokenEPAllowReusePvtKeyJwt(
                 getFirstPropertyValue(spOIDCProperties, TOKEN_EP_ALLOW_REUSE_PVT_KEY_JWT), tokenAuthMethod);
-        if (tokenEPAllowReusePvtKeyJWT != null) {
-            oauthApp.setTokenEndpointAllowReusePvtKeyJwt(Boolean.parseBoolean(tokenEPAllowReusePvtKeyJWT));
+        if (tokenEPAllowReusePvtKeyJwt != null) {
+            oauthApp.setTokenEndpointAllowReusePvtKeyJwt(Boolean.parseBoolean(tokenEPAllowReusePvtKeyJwt));
         }
         String tokenSignatureAlgorithm = getFirstPropertyValue(spOIDCProperties, TOKEN_AUTH_SIGNATURE_ALGORITHM);
         if (tokenSignatureAlgorithm != null) {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dao/OAuthAppDAO.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dao/OAuthAppDAO.java
@@ -47,6 +47,7 @@ import org.wso2.carbon.identity.oauth.internal.OAuthComponentServiceHolder;
 import org.wso2.carbon.identity.oauth.tokenprocessor.PlainTextPersistenceProcessor;
 import org.wso2.carbon.identity.oauth.tokenprocessor.TokenPersistenceProcessor;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
+import org.wso2.carbon.identity.oauth2.IdentityOAuth2ServerException;
 import org.wso2.carbon.identity.oauth2.internal.OAuth2ServiceComponentHolder;
 import org.wso2.carbon.identity.oauth2.model.AccessTokenDO;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
@@ -102,6 +103,7 @@ import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCConfigPro
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCConfigProperties.TOKEN_BINDING_TYPE;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCConfigProperties.TOKEN_BINDING_TYPE_NONE;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCConfigProperties.TOKEN_BINDING_VALIDATION;
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCConfigProperties.TOKEN_EP_ALLOW_REUSE_PVT_KEY_JWT;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCConfigProperties.TOKEN_REVOCATION_WITH_IDP_SESSION_TERMINATION;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCConfigProperties.TOKEN_TYPE;
 import static org.wso2.carbon.identity.oauth2.util.OAuth2Util.OPENID_CONNECT_AUDIENCE;
@@ -983,6 +985,10 @@ public class OAuthAppDAO {
                 prepStatementForPropertyAdd, preparedStatementForPropertyUpdate);
 
         addOrUpdateOIDCSpProperty(preprocessedClientId, spTenantId, spOIDCProperties,
+                TOKEN_EP_ALLOW_REUSE_PVT_KEY_JWT, String.valueOf(oauthAppDO.isTokenEndpointAllowReusePvtKeyJwt()),
+                prepStatementForPropertyAdd, preparedStatementForPropertyUpdate);
+
+        addOrUpdateOIDCSpProperty(preprocessedClientId, spTenantId, spOIDCProperties,
                 TOKEN_AUTH_SIGNATURE_ALGORITHM, oauthAppDO.getTokenEndpointAuthSignatureAlgorithm(),
                 prepStatementForPropertyAdd, preparedStatementForPropertyUpdate);
 
@@ -1637,6 +1643,10 @@ public class OAuthAppDAO {
                     TOKEN_AUTH_METHOD, consumerAppDO.getTokenEndpointAuthMethod());
 
             addToBatchForOIDCPropertyAdd(processedClientId, spTenantId, prepStmtAddOIDCProperty,
+                    TOKEN_EP_ALLOW_REUSE_PVT_KEY_JWT,
+                    String.valueOf(consumerAppDO.isTokenEndpointAllowReusePvtKeyJwt()));
+
+            addToBatchForOIDCPropertyAdd(processedClientId, spTenantId, prepStmtAddOIDCProperty,
                     TOKEN_AUTH_SIGNATURE_ALGORITHM, consumerAppDO.getTokenEndpointAuthSignatureAlgorithm());
 
             addToBatchForOIDCPropertyAdd(processedClientId, spTenantId, prepStmtAddOIDCProperty, SECTOR_IDENTIFIER_URI,
@@ -1732,7 +1742,8 @@ public class OAuthAppDAO {
         return spOIDCProperties;
     }
 
-    private void setSpOIDCProperties(Map<String, List<String>> spOIDCProperties, OAuthAppDO oauthApp) {
+    private void setSpOIDCProperties(Map<String, List<String>> spOIDCProperties, OAuthAppDO oauthApp)
+            throws IdentityOAuth2ServerException {
 
         // Handle OIDC audience values
         if (isOIDCAudienceEnabled() &&
@@ -1794,6 +1805,11 @@ public class OAuthAppDAO {
         String tokenAuthMethod = getFirstPropertyValue(spOIDCProperties, TOKEN_AUTH_METHOD);
         if (tokenAuthMethod != null) {
             oauthApp.setTokenEndpointAuthMethod(tokenAuthMethod);
+        }
+        String tokenEPAllowReusePvtKeyJWT = OAuthUtil.getValueOfTokenEPAllowReusePvtKeyJWT(
+                getFirstPropertyValue(spOIDCProperties, TOKEN_EP_ALLOW_REUSE_PVT_KEY_JWT), tokenAuthMethod);
+        if (tokenEPAllowReusePvtKeyJWT != null) {
+            oauthApp.setTokenEndpointAllowReusePvtKeyJwt(Boolean.parseBoolean(tokenEPAllowReusePvtKeyJWT));
         }
         String tokenSignatureAlgorithm = getFirstPropertyValue(spOIDCProperties, TOKEN_AUTH_SIGNATURE_ALGORITHM);
         if (tokenSignatureAlgorithm != null) {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dao/OAuthAppDO.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dao/OAuthAppDO.java
@@ -81,6 +81,7 @@ public class OAuthAppDO extends InboundConfigurationProtocol implements Serializ
     private boolean tokenRevocationWithIDPSessionTerminationEnabled;
     private boolean tokenBindingValidationEnabled;
     private String tokenEndpointAuthMethod;
+    private Boolean tokenEndpointAllowReusePvtKeyJwt;
     private String tokenEndpointAuthSignatureAlgorithm;
     private String sectorIdentifierURI;
     private String idTokenSignatureAlgorithm;
@@ -381,6 +382,16 @@ public class OAuthAppDO extends InboundConfigurationProtocol implements Serializ
     public void setTokenEndpointAuthMethod(String tokenEndpointAuthMethod) {
 
         this.tokenEndpointAuthMethod = tokenEndpointAuthMethod;
+    }
+
+    public Boolean isTokenEndpointAllowReusePvtKeyJwt() {
+
+        return tokenEndpointAllowReusePvtKeyJwt;
+    }
+
+    public void setTokenEndpointAllowReusePvtKeyJwt(Boolean tokenEndpointAllowReusePvtKeyJwt) {
+
+        this.tokenEndpointAllowReusePvtKeyJwt = tokenEndpointAllowReusePvtKeyJwt;
     }
 
     public String getTokenEndpointAuthSignatureAlgorithm() {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dto/OAuthConsumerAppDTO.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dto/OAuthConsumerAppDTO.java
@@ -67,6 +67,7 @@ public class OAuthConsumerAppDTO implements InboundProtocolConfigurationDTO {
     private boolean tokenBindingValidationEnabled;
     private String tokenEndpointAuthMethod;
     private String tokenEndpointAuthSignatureAlgorithm;
+    private Boolean tokenEndpointAllowReusePvtKeyJwt;
     private String sectorIdentifierURI;
     private String idTokenSignatureAlgorithm;
     private String requestObjectSignatureAlgorithm;
@@ -382,6 +383,16 @@ public class OAuthConsumerAppDTO implements InboundProtocolConfigurationDTO {
     public void setTokenEndpointAuthSignatureAlgorithm(String tokenEndpointAuthSignatureAlgorithm) {
 
         this.tokenEndpointAuthSignatureAlgorithm = tokenEndpointAuthSignatureAlgorithm;
+    }
+
+    public Boolean isTokenEndpointAllowReusePvtKeyJwt() {
+
+        return tokenEndpointAllowReusePvtKeyJwt;
+    }
+
+    public void setTokenEndpointAllowReusePvtKeyJwt(Boolean tokenEndpointAllowReusePvtKeyJwt) {
+
+        this.tokenEndpointAllowReusePvtKeyJwt = tokenEndpointAllowReusePvtKeyJwt;
     }
 
     public String getSectorIdentifierURI() {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/internal/OAuthComponentServiceHolder.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/internal/OAuthComponentServiceHolder.java
@@ -22,6 +22,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.application.mgt.AuthorizedAPIManagementService;
+import org.wso2.carbon.identity.configuration.mgt.core.ConfigurationManager;
 import org.wso2.carbon.identity.cors.mgt.core.CORSManagementService;
 import org.wso2.carbon.identity.oauth.OAuthAdminServiceImpl;
 import org.wso2.carbon.identity.oauth.OauthInboundAuthConfigHandler;
@@ -80,6 +81,7 @@ public class OAuthComponentServiceHolder {
     private AuthorizedAPIManagementService authorizedAPIManagementService;
     private IdpManager idpManager;
     private OrganizationUserSharingService organizationUserSharingService;
+    private ConfigurationManager configurationManager;
 
     /**
      * Get the list of scope validator implementations available.
@@ -510,5 +512,25 @@ public class OAuthComponentServiceHolder {
     public void setOrganizationUserSharingService(OrganizationUserSharingService organizationUserSharingService) {
 
         this.organizationUserSharingService = organizationUserSharingService;
+    }
+
+    /**
+     * Get the ConfigurationManager instance.
+     *
+     * @return ConfigurationManager The ConfigurationManager instance.
+     */
+    public ConfigurationManager getConfigurationManager() {
+
+        return configurationManager;
+    }
+
+    /**
+     * Set the ConfigurationManager instance.
+     *
+     * @param configurationManager ConfigurationManager The ConfigurationManager instance.
+     */
+    public void setConfigurationManager(ConfigurationManager configurationManager) {
+
+        this.configurationManager = configurationManager;
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/internal/OAuthServiceComponent.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/internal/OAuthServiceComponent.java
@@ -30,6 +30,7 @@ import org.wso2.carbon.identity.application.authentication.framework.UserSession
 import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.application.mgt.AuthorizedAPIManagementService;
 import org.wso2.carbon.identity.application.mgt.inbound.protocol.ApplicationInboundAuthConfigHandler;
+import org.wso2.carbon.identity.configuration.mgt.core.ConfigurationManager;
 import org.wso2.carbon.identity.core.util.IdentityCoreInitializedEvent;
 import org.wso2.carbon.identity.cors.mgt.core.CORSManagementService;
 import org.wso2.carbon.identity.event.handler.AbstractEventHandler;
@@ -520,5 +521,39 @@ public class OAuthServiceComponent {
             log.debug("Unset organization user sharing service.");
         }
         OAuthComponentServiceHolder.getInstance().setOrganizationUserSharingService(null);
+    }
+
+    /**
+     * Set the ConfigurationManager.
+     *
+     * @param configurationManager The {@code ConfigurationManager} instance.
+     */
+    @Reference(
+            name = "resource.configuration.manager",
+            service = ConfigurationManager.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unregisterConfigurationManager"
+    )
+    protected void registerConfigurationManager(ConfigurationManager configurationManager) {
+
+        if (log.isDebugEnabled()) {
+            log.debug("Registering the ConfigurationManager in JWT Client Authenticator ManagementService.");
+        }
+        OAuthComponentServiceHolder.getInstance().setConfigurationManager(configurationManager);
+    }
+
+
+    /**
+     * Unset the ConfigurationManager.
+     *
+     * @param configurationManager The {@code ConfigurationManager} instance.
+     */
+    protected void unregisterConfigurationManager(ConfigurationManager configurationManager) {
+
+        if (log.isDebugEnabled()) {
+            log.debug("Unregistering the ConfigurationManager in JWT Client Authenticator ManagementService.");
+        }
+        OAuthComponentServiceHolder.getInstance().setConfigurationManager(null);
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImplTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImplTest.java
@@ -850,6 +850,34 @@ public class OAuthAdminServiceImplTest {
         }
     }
 
+    @DataProvider(name = "getTokenAuthMethodAndTokenReuseConfigData")
+    public Object[][] getTokenAuthMethodAndTokenReuseConfigData() {
+
+        return new Object[][]{
+                // Client auth method, Expected result.
+                {"private_key_jwt", null, true},
+                {null, true, true},
+                {"", true, true},
+                {" ", true, true},
+                {"dummy_method", true, true},
+                {"private_key_jwt", true, false},
+                {null, null, false},
+                {"dummy_method", null, false}};
+    }
+
+    @Test(description = "Test invalid reuse token config & client auth method combination.",
+            dataProvider = "getTokenAuthMethodAndTokenReuseConfigData")
+    private void testInvalidReuseTokenRequestAndClientAuthMethod(String tokenEndpointAuthMethod,
+                                                                  Boolean tokenEndpointReusePvtKeyJWT,
+                                                                  boolean expectedResult) throws Exception {
+
+        OAuthAdminServiceImpl oAuthAdminService = new OAuthAdminServiceImpl();
+
+        Assert.assertEquals(invokePrivateMethod(oAuthAdminService,
+                "isInvalidTokenEPReusePvtKeyJWTRequest", new Class[]{String.class, Boolean.class},
+                tokenEndpointAuthMethod, tokenEndpointReusePvtKeyJWT), expectedResult);
+    }
+
     @Test(description = "Test validating signature algorithm")
     private void testValidateSignatureAlgorithm() throws Exception {
 
@@ -1055,6 +1083,14 @@ public class OAuthAdminServiceImplTest {
                 paramTypes[i] = params[i].getClass().getInterfaces()[0];
             }
         }
+        Method method = object.getClass().getDeclaredMethod(methodName, paramTypes);
+        method.setAccessible(true);
+        return method.invoke(object, params);
+    }
+
+    private Object invokePrivateMethod(Object object, String methodName, Class<?>[] paramTypes, Object... params)
+            throws Exception {
+
         Method method = object.getClass().getDeclaredMethod(methodName, paramTypes);
         method.setAccessible(true);
         return method.invoke(object, params);

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImplTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImplTest.java
@@ -868,14 +868,14 @@ public class OAuthAdminServiceImplTest {
     @Test(description = "Test invalid reuse token config & client auth method combination.",
             dataProvider = "getTokenAuthMethodAndTokenReuseConfigData")
     private void testInvalidReuseTokenRequestAndClientAuthMethod(String tokenEndpointAuthMethod,
-                                                                  Boolean tokenEndpointReusePvtKeyJWT,
+                                                                  Boolean tokenEndpointAllowReusePvtKeyJwt,
                                                                   boolean expectedResult) throws Exception {
 
         OAuthAdminServiceImpl oAuthAdminService = new OAuthAdminServiceImpl();
 
         Assert.assertEquals(invokePrivateMethod(oAuthAdminService,
-                "isInvalidTokenEPReusePvtKeyJWTRequest", new Class[]{String.class, Boolean.class},
-                tokenEndpointAuthMethod, tokenEndpointReusePvtKeyJWT), expectedResult);
+                "isInvalidTokenEPReusePvtKeyJwtRequest", new Class[]{String.class, Boolean.class},
+                tokenEndpointAuthMethod, tokenEndpointAllowReusePvtKeyJwt), expectedResult);
     }
 
     @Test(description = "Test validating signature algorithm")


### PR DESCRIPTION
## Purpose
> This PR contains changes relevant to on-boarding of App level config to `Allow Reuse of Private Key JWT`. The following component has been affected by the PR.
- `components/org.wso2.carbon.identity.api.server.dcr`
    - Updated the DTOs related to DCR endpoint.

- `components/org.wso2.carbon.identity.oauth.common`
    - Constant re-initializing to avoid the cyclic dependency.

- `components/org.wso2.carbon.identity.oauth.dcr`
    - Updated the beans related DCR endpoint.

- `components/org.wso2.carbon.identity.oauth`
    - Updated DTOs and beans related OAuth Apps.
    - Implemented logic to read org level config using the `ConfigurationManager`.

### Please Note:

- The config will be saved as a SP OIDC property. 
- For the already created applications, as the config is not added, the old org level config will be taken.
    - When retrieving the application via a GET request, if the config is unavailable, org level config will be set.
- For the newly created applications, the user configured value will be saved.
    - The org level config will be totally irrelevant for the new application.

Related PRs:
> https://github.com/wso2/product-is/issues/20546