### PR TITLE
Fix userinfo retriaval with post call

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/user/OpenIDConnectUserEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/user/OpenIDConnectUserEndpoint.java
@@ -26,7 +26,6 @@ import org.apache.oltu.oauth2.common.exception.OAuthSystemException;
 import org.apache.oltu.oauth2.common.message.OAuthResponse;
 import org.wso2.carbon.identity.oauth.common.OAuth2ErrorCodes;
 import org.wso2.carbon.identity.oauth.common.OAuthConstants;
-import org.wso2.carbon.identity.oauth.endpoint.OAuthRequestWrapper;
 import org.wso2.carbon.identity.oauth.endpoint.user.impl.UserInfoEndpointConfig;
 import org.wso2.carbon.identity.oauth.endpoint.user.impl.UserInfoJWTResponse;
 import org.wso2.carbon.identity.oauth.user.UserInfoAccessTokenValidator;
@@ -35,19 +34,14 @@ import org.wso2.carbon.identity.oauth.user.UserInfoRequestValidator;
 import org.wso2.carbon.identity.oauth.user.UserInfoResponseBuilder;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2TokenValidationResponseDTO;
 
-import java.util.List;
-import java.util.Map;
-
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.ResponseBuilder;
 
@@ -68,7 +62,6 @@ public class OpenIDConnectUserEndpoint {
 
     @GET
     @Path("/")
-    @Consumes("application/x-www-form-urlencoded")
     public Response getUserClaims(@Context HttpServletRequest request) throws OAuthSystemException {
 
         String userInfoResponse;
@@ -107,12 +100,11 @@ public class OpenIDConnectUserEndpoint {
 
     @POST
     @Path("/")
-    @Consumes("application/x-www-form-urlencoded")
     @Produces("application/json")
-    public Response getUserClaimsPost(@Context HttpServletRequest request, MultivaluedMap<String, String> paramMap)
+    public Response getUserClaimsPost(@Context HttpServletRequest request)
             throws OAuthSystemException {
 
-        return getUserClaims(new OAuthRequestWrapper(request, (Map<String, List<String>>) paramMap));
+        return getUserClaims(request);
     }
 
     private ResponseBuilder getResponseBuilderWithCacheControlHeaders() {

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/user/impl/UserInforRequestDefaultValidator.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/user/impl/UserInforRequestDefaultValidator.java
@@ -19,6 +19,7 @@ package org.wso2.carbon.identity.oauth.endpoint.user.impl;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.oltu.oauth2.common.error.OAuthError;
+import org.wso2.carbon.identity.oauth.endpoint.util.EndpointUtil;
 import org.wso2.carbon.identity.oauth.user.UserInfoEndpointException;
 import org.wso2.carbon.identity.oauth.user.UserInfoRequestValidator;
 
@@ -30,6 +31,7 @@ import java.nio.charset.CharsetDecoder;
 import java.nio.charset.StandardCharsets;
 
 import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.HttpMethod;
 import javax.ws.rs.core.HttpHeaders;
 
 /**
@@ -40,27 +42,63 @@ import javax.ws.rs.core.HttpHeaders;
 public class UserInforRequestDefaultValidator implements UserInfoRequestValidator {
 
     private static final String US_ASCII = "US-ASCII";
-    private static final String ACCESS_TOKEN_PARAM = "access_token";
+    private static final String ACCESS_TOKEN_PARAM = "access_token=";
     private static final String BEARER = "Bearer";
+    private static final String CONTENT_TYPE_HEADER_VALUE = "application/x-www-form-urlencoded";
+    public static final String CHARSET = "charset=";
 
     @Override
     public String validateRequest(HttpServletRequest request) throws UserInfoEndpointException {
 
         String authzHeaders = request.getHeader(HttpHeaders.AUTHORIZATION);
-        String accessToken = request.getParameter(ACCESS_TOKEN_PARAM);
-        if (StringUtils.isBlank(authzHeaders) && StringUtils.isNotBlank(accessToken)) {
-            return accessToken;
-        }
+        if (authzHeaders == null) {
+            String contentTypeHeaders = request.getHeader(HttpHeaders.CONTENT_TYPE);
+            // To validate the Content_Type header.
+            if (StringUtils.isBlank(contentTypeHeaders)) {
+                throw new UserInfoEndpointException(OAuthError.ResourceResponse.INVALID_REQUEST,
+                        "Authorization or Content-Type header is missing");
+            }
 
-        if (StringUtils.isBlank(authzHeaders)) {
-            throw new UserInfoEndpointException(OAuthError.ResourceResponse.INVALID_REQUEST, "Bearer token missing");
-        }
+            // Restricting passing the access token via request body in GET requests.
+            if (HttpMethod.GET.equals(request.getMethod())) {
+                throw new UserInfoEndpointException(OAuthError.ResourceResponse.INVALID_REQUEST,
+                        "Authorization header is missing");
+            }
+            if (contentTypeHeaders.trim().startsWith(CONTENT_TYPE_HEADER_VALUE)) {
+                String charset = getCharsetFromContentType(contentTypeHeaders);
 
+                // Use a default charset if none is provided
+                Charset encodingCharset;
+                try {
+                    encodingCharset = charset != null ? Charset.forName(charset) : StandardCharsets.UTF_8;
+                } catch (IllegalArgumentException e) {
+                    encodingCharset = StandardCharsets.UTF_8;
+                }
+                String[] arrAccessToken = new String[2];
+                String requestBody = EndpointUtil.readRequestBody(request, encodingCharset);
+                String[] arrAccessTokenNew;
+                // To check whether the entity-body consist entirely of ASCII [USASCII] characters.
+                if (!isPureAscii(requestBody)) {
+                    throw new UserInfoEndpointException(OAuthError.ResourceResponse.INVALID_REQUEST,
+                            "Body contains non ASCII characters");
+                }
+                if (requestBody.contains(ACCESS_TOKEN_PARAM)) {
+                    arrAccessToken = requestBody.trim().split(ACCESS_TOKEN_PARAM);
+                    if (arrAccessToken[1].contains("&")) {
+                        arrAccessTokenNew = arrAccessToken[1].split("&", 2);
+                        return arrAccessTokenNew[0];
+                    }
+                }
+                return arrAccessToken[1];
+            } else {
+                throw new UserInfoEndpointException(OAuthError.ResourceResponse.INVALID_REQUEST,
+                        "Content-Type header is wrong");
+            }
+        }
         String[] authzHeaderInfo = authzHeaders.trim().split(" ");
         if (authzHeaderInfo.length < 2 || !BEARER.equals(authzHeaderInfo[0])) {
             throw new UserInfoEndpointException(OAuthError.ResourceResponse.INVALID_REQUEST, "Bearer token missing");
         }
-
         return authzHeaderInfo[1];
     }
 
@@ -75,5 +113,18 @@ public class UserInforRequestDefaultValidator implements UserInfoRequestValidato
             return false;
         }
         return true;
+    }
+
+    private String getCharsetFromContentType(String contentTypeHeader) {
+        // Split the Content-Type header value to extract charset
+        String[] parts = contentTypeHeader.split(";");
+
+        for (String part : parts) {
+            String trimmedPart = part.trim();
+            if (trimmedPart.toLowerCase().startsWith(CHARSET)) {
+                return trimmedPart.substring(CHARSET.length()).trim();
+            }
+        }
+        return null;
     }
 }

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
@@ -33,6 +33,7 @@ import org.apache.http.client.utils.URIBuilder;
 import org.apache.oltu.oauth2.as.request.OAuthAuthzRequest;
 import org.apache.oltu.oauth2.as.response.OAuthASResponse;
 import org.apache.oltu.oauth2.common.OAuth;
+import org.apache.oltu.oauth2.common.error.OAuthError;
 import org.apache.oltu.oauth2.common.exception.OAuthProblemException;
 import org.apache.oltu.oauth2.common.exception.OAuthSystemException;
 import org.owasp.encoder.Encode;
@@ -87,6 +88,7 @@ import org.wso2.carbon.identity.oauth.endpoint.exception.TokenEndpointBadRequest
 import org.wso2.carbon.identity.oauth.endpoint.message.OAuthMessage;
 import org.wso2.carbon.identity.oauth.par.core.ParAuthService;
 import org.wso2.carbon.identity.oauth.par.exceptions.ParClientException;
+import org.wso2.carbon.identity.oauth.user.UserInfoEndpointException;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2ScopeConsentException;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2ScopeException;
@@ -128,6 +130,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URISyntaxException;
 import java.net.URLEncoder;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
@@ -136,6 +139,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Scanner;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
@@ -2144,5 +2148,26 @@ public class EndpointUtil {
             log.error(message, e);
             throw new ParClientException(e.getErrorCode(), e.getMessage());
         }
+    }
+
+    /**
+     * Read request body from Servlet request.
+     *
+     * @param request Http servlet request.
+     * @return Request body.
+     * @throws UserInfoEndpointException If an error occurred while reading the request body.
+     */
+    public static String readRequestBody(HttpServletRequest request, Charset charset) throws UserInfoEndpointException {
+
+        StringBuilder stringBuilder = new StringBuilder();
+        try (Scanner scanner = new Scanner(request.getInputStream(), charset.name())) {
+            while (scanner.hasNextLine()) {
+                stringBuilder.append(scanner.nextLine());
+            }
+        } catch (IOException e) {
+            throw new UserInfoEndpointException(OAuthError.ResourceResponse.INVALID_REQUEST,
+                    "Unable to read the request body");
+        }
+        return stringBuilder.toString();
     }
 }

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/user/OpenIDConnectUserEndpointTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/user/OpenIDConnectUserEndpointTest.java
@@ -37,7 +37,6 @@ import org.wso2.carbon.identity.oauth2.dto.OAuth2TokenValidationResponseDTO;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 
 import java.lang.reflect.Method;
-import java.util.Enumeration;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -169,21 +168,7 @@ public class OpenIDConnectUserEndpointTest {
             assertEquals(metadataValue2, "[no-cache]", "Values are not equal");
             assertNotNull(response);
             assertEquals(response.getEntity().toString(), authResponse, "Response values are not same");
-
-            when(httpServletRequest.getParameterNames()).thenReturn(new Enumeration<String>() {
-                @Override
-                public boolean hasMoreElements() {
-
-                    return false;
-                }
-
-                @Override
-                public String nextElement() {
-
-                    return null;
-                }
-            });
-            openIDConnectUserEndpoint.getUserClaimsPost(httpServletRequest, paramMap);
+            openIDConnectUserEndpoint.getUserClaimsPost(httpServletRequest);
         }
     }
 


### PR DESCRIPTION
## Purpose
Currently, the userinfo endpoint fails to give response with POST calls if the contentType header is not present in the request. But in lower versions, we support this behavior. With this fix, we bring the expected behavior

### Fix explain
1. Bring back the behavior before Issue[1]/PR[1] which is to validate the content type at code level instead on using @Consumer annotation.
2. Remove the fix done in Issue[2]/PR[2] as POST body token resolving was already available in step 1 solution.
3. Prevent allowing passing token in the body of a GET request.
4. Bring removed unit tests in PR[1]. Improve the tests to work with newer versions.

We could bring the behavior before  Issue[1]/PR[1] because the said issue in the Issue[1] is resolved in `RequestCorrelationIdValve`  and the request body is passed to userinfo endpoint level.

## Related Issues
- [1] https://github.com/wso2/product-is/issues/4403
- [2]chttps://github.com/wso2/product-is/issues/10387

## Related PRs
- [1] https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/1065
- [2] https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/1535