### PR TITLE
Fix refresh token expiry time issue

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/RefreshGrantHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/RefreshGrantHandler.java
@@ -575,7 +575,7 @@ public class RefreshGrantHandler extends AbstractAuthorizationGrantHandler {
         // if a VALID validity period is set through the callback, then use it
         long callbackValidityPeriod = tokReqMsgCtx.getValidityPeriod();
         if (callbackValidityPeriod != OAuthConstants.UNASSIGNED_VALIDITY_PERIOD) {
-            validityPeriodInMillis = callbackValidityPeriod * SECONDS_TO_MILISECONDS_FACTOR;
+            validityPeriodInMillis = callbackValidityPeriod;
         }
         return validityPeriodInMillis;
     }


### PR DESCRIPTION
### Proposed changes in this pull request

Fix converting the callback validity period to millisecond, since its already set in milliseconds.
This change is an immediate fix to avoid increasing the token expiry time exponentially. The complete solution needs to be revisited.
