### PR TITLE
Authorise all scopes for all application upon server-wide configuration

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
@@ -169,6 +169,7 @@ public class OAuthServerConfiguration {
     private boolean removeUsernameFromIntrospectionResponseForAppTokens = true;
     private boolean useLegacyScopesAsAliasForNewScopes = false;
     private boolean useLegacyPermissionAccessForUserBasedAuth = false;
+    private boolean authorizeAllScopes = false;
     private String accessTokenPartitioningDomains = null;
     private TokenPersistenceProcessor persistenceProcessor = null;
     private Set<OAuthCallbackHandlerMetaData> callbackHandlerMetaData = new HashSet<>();
@@ -534,6 +535,9 @@ public class OAuthServerConfiguration {
 
         // Read config for restricted query parameters in oauth requests
         parseRestrictedQueryParameters(oauthElem);
+
+        // Read config for allow all scopes for an application
+        parseAuthorizeAllScopes(oauthElem);
     }
 
     /**
@@ -3667,6 +3671,31 @@ public class OAuthServerConfiguration {
         return useLegacyPermissionAccessForUserBasedAuth;
     }
 
+    /**
+     * Parse the AuthorizeAllScopes configuration that authorize all scopes for all applications.
+     *
+     * @param oauthConfigElem oauthConfigElem.
+     */
+    private void parseAuthorizeAllScopes(OMElement oauthConfigElem) {
+
+        OMElement authorizeAllScopesElem = oauthConfigElem.getFirstChildWithName(
+                getQNameWithIdentityNS(ConfigElements.AUTHORIZE_ALL_SCOPES));
+        if (authorizeAllScopesElem != null) {
+            authorizeAllScopes = Boolean.parseBoolean(authorizeAllScopesElem.getText());
+        }
+    }
+
+    /**
+     * This method returns the value of the property AuthorizeAllScopes for the OAuth
+     * configuration in identity.xml.
+     *
+     * @return true if the AuthorizeAllScopes is enabled.
+     */
+    public boolean isAuthorizeAllScopes() {
+
+        return authorizeAllScopes;
+    }
+
     private static void setOAuthResponseJspPageAvailable() {
 
         java.nio.file.Path path = Paths.get(CarbonUtils.getCarbonHome(), "repository", "deployment",
@@ -4041,6 +4070,7 @@ public class OAuthServerConfiguration {
         private static final String SCOPE_METADATA_EXTENSION_IMPL = "ScopeMetadataService";
         private static final String RESTRICTED_QUERY_PARAMETERS_ELEMENT = "RestrictedQueryParameters";
         private static final String RESTRICTED_QUERY_PARAMETER_ELEMENT = "Parameter";
+        private static final String AUTHORIZE_ALL_SCOPES = "AuthorizeAllScopes";
     }
 
 }


### PR DESCRIPTION
For IS 7.x compatibility with APIM 4.x, it is required to make all api resources in that organisation available for any application.  This is achieved by allowing all scopes to be authorised for all applications upon server-wide configuration `authorize_all_scopes`. This will not make any impact on the default behaviour. 

Since we are considering all scopes as authorized for all applications, internal and console scopes will be made available as well. With the 'SYSTEM' scope/scope requesting method, we will be issuing all internal and console scopes. UI support is not required and the console will not reflect this. 


