### PR TITLE
Add ext_allowed_audience param to DCR

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.dcr/src/gen/java/org/wso2/carbon/identity/oauth2/dcr/endpoint/dto/ApplicationDTO.java
+++ b/components/org.wso2.carbon.identity.api.server.dcr/src/gen/java/org/wso2/carbon/identity/oauth2/dcr/endpoint/dto/ApplicationDTO.java
@@ -81,6 +81,7 @@ public class ApplicationDTO  {
     private String requestObjectEncryptionMethod = null;
     private String softwareStatement = null;
     private  Map<String, Object> additionalAttributes;
+    private String extAllowedAudience;
 
   /**
    **/
@@ -447,6 +448,15 @@ public class ApplicationDTO  {
     return additionalAttributes;
   }
 
+  @ApiModelProperty(value = "")
+  @JsonProperty("ext_allowed_audience")
+  public String getExtAllowedAudience() {
+    return extAllowedAudience;
+  }
+  public void setExtAllowedAudience(String extAllowedAudience) {
+    this.extAllowedAudience = extAllowedAudience;
+  }
+
   @Override
   public String toString()  {
     StringBuilder sb = new StringBuilder();
@@ -483,6 +493,7 @@ public class ApplicationDTO  {
     sb.append("  requestObjectEncryptionMethod: ").append(requestObjectEncryptionMethod).append("\n");
     sb.append("  softwareStatement: ").append(softwareStatement).append("\n");
     sb.append("  additionalAttributes: ").append(additionalAttributes).append("\n");
+    sb.append("  extAllowedAudience: ").append(extAllowedAudience).append("\n");
         
     sb.append("}\n");
     return sb.toString();

--- a/components/org.wso2.carbon.identity.api.server.dcr/src/gen/java/org/wso2/carbon/identity/oauth2/dcr/endpoint/dto/RegistrationRequestDTO.java
+++ b/components/org.wso2.carbon.identity.api.server.dcr/src/gen/java/org/wso2/carbon/identity/oauth2/dcr/endpoint/dto/RegistrationRequestDTO.java
@@ -64,6 +64,7 @@ public class RegistrationRequestDTO  {
   private String requestObjectEncryptionMethod = null;
   private String softwareStatement = null;
   private final Map<String, Object> additionalAttributes = new HashMap<>();
+  private String extAllowedAudience;
 
   @ApiModelProperty(required = true)
   @JsonProperty("redirect_uris")
@@ -487,6 +488,15 @@ public class RegistrationRequestDTO  {
     return additionalAttributes;
   }
 
+  @ApiModelProperty(value = "")
+  @JsonProperty("ext_allowed_audience")
+  public String getExtAllowedAudience() {
+    return extAllowedAudience;
+  }
+  public void setExtAllowedAudience(String extAllowedAudience) {
+    this.extAllowedAudience = extAllowedAudience;
+  }
+
   @Override
   public String toString()  {
     StringBuilder sb = new StringBuilder();
@@ -534,6 +544,7 @@ public class RegistrationRequestDTO  {
     sb.append(" request_object_encryption_alg: ").append(requestObjectEncryptionAlgorithm).append("\n");
     sb.append(" request_object_encryption_enc").append(requestObjectEncryptionMethod).append("\n");
     sb.append("  additionalAttributes: ").append(additionalAttributes).append("\n");
+    sb.append("  extAllowedAudience: ").append(extAllowedAudience).append("\n");
     sb.append("}\n");
     return sb.toString();
   }

--- a/components/org.wso2.carbon.identity.api.server.dcr/src/gen/java/org/wso2/carbon/identity/oauth2/dcr/endpoint/dto/UpdateRequestDTO.java
+++ b/components/org.wso2.carbon.identity.api.server.dcr/src/gen/java/org/wso2/carbon/identity/oauth2/dcr/endpoint/dto/UpdateRequestDTO.java
@@ -52,6 +52,7 @@ public class UpdateRequestDTO {
     private String requestObjectEncryptionMethod = null;
     private String softwareStatement = null;
     private final Map<String, Object> additionalAttributes = new HashMap<>();
+    private String extAllowedAudience;
 
     @ApiModelProperty(value = "")
     @JsonProperty("redirect_uris")
@@ -412,6 +413,15 @@ public class UpdateRequestDTO {
         return additionalAttributes;
     }
 
+    @ApiModelProperty(value = "")
+    @JsonProperty("ext_allowed_audience")
+    public String getExtAllowedAudience() {
+        return extAllowedAudience;
+    }
+    public void setExtAllowedAudience(String extAllowedAudience) {
+        this.extAllowedAudience = extAllowedAudience;
+    }
+
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
@@ -443,6 +453,7 @@ public class UpdateRequestDTO {
         sb.append("  request_object_signing_alg: ").append(requestObjectSigningAlg).append("\n");
         sb.append("  tls_client_auth_subject_dn: ").append(tlsClientAuthSubjectDn).append("\n");
         sb.append("  additionalAttributes: ").append(additionalAttributes).append("\n");
+        sb.append("  extAllowedAudience: ").append(extAllowedAudience).append("\n");
         sb.append("}\n");
         return sb.toString();
     }

--- a/components/org.wso2.carbon.identity.api.server.dcr/src/main/java/org/wso2/carbon/identity/oauth2/dcr/endpoint/util/DCRMUtils.java
+++ b/components/org.wso2.carbon.identity.api.server.dcr/src/main/java/org/wso2/carbon/identity/oauth2/dcr/endpoint/util/DCRMUtils.java
@@ -103,6 +103,7 @@ public class DCRMUtils {
         appRegistrationRequest.setSubjectType(registrationRequestDTO.getSubjectType());
         appRegistrationRequest.setSoftwareStatement(registrationRequestDTO.getSoftwareStatement());
         appRegistrationRequest.setAdditionalAttributes(registrationRequestDTO.getAdditionalAttributes());
+        appRegistrationRequest.setExtAllowedAudience(registrationRequestDTO.getExtAllowedAudience());
         return appRegistrationRequest;
 
     }
@@ -148,6 +149,7 @@ public class DCRMUtils {
         applicationUpdateRequest.setSubjectType(updateRequestDTO.getSubjectType());
         applicationUpdateRequest.setSoftwareStatement(updateRequestDTO.getSoftwareStatement());
         applicationUpdateRequest.setAdditionalAttributes(updateRequestDTO.getAdditionalAttributes());
+        applicationUpdateRequest.setExtAllowedAudience(updateRequestDTO.getExtAllowedAudience());
         return applicationUpdateRequest;
     }
 
@@ -255,6 +257,7 @@ public class DCRMUtils {
         applicationDTO.setTlsClientCertificateBoundAccessToken(application.isTlsClientCertificateBoundAccessTokens());
         applicationDTO.setSoftwareStatement(application.getSoftwareStatement());
         applicationDTO.setAdditionalAttributes(application.getAdditionalAttributes());
+        applicationDTO.setExtAllowedAudience(application.getExtAllowedAudience());
         return applicationDTO;
     }
 

--- a/components/org.wso2.carbon.identity.api.server.dcr/src/main/resources/api.identity.oauth.dcr.endpoint.yaml
+++ b/components/org.wso2.carbon.identity.api.server.dcr/src/main/resources/api.identity.oauth.dcr.endpoint.yaml
@@ -364,6 +364,8 @@ definitions:
         type: string
       request_object_encryption_enc:
         type: string
+      ext_allowed_audience:
+        type: string
 #-----------------------------------------------------
 # The Application Update Request Object
 #-----------------------------------------------------
@@ -443,6 +445,8 @@ definitions:
       request_object_encryption_alg:
         type: string
       request_object_encryption_enc:
+        type: string
+      ext_allowed_audience:
         type: string
 #-----------------------------------------------------
 # The OAuth2 Application Object
@@ -524,6 +528,8 @@ definitions:
       request_object_encryption_method:
         type: string
       software_statement:
+        type: string
+      ext_allowed_audience:
         type: string
 
 #-----------------------------------------------------

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/bean/Application.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/bean/Application.java
@@ -61,8 +61,8 @@ public class Application implements Serializable {
     private String idTokenEncryptionAlgorithm = null;
     private String idTokenEncryptionMethod = null;
     private String softwareStatement = null;
-
     private Map<String, Object> additionalAttributes;
+    private String extAllowedAudience;
 
     public void setAdditionalAttributes(Map<String, Object> additionalAttributes) {
 
@@ -72,6 +72,15 @@ public class Application implements Serializable {
     public Map<String, Object> getAdditionalAttributes() {
 
         return additionalAttributes;
+    }
+
+    public String getExtAllowedAudience() {
+
+        return extAllowedAudience;
+    }
+    public void setExtAllowedAudience(String extAllowedAudience) {
+
+        this.extAllowedAudience = extAllowedAudience;
     }
 
     public String getSoftwareStatement() {

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/bean/ApplicationRegistrationRequest.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/bean/ApplicationRegistrationRequest.java
@@ -67,6 +67,7 @@ public class ApplicationRegistrationRequest implements Serializable {
     private String requestObjectEncryptionAlgorithm;
     private String requestObjectEncryptionMethod;
     private Map<String, Object> additionalAttributes;
+    private String extAllowedAudience;
 
     public void setAdditionalAttributes(Map<String, Object> additionalAttributes) {
 
@@ -76,6 +77,15 @@ public class ApplicationRegistrationRequest implements Serializable {
     public Map<String, Object> getAdditionalAttributes() {
 
         return additionalAttributes;
+    }
+
+    public String getExtAllowedAudience() {
+
+        return extAllowedAudience;
+    }
+    public void setExtAllowedAudience(String extAllowedAudience) {
+
+        this.extAllowedAudience = extAllowedAudience;
     }
 
     public String getJwksURI() {

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/bean/ApplicationRegistrationRequest.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/bean/ApplicationRegistrationRequest.java
@@ -83,6 +83,7 @@ public class ApplicationRegistrationRequest implements Serializable {
 
         return extAllowedAudience;
     }
+
     public void setExtAllowedAudience(String extAllowedAudience) {
 
         this.extAllowedAudience = extAllowedAudience;

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/bean/ApplicationUpdateRequest.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/bean/ApplicationUpdateRequest.java
@@ -63,6 +63,7 @@ public class ApplicationUpdateRequest implements Serializable {
     private String requestObjectEncryptionAlgorithm;
     private String requestObjectEncryptionMethod;
     private Map<String, Object> additionalAttributes;
+    private String extAllowedAudience;
 
     public void setAdditionalAttributes(Map<String, Object> additionalAttributes) {
 
@@ -72,6 +73,15 @@ public class ApplicationUpdateRequest implements Serializable {
     public Map<String, Object> getAdditionalAttributes() {
 
         return additionalAttributes;
+    }
+
+    public String getExtAllowedAudience() {
+
+        return extAllowedAudience;
+    }
+    public void setExtAllowedAudience(String extAllowedAudience) {
+
+        this.extAllowedAudience = extAllowedAudience;
     }
 
     public List<String> getRedirectUris() {

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/bean/ApplicationUpdateRequest.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/bean/ApplicationUpdateRequest.java
@@ -79,6 +79,7 @@ public class ApplicationUpdateRequest implements Serializable {
 
         return extAllowedAudience;
     }
+
     public void setExtAllowedAudience(String extAllowedAudience) {
 
         this.extAllowedAudience = extAllowedAudience;

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/service/DCRMService.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/service/DCRMService.java
@@ -710,7 +710,6 @@ public class DCRMService {
         if (OAuth2Constants.TokenBinderType.CERTIFICATE_BASED_TOKEN_BINDER.equals(createdApp.getTokenBindingType())) {
             application.setTlsClientCertificateBoundAccessTokens(true);
         }
-//        application.setExtAllowedAudience(serviceProvider.getAssociatedRolesConfig().getAllowedAudience());
         return application;
     }
 

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/service/DCRMService.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/service/DCRMService.java
@@ -614,9 +614,9 @@ public class DCRMService {
 
         if (StringUtils.isNotEmpty(registrationRequest.getExtAllowedAudience()) &&
                 registrationRequest.getExtAllowedAudience().equalsIgnoreCase(ORG_ROLE_AUDIENCE)) {
-        AssociatedRolesConfig associatedRolesConfig = new AssociatedRolesConfig();
-        associatedRolesConfig.setAllowedAudience(registrationRequest.getExtAllowedAudience().toLowerCase());
-        serviceProvider.setAssociatedRolesConfig(associatedRolesConfig);
+            AssociatedRolesConfig associatedRolesConfig = new AssociatedRolesConfig();
+            associatedRolesConfig.setAllowedAudience(registrationRequest.getExtAllowedAudience().toLowerCase());
+            serviceProvider.setAssociatedRolesConfig(associatedRolesConfig);
         }
         OAuthConsumerAppDTO createdApp;
         try {

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/util/DCRConstants.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/util/DCRConstants.java
@@ -36,6 +36,8 @@ public final class DCRConstants {
     // Regex for validating application name.
     public static final String APP_NAME_VALIDATING_REGEX = "^[a-zA-Z0-9._-]*$";
     public static final String UNSUPPORTED_CHARACTERS_IN_REGISTRY = "[\\\\/:*?\"`,~!@#$&;%^*()+=<{}>'|]";
+    public static final String ORG_ROLE_AUDIENCE = "organization";
+    public static final String APP_ROLE_AUDIENCE = "application";
 
     /**
      * Contains the constants related to DCR operations.


### PR DESCRIPTION
Currently upon application creation through DCR, we do not provide support to set the role audience in the application.  Through this update, we are introducing a new param ext_allowed_audience to set the role audience while application creation through DCR.

