### PR TITLE
Add support for additional attributes in the DCR endpoint

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.dcr/src/gen/java/org/wso2/carbon/identity/oauth2/dcr/endpoint/dto/ApplicationDTO.java
+++ b/components/org.wso2.carbon.identity.api.server.dcr/src/gen/java/org/wso2/carbon/identity/oauth2/dcr/endpoint/dto/ApplicationDTO.java
@@ -1,7 +1,10 @@
 package org.wso2.carbon.identity.oauth2.dcr.endpoint.dto;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+
 import io.swagger.annotations.*;
 import com.fasterxml.jackson.annotation.*;
 
@@ -76,8 +79,8 @@ public class ApplicationDTO  {
     private String requestObjectEncryptionAlgorithm = null;
     private String requestObjectEncryptionMethod = null;
     private String softwareStatement = null;
+    private  Map<String, Object> additionalAttributes;
 
-  
   /**
    **/
   @ApiModelProperty(value = "")
@@ -423,6 +426,15 @@ public class ApplicationDTO  {
     this.softwareStatement = softwareStatement;
   }
 
+  public void setAdditionalAttributes(Map<String, Object> additionalAttributes) {
+    this.additionalAttributes = additionalAttributes;
+  }
+
+  @JsonAnyGetter
+  public Map<String, Object> getAdditionalAttributes() {
+    return additionalAttributes;
+  }
+
   @Override
   public String toString()  {
     StringBuilder sb = new StringBuilder();
@@ -458,6 +470,7 @@ public class ApplicationDTO  {
     sb.append("  requestObjectEncryptionAlgorithm: ").append(requestObjectEncryptionAlgorithm).append("\n");
     sb.append("  requestObjectEncryptionMethod: ").append(requestObjectEncryptionMethod).append("\n");
     sb.append("  softwareStatement: ").append(softwareStatement).append("\n");
+    sb.append("  additionalAttributes: ").append(additionalAttributes).append("\n");
         
     sb.append("}\n");
     return sb.toString();

--- a/components/org.wso2.carbon.identity.api.server.dcr/src/gen/java/org/wso2/carbon/identity/oauth2/dcr/endpoint/dto/RegistrationRequestDTO.java
+++ b/components/org.wso2.carbon.identity.api.server.dcr/src/gen/java/org/wso2/carbon/identity/oauth2/dcr/endpoint/dto/RegistrationRequestDTO.java
@@ -1,11 +1,16 @@
 package org.wso2.carbon.identity.oauth2.dcr.endpoint.dto;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.json.JSONObject;
 
 import javax.validation.constraints.NotNull;
 
@@ -57,6 +62,7 @@ public class RegistrationRequestDTO  {
   private String requestObjectEncryptionAlgorithm = null;
   private String requestObjectEncryptionMethod = null;
   private String softwareStatement = null;
+  private final Map<String, Object> additionalAttributes = new HashMap<>();
 
   @ApiModelProperty(required = true)
   @JsonProperty("redirect_uris")
@@ -459,6 +465,15 @@ public class RegistrationRequestDTO  {
     this.softwareStatement = softwareStatement;
   }
 
+  @JsonAnySetter
+  public void setAdditionalAttributes(String key, Object value) {
+    additionalAttributes.put(key, value);
+  }
+
+  public Map<String, Object> getAdditionalAttributes() {
+    return additionalAttributes;
+  }
+
   @Override
   public String toString()  {
     StringBuilder sb = new StringBuilder();
@@ -505,6 +520,7 @@ public class RegistrationRequestDTO  {
     sb.append(" subject_type: ").append(subjectType).append("\n");
     sb.append(" request_object_encryption_alg: ").append(requestObjectEncryptionAlgorithm).append("\n");
     sb.append(" request_object_encryption_enc").append(requestObjectEncryptionMethod).append("\n");
+    sb.append("  additionalAttributes: ").append(additionalAttributes).append("\n");
     sb.append("}\n");
     return sb.toString();
   }

--- a/components/org.wso2.carbon.identity.api.server.dcr/src/gen/java/org/wso2/carbon/identity/oauth2/dcr/endpoint/dto/UpdateRequestDTO.java
+++ b/components/org.wso2.carbon.identity.api.server.dcr/src/gen/java/org/wso2/carbon/identity/oauth2/dcr/endpoint/dto/UpdateRequestDTO.java
@@ -1,8 +1,11 @@
 package org.wso2.carbon.identity.oauth2.dcr.endpoint.dto;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
@@ -47,6 +50,7 @@ public class UpdateRequestDTO {
     private String requestObjectEncryptionAlgorithm = null;
     private String requestObjectEncryptionMethod = null;
     private String softwareStatement = null;
+    private final Map<String, Object> additionalAttributes = new HashMap<>();
 
     @ApiModelProperty(value = "")
     @JsonProperty("redirect_uris")
@@ -386,6 +390,14 @@ public class UpdateRequestDTO {
         this.jwksUri = jwksUri;
     }
 
+    @JsonAnySetter
+    public void setAdditionalAttributes(String key, Object value) {
+        additionalAttributes.put(key, value);
+    }
+
+    public Map<String, Object> getAdditionalAttributes() {
+        return additionalAttributes;
+    }
 
     @Override
     public String toString() {
@@ -417,6 +429,7 @@ public class UpdateRequestDTO {
         sb.append("  id_token_encrypted_response_enc: ").append(idTokenEncryptedResponseEnc).append("\n");
         sb.append("  request_object_signing_alg: ").append(requestObjectSigningAlg).append("\n");
         sb.append("  tls_client_auth_subject_dn: ").append(tlsClientAuthSubjectDn).append("\n");
+        sb.append("  additionalAttributes: ").append(additionalAttributes).append("\n");
         sb.append("}\n");
         return sb.toString();
     }

--- a/components/org.wso2.carbon.identity.api.server.dcr/src/main/java/org/wso2/carbon/identity/oauth2/dcr/endpoint/util/DCRMUtils.java
+++ b/components/org.wso2.carbon.identity.api.server.dcr/src/main/java/org/wso2/carbon/identity/oauth2/dcr/endpoint/util/DCRMUtils.java
@@ -100,6 +100,7 @@ public class DCRMUtils {
                 (registrationRequestDTO.isTlsClientCertificateBoundAccessToken());
         appRegistrationRequest.setSubjectType(registrationRequestDTO.getSubjectType());
         appRegistrationRequest.setSoftwareStatement(registrationRequestDTO.getSoftwareStatement());
+        appRegistrationRequest.setAdditionalAttributes(registrationRequestDTO.getAdditionalAttributes());
         return appRegistrationRequest;
 
     }
@@ -142,6 +143,7 @@ public class DCRMUtils {
                 (updateRequestDTO.isTlsClientCertificateBoundAccessToken());
         applicationUpdateRequest.setSubjectType(updateRequestDTO.getSubjectType());
         applicationUpdateRequest.setSoftwareStatement(updateRequestDTO.getSoftwareStatement());
+        applicationUpdateRequest.setAdditionalAttributes(updateRequestDTO.getAdditionalAttributes());
         return applicationUpdateRequest;
     }
 
@@ -247,6 +249,7 @@ public class DCRMUtils {
         applicationDTO.setRequirePushAuthorizationRequest(application.isRequirePushedAuthorizationRequests());
         applicationDTO.setTlsClientCertificateBoundAccessToken(application.isTlsClientCertificateBoundAccessTokens());
         applicationDTO.setSoftwareStatement(application.getSoftwareStatement());
+        applicationDTO.setAdditionalAttributes(application.getAdditionalAttributes());
         return applicationDTO;
     }
 

--- a/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
+++ b/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
@@ -278,6 +278,7 @@ public final class OAuthConstants {
     public static final String PRIVATE_KEY_JWT = "private_key_jwt";
     public static final String TLS_CLIENT_AUTH = "tls_client_auth";
     public static final String RESTRICTED_ENCRYPTION_ALGORITHM = "RSA1_5";
+    public static final String ADDITIONAL_ATTRIBUTE_FILTER = "OAuth.DCRM.AdditionalAttributeFilter";
 
     private OAuthConstants() {
 

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/DCRMConstants.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/DCRMConstants.java
@@ -57,7 +57,9 @@ public class DCRMConstants {
         FAILED_TO_VALIDATE_TENANT_DOMAIN("Error occurred during validating tenant domain for consumer key: %s"),
         FAILED_TO_GET_TENANT_ADMIN("Error occurred during white getting tenant admin."),
         SIGNATURE_VALIDATION_FAILED("Signature validation failed for the software statement"),
-        MANDATORY_SOFTWARE_STATEMENT("Mandatory software statement is missing");
+        MANDATORY_SOFTWARE_STATEMENT("Mandatory software statement is missing"),
+        FAILED_TO_READ_SSA("Error occurred while reading the software statement"),
+        ADDITIONAL_ATTRIBUTE_ERROR("Error occurred while handling additional attributes");
 
         private final String message;
         private final String errorCode;

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/bean/Application.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/bean/Application.java
@@ -20,6 +20,7 @@ package org.wso2.carbon.identity.oauth.dcr.bean;
 
 import java.io.Serializable;
 import java.util.List;
+import java.util.Map;
 
 /**
  * This object contains the context related to OAuth application.
@@ -59,6 +60,16 @@ public class Application implements Serializable {
     private String idTokenEncryptionAlgorithm = null;
     private String idTokenEncryptionMethod = null;
     private String softwareStatement = null;
+
+    private Map<String, Object> additionalAttributes;
+
+    public void setAdditionalAttributes(Map<String, Object> additionalAttributes) {
+        this.additionalAttributes = additionalAttributes;
+    }
+
+    public Map<String, Object> getAdditionalAttributes() {
+        return additionalAttributes;
+    }
 
     public String getSoftwareStatement() {
 

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/bean/Application.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/bean/Application.java
@@ -64,10 +64,12 @@ public class Application implements Serializable {
     private Map<String, Object> additionalAttributes;
 
     public void setAdditionalAttributes(Map<String, Object> additionalAttributes) {
+
         this.additionalAttributes = additionalAttributes;
     }
 
     public Map<String, Object> getAdditionalAttributes() {
+
         return additionalAttributes;
     }
 

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/bean/ApplicationRegistrationRequest.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/bean/ApplicationRegistrationRequest.java
@@ -21,6 +21,7 @@ package org.wso2.carbon.identity.oauth.dcr.bean;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 /**
  * This object contains the context related to OAuth application registration request.
@@ -64,6 +65,15 @@ public class ApplicationRegistrationRequest implements Serializable {
     private String subjectType;
     private String requestObjectEncryptionAlgorithm;
     private String requestObjectEncryptionMethod;
+    private Map<String, Object> additionalAttributes;
+
+    public void setAdditionalAttributes(Map<String, Object> additionalAttributes) {
+        this.additionalAttributes = additionalAttributes;
+    }
+
+    public Map<String, Object> getAdditionalAttributes() {
+        return additionalAttributes;
+    }
 
     public String getJwksURI() {
 

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/bean/ApplicationRegistrationRequest.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/bean/ApplicationRegistrationRequest.java
@@ -68,10 +68,12 @@ public class ApplicationRegistrationRequest implements Serializable {
     private Map<String, Object> additionalAttributes;
 
     public void setAdditionalAttributes(Map<String, Object> additionalAttributes) {
+
         this.additionalAttributes = additionalAttributes;
     }
 
     public Map<String, Object> getAdditionalAttributes() {
+
         return additionalAttributes;
     }
 

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/bean/ApplicationUpdateRequest.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/bean/ApplicationUpdateRequest.java
@@ -21,6 +21,7 @@ package org.wso2.carbon.identity.oauth.dcr.bean;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 /**
  * This object contains the context related to OAuth application update request.
@@ -60,6 +61,15 @@ public class ApplicationUpdateRequest implements Serializable {
     private String subjectType;
     private String requestObjectEncryptionAlgorithm;
     private String requestObjectEncryptionMethod;
+    private Map<String, Object> additionalAttributes;
+
+    public void setAdditionalAttributes(Map<String, Object> additionalAttributes) {
+        this.additionalAttributes = additionalAttributes;
+    }
+
+    public Map<String, Object> getAdditionalAttributes() {
+        return additionalAttributes;
+    }
 
     public List<String> getRedirectUris() {
 

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/bean/ApplicationUpdateRequest.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/bean/ApplicationUpdateRequest.java
@@ -64,10 +64,12 @@ public class ApplicationUpdateRequest implements Serializable {
     private Map<String, Object> additionalAttributes;
 
     public void setAdditionalAttributes(Map<String, Object> additionalAttributes) {
+
         this.additionalAttributes = additionalAttributes;
     }
 
     public Map<String, Object> getAdditionalAttributes() {
+
         return additionalAttributes;
     }
 

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/handler/AdditionalAttributeFilter.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/handler/AdditionalAttributeFilter.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth.dcr.handler;
+
+import org.wso2.carbon.identity.application.common.model.ServiceProviderProperty;
+import org.wso2.carbon.identity.oauth.dcr.bean.ApplicationRegistrationRequest;
+import org.wso2.carbon.identity.oauth.dcr.bean.ApplicationUpdateRequest;
+import org.wso2.carbon.identity.oauth.dcr.exception.DCRMClientException;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Interface class for filtering, validating and returning additional attributes in DCR requests
+ */
+public interface AdditionalAttributeFilter {
+
+    /**
+     * Filter and validate additional attributes in the DCR registration request. Other information of the DCR
+     * registration request is also passed to the method to make decisions based on them. Additional attributes passed
+     * as SSA claims also can be accessed here. The attributes returned from this method will be stored as service
+     * provider metadata as String values. Of the returned attributes, the keys returned from the getAttributeKeys
+     * method will be sent back in the DCR register response.
+     * @param registrationRequest DCR registration request.
+     * @param ssaClaims SSA claims.
+     * @return Processed additional attributes to be stored and returned in the DCR register response.
+     * @throws DCRMClientException In case of validation failure or any other blocking error.
+     */
+    Map<String, Object> filterDCRRegisterAttributes(ApplicationRegistrationRequest registrationRequest,
+                                                    Map<String, Object> ssaClaims) throws DCRMClientException;
+
+    /**
+     * Filter and validate additional attributes in the DCR update request. Other information of the DCR update
+     * request is also passed to the method to make decisions based on them. Additional attributes passed as SSA
+     * claims also can be accessed here. The attributes returned from this method will be stored as service provider
+     * metadata as String values. If any of the keys already exists as metadata, they will be updated. Of the returned
+     * attributes, the keys returned from the getAttributeKeys method will be sent back in the DCR update response.
+     * @param updateRequest DCR update request.
+     * @param ssaClaims SSA claims.
+     * @param spProp Existing service provider properties.
+     * @return Processed additional attributes to be stored and returned in the DCR update response.
+     * @throws DCRMClientException In case of validation failure or any other blocking error.
+     */
+    Map<String, Object> filterDCRUpdateAttributes(ApplicationUpdateRequest updateRequest, Map<String, Object> ssaClaims,
+                                                  ServiceProviderProperty[] spProp) throws DCRMClientException;
+
+    /**
+     * Process the stored DCR additional attributes in the DCR GET request. Of the stored additional attributes in the
+     * DCR register and update requests, the keys returned from the getAttributeKeys method will be sent into this
+     * method. Since the attributes are stored as String values, they can be processed and converted to the required
+     * type here before sending back in the DCR GET response.
+     * @param storedAttributes Stored additional attributes for the application being retrieved.
+     * @return Processed additional attributes to be sent in the DCR GET response.
+     * @throws DCRMClientException In case of validation failure or any other blocking error.
+     */
+    Map<String, Object> processDCRGetAttributes(Map<String, String> storedAttributes) throws DCRMClientException;
+
+    /**
+     * Get the keys of additional attributes to be returned in the DCR register, update and get responses.
+     * @return List of attribute keys.
+     */
+    List<String> getResponseAttributeKeys();
+
+}

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/service/DCRMServiceTest.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/service/DCRMServiceTest.java
@@ -135,7 +135,7 @@ public class DCRMServiceTest {
         lenient().when(mockApplicationManagementService.getServiceProviderByClientId(anyString(), anyString(),
                         anyString())).thenReturn(new ServiceProvider());
         mockOAuthServerConfiguration = mock(OAuthServerConfiguration.class);
-        
+
         oAuthServerConfiguration = mockStatic(OAuthServerConfiguration.class);
         oAuthServerConfiguration.when(OAuthServerConfiguration::getInstance).thenReturn(mockOAuthServerConfiguration);
         oAuth2Util = mockStatic(OAuth2Util.class);
@@ -145,7 +145,7 @@ public class DCRMServiceTest {
         mockConfigurationManager = mock(ConfigurationManager.class);
         DCRDataHolder.getInstance().setConfigurationManager(mockConfigurationManager);
     }
-    
+
     @AfterMethod
     public void tearDown() {
 
@@ -1207,7 +1207,7 @@ public class DCRMServiceTest {
         ServiceProvider serviceProvider = new ServiceProvider();
         Map<String, Object> spProperties = new HashMap<>();
         spProperties.put(OAuthConstants.IS_THIRD_PARTY_APP, true);
-        invokePrivateMethod(dcrmService, "addSPProperties", spProperties, serviceProvider);
+        invokePrivateMethod(dcrmService, "addSPProperties", spProperties, serviceProvider, false);
         ServiceProviderProperty[] serviceProviderProperties = serviceProvider.getSpProperties();
         boolean propertyExists = Arrays.stream(serviceProviderProperties)
                 .anyMatch(property -> property.getName().equals(OAuthConstants.IS_THIRD_PARTY_APP));


### PR DESCRIPTION
### Proposed changes in this pull request

- This PR introduces the support for additional attributes in the DCR endpoint. Additional attributes can be sent in the registration request, updated in the DCR update request, and retrieved in the get request. Additional attributes can be filtered, validated, and stored as required. More details on the extension is available in the interface comments.
