### PR TITLE
Add validation while retrieving claimsets from encrypted JWT tokens

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuer.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuer.java
@@ -244,8 +244,12 @@ public class JWTTokenIssuer extends OauthTokenIssuerImpl {
 
         try {
             JWT parsedJwtToken = JWTParser.parse(accessToken);
+            // JWT ClaimsSet can be null if the ID token is encrypted.
+            if (parsedJwtToken.getJWTClaimsSet() == null) {
+                throw new OAuthSystemException("JWT claims set is null in the JWT token.");
+            }
             String jwtId = parsedJwtToken.getJWTClaimsSet().getJWTID();
-            if (jwtId == null) {
+            if (StringUtils.isBlank(jwtId)) {
                 throw new OAuthSystemException("JTI could not be retrieved from the JWT token.");
             }
             return jwtId;


### PR DESCRIPTION
This PR adds a validation the existence of JWTClaimsSets before fetching the JWTID from it. In cases of encrypted ID tokens, JWTClaimsSets can be null.

Related issue:
- https://github.com/wso2/product-is/issues/20640