### PR TITLE
Fix jdbc scope validator invalid scope issue

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/JDBCScopeValidator.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/JDBCScopeValidator.java
@@ -93,6 +93,11 @@ public class JDBCScopeValidator extends OAuth2ScopeValidator {
     private static final String SCOPE_VALIDATOR_NAME = "Role based scope validator";
     private static final String OPENID = "openid";
     private static final String PRESERVE_CASE_SENSITIVITY = "preservedCaseSensitive";
+    private static final String SCOPE_VALIDATOR_PRESERVE_CASE_SENSITIVITY_CONFIG =
+            "OAuth.ScopeValidationPreserveCaseSensitivity";
+
+    private static final boolean SCOPE_VALIDATOR_PRESERVE_CASE_SENSITIVITY =
+            Boolean.parseBoolean(IdentityUtil.getProperty(SCOPE_VALIDATOR_PRESERVE_CASE_SENSITIVITY_CONFIG));
 
     private static final Log log = LogFactory.getLog(JDBCScopeValidator.class);
 
@@ -411,7 +416,7 @@ public class JDBCScopeValidator extends OAuth2ScopeValidator {
 
         //Check if the user still has a valid role for this scope.
         Set<String> scopeRoles = new HashSet<>(rolesOfScope);
-        if (preservedCaseSensitive) {
+        if (preservedCaseSensitive || SCOPE_VALIDATOR_PRESERVE_CASE_SENSITIVITY) {
             rolesOfScope.retainAll(Arrays.asList(userRoles));
         } else {
             Set<String> rolesOfScopeLowerCase = new HashSet<>();


### PR DESCRIPTION
When jdbc scope validator is enabled, the scopes are not properly validated due to a fix added with PR[1]. The PR[1] was added with the intention of supporting scopes with case sensitivity. The PR[1] uses environmental variable `preservedCaseSensitive` to determine if case sensitivity is enabled or not. This PR will add a separate config to configure this behavior via deployment.toml file. 

With this PR, we will not change the default behavior which is preserve case sensitivity false. 

Add following config to deployment.toml file to enable/disable case sensitivity for jdbc scope validator

```
[oauth.scope_validator]
preserve_case_sensitivity=true
```

## Related Issues
- https://github.com/wso2/product-is/issues/20573
- https://github.com/wso2/product-apim/issues/12584

## Related PRs
- [1] https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/1812