### PR TITLE
Fix sid claim in the id tokens obtained through refresh token grant

### DIFF
--- a/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/backchannellogout/ClaimProviderImpl.java
+++ b/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/backchannellogout/ClaimProviderImpl.java
@@ -17,6 +17,7 @@
  */
 package org.wso2.carbon.identity.oidc.session.backchannellogout;
 
+import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -28,6 +29,7 @@ import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.authz.OAuthAuthzReqMessageContext;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2AccessTokenRespDTO;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2AuthorizeRespDTO;
+import org.wso2.carbon.identity.oauth2.model.HttpRequestHeader;
 import org.wso2.carbon.identity.oauth2.token.OAuthTokenReqMessageContext;
 import org.wso2.carbon.identity.oidc.session.OIDCSessionConstants;
 import org.wso2.carbon.identity.oidc.session.OIDCSessionState;
@@ -39,6 +41,7 @@ import java.util.Map;
 import java.util.UUID;
 
 import javax.servlet.http.Cookie;
+import javax.ws.rs.core.HttpHeaders;
 
 /**
  * This class is used to insert sid claim into ID token.
@@ -87,17 +90,26 @@ public class ClaimProviderImpl implements ClaimProvider {
         Map<String, Object> additionalClaims = new HashMap<>();
         String claimValue = null;
         String accessCode = oAuthTokenReqMessageContext.getOauth2AccessTokenReqDTO().getAuthorizationCode();
-        if (StringUtils.isBlank(accessCode)) {
+
+        if (StringUtils.isNotBlank(accessCode)) {
+            AuthorizationGrantCacheEntry authzGrantCacheEntry =
+                    getAuthorizationGrantCacheEntryFromCode(accessCode);
+            if (authzGrantCacheEntry != null) {
+                claimValue = authzGrantCacheEntry.getOidcSessionId();
+            }
+        } else if (OAuthConstants.GrantTypes.REFRESH_TOKEN.equalsIgnoreCase(
+                oAuthTokenReqMessageContext.getOauth2AccessTokenReqDTO().getGrantType())) {
+            OIDCSessionState previousSession = getSessionState(oAuthTokenReqMessageContext);
+            if (previousSession != null) {
+                claimValue = previousSession.getSidClaim();
+            }
+        } else {
             if (log.isDebugEnabled()) {
                 log.debug("AccessCode is null. Possibly a back end grant");
             }
             return additionalClaims;
         }
-        AuthorizationGrantCacheEntry authzGrantCacheEntry =
-                getAuthorizationGrantCacheEntryFromCode(accessCode);
-        if (authzGrantCacheEntry != null) {
-            claimValue = authzGrantCacheEntry.getOidcSessionId();
-        }
+
         if (claimValue != null) {
             if (log.isDebugEnabled()) {
                 log.debug("sid claim is found in the session state");
@@ -123,6 +135,41 @@ public class ClaimProviderImpl implements ClaimProvider {
                             .getOIDCSessionState(cookie.getValue(), oAuthAuthzReqMessageContext.
                                     getAuthorizationReqDTO().getLoggedInTenantDomain());
                     return previousSessionState;
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Get session state using opbs cookie.
+     *
+     * @param oAuthTokenReqMessageContext OAuth Token Request Message Context.
+     * @return OIDC session state.
+     */
+    private OIDCSessionState getSessionState(OAuthTokenReqMessageContext oAuthTokenReqMessageContext) {
+
+        HttpRequestHeader[] httpRequestHeaders = oAuthTokenReqMessageContext.getOauth2AccessTokenReqDTO()
+                .getHttpRequestHeaders();
+        if (ArrayUtils.isEmpty(httpRequestHeaders)) {
+            return null;
+        }
+        for (HttpRequestHeader httpRequestHeader : httpRequestHeaders) {
+            if (HttpHeaders.COOKIE.equalsIgnoreCase(httpRequestHeader.getName())) {
+                if (ArrayUtils.isEmpty(httpRequestHeader.getValue())) {
+                    return null;
+                }
+                String[] cookies = httpRequestHeader.getValue()[0].split(";");
+                for (String cookie : cookies) {
+                    String[] cookieParts = cookie.split("=");
+                    if (cookieParts.length == 2 && OIDCSessionConstants.OPBS_COOKIE_ID.equals(cookieParts[0].trim())) {
+                        String opbsCookieValue = cookieParts[1];
+                        if (StringUtils.isBlank(opbsCookieValue)) {
+                            return null;
+                        }
+                        return OIDCSessionManagementUtil.getSessionManager().getOIDCSessionState(opbsCookieValue,
+                                oAuthTokenReqMessageContext.getAuthorizedUser().getTenantDomain());
+                    }
                 }
             }
         }


### PR DESCRIPTION
**Description**
Fix the issue of "sid" attribute is not included in the id tokens obtained through refresh token grant.
In this fix, session id is obtained using opbs cookie in refresh grant flow and set as the sid claim in the ID token.

Issue - https://github.com/wso2/product-is/issues/20836