### PR TITLE
Add v2 configs to oauth endpoints

### DIFF
--- a/components/org.wso2.carbon.identity.discovery/src/main/java/org/wso2/carbon/identity/discovery/builders/ProviderConfigBuilder.java
+++ b/components/org.wso2.carbon.identity.discovery/src/main/java/org/wso2/carbon/identity/discovery/builders/ProviderConfigBuilder.java
@@ -116,9 +116,11 @@ public class ProviderConfigBuilder {
         providerConfig.setSubjectTypesSupported(new String[]{"public", "pairwise"});
 
         providerConfig.setCheckSessionIframe(buildServiceUrl(IdentityConstants.OAuth.CHECK_SESSION,
-                IdentityUtil.getProperty(IdentityConstants.OAuth.OIDC_CHECK_SESSION_EP_URL)));
+                IdentityUtil.getProperty(IdentityConstants.OAuth.OIDC_CHECK_SESSION_EP_URL),
+                IdentityUtil.getProperty(IdentityConstants.OAuth.OIDC_CHECK_SESSION_EP_URL_V2)));
         providerConfig.setEndSessionEndpoint(buildServiceUrl(IdentityConstants.OAuth.LOGOUT,
-                IdentityUtil.getProperty(IdentityConstants.OAuth.OIDC_LOGOUT_EP_URL)));
+                IdentityUtil.getProperty(IdentityConstants.OAuth.OIDC_LOGOUT_EP_URL),
+                IdentityUtil.getProperty(IdentityConstants.OAuth.OIDC_LOGOUT_EP_URL_V2)));
         try {
             providerConfig.setUserinfoSigningAlgValuesSupported(new String[] {
                     OAuth2Util.mapSignatureAlgorithmForJWSAlgorithm(

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/api/auth/ApiAuthnHandler.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/api/auth/ApiAuthnHandler.java
@@ -216,7 +216,7 @@ public class ApiAuthnHandler {
         List<Link> links = new ArrayList<>();
         Link authnEpLink = new Link();
         authnEpLink.setName(AUTHENTICATION_EP_LINK_NAME);
-        String href = OAuth2Util.buildServiceUrl(AUTHENTICATION_EP, null);
+        String href = OAuth2Util.buildServiceUrl(AUTHENTICATION_EP, null, null);
         authnEpLink.setHref(href);
         authnEpLink.setMethod(HTTP_POST);
         links.add(authnEpLink);

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
@@ -122,21 +122,37 @@ public class OAuthServerConfiguration {
     private static final Log log = LogFactory.getLog(OAuthServerConfiguration.class);
     private static OAuthServerConfiguration instance;
     private static String oauth1RequestTokenUrl = null;
+    private static String oauth1RequestTokenUrlV2 = null;
     private static String oauth1AuthorizeUrl = null;
+    private static String oauth1AuthorizeUrlV2 = null;
     private static String oauth1AccessTokenUrl = null;
+    private static String oauth1AccessTokenUrlV2 = null;
     private static String oauth2AuthzEPUrl = null;
+    private static String oauth2AuthzEPUrlV2 = null;
     private static String oauth2ParEPUrl = null;
+    private static String oauth2ParEPUrlV2 = null;
     private static String oauth2TokenEPUrl = null;
+    private static String oauth2TokenEPUrlV2 = null;
     private static String oauth2UserInfoEPUrl = null;
+    private static String oauth2UserInfoEPUrlV2 = null;
     private static String oauth2RevocationEPUrl = null;
+    private static String oauth2RevocationEPUrlV2 = null;
     private static String oauth2IntrospectionEPUrl = null;
+    private static String oauth2IntrospectionEPUrlV2 = null;
     private static String oidcConsentPageUrl = null;
+    private static String oidcConsentPageUrlV2 = null;
     private static String oauth2DCREPUrl = null;
+    private static String oauth2DCREPUrlV2 = null;
     private static String oauth2JWKSPageUrl = null;
+    private static String oauth2JWKSPageUrlV2 = null;
     private static String oidcWebFingerEPUrl = null;
+    private static String oidcWebFingerEPUrlV2 = null;
     private static String oidcDiscoveryUrl = null;
+    private static String oidcDiscoveryUrlV2 = null;
     private static String oauth2ConsentPageUrl = null;
+    private static String oauth2ConsentPageUrlV2 = null;
     private static String oauth2ErrorPageUrl = null;
+    private static String oauth2ErrorPageUrlV2 = null;
     private static boolean isOAuthResponseJspPageAvailable = false;
     private long authorizationCodeValidityPeriodInSeconds = 300;
     private long userAccessTokenValidityPeriodInSeconds = 3600;
@@ -321,6 +337,7 @@ public class OAuthServerConfiguration {
     private int deviceCodePollingInterval = 5000;
     private String deviceCodeKeySet = "BCDFGHJKLMNPQRSTVWXYZbcdfghjklmnpqrstvwxyz23456789";
     private String deviceAuthzEPUrl = null;
+    private String deviceAuthzEPUrlV2 = null;
     private List<String> supportedTokenEndpointSigningAlgorithms = new ArrayList<>();
     private Boolean roleBasedScopeIssuerEnabledConfig = false;
     private String scopeMetadataExtensionImpl = null;
@@ -406,6 +423,9 @@ public class OAuthServerConfiguration {
 
         // read OAuth URLs
         parseOAuthURLs(oauthElem);
+
+        // Read v2 OAuth URLS
+        parseV2OAuthURLs(oauthElem);
 
         // read token renewal per request config.
         // if enabled access token and refresh token will be renewed for each token endpoint call.
@@ -754,6 +774,76 @@ public class OAuthServerConfiguration {
         return deviceAuthzEPUrl;
     }
 
+    public String getOAuth1RequestTokenUrlV2() {
+
+        return oauth1RequestTokenUrlV2;
+    }
+
+    public String getOauth1AuthorizeUrlV2() {
+
+        return oauth1AuthorizeUrlV2;
+    }
+
+    public String getOauth1AccessTokenUrlV2() {
+
+        return oauth1AccessTokenUrlV2;
+    }
+
+    public String getOauth2AuthzEPUrlV2() {
+
+        return oauth2AuthzEPUrlV2;
+    }
+
+    public String getOauth2ParEPUrlV2() {
+
+        return oauth2ParEPUrlV2;
+    }
+
+    public String getOauth2TokenEPUrlV2() {
+
+        return oauth2TokenEPUrlV2;
+    }
+
+    public String getOauth2DCREPUrlV2() {
+
+        return oauth2DCREPUrlV2;
+    }
+
+    public String getOauth2JWKSPageUrlV2() {
+
+        return oauth2JWKSPageUrlV2;
+    }
+
+    public String getOidcDiscoveryUrlV2() {
+
+        return oidcDiscoveryUrlV2;
+    }
+
+    public String getOidcWebFingerEPUrlV2() {
+
+        return oidcWebFingerEPUrlV2;
+    }
+
+    public String getOauth2UserInfoEPUrlV2() {
+
+        return oauth2UserInfoEPUrlV2;
+    }
+
+    public String getOauth2RevocationEPUrlV2() {
+
+        return oauth2RevocationEPUrlV2;
+    }
+
+    public String getOauth2IntrospectionEPUrlV2() {
+
+        return oauth2IntrospectionEPUrlV2;
+    }
+
+    public String getDeviceAuthzEPUrlV2() {
+
+        return deviceAuthzEPUrlV2;
+    }
+
     public boolean isRoleBasedScopeIssuerEnabled() {
 
         return roleBasedScopeIssuerEnabledConfig;
@@ -887,12 +977,27 @@ public class OAuthServerConfiguration {
         return oidcConsentPageUrl;
     }
 
+    public String getOIDCConsentPageUrlV2() {
+
+        return oidcConsentPageUrlV2;
+    }
+
     public String getOauth2ConsentPageUrl() {
         return oauth2ConsentPageUrl;
     }
 
+    public String getOauth2ConsentPageUrlV2() {
+
+        return oauth2ConsentPageUrlV2;
+    }
+
     public String getOauth2ErrorPageUrl() {
         return oauth2ErrorPageUrl;
+    }
+
+    public String getOauth2ErrorPageUrlV2() {
+
+        return oauth2ErrorPageUrlV2;
     }
 
     public boolean isPasswordFlowEnhancementsEnabled() {
@@ -2206,6 +2311,121 @@ public class OAuthServerConfiguration {
         if (elem != null) {
             if (StringUtils.isNotBlank(elem.getText())) {
                 deviceAuthzEPUrl = IdentityUtil.fillURLPlaceholders(elem.getText());
+            }
+        }
+    }
+
+    private void parseV2OAuthURLs(OMElement oauthConfigElem) {
+
+        OMElement oauthConfigElemV2 = oauthConfigElem.getFirstChildWithName(getQNameWithIdentityNS(ConfigElements.V2));
+
+        if (oauthConfigElemV2 == null) {
+            return;
+        }
+
+        OMElement elem = oauthConfigElemV2.getFirstChildWithName(
+                getQNameWithIdentityNS(ConfigElements.OAUTH1_REQUEST_TOKEN_URL));
+        if (elem != null) {
+            if (StringUtils.isNotBlank(elem.getText())) {
+                oauth1RequestTokenUrlV2 = IdentityUtil.fillURLPlaceholders(elem.getText());
+            }
+        }
+        elem = oauthConfigElemV2.getFirstChildWithName(getQNameWithIdentityNS(ConfigElements.OAUTH1_AUTHORIZE_URL));
+        if (elem != null) {
+            if (StringUtils.isNotBlank(elem.getText())) {
+                oauth1AuthorizeUrlV2 = IdentityUtil.fillURLPlaceholders(elem.getText());
+            }
+        }
+        elem = oauthConfigElemV2.getFirstChildWithName(getQNameWithIdentityNS(ConfigElements.OAUTH1_ACCESS_TOKEN_URL));
+        if (elem != null) {
+            if (StringUtils.isNotBlank(elem.getText())) {
+                oauth1AccessTokenUrlV2 = IdentityUtil.fillURLPlaceholders(elem.getText());
+            }
+        }
+        elem = oauthConfigElemV2.getFirstChildWithName(getQNameWithIdentityNS(ConfigElements.OAUTH2_AUTHZ_EP_URL));
+        if (elem != null) {
+            if (StringUtils.isNotBlank(elem.getText())) {
+                oauth2AuthzEPUrlV2 = IdentityUtil.fillURLPlaceholders(elem.getText());
+            }
+        }
+        elem = oauthConfigElemV2.getFirstChildWithName(getQNameWithIdentityNS(ConfigElements.OAUTH2_PAR_EP_URL));
+        if (elem != null) {
+            if (StringUtils.isNotBlank(elem.getText())) {
+                oauth2ParEPUrlV2 = IdentityUtil.fillURLPlaceholders(elem.getText());
+            }
+        }
+        elem = oauthConfigElemV2.getFirstChildWithName(getQNameWithIdentityNS(ConfigElements.OAUTH2_TOKEN_EP_URL));
+        if (elem != null) {
+            if (StringUtils.isNotBlank(elem.getText())) {
+                oauth2TokenEPUrlV2 = IdentityUtil.fillURLPlaceholders(elem.getText());
+            }
+        }
+        elem = oauthConfigElemV2.getFirstChildWithName(getQNameWithIdentityNS(ConfigElements.OAUTH2_USERINFO_EP_URL));
+        if (elem != null) {
+            if (StringUtils.isNotBlank(elem.getText())) {
+                oauth2UserInfoEPUrlV2 = IdentityUtil.fillURLPlaceholders(elem.getText());
+            }
+        }
+        elem = oauthConfigElemV2.getFirstChildWithName(
+                getQNameWithIdentityNS(ConfigElements.OAUTH2_REVOCATION_EP_URL));
+        if (elem != null) {
+            if (StringUtils.isNotBlank(elem.getText())) {
+                oauth2RevocationEPUrlV2 = IdentityUtil.fillURLPlaceholders(elem.getText());
+            }
+        }
+        elem = oauthConfigElemV2.getFirstChildWithName(
+                getQNameWithIdentityNS(ConfigElements.OAUTH2_INTROSPECTION_EP_URL));
+        if (elem != null) {
+            if (StringUtils.isNotBlank(elem.getText())) {
+                oauth2IntrospectionEPUrlV2 = IdentityUtil.fillURLPlaceholders(elem.getText());
+            }
+        }
+        elem = oauthConfigElemV2.getFirstChildWithName(getQNameWithIdentityNS(ConfigElements.OAUTH2_CONSENT_PAGE_URL));
+        if (elem != null) {
+            if (StringUtils.isNotBlank(elem.getText())) {
+                oauth2ConsentPageUrlV2 = IdentityUtil.fillURLPlaceholders(elem.getText());
+            }
+        }
+        elem = oauthConfigElemV2.getFirstChildWithName(getQNameWithIdentityNS(ConfigElements.OAUTH2_DCR_EP_URL));
+        if (elem != null) {
+            if (StringUtils.isNotBlank(elem.getText())) {
+                oauth2DCREPUrlV2 = IdentityUtil.fillURLPlaceholders(elem.getText());
+            }
+        }
+        elem = oauthConfigElemV2.getFirstChildWithName(getQNameWithIdentityNS(ConfigElements.OAUTH2_JWKS_PAGE_URL));
+        if (elem != null) {
+            if (StringUtils.isNotBlank(elem.getText())) {
+                oauth2JWKSPageUrlV2 = IdentityUtil.fillURLPlaceholders(elem.getText());
+            }
+        }
+        elem = oauthConfigElemV2.getFirstChildWithName(getQNameWithIdentityNS(ConfigElements.OIDC_DISCOVERY_EP_URL));
+        if (elem != null) {
+            if (StringUtils.isNotBlank(elem.getText())) {
+                oidcDiscoveryUrlV2 = IdentityUtil.fillURLPlaceholders(elem.getText());
+            }
+        }
+        elem = oauthConfigElemV2.getFirstChildWithName(getQNameWithIdentityNS(ConfigElements.OIDC_WEB_FINGER_EP_URL));
+        if (elem != null) {
+            if (StringUtils.isNotBlank(elem.getText())) {
+                oidcWebFingerEPUrlV2 = IdentityUtil.fillURLPlaceholders(elem.getText());
+            }
+        }
+        elem = oauthConfigElemV2.getFirstChildWithName(getQNameWithIdentityNS(ConfigElements.OIDC_CONSENT_PAGE_URL));
+        if (elem != null) {
+            if (StringUtils.isNotBlank(elem.getText())) {
+                oidcConsentPageUrlV2 = IdentityUtil.fillURLPlaceholders(elem.getText());
+            }
+        }
+        elem = oauthConfigElemV2.getFirstChildWithName(getQNameWithIdentityNS(ConfigElements.OAUTH2_ERROR_PAGE_URL));
+        if (elem != null) {
+            if (StringUtils.isNotBlank(elem.getText())) {
+                oauth2ErrorPageUrlV2 = IdentityUtil.fillURLPlaceholders(elem.getText());
+            }
+        }
+        elem = oauthConfigElemV2.getFirstChildWithName(getQNameWithIdentityNS(ConfigElements.DEVICE_AUTHZ_EP_URL));
+        if (elem != null) {
+            if (StringUtils.isNotBlank(elem.getText())) {
+                deviceAuthzEPUrlV2 = IdentityUtil.fillURLPlaceholders(elem.getText());
             }
         }
     }
@@ -3824,6 +4044,7 @@ public class OAuthServerConfiguration {
         public static final String OAUTH2_ERROR_PAGE_URL = "OAuth2ErrorPage";
         public static final String OIDC_CONSENT_PAGE_URL = "OIDCConsentPage";
         public static final String DEVICE_AUTHZ_EP_URL = "OAuth2DeviceAuthzEPUrl";
+        public static final String V2 = "V2";
 
         // JWT Generator
         public static final String AUTHORIZATION_CONTEXT_TOKEN_GENERATION = "AuthorizationContextTokenGeneration";

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -1484,29 +1484,35 @@ public class OAuth2Util {
 
         public static String getOAuth2AuthzEPUrl() {
 
-            return buildUrl(OAUTH2_AUTHZ_EP_URL, OAuthServerConfiguration.getInstance()::getOAuth2AuthzEPUrl);
+            return buildUrl(OAUTH2_AUTHZ_EP_URL, OAuthServerConfiguration.getInstance()::getOAuth2AuthzEPUrl,
+                    OAuthServerConfiguration.getInstance()::getOauth2AuthzEPUrlV2);
         }
 
         public static String getOAuth2ParEPUrl() {
 
-            return buildUrl(OAUTH2_PAR_EP_URL, OAuthServerConfiguration.getInstance()::getOAuth2ParEPUrl);
+            return buildUrl(OAUTH2_PAR_EP_URL, OAuthServerConfiguration.getInstance()::getOAuth2ParEPUrl,
+                    OAuthServerConfiguration.getInstance()::getOauth2ParEPUrlV2);
         }
 
         public static String getOAuth2TokenEPUrl() {
 
-            return buildUrl(OAUTH2_TOKEN_EP_URL, OAuthServerConfiguration.getInstance()::getOAuth2TokenEPUrl);
+            return buildUrl(OAUTH2_TOKEN_EP_URL, OAuthServerConfiguration.getInstance()::getOAuth2TokenEPUrl,
+                    OAuthServerConfiguration.getInstance()::getOauth2TokenEPUrlV2);
         }
 
         public static String getOAuth2MTLSParEPUrl() {
 
             return buildUrlWithHostname(OAUTH2_PAR_EP_URL, OAuthServerConfiguration.getInstance()::getOAuth2ParEPUrl,
+                    OAuthServerConfiguration.getInstance()::getOauth2ParEPUrlV2,
                     IdentityUtil.getProperty(OAuthConstants.MTLS_HOSTNAME));
         }
 
         public static String getOAuth2MTLSTokenEPUrl() {
 
-            return buildUrlWithHostname(OAUTH2_TOKEN_EP_URL, OAuthServerConfiguration.getInstance()::
-                    getOAuth2TokenEPUrl, IdentityUtil.getProperty(OAuthConstants.MTLS_HOSTNAME));
+            return buildUrlWithHostname(OAUTH2_TOKEN_EP_URL,
+                    OAuthServerConfiguration.getInstance()::getOAuth2TokenEPUrl,
+                    OAuthServerConfiguration.getInstance()::getOauth2TokenEPUrlV2,
+                    IdentityUtil.getProperty(OAuthConstants.MTLS_HOSTNAME));
         }
 
         /**
@@ -1519,7 +1525,8 @@ public class OAuth2Util {
         public static String getOAuth2DCREPUrl(String tenantDomain) throws URISyntaxException {
 
             String oauth2TokenEPUrl =
-                    buildUrl(OAUTH2_DCR_EP_URL, OAuthServerConfiguration.getInstance()::getOAuth2DCREPUrl);
+                    buildUrl(OAUTH2_DCR_EP_URL, OAuthServerConfiguration.getInstance()::getOAuth2DCREPUrl,
+                            OAuthServerConfiguration.getInstance()::getOauth2DCREPUrlV2);
 
             if (!IdentityTenantUtil.isTenantQualifiedUrlsEnabled() && isNotSuperTenant(tenantDomain)) {
                 //Append tenant domain to path when the tenant-qualified url mode is disabled.
@@ -1538,7 +1545,8 @@ public class OAuth2Util {
         public static String getOAuth2JWKSPageUrl(String tenantDomain) throws URISyntaxException {
 
             String auth2JWKSPageUrl = buildUrl(OAUTH2_JWKS_EP_URL,
-                    OAuthServerConfiguration.getInstance()::getOAuth2JWKSPageUrl);
+                    OAuthServerConfiguration.getInstance()::getOAuth2JWKSPageUrl,
+                    OAuthServerConfiguration.getInstance()::getOauth2JWKSPageUrlV2);
 
             if (!IdentityTenantUtil.isTenantQualifiedUrlsEnabled() && isNotSuperTenant(tenantDomain)) {
                 //Append tenant domain to path when the tenant-qualified url mode is disabled.
@@ -1549,13 +1557,15 @@ public class OAuth2Util {
 
         public static String getOidcWebFingerEPUrl() {
 
-            return buildUrl(OIDC_WEB_FINGER_EP_URL, OAuthServerConfiguration.getInstance()::getOidcWebFingerEPUrl);
+            return buildUrl(OIDC_WEB_FINGER_EP_URL, OAuthServerConfiguration.getInstance()::getOidcWebFingerEPUrl,
+                    OAuthServerConfiguration.getInstance()::getOidcWebFingerEPUrlV2);
         }
 
         public static String getOidcDiscoveryEPUrl(String tenantDomain) throws URISyntaxException {
 
             String oidcDiscoveryEPUrl = buildUrl(OAUTH2_DISCOVERY_EP_URL,
-                    OAuthServerConfiguration.getInstance()::getOidcDiscoveryUrl);
+                    OAuthServerConfiguration.getInstance()::getOidcDiscoveryUrl,
+                    OAuthServerConfiguration.getInstance()::getOidcDiscoveryUrlV2);
 
             if (!IdentityTenantUtil.isTenantQualifiedUrlsEnabled() && isNotSuperTenant(tenantDomain)) {
                 //Append tenant domain to path when the tenant-qualified url mode is disabled.
@@ -1566,7 +1576,8 @@ public class OAuth2Util {
 
         public static String getOAuth2UserInfoEPUrl() {
 
-            return buildUrl(OAUTH2_USER_INFO_EP_URL, OAuthServerConfiguration.getInstance()::getOauth2UserInfoEPUrl);
+            return buildUrl(OAUTH2_USER_INFO_EP_URL, OAuthServerConfiguration.getInstance()::getOauth2UserInfoEPUrl,
+                    OAuthServerConfiguration.getInstance()::getOauth2UserInfoEPUrlV2);
         }
 
         /**
@@ -1576,7 +1587,8 @@ public class OAuth2Util {
          */
         public static String getOAuth2RevocationEPUrl() {
 
-            return buildUrl(OAUTH2_REVOKE_EP_URL, OAuthServerConfiguration.getInstance()::getOauth2RevocationEPUrl);
+            return buildUrl(OAUTH2_REVOKE_EP_URL, OAuthServerConfiguration.getInstance()::getOauth2RevocationEPUrl,
+                    OAuthServerConfiguration.getInstance()::getOauth2RevocationEPUrlV2);
         }
 
         /**
@@ -1587,7 +1599,8 @@ public class OAuth2Util {
         public static String getOAuth2IntrospectionEPUrl() {
 
             return buildUrl(OAUTH2_INTROSPECT_EP_URL,
-                    OAuthServerConfiguration.getInstance()::getOauth2IntrospectionEPUrl);
+                    OAuthServerConfiguration.getInstance()::getOauth2IntrospectionEPUrl,
+                    OAuthServerConfiguration.getInstance()::getOauth2IntrospectionEPUrlV2);
         }
 
         /**
@@ -1600,7 +1613,8 @@ public class OAuth2Util {
         public static String getOAuth2IntrospectionEPUrl(String tenantDomain) throws URISyntaxException {
 
             String getOAuth2IntrospectionEPUrl = buildUrl(OAUTH2_INTROSPECT_EP_URL,
-                    OAuthServerConfiguration.getInstance()::getOauth2IntrospectionEPUrl);
+                    OAuthServerConfiguration.getInstance()::getOauth2IntrospectionEPUrl,
+                    OAuthServerConfiguration.getInstance()::getOauth2IntrospectionEPUrlV2);
 
             if (!IdentityTenantUtil.isTenantQualifiedUrlsEnabled() && isNotSuperTenant(tenantDomain)) {
                 // Append tenant domain to path when the tenant-qualified url mode is disabled.
@@ -1612,17 +1626,20 @@ public class OAuth2Util {
 
         public static String getOIDCConsentPageUrl() {
 
-            return buildUrl(OIDC_CONSENT_EP_URL, OAuthServerConfiguration.getInstance()::getOIDCConsentPageUrl);
+            return buildUrl(OIDC_CONSENT_EP_URL, OAuthServerConfiguration.getInstance()::getOIDCConsentPageUrl,
+                    OAuthServerConfiguration.getInstance()::getOIDCConsentPageUrlV2);
         }
 
         public static String getOAuth2ConsentPageUrl() {
 
-            return buildUrl(OAUTH2_CONSENT_EP_URL, OAuthServerConfiguration.getInstance()::getOauth2ConsentPageUrl);
+            return buildUrl(OAUTH2_CONSENT_EP_URL, OAuthServerConfiguration.getInstance()::getOauth2ConsentPageUrl,
+                    OAuthServerConfiguration.getInstance()::getOauth2ConsentPageUrlV2);
         }
 
         public static String getOAuth2ErrorPageUrl() {
 
-            return buildUrl(OAUTH2_ERROR_EP_URL, OAuthServerConfiguration.getInstance()::getOauth2ErrorPageUrl);
+            return buildUrl(OAUTH2_ERROR_EP_URL, OAuthServerConfiguration.getInstance()::getOauth2ErrorPageUrl,
+                    OAuthServerConfiguration.getInstance()::getOauth2ErrorPageUrlV2);
         }
 
         private static String appendTenantDomainAsPathParamInLegacyMode(String url, String tenantDomain)
@@ -1636,7 +1653,8 @@ public class OAuth2Util {
 
         public static String getDeviceAuthzEPUrl() {
 
-            return buildUrl(DEVICE_AUTHZ_EP_URL, OAuthServerConfiguration.getInstance()::getDeviceAuthzEPUrl);
+            return buildUrl(DEVICE_AUTHZ_EP_URL, OAuthServerConfiguration.getInstance()::getDeviceAuthzEPUrl,
+                    OAuthServerConfiguration.getInstance()::getDeviceAuthzEPUrlV2);
         }
     }
 
@@ -1674,15 +1692,40 @@ public class OAuth2Util {
      *
      * @param defaultContext              Default URL context.
      * @param getValueFromFileBasedConfig File-based Configuration.
+     * @param getValueFromFileBasedConfigV2 File-based Configuration V2.
      * @return Absolute URL.
      */
-    private static String buildUrl(String defaultContext, Supplier<String> getValueFromFileBasedConfig) {
+    private static String buildUrl(String defaultContext, Supplier<String> getValueFromFileBasedConfig,
+                                   Supplier<String> getValueFromFileBasedConfigV2) {
 
         String oauth2EndpointURLInFile = null;
+        String oauth2EndpointURLV2InFile = null;
         if (getValueFromFileBasedConfig != null) {
             oauth2EndpointURLInFile = getValueFromFileBasedConfig.get();
         }
-        return buildServiceUrl(defaultContext, oauth2EndpointURLInFile);
+        if (getValueFromFileBasedConfigV2 != null) {
+            oauth2EndpointURLV2InFile = getValueFromFileBasedConfigV2.get();
+        }
+        return buildServiceUrl(defaultContext, oauth2EndpointURLInFile, oauth2EndpointURLV2InFile);
+    }
+
+    /**
+     * Builds a URL with a given context in both the tenant-qualified url supported mode and the legacy mode.
+     * Returns the absolute URL build from the default context in the tenant-qualified url supported mode. Gives
+     * precedence to the file configurations in the legacy mode and returns the absolute url build from file
+     * configuration context.
+     *
+     * @Deprecated use @link #buildUrlWithHostname(String, Supplier, Supplier, String) instead.
+     * @param defaultContext              Default URL context.
+     * @param getValueFromFileBasedConfig File-based Configuration.
+     * @param hostname                    hostname of the service
+     * @return Absolute URL.
+     */
+    @Deprecated
+    private static String buildUrlWithHostname(String defaultContext, Supplier<String> getValueFromFileBasedConfig,
+                                               String hostname) {
+
+        return buildUrlWithHostname(defaultContext, getValueFromFileBasedConfig, null, hostname);
     }
 
     /**
@@ -1697,28 +1740,54 @@ public class OAuth2Util {
      * @return Absolute URL.
      */
     private static String buildUrlWithHostname(String defaultContext, Supplier<String> getValueFromFileBasedConfig,
-                                               String hostname) {
+                                               Supplier<String> getValueFromFileBasedConfigV2, String hostname) {
 
         String oauth2EndpointURLInFile = null;
+        String oauth2EndpointURLV2InFile = null;
         if (getValueFromFileBasedConfig != null) {
             oauth2EndpointURLInFile = getValueFromFileBasedConfig.get();
         }
-        return hostname != null ? buildServiceUrlWithHostname(defaultContext, oauth2EndpointURLInFile, hostname) :
-                buildServiceUrl(defaultContext, oauth2EndpointURLInFile);
+        if (getValueFromFileBasedConfigV2 != null) {
+            oauth2EndpointURLV2InFile = getValueFromFileBasedConfigV2.get();
+        }
+        return hostname != null ?
+                buildServiceUrlWithHostname(defaultContext, oauth2EndpointURLInFile, oauth2EndpointURLV2InFile,
+                        hostname) : buildServiceUrl(defaultContext, oauth2EndpointURLInFile, oauth2EndpointURLV2InFile);
     }
 
     /**
      * Returns the public service url given the default context and the url picked from the configuration based on
      * the 'tenant_context.enable_tenant_qualified_urls' mode set in deployment.toml.
      *
+     * @Deprecated use @link #buildServiceUrl(String, String, String) instead.
      * @param defaultContext default url context path
      * @param oauth2EndpointURLInFile  url picked from the file configuration
      * @return absolute public url of the service if 'enable_tenant_qualified_urls' is 'true', else returns the url
      * from the file config
      */
+    @Deprecated
     public static String buildServiceUrl(String defaultContext, String oauth2EndpointURLInFile) {
 
+        return buildServiceUrl(defaultContext, oauth2EndpointURLInFile, null);
+    }
+
+    /**
+     * Returns the public service url given the default context and the url picked from the configuration based on
+     * the 'tenant_context.enable_tenant_qualified_urls' mode set in deployment.toml.
+     *
+     * @param defaultContext            default url context path
+     * @param oauth2EndpointURLInFile   url picked from the file configuration
+     * @param oauth2EndpointURLV2InFile url picked from the file configuration for V2
+     * @return absolute public url of the service if 'enable_tenant_qualified_urls' is 'true', else returns the url
+     * from the file config
+     */
+    public static String buildServiceUrl(String defaultContext, String oauth2EndpointURLInFile,
+                                         String oauth2EndpointURLV2InFile) {
+
         if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled()) {
+            if (StringUtils.isNotBlank(oauth2EndpointURLV2InFile)) {
+                return oauth2EndpointURLV2InFile;
+            }
             try {
                 String organizationId = PrivilegedCarbonContext.getThreadLocalCarbonContext().getOrganizationId();
                 return ServiceURLBuilder.create().addPath(defaultContext).setOrganization(organizationId).build()
@@ -1742,6 +1811,24 @@ public class OAuth2Util {
      * Returns the public service url given the default context and the url picked from the configuration based on
      * the 'tenant_context.enable_tenant_qualified_urls' mode set in deployment.toml.
      *
+     * @Deprecated use @link #buildServiceUrlWithHostname(String, String, String, String) instead.
+     * @param defaultContext          default url context path
+     * @param oauth2EndpointURLInFile url picked from the file configuration
+     * @param hostname                hostname of the service
+     * @return absolute public url of the service if 'enable_tenant_qualified_urls' is 'true', else returns the url
+     * from the file config
+     */
+    @Deprecated
+    public static String buildServiceUrlWithHostname(String defaultContext, String oauth2EndpointURLInFile,
+                                                     String hostname) {
+
+        return buildServiceUrlWithHostname(defaultContext, oauth2EndpointURLInFile, null, hostname);
+    }
+
+    /**
+     * Returns the public service url given the default context and the url picked from the configuration based on
+     * the 'tenant_context.enable_tenant_qualified_urls' mode set in deployment.toml.
+     *
      * @param defaultContext          default url context path
      * @param oauth2EndpointURLInFile url picked from the file configuration
      * @param hostname                hostname of the service
@@ -1749,9 +1836,12 @@ public class OAuth2Util {
      * from the file config
      */
     public static String buildServiceUrlWithHostname(String defaultContext, String oauth2EndpointURLInFile,
-                                                     String hostname) {
+                                                     String oauth2EndpointURLInFileV2, String hostname) {
 
         if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled()) {
+            if (StringUtils.isNotBlank(oauth2EndpointURLInFileV2)) {
+                return oauth2EndpointURLInFileV2;
+            }
             try {
                 String organizationId = PrivilegedCarbonContext.getThreadLocalCarbonContext().getOrganizationId();
                 return ServiceURLBuilder.create().addPath(defaultContext).setOrganization(organizationId)

--- a/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/OIDCSessionConstants.java
+++ b/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/OIDCSessionConstants.java
@@ -51,6 +51,7 @@ public class OIDCSessionConstants {
 
         public static final String OIDC_LOGOUT_CONSENT_PAGE_URL = "OIDCLogoutConsentPage";
         public static final String OIDC_LOGOUT_PAGE_URL = "OIDCLogoutPage";
+        public static final String V2 = "V2";
         public static final String HANDLE_ALREADY_LOGGED_OUT_SESSIONS_GRACEFULLY =
                 "HandleAlreadyLoggedOutSessionsGracefully";
     }

--- a/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/config/OIDCSessionManagementConfiguration.java
+++ b/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/config/OIDCSessionManagementConfiguration.java
@@ -41,6 +41,8 @@ public class OIDCSessionManagementConfiguration {
 
     private String oidcLogoutConsentPageUrl = null;
     private String oidcLogoutPageUrl = null;
+    private String oidcLogoutConsentPageUrlV2 = null;
+    private String oidcLogoutPageUrlV2 = null;
     private boolean handleAlreadyLoggedOutSessionsGracefully = false;
 
     private static final String CONFIG_ELEM_OAUTH = "OAuth";
@@ -79,6 +81,16 @@ public class OIDCSessionManagementConfiguration {
     }
 
     /**
+     * Returns configured OIDC Logout Consent page V2 URL.
+     *
+     * @return OIDC Logout Consent page URL
+     */
+    public String getOIDCLogoutConsentPageUrlV2() {
+
+        return oidcLogoutConsentPageUrlV2;
+    }
+
+    /**
      * Returns configured OIDC Logout page URL.
      *
      * @return OIDC Logout page URL
@@ -86,6 +98,16 @@ public class OIDCSessionManagementConfiguration {
     public String getOIDCLogoutPageUrl() {
 
         return oidcLogoutPageUrl;
+    }
+
+    /**
+     * Returns configured OIDC Logout page V2 URL.
+     *
+     * @return OIDC Logout page URL
+     */
+    public String getOIDCLogoutPageUrlV2() {
+
+        return oidcLogoutPageUrlV2;
     }
 
     private void buildConfiguration() {
@@ -119,11 +141,39 @@ public class OIDCSessionManagementConfiguration {
         if (element != null) {
             handleAlreadyLoggedOutSessionsGracefully = Boolean.parseBoolean(element.getText());
         }
+
+        buildConfigurationsV2(oauthConfigElement);
     }
 
     private QName getQNameWithIdentityNS(String localPart) {
 
         return new QName(IdentityCoreConstants.IDENTITY_DEFAULT_NAMESPACE, localPart);
+    }
+
+    private void buildConfigurationsV2(OMElement oauthConfigElement) {
+
+        OMElement oauthConfigElementV2 = oauthConfigElement.getFirstChildWithName(getQNameWithIdentityNS(
+                OIDCSessionConstants.OIDCConfigElements.V2));
+
+        if (oauthConfigElementV2 == null) {
+            return;
+        }
+
+        OMElement element = oauthConfigElementV2.getFirstChildWithName(
+                getQNameWithIdentityNS(OIDCSessionConstants.OIDCConfigElements.OIDC_LOGOUT_CONSENT_PAGE_URL));
+        if (element != null) {
+            if (StringUtils.isNotBlank(element.getText())) {
+                oidcLogoutConsentPageUrlV2 = IdentityUtil.fillURLPlaceholders(element.getText());
+            }
+        }
+
+        element = oauthConfigElementV2.getFirstChildWithName(
+                getQNameWithIdentityNS(OIDCSessionConstants.OIDCConfigElements.OIDC_LOGOUT_PAGE_URL));
+        if (element != null) {
+            if (StringUtils.isNotBlank(element.getText())) {
+                oidcLogoutPageUrlV2 = IdentityUtil.fillURLPlaceholders(element.getText());
+            }
+        }
     }
 
     /**

--- a/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/util/OIDCSessionManagementUtil.java
+++ b/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/util/OIDCSessionManagementUtil.java
@@ -327,7 +327,8 @@ public class OIDCSessionManagementUtil {
     public static String getOIDCLogoutConsentURL() {
 
         return OAuth2Util.buildServiceUrl(OAuthConstants.OAuth20Endpoints.OIDC_LOGOUT_CONSENT_EP_URL,
-                OIDCSessionManagementConfiguration.getInstance().getOIDCLogoutConsentPageUrl());
+                OIDCSessionManagementConfiguration.getInstance().getOIDCLogoutConsentPageUrl(),
+                OIDCSessionManagementConfiguration.getInstance().getOIDCLogoutConsentPageUrlV2());
     }
 
     /**
@@ -338,7 +339,8 @@ public class OIDCSessionManagementUtil {
     public static String getOIDCLogoutURL() {
 
         return OAuth2Util.buildServiceUrl(OAuthConstants.OAuth20Endpoints.OIDC_DEFAULT_LOGOUT_RESPONSE_URL,
-                OIDCSessionManagementConfiguration.getInstance().getOIDCLogoutPageUrl());
+                OIDCSessionManagementConfiguration.getInstance().getOIDCLogoutPageUrl(),
+                OIDCSessionManagementConfiguration.getInstance().getOIDCLogoutPageUrlV2());
     }
 
     /**


### PR DESCRIPTION
### Proposed changes in this pull request

With IS 7.0.0 release, file based configuration honouring to oauth endpoints was removed(In default behaviour which is the tenant qualified URLs enabled). This PR will add new set of configs to support file based configurations for oauth endpoints for IS-7.0.0 when tenant qualified urls enabled.

## Related Issues
- https://github.com/wso2/product-is/issues/20709

## Related PRs
Merge this PR after merging: https://github.com/wso2/carbon-identity-framework/pull/5829