### PR TITLE
Skip token binding validation for the request binding type

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -4738,8 +4738,13 @@ public class OAuth2Util {
     public static boolean isValidTokenBinding(TokenBinding tokenBinding, HttpServletRequest request) {
 
         if (request == null || tokenBinding == null || StringUtils.isBlank(tokenBinding.getBindingReference())
-                || StringUtils.isBlank(tokenBinding.getBindingType())
-                || OAuthConstants.REQUEST_BINDING_TYPE.equals(tokenBinding.getBindingType())) {
+                || StringUtils.isBlank(tokenBinding.getBindingType())) {
+            return true;
+        }
+
+        /* The request token binding type can't be validated, as it is an auto generated UUID to issue unique JWT tokens
+            by avoiding revocation of already issued JWT tokens. */
+        if (OAuthConstants.REQUEST_BINDING_TYPE.equals(tokenBinding.getBindingType())) {
             return true;
         }
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -4738,7 +4738,8 @@ public class OAuth2Util {
     public static boolean isValidTokenBinding(TokenBinding tokenBinding, HttpServletRequest request) {
 
         if (request == null || tokenBinding == null || StringUtils.isBlank(tokenBinding.getBindingReference())
-                || StringUtils.isBlank(tokenBinding.getBindingType())) {
+                || StringUtils.isBlank(tokenBinding.getBindingType())
+                || OAuthConstants.REQUEST_BINDING_TYPE.equals(tokenBinding.getBindingType())) {
             return true;
         }
 


### PR DESCRIPTION
### Proposed changes in this pull request

The "request" binding type is introduced with this effort 
- https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2018 where an auto generated UUID is set as the token binding in order to make JWT tokens not get revoked.

But when the JWT token is send for the endpoints like user-info where token binding is validated, it gets failed as there is no binding is passed. Actually there is no binding can be passed as it was generated internally within IS to avoid the token revocation.

#### Related Issues
- https://github.com/wso2/product-is/issues/20604