### PR TITLE
Improve client exception handling for new scope validation handler

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/DefaultOAuth2ScopeValidator.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/DefaultOAuth2ScopeValidator.java
@@ -36,6 +36,7 @@ import org.wso2.carbon.identity.oauth.OAuthAdminServiceImpl;
 import org.wso2.carbon.identity.oauth.common.OAuthConstants;
 import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
 import org.wso2.carbon.identity.oauth.internal.OAuthComponentServiceHolder;
+import org.wso2.carbon.identity.oauth2.IdentityOAuth2ClientException;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.authz.OAuthAuthzReqMessageContext;
 import org.wso2.carbon.identity.oauth2.dao.SharedAppResolveDAO;
@@ -44,6 +45,7 @@ import org.wso2.carbon.identity.oauth2.token.OAuthTokenReqMessageContext;
 import org.wso2.carbon.identity.oauth2.util.AuthzUtil;
 import org.wso2.carbon.identity.oauth2.validators.validationhandler.ScopeValidationContext;
 import org.wso2.carbon.identity.oauth2.validators.validationhandler.ScopeValidationHandler;
+import org.wso2.carbon.identity.oauth2.validators.validationhandler.ScopeValidationHandlerClientException;
 import org.wso2.carbon.identity.oauth2.validators.validationhandler.ScopeValidationHandlerException;
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
 
@@ -205,6 +207,8 @@ public class DefaultOAuth2ScopeValidator {
                     try {
                         validatedScopes = scopeValidationHandler.validateScopes(requestedScopes,
                                 authorizedScopes.getScopes(), scopeValidationContext);
+                    } catch (ScopeValidationHandlerClientException e) {
+                        throw new IdentityOAuth2ClientException(e.getMessage(), e);
                     } catch (ScopeValidationHandlerException e) {
                         throw new IdentityOAuth2Exception("Error while validating policies roles from " +
                                 "authorization service.", e);

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/validationhandler/ScopeValidationHandlerClientException.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/validationhandler/ScopeValidationHandlerClientException.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth2.validators.validationhandler;
+
+/**
+ * ScopeValidatorPolicyHandlerClientException
+ */
+public class ScopeValidationHandlerClientException extends ScopeValidationHandlerException {
+
+    /**
+     * Constructs a new exception with an error message.
+     *
+     * @param message The detail message.
+     */
+    public ScopeValidationHandlerClientException(String message) {
+
+        super(message);
+    }
+
+    /**
+     * Constructs a new exception with the message and cause.
+     *
+     * @param message The detail message.
+     * @param cause The cause.
+     */
+    public ScopeValidationHandlerClientException(String message, Throwable cause) {
+
+        super(message, cause);
+    }
+}

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/validationhandler/impl/RoleBasedScopeValidationHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/validationhandler/impl/RoleBasedScopeValidationHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2023-2024, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -28,12 +28,14 @@ import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.oauth.common.OAuthConstants;
 import org.wso2.carbon.identity.oauth.internal.OAuthComponentServiceHolder;
+import org.wso2.carbon.identity.oauth2.IdentityOAuth2ClientException;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.Oauth2ScopeConstants;
 import org.wso2.carbon.identity.oauth2.internal.OAuth2ServiceComponentHolder;
 import org.wso2.carbon.identity.oauth2.util.AuthzUtil;
 import org.wso2.carbon.identity.oauth2.validators.validationhandler.ScopeValidationContext;
 import org.wso2.carbon.identity.oauth2.validators.validationhandler.ScopeValidationHandler;
+import org.wso2.carbon.identity.oauth2.validators.validationhandler.ScopeValidationHandlerClientException;
 import org.wso2.carbon.identity.oauth2.validators.validationhandler.ScopeValidationHandlerException;
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
 import org.wso2.carbon.identity.role.v2.mgt.core.RoleConstants;
@@ -99,6 +101,8 @@ public class RoleBasedScopeValidationHandler implements ScopeValidationHandler {
             List<String> filteredScopes = appAuthorizedScopes.stream().filter(associatedScopes::contains)
                     .collect(Collectors.toList());
             return requestedScopes.stream().filter(filteredScopes::contains).collect(Collectors.toList());
+        } catch (IdentityOAuth2ClientException e) {
+            throw new ScopeValidationHandlerClientException(e.getMessage(), e);
         } catch (IdentityOAuth2Exception | IdentityRoleManagementException e) {
             throw new ScopeValidationHandlerException("Error while validation scope with RBAC Scope Validation " +
                     "handler", e);


### PR DESCRIPTION
### Proposed changes in this pull request

$subject


The exception handling improvement is suggested due to there can be client errors which can cause the scope validation to be failed. Ex: Trying to switch to an organization which the user doesn't have an association. As there is no association, the scope validation fails. In such cases, instead of having server exception, we can handle the client exception.

Then the response will be like. 

<img width="830" alt="Screenshot 2024-07-03 at 08 15 51" src="https://github.com/wso2-extensions/identity-inbound-auth-oauth/assets/35717390/75beb357-0025-4101-a70e-b899a74e0629">
