### PR TITLE
Integrate IdentityKeyStoreResolver

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/jwks/JwksEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/jwks/JwksEndpoint.java
@@ -30,15 +30,14 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.base.MultitenantConstants;
-import org.wso2.carbon.core.util.KeyStoreManager;
-import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
-import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.core.IdentityKeyStoreResolver;
+import org.wso2.carbon.identity.core.util.IdentityKeyStoreResolverConstants;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.oauth.common.OAuthConstants;
 import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
-import org.wso2.carbon.utils.security.KeystoreUtils;
+import org.wso2.carbon.utils.CarbonUtils;
 
 import java.security.KeyStore;
 import java.security.cert.Certificate;
@@ -78,22 +77,9 @@ public class JwksEndpoint {
         String tenantDomain = getTenantDomain();
 
         try {
-            final KeyStore keystore;
+            final KeyStore keystore = IdentityKeyStoreResolver.getInstance().getKeyStore(
+                    tenantDomain, IdentityKeyStoreResolverConstants.InboundProtocol.OAUTH);
             List<CertificateInfo> certificateInfoList = new ArrayList<>();
-            if (MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equalsIgnoreCase(tenantDomain)) {
-                KeyStoreManager keyStoreManager = KeyStoreManager.getInstance(MultitenantConstants.SUPER_TENANT_ID);
-                keystore = keyStoreManager.getPrimaryKeyStore();
-            } else {
-                try {
-                    int tenantId = IdentityTenantUtil.getTenantId(tenantDomain);
-                    IdentityTenantUtil.initializeRegistry(tenantId);
-                    FrameworkUtils.startTenantFlow(tenantDomain);
-                    KeyStoreManager keyStoreManager = KeyStoreManager.getInstance(tenantId);
-                    keystore = keyStoreManager.getKeyStore(generateKSNameFromDomainName(tenantDomain));
-                } finally {
-                    FrameworkUtils.endTenantFlow();
-                }
-            }
             Enumeration enumeration = keystore.aliases();
             while (enumeration.hasMoreElements()) {
                 String alias = (String) enumeration.nextElement();
@@ -248,16 +234,6 @@ public class JwksEndpoint {
             log.error(errorMesage);
         }
         return errorMesage;
-    }
-
-    /**
-     * This method generates the key store file name from the Domain Name.
-     *
-     * @return key store file name
-     */
-    private String generateKSNameFromDomainName(String tenantDomain) {
-
-        return KeystoreUtils.getKeyStoreFileLocation(tenantDomain);
     }
 
     /**

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/jwks/JwksEndpointTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/jwks/JwksEndpointTest.java
@@ -45,7 +45,6 @@ import org.wso2.carbon.identity.oauth2.internal.OAuth2ServiceComponentHolder;
 import org.wso2.carbon.identity.oauth2.keyidprovider.DefaultKeyIDProviderImpl;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 import org.wso2.carbon.utils.CarbonUtils;
-import org.wso2.carbon.utils.security.KeystoreUtils;
 
 import java.io.FileInputStream;
 import java.lang.reflect.Field;
@@ -59,7 +58,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mockStatic;
@@ -213,8 +211,8 @@ public class JwksEndpointTest {
                         .thenReturn("YmUwN2EzOGI3ZTI0Y2NiNTNmZWFlZjI5Mm" +
                                 "VjZjdjZTYzZjI0M2MxNDQ1YjQwNjI3NjYyZmZlYzkwNzY0YjU4NQ");
 
-                identityKeyStoreResolver.when(() ->
-                        IdentityKeyStoreResolver.getInstance()).thenReturn(mockIdentityKeyStoreResolver);
+                identityKeyStoreResolver.when(() -> IdentityKeyStoreResolver.getInstance())
+                        .thenReturn(mockIdentityKeyStoreResolver);
 
                 lenient().when(mockIdentityKeyStoreResolver
                                 .getKeyStore("carbon.super", IdentityKeyStoreResolverConstants.InboundProtocol.OAUTH))

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/jwks/JwksEndpointTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/jwks/JwksEndpointTest.java
@@ -31,7 +31,6 @@ import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 import org.wso2.carbon.base.CarbonBaseConstants;
 import org.wso2.carbon.base.MultitenantConstants;
-import org.wso2.carbon.base.ServerConfiguration;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
 import org.wso2.carbon.identity.core.IdentityKeyStoreResolver;
 import org.wso2.carbon.identity.core.util.IdentityKeyStoreResolverConstants;
@@ -67,9 +66,6 @@ import static org.testng.Assert.fail;
 
 @Listeners(MockitoTestNGListener.class)
 public class JwksEndpointTest {
-
-    @Mock
-    ServerConfiguration serverConfiguration;
 
     @Mock
     OAuthServerConfiguration mockOAuthServerConfiguration;

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authcontext/JWTTokenGenerator.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authcontext/JWTTokenGenerator.java
@@ -31,11 +31,10 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.base.MultitenantConstants;
-import org.wso2.carbon.core.util.KeyStoreManager;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
-import org.wso2.carbon.identity.base.IdentityException;
+import org.wso2.carbon.identity.core.IdentityKeyStoreResolver;
 import org.wso2.carbon.identity.core.util.IdentityCoreConstants;
-import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.core.util.IdentityKeyStoreResolverConstants;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.oauth.common.exception.InvalidOAuthClientException;
 import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
@@ -60,10 +59,8 @@ import org.wso2.carbon.user.core.UserStoreManager;
 import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.carbon.user.core.util.UserCoreUtil;
 import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
-import org.wso2.carbon.utils.security.KeystoreUtils;
 
 import java.security.Key;
-import java.security.KeyStore;
 import java.security.MessageDigest;
 import java.security.cert.Certificate;
 import java.security.interfaces.RSAPrivateKey;
@@ -72,12 +69,10 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
-import java.util.Map;
 import java.util.SortedMap;
 import java.util.StringTokenizer;
 import java.util.TreeSet;
 import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * This class represents the JSON Web Token generator.
@@ -104,9 +99,6 @@ public class JWTTokenGenerator implements AuthorizationContextTokenGenerator {
     private boolean includeClaims = true;
 
     private boolean enableSigning = true;
-
-    private static Map<Integer, Key> privateKeys = new ConcurrentHashMap<Integer, Key>();
-    private static Map<Integer, Certificate> publicCerts = new ConcurrentHashMap<Integer, Certificate>();
 
     private ClaimCache claimsLocalCache;
 
@@ -319,7 +311,8 @@ public class JWTTokenGenerator implements AuthorizationContextTokenGenerator {
                                        int tenantId)
             throws IdentityOAuth2Exception {
         try {
-            Key privateKey = getPrivateKey(tenantDomain, tenantId);
+            Key privateKey = IdentityKeyStoreResolver.getInstance()
+                    .getPrivateKey(tenantDomain, IdentityKeyStoreResolverConstants.InboundProtocol.OAUTH);
             JWSSigner signer = OAuth2Util.createJWSSigner((RSAPrivateKey) privateKey);
             signedJWT.sign(signer);
             return signedJWT;
@@ -407,8 +400,8 @@ public class JWTTokenGenerator implements AuthorizationContextTokenGenerator {
     private String getThumbPrint(String tenantDomain, int tenantId) throws IdentityOAuth2Exception {
 
         try {
-
-            Certificate certificate = getCertificate(tenantDomain, tenantId);
+            Certificate certificate = IdentityKeyStoreResolver.getInstance()
+                    .getCertificate(tenantDomain, IdentityKeyStoreResolverConstants.InboundProtocol.OAUTH);
 
             // TODO: maintain a hashmap with tenants' pubkey thumbprints after first initialization
 
@@ -427,94 +420,6 @@ public class JWTTokenGenerator implements AuthorizationContextTokenGenerator {
             String error = "Error in obtaining certificate for tenant " + tenantDomain;
             throw new IdentityOAuth2Exception(error, e);
         }
-    }
-
-    private Key getPrivateKey(String tenantDomain, int tenantId) throws IdentityOAuth2Exception {
-
-        if (tenantDomain == null) {
-            tenantDomain = MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
-        }
-
-        if (tenantId == 0) {
-            tenantId = OAuth2Util.getTenantId(tenantDomain);
-        }
-
-        Key privateKey = null;
-
-        if (!(privateKeys.containsKey(tenantId))) {
-
-            try {
-                IdentityTenantUtil.initializeRegistry(tenantId, tenantDomain);
-            } catch (IdentityException e) {
-                throw new IdentityOAuth2Exception("Error occurred while loading registry for tenant " + tenantDomain,
-                        e);
-            }
-
-            // get tenant's key store manager
-            KeyStoreManager tenantKSM = KeyStoreManager.getInstance(tenantId);
-
-            if (!tenantDomain.equals(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME)) {
-                // derive key store name
-                String fileName = KeystoreUtils.getKeyStoreFileLocation(tenantDomain);
-                // obtain private key
-                privateKey = tenantKSM.getPrivateKey(fileName, tenantDomain);
-
-            } else {
-                try {
-                    privateKey = tenantKSM.getDefaultPrivateKey();
-                } catch (Exception e) {
-                    log.error("Error while obtaining private key for super tenant", e);
-                }
-            }
-            if (privateKey != null) {
-                privateKeys.put(tenantId, privateKey);
-            }
-        } else {
-            privateKey = privateKeys.get(tenantId);
-        }
-        return privateKey;
-    }
-
-    private Certificate getCertificate(String tenantDomain, int tenantId) throws Exception {
-
-        if (tenantDomain == null) {
-            tenantDomain = MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
-        }
-
-        if (tenantId == 0) {
-            tenantId = OAuth2Util.getTenantId(tenantDomain);
-        }
-
-        Certificate publicCert = null;
-
-        if (!(publicCerts.containsKey(tenantId))) {
-
-            try {
-                IdentityTenantUtil.initializeRegistry(tenantId, tenantDomain);
-            } catch (IdentityException e) {
-                throw new IdentityOAuth2Exception("Error occurred while loading registry for tenant " + tenantDomain,
-                        e);
-            }
-
-            // get tenant's key store manager
-            KeyStoreManager tenantKSM = KeyStoreManager.getInstance(tenantId);
-
-            KeyStore keyStore = null;
-            if (!tenantDomain.equals(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME)) {
-                // derive key store name
-                String fileName = KeystoreUtils.getKeyStoreFileLocation(tenantDomain);
-                keyStore = tenantKSM.getKeyStore(fileName);
-                publicCert = keyStore.getCertificate(tenantDomain);
-            } else {
-                publicCert = tenantKSM.getDefaultPrimaryCertificate();
-            }
-            if (publicCert != null) {
-                publicCerts.put(tenantId, publicCert);
-            }
-        } else {
-            publicCert = publicCerts.get(tenantId);
-        }
-        return publicCert;
     }
 
     /**

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuer.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuer.java
@@ -459,17 +459,16 @@ public class JWTTokenIssuer extends OauthTokenIssuerImpl {
 
         try {
             String tenantDomain = resolveSigningTenantDomain(tokenContext, authorizationContext);
-            int tenantId = IdentityTenantUtil.getTenantId(tenantDomain);
 
             // Add claim with signer tenant to jwt claims set.
             jwtClaimsSet = setSignerRealm(tenantDomain, jwtClaimsSet);
 
-            Key privateKey = getPrivateKey(tenantDomain, tenantId);
+            Key privateKey = getPrivateKey(tenantDomain);
             JWSSigner signer = OAuth2Util.createJWSSigner((RSAPrivateKey) privateKey);
             JWSHeader.Builder headerBuilder = new JWSHeader.Builder((JWSAlgorithm) signatureAlgorithm);
-            Certificate certificate = OAuth2Util.getCertificate(tenantDomain, tenantId);
+            Certificate certificate = OAuth2Util.getCertificate(tenantDomain);
             String certThumbPrint = OAuth2Util.getThumbPrintWithPrevAlgorithm(certificate, false);
-            headerBuilder.keyID(OAuth2Util.getKID(OAuth2Util.getCertificate(tenantDomain, tenantId),
+            headerBuilder.keyID(OAuth2Util.getKID(OAuth2Util.getCertificate(tenantDomain),
                     (JWSAlgorithm) signatureAlgorithm, tenantDomain));
 
             if (authorizationContext != null && authorizationContext.isSubjectTokenFlow()) {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuer.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuer.java
@@ -38,7 +38,6 @@ import org.apache.oltu.oauth2.common.exception.OAuthSystemException;
 import org.wso2.carbon.identity.application.authentication.framework.exception.UserIdNotFoundException;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
 import org.wso2.carbon.identity.base.IdentityConstants;
-import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.oauth.common.OAuthConstants;
 import org.wso2.carbon.identity.oauth.common.exception.InvalidOAuthClientException;

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/JWTUtils.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/JWTUtils.java
@@ -468,8 +468,12 @@ public class JWTUtils {
         X509Certificate x509Certificate;
         String tenantDomain = getTenantDomain();
         try {
-            x509Certificate = (X509Certificate) IdentityApplicationManagementUtil
-                    .decodeCertificate(idp.getCertificate());
+            if (IdentityApplicationConstants.RESIDENT_IDP_RESERVED_NAME.equals(idp.getIdentityProviderName())) {
+                x509Certificate = (X509Certificate) OAuth2Util.getCertificate(tenantDomain);
+            } else {
+                x509Certificate = (X509Certificate) IdentityApplicationManagementUtil
+                        .decodeCertificate(idp.getCertificate());
+            }
         } catch (CertificateException e) {
             throw new IdentityOAuth2Exception("Error occurred while decoding public certificate of Identity Provider "
                     + idp.getIdentityProviderName() + " for tenant domain " + tenantDomain, e);

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -3343,7 +3343,14 @@ public class OAuth2Util {
         }
     }
 
-    public static Key getPrivateKey(String tenantDomain, int tenantId) throws IdentityOAuth2Exception {
+    /**
+     * Method to obatin Default Private key for OAuth2 protocol.
+     *
+     * @param tenantDomain Tenant Domain as a String.
+     * @return Default Private key for OAuth2 protocol.
+     * @throws IdentityOAuth2Exception When failed to obtain the private key for the requested tenant.
+     */
+    public static Key getPrivateKey(String tenantDomain) throws IdentityOAuth2Exception {
 
         try {
             return IdentityKeyStoreResolver.getInstance().getPrivateKey(
@@ -3351,6 +3358,19 @@ public class OAuth2Util {
         } catch (IdentityKeyStoreResolverException e) {
             throw new IdentityOAuth2Exception("Error while obtaining private key", e);
         }
+    }
+
+    /**
+     * Method to obatin Default Private key for OAuth2 protocol.
+     *
+     * @param tenantDomain Tenant Domain as a String.
+     * @param tenantId     Tenan ID as an integer.
+     * @return Default Private key for OAuth2 protocol.
+     * @throws IdentityOAuth2Exception When failed to obtain the private key for the requested tenant.
+     */
+    public static Key getPrivateKey(String tenantDomain, int tenantId) throws IdentityOAuth2Exception {
+
+        return getPrivateKey(tenantDomain);
     }
 
     /**
@@ -3502,11 +3522,10 @@ public class OAuth2Util {
      * Method to obatin Default Signing certificate for the tenant.
      *
      * @param tenantDomain Tenant Domain as a String.
-     * @param tenantId     Tenan ID as an integer.
-     * @return Default Signing Certificate of the tenant domain.
+     * @return Default Signing Certificate of the tenant domain for the OAuth2 protocol.
      * @throws IdentityOAuth2Exception When failed to obtain the certificate for the requested tenant.
      */
-    public static Certificate getCertificate(String tenantDomain, int tenantId) throws IdentityOAuth2Exception {
+    public static Certificate getCertificate(String tenantDomain) throws IdentityOAuth2Exception {
 
         try {
             return IdentityKeyStoreResolver.getInstance().getCertificate(
@@ -3514,6 +3533,19 @@ public class OAuth2Util {
         } catch (IdentityKeyStoreResolverException e) {
             throw new IdentityOAuth2Exception("Error while obtaining public certificate.", e);
         }
+    }
+
+    /**
+     * Method to obatin Default Signing certificate for the tenant.
+     *
+     * @param tenantDomain Tenant Domain as a String.
+     * @param tenantId     Tenan ID as an integer.
+     * @return Default Signing Certificate of the tenant domain for the OAuth2 protocol.
+     * @throws IdentityOAuth2Exception When failed to obtain the certificate for the requested tenant.
+     */
+    public static Certificate getCertificate(String tenantDomain, int tenantId) throws IdentityOAuth2Exception {
+
+        return getCertificate(tenantDomain);
     }
 
     /**

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -87,7 +87,13 @@ import org.wso2.carbon.identity.consent.server.configs.mgt.exceptions.ConsentSer
 import org.wso2.carbon.identity.core.IdentityKeyStoreResolver;
 import org.wso2.carbon.identity.core.ServiceURLBuilder;
 import org.wso2.carbon.identity.core.URLBuilderException;
-import org.wso2.carbon.identity.core.util.*;
+import org.wso2.carbon.identity.core.util.IdentityConfigParser;
+import org.wso2.carbon.identity.core.util.IdentityCoreConstants;
+import org.wso2.carbon.identity.core.util.IdentityDatabaseUtil;
+import org.wso2.carbon.identity.core.util.IdentityKeyStoreResolverConstants;
+import org.wso2.carbon.identity.core.util.IdentityKeyStoreResolverException;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.oauth.IdentityOAuthAdminException;
 import org.wso2.carbon.identity.oauth.cache.AppInfoCache;
 import org.wso2.carbon.identity.oauth.cache.CacheEntry;
@@ -2834,10 +2840,7 @@ public class OAuth2Util {
                 log.debug("Error occurred while validating id token signature.");
             }
             return false;
-        }  catch (IdentityKeyStoreResolverException e) {
-            log.error("Error occurred while validating id token signature.");
-            return false;
-        } catch (Exception e) {
+        }  catch (Exception e) {
             log.error("Error occurred while validating id token signature.");
             return false;
         }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -2840,7 +2840,7 @@ public class OAuth2Util {
                 log.debug("Error occurred while validating id token signature.");
             }
             return false;
-        }  catch (Exception e) {
+        } catch (Exception e) {
             log.error("Error occurred while validating id token signature.");
             return false;
         }

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/authcontext/JWTTokenGeneratorTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/authcontext/JWTTokenGeneratorTest.java
@@ -33,6 +33,7 @@ import org.wso2.carbon.identity.common.testng.WithCarbonHome;
 import org.wso2.carbon.identity.common.testng.WithH2Database;
 import org.wso2.carbon.identity.common.testng.WithKeyStore;
 import org.wso2.carbon.identity.common.testng.WithRealmService;
+import org.wso2.carbon.identity.core.IdentityKeyStoreResolver;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.oauth.IdentityOAuthAdminException;
@@ -46,7 +47,6 @@ import org.wso2.carbon.identity.oauth2.dto.OAuth2TokenValidationResponseDTO;
 import org.wso2.carbon.identity.oauth2.internal.OAuth2ServiceComponentHolder;
 import org.wso2.carbon.identity.oauth2.keyidprovider.DefaultKeyIDProviderImpl;
 import org.wso2.carbon.identity.oauth2.model.AccessTokenDO;
-import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 import org.wso2.carbon.identity.oauth2.validators.OAuth2TokenValidationMessageContext;
 import org.wso2.carbon.identity.testutil.ReadCertStoreSampleUtil;
 import org.wso2.carbon.user.core.UserCoreConstants;
@@ -163,16 +163,16 @@ public class JWTTokenGeneratorTest {
             addSampleOauth2Application();
             ClaimCache claimsLocalCache = ClaimCache.getInstance();
             setPrivateField(jwtTokenGenerator, "claimsLocalCache", claimsLocalCache);
-            Map<Integer, Certificate> publicCerts = new ConcurrentHashMap<>();
-            publicCerts.put(-1234, ReadCertStoreSampleUtil.createKeyStore(getClass())
+            Map<String, Certificate> publicCerts = new ConcurrentHashMap<>();
+            publicCerts.put("-1234", ReadCertStoreSampleUtil.createKeyStore(getClass())
                     .getCertificate("wso2carbon"));
             OAuthComponentServiceHolder.getInstance().setRealmService(realmService);
             when(realmService.getTenantManager()).thenReturn(tenantManager);
-            setFinalStatic(OAuth2Util.class.getDeclaredField("publicCerts"), publicCerts);
-            Map<Integer, Key> privateKeys = new ConcurrentHashMap<>();
-            privateKeys.put(-1234, ReadCertStoreSampleUtil.createKeyStore(getClass())
+            setFinalStatic(IdentityKeyStoreResolver.class.getDeclaredField("publicCerts"), publicCerts);
+            Map<String, Key> privateKeys = new ConcurrentHashMap<>();
+            privateKeys.put("-1234", ReadCertStoreSampleUtil.createKeyStore(getClass())
                     .getKey("wso2carbon", "wso2carbon".toCharArray()));
-            setFinalStatic(OAuth2Util.class.getDeclaredField("privateKeys"), privateKeys);
+            setFinalStatic(IdentityKeyStoreResolver.class.getDeclaredField("privateKeys"), privateKeys);
 
             accessToken.setTokenType("Bearer");
             oAuth2TokenValidationRequestDTO.setAccessToken(accessToken);

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/openidconnect/DefaultIDTokenBuilderTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/openidconnect/DefaultIDTokenBuilderTest.java
@@ -43,6 +43,7 @@ import org.wso2.carbon.identity.common.testng.WithCarbonHome;
 import org.wso2.carbon.identity.common.testng.WithH2Database;
 import org.wso2.carbon.identity.common.testng.WithKeyStore;
 import org.wso2.carbon.identity.common.testng.WithRealmService;
+import org.wso2.carbon.identity.core.IdentityKeyStoreResolver;
 import org.wso2.carbon.identity.core.persistence.JDBCPersistenceManager;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
@@ -70,7 +71,6 @@ import org.wso2.carbon.identity.oauth2.model.AccessTokenDO;
 import org.wso2.carbon.identity.oauth2.test.utils.CommonTestUtils;
 import org.wso2.carbon.identity.oauth2.token.OAuthTokenReqMessageContext;
 import org.wso2.carbon.identity.oauth2.token.handlers.grant.saml.SAML2BearerGrantHandlerTest;
-import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 import org.wso2.carbon.identity.openidconnect.dao.ScopeClaimMappingDAOImpl;
 import org.wso2.carbon.identity.openidconnect.internal.OpenIDConnectServiceComponentHolder;
 import org.wso2.carbon.identity.openidconnect.model.RequestedClaim;
@@ -250,14 +250,14 @@ public class DefaultIDTokenBuilderTest {
                     .addUser(TestConstants.USER_NAME, TestConstants.PASSWORD, new String[0], claims,
                              TestConstants.DEFAULT_PROFILE);
 
-        Map<Integer, Certificate> publicCerts = new ConcurrentHashMap<>();
-        publicCerts.put(SUPER_TENANT_ID, ReadCertStoreSampleUtil.createKeyStore(getClass())
+        Map<String, Certificate> publicCerts = new ConcurrentHashMap<>();
+        publicCerts.put(String.valueOf(SUPER_TENANT_ID), ReadCertStoreSampleUtil.createKeyStore(getClass())
                                                                 .getCertificate("wso2carbon"));
-        setFinalStatic(OAuth2Util.class.getDeclaredField("publicCerts"), publicCerts);
-        Map<Integer, Key> privateKeys = new ConcurrentHashMap<>();
-        privateKeys.put(SUPER_TENANT_ID, ReadCertStoreSampleUtil.createKeyStore(getClass())
+        setFinalStatic(IdentityKeyStoreResolver.class.getDeclaredField("publicCerts"), publicCerts);
+        Map<String, Key> privateKeys = new ConcurrentHashMap<>();
+        privateKeys.put(String.valueOf(SUPER_TENANT_ID), ReadCertStoreSampleUtil.createKeyStore(getClass())
                                                                 .getKey("wso2carbon", "wso2carbon".toCharArray()));
-        setFinalStatic(OAuth2Util.class.getDeclaredField("privateKeys"), privateKeys);
+        setFinalStatic(IdentityKeyStoreResolver.class.getDeclaredField("privateKeys"), privateKeys);
 
         OpenIDConnectServiceComponentHolder.getInstance()
                 .getOpenIDConnectClaimFilters().add(new OpenIDConnectClaimFilterImpl());


### PR DESCRIPTION
# Purpose
- This PR integrates the `IdentityKeyStoreResolver` class into the OAuth flow.
- This will allow users to define custom key stores to be used in the authentication flow.
# Important
- Before merging this PR,
  - Carbon Kernel version should be bumped
  - Following PRs should be merged,
    - https://github.com/wso2/carbon-kernel/pull/4025
    - https://github.com/wso2/carbon-identity-framework/pull/5794
---
- Problem Statement: https://github.com/wso2-enterprise/iam-product-management/issues/67
- Public Git Issue: https://github.com/wso2/product-is/issues/20564