### PR TITLE
Implement the capability to hide x5c parameter in JWKS response

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/jwks/JwksEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/jwks/JwksEndpoint.java
@@ -70,6 +70,7 @@ public class JwksEndpoint {
     private static final String SECURITY_KEY_STORE_PW = "Security.KeyStore.Password";
     private static final String KEYS = "keys";
     private static final String ADD_PREVIOUS_VERSION_KID = "JWTValidatorConfigs.JWKSEndpoint.AddPreviousVersionKID";
+    private static final String ENABLE_X5C_IN_RESPONSE = "JWTValidatorConfigs.JWKSEndpoint.EnableX5CInResponse";
     public static final String JWKS_IS_THUMBPRINT_HEXIFY_REQUIRED = "JWTValidatorConfigs.JWKSEndpoint" +
             ".IsThumbprintHexifyRequired";
 
@@ -171,7 +172,9 @@ public class JwksEndpoint {
         }
         jwk.algorithm(algorithm);
         jwk.keyUse(KeyUse.parse(KEY_USE));
-        jwk.x509CertChain(encodedCertList);
+        if (Boolean.parseBoolean(IdentityUtil.getProperty(ENABLE_X5C_IN_RESPONSE))) {
+            jwk.x509CertChain(encodedCertList);
+        }
         if (!Boolean.parseBoolean(IdentityUtil.getProperty(JWKS_IS_THUMBPRINT_HEXIFY_REQUIRED))) {
             JWK parsedJWK = JWK.parse(certificate);
             jwk.x509CertSHA256Thumbprint(parsedJWK.getX509CertSHA256Thumbprint());

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/jwks/JwksEndpointTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/jwks/JwksEndpointTest.java
@@ -87,6 +87,7 @@ public class JwksEndpointTest {
     private static final String USE = "sig";
     private static final JSONArray X5C_ARRAY = new JSONArray();
     private static final JSONArray X5T_ARRAY = new JSONArray();
+    private static final String ENABLE_X5C_IN_RESPONSE = "JWTValidatorConfigs.JWKSEndpoint.EnableX5CInResponse";
     private JwksEndpoint jwksEndpoint;
     private Object identityUtilObj;
 
@@ -160,7 +161,8 @@ public class JwksEndpointTest {
 
             // When the OAuth2Util is mocked, OAuthServerConfiguration instance should be available.
             try (MockedStatic<OAuth2Util> oAuth2Util = mockStatic(OAuth2Util.class);
-                 MockedStatic<KeyStoreManager> keyStoreManager = mockStatic(KeyStoreManager.class);) {
+                 MockedStatic<KeyStoreManager> keyStoreManager = mockStatic(KeyStoreManager.class);
+                 MockedStatic<IdentityUtil> identityUtil = mockStatic(IdentityUtil.class)) {
 
                 carbonUtils.when(CarbonUtils::getServerConfiguration).thenReturn(serverConfiguration);
                 when(serverConfiguration.getFirstProperty("Security.KeyStore.Location")).thenReturn(
@@ -226,6 +228,7 @@ public class JwksEndpointTest {
                 keyStoreManager.when(() -> KeyStoreManager.getInstance(anyInt())).thenReturn(mockKeyStoreManager);
                 lenient().when(mockKeyStoreManager.getKeyStore("foo-com.jks")).thenReturn(
                         getKeyStoreFromFile("foo-com.jks", "foo.com"));
+                identityUtil.when(() -> IdentityUtil.getProperty(ENABLE_X5C_IN_RESPONSE)).thenReturn("true");
 
                 String result = jwksEndpoint.jwks();
 


### PR DESCRIPTION
### Proposed changes in this pull request
$subject

### Related Issues
- https://github.com/wso2/product-is/issues/20879

### Depends on
- https://github.com/wso2/carbon-identity-framework/pull/5882