### PR TITLE
[Impersoantion] fix impersonation id_token resposne

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
+++ b/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
@@ -187,6 +187,7 @@ public final class OAuthConstants {
     public static final String CODE_IDTOKEN = "code id_token";
     public static final String CODE_IDTOKEN_TOKEN = "code id_token token";
     public static final String SUBJECT_TOKEN = "subject_token";
+    public static final String ID_TOKEN_SUBJECT_TOKEN = "id_token subject_token";
     public static final String IMPERSONATED_SUBJECT = "IMPERSONATED_SUBJECT";
     public static final String IMPERSONATING_ACTOR = "IMPERSONATING_ACTOR";
     public static final String IDTOKEN_TOKEN = "id_token token";

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/handlers/util/ResponseTypeHandlerUtil.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/handlers/util/ResponseTypeHandlerUtil.java
@@ -390,6 +390,8 @@ public class ResponseTypeHandlerUtil {
      * This access token details are not necessary for respDTO when issuing the id_token.
      * So a new OAuth2AuthorizeRespDTO object is created and set all the relevant details that are needed in
      * DefaultIDTokenBuilder class. After the id_token is issued, set the id_token value to respDTO object and return.
+     * In Impersonation flow, if the response type is `id_token subject_token`,
+     * Authorization Server (AS) should issue an ID token regardless of the presence of the openid scope.
      * @param respDTO
      * @param accessTokenDO
      * @param oauthAuthzMsgCtx
@@ -400,7 +402,8 @@ public class ResponseTypeHandlerUtil {
                                                                  AccessTokenDO accessTokenDO,
                                                                  OAuthAuthzReqMessageContext oauthAuthzMsgCtx)
             throws IdentityOAuth2Exception {
-        if (isOIDCRequest(oauthAuthzMsgCtx)) {
+        if (isOIDCRequest(oauthAuthzMsgCtx) || isImpersonationIdTokenResponseType(oauthAuthzMsgCtx
+                .getAuthorizationReqDTO().getResponseType())) {
             OAuth2AuthorizeRespDTO newRespDTO = new OAuth2AuthorizeRespDTO();
             if (accessTokenDO != null) {
                 newRespDTO.setAccessToken(accessTokenDO.getAccessToken());
@@ -411,6 +414,17 @@ public class ResponseTypeHandlerUtil {
             respDTO.setOidcSessionId(newRespDTO.getOidcSessionId());
         }
         return  respDTO;
+    }
+
+    /**
+     * Checks if the given response type is for an impersonation flow with ID token.
+     *
+     * @param responseType The response type to check.
+     * @return true if the response type matches id_token subject_token
+     */
+    private static boolean isImpersonationIdTokenResponseType(String responseType) {
+
+        return StringUtils.equals(responseType, OAuthConstants.ID_TOKEN_SUBJECT_TOKEN);
     }
 
     private static boolean isOIDCRequest (OAuthAuthzReqMessageContext msgCtx) {

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/authz/handlers/SubjectTokenResponseTypeHandlerTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/authz/handlers/SubjectTokenResponseTypeHandlerTest.java
@@ -105,13 +105,15 @@ public class SubjectTokenResponseTypeHandlerTest {
     @DataProvider(name = "IssueSubjectTokenDataProvider")
     public Object[][] issueSubjectTokenDataProvider() {
         return new Object[][]{
-                {"subject_token"},
-                {"id_token subject_token"},
+                {"subject_token" , "scope_1 openid"},
+                {"subject_token" , "scope_1"},
+                {"id_token subject_token", "scope_1 openid"},
+                {"id_token subject_token", "scope_1"}
         };
     }
 
     @Test(dataProvider = "IssueSubjectTokenDataProvider")
-    public void issueSubjectTokenTest(String responseType) throws Exception {
+    public void issueSubjectTokenTest(String responseType, String scope) throws Exception {
 
         OAuthComponentServiceHolder.getInstance().setOauth2Service(oAuth2Service);
         try (MockedStatic<ResponseTypeHandlerUtil> responseTypeHandlerUtil =
@@ -139,7 +141,7 @@ public class SubjectTokenResponseTypeHandlerTest {
             authorizationReqDTO.setResponseType(responseType);
             authorizationReqDTO.setUser(user);
             authAuthzReqMessageContext = new OAuthAuthzReqMessageContext(authorizationReqDTO);
-            authAuthzReqMessageContext.setApprovedScope(new String[]{"scope1", "scope2", OAuthConstants.Scope.OPENID});
+            authAuthzReqMessageContext.setApprovedScope(scope.split(" "));
 
             OAuthAppDO oAuthAppDO = new OAuthAppDO();
             oAuthAppDO.setGrantTypes("code");


### PR DESCRIPTION
### Proposed changes in this pull request
Issue: https://github.com/wso2/product-is/issues/20066

Currently id token is issued only if open id presented in scopes. 
But In Impersonation flow, if the response type is `id_token subject_token`,Authorization Server (AS) should issue an ID token regardless of the presence of the openid scope.