### PR TITLE
Handle all client authentication methods are allowed case

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthUtil.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthUtil.java
@@ -1248,7 +1248,8 @@ public final class OAuthUtil {
                                                               String tokenAuthMethod)
             throws IdentityOAuth2ServerException {
 
-        if (tokenEPAllowReusePvtKeyJwtValue == null && StringUtils.isNotBlank(tokenAuthMethod)
+        if ((tokenEPAllowReusePvtKeyJwtValue == null ||
+                tokenEPAllowReusePvtKeyJwtValue.equals("null")) && StringUtils.isNotBlank(tokenAuthMethod)
                 && OAuthConstants.PRIVATE_KEY_JWT.equals(tokenAuthMethod)) {
             try {
                 tokenEPAllowReusePvtKeyJwtValue = readTenantConfigurationPvtKeyJWTReuse();

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dao/OAuthAppDAO.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dao/OAuthAppDAO.java
@@ -1810,7 +1810,7 @@ public class OAuthAppDAO {
         }
         String tokenEPAllowReusePvtKeyJwt = OAuthUtil.getValueOfTokenEPAllowReusePvtKeyJwt(
                 getFirstPropertyValue(spOIDCProperties, TOKEN_EP_ALLOW_REUSE_PVT_KEY_JWT), tokenAuthMethod);
-        if (tokenEPAllowReusePvtKeyJwt != null) {
+        if (tokenEPAllowReusePvtKeyJwt != null && !tokenEPAllowReusePvtKeyJwt.equals("null")) {
             oauthApp.setTokenEndpointAllowReusePvtKeyJwt(Boolean.parseBoolean(tokenEPAllowReusePvtKeyJwt));
         }
         String tokenSignatureAlgorithm = getFirstPropertyValue(spOIDCProperties, TOKEN_AUTH_SIGNATURE_ALGORITHM);


### PR DESCRIPTION
### Proposed changes in this pull request

$subject

When all authentication methods are allowed, the for newly created applications the configs will be saved as "null". When this is the case, the org level config should be set as the config value..