### PR TITLE
Engage pre-issue-access-token action based on a config enabled or disabled at server-level.

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AbstractAuthorizationGrantHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AbstractAuthorizationGrantHandler.java
@@ -496,11 +496,14 @@ public abstract class AbstractAuthorizationGrantHandler implements Authorization
         OAuthAppDO oAuthAppBean = getoAuthApp(tokenReqMessageContext.getOauth2AccessTokenReqDTO().getClientId());
         String grantType = tokenReqMessageContext.getOauth2AccessTokenReqDTO().getGrantType();
 
-        // Allow for following grant types and for JWT access tokens only.
-        return (OAuthConstants.GrantTypes.AUTHORIZATION_CODE.equals(grantType) ||
-                OAuthConstants.GrantTypes.CLIENT_CREDENTIALS.equals(grantType) ||
-                OAuthConstants.GrantTypes.PASSWORD.equals(grantType) ||
-                OAuthConstants.GrantTypes.REFRESH_TOKEN.equals(grantType)) &&
+        // Allow for following grant types and for JWT access tokens if,
+        // pre issue access token action invocation is enabled at server level.
+        return OAuthComponentServiceHolder.getInstance().getActionExecutorService()
+                .isExecutionEnabled(ActionType.PRE_ISSUE_ACCESS_TOKEN) &&
+                (OAuthConstants.GrantTypes.AUTHORIZATION_CODE.equals(grantType) ||
+                        OAuthConstants.GrantTypes.CLIENT_CREDENTIALS.equals(grantType) ||
+                        OAuthConstants.GrantTypes.PASSWORD.equals(grantType) ||
+                        OAuthConstants.GrantTypes.REFRESH_TOKEN.equals(grantType)) &&
                 JWT_TOKEN_TYPE.equals(oAuthAppBean.getTokenType());
     }
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/RefreshGrantHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/RefreshGrantHandler.java
@@ -718,9 +718,11 @@ public class RefreshGrantHandler extends AbstractAuthorizationGrantHandler {
         String grantType = refreshTokenValidationDataDO.getGrantType();
 
         // Allow if refresh token is issued for token requests from following grant types and,
-        // for JWT access tokens only.
-        return (OAuthConstants.GrantTypes.AUTHORIZATION_CODE.equals(grantType) ||
-                OAuthConstants.GrantTypes.PASSWORD.equals(grantType)) &&
+        // for JWT access tokens if pre issue access token action invocation is enabled at server level.
+        return OAuthComponentServiceHolder.getInstance().getActionExecutorService()
+                .isExecutionEnabled(ActionType.PRE_ISSUE_ACCESS_TOKEN) &&
+                (OAuthConstants.GrantTypes.AUTHORIZATION_CODE.equals(grantType) ||
+                        OAuthConstants.GrantTypes.PASSWORD.equals(grantType)) &&
                 JWT_TOKEN_TYPE.equals(oAuthAppBean.getTokenType());
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -909,7 +909,7 @@
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!-- Carbon Identity Framework version -->
-        <carbon.identity.framework.version>7.3.61</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.3.62</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.25.234, 8.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 

--- a/pom.xml
+++ b/pom.xml
@@ -909,7 +909,7 @@
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!-- Carbon Identity Framework version -->
-        <carbon.identity.framework.version>7.3.50</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.3.61</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.25.234, 8.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 


### PR DESCRIPTION
### Proposed changes in this pull request

Add support to enable/disable pre issue token action execution based on a server level config.
Related to https://github.com/wso2/product-is/issues/20739

Related PRs:
https://github.com/wso2/carbon-identity-framework/pull/5836
https://github.com/wso2/carbon-identity-framework/pull/5837

### When should this PR be merged
soon.
