### PR TITLE
Add config to keep OIDC scopes in consent URL

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtilTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtilTest.java
@@ -340,6 +340,7 @@ public class EndpointUtilTest {
                 }
 
                 EndpointUtil.setOAuthAdminService(mockedOAuthAdminService);
+                lenient().when(mockedOAuthAdminService.getScopeNames()).thenReturn(new String[0]);
                 lenient().when(mockedOAuthAdminService.getRegisteredOIDCScope(anyString()))
                         .thenReturn(Arrays.asList("openid", "email", "profile", "groups"));
 


### PR DESCRIPTION
### Purpose
- Redirect to consent page even when only OIDC scopes are requested
- Following configuration has been added to maintain current behaviour. The default value will be `false`
```
[oauth]
keep_oidc_scopes_in_consent_url = true
```