### PR TITLE
Use application tenant domain to retrieve client app

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/TokenValidationHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/TokenValidationHandler.java
@@ -31,15 +31,13 @@ import org.wso2.carbon.identity.central.log.mgt.utils.LogConstants;
 import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
-import org.wso2.carbon.identity.oauth.OAuthAdminServiceImpl;
 import org.wso2.carbon.identity.oauth.common.OAuthConstants;
 import org.wso2.carbon.identity.oauth.common.exception.InvalidOAuthClientException;
 import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
 import org.wso2.carbon.identity.oauth.dao.OAuthAppDO;
-import org.wso2.carbon.identity.oauth.dto.OAuthConsumerAppDTO;
-import org.wso2.carbon.identity.oauth.internal.OAuthComponentServiceHolder;
 import org.wso2.carbon.identity.oauth.tokenprocessor.TokenProvider;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
+import org.wso2.carbon.identity.oauth2.IdentityOAuth2ServerException;
 import org.wso2.carbon.identity.oauth2.OAuth2Constants;
 import org.wso2.carbon.identity.oauth2.authcontext.AuthorizationContextTokenGenerator;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2ClientApplicationDTO;
@@ -575,7 +573,7 @@ public class TokenValidationHandler {
                     .isRemoveUsernameFromIntrospectionResponseForAppTokensEnabled();
             boolean isAppTokenType = StringUtils.equals(OAuthConstants.UserType.APPLICATION, tokenType);
             boolean removeUsernameFromAppTokenEnabledAppConfig =
-                    isOmitUsernameInIntrospectionRespForAppTokens(accessTokenDO, tenantDomain);
+                    isOmitUsernameInIntrospectionRespForAppTokens(accessTokenDO);
 
             // should be in seconds
             introResp.setIat(accessTokenDO.getIssuedTime().getTime() / 1000);
@@ -678,16 +676,23 @@ public class TokenValidationHandler {
         return introResp;
     }
 
-    private static boolean isOmitUsernameInIntrospectionRespForAppTokens(AccessTokenDO accessTokenDO,
-                                                                         String tenantDomain)
+    private static boolean isOmitUsernameInIntrospectionRespForAppTokens(AccessTokenDO accessTokenDO)
             throws IdentityOAuth2Exception {
 
-        OAuthAdminServiceImpl oAuthAdminService = OAuthComponentServiceHolder.getInstance().getoAuthAdminService();
         boolean omitUsernameInIntrospectionRespForAppTokens;
         try {
-            OAuthConsumerAppDTO oAuthApp = oAuthAdminService.getOAuthApplicationData(accessTokenDO.getConsumerKey(),
-                    tenantDomain);
-            omitUsernameInIntrospectionRespForAppTokens = oAuthApp.isOmitUsernameInIntrospectionRespForAppTokens();
+            String appResidentTenantDomain = null;
+            int appResidentTenantId = accessTokenDO.getAppResidentTenantId();
+            if (appResidentTenantId != MultitenantConstants.INVALID_TENANT_ID) {
+                appResidentTenantDomain = IdentityTenantUtil.getTenantDomain(appResidentTenantId);
+                OAuthAppDO oAuthAppDO = OAuth2Util.getAppInformationByClientId(accessTokenDO.getConsumerKey(),
+                        appResidentTenantDomain);
+                omitUsernameInIntrospectionRespForAppTokens = oAuthAppDO
+                        .isOmitUsernameInIntrospectionRespForAppTokens();
+            } else {
+                throw new IdentityOAuth2ServerException("Invalid tenant domain found in access token issue for"
+                        + " client id: " + accessTokenDO.getConsumerKey());
+            }
         } catch (Exception e) {
             throw new IdentityOAuth2Exception("Error occurred while retrieving OAuth2 application data for client id:" +
                     accessTokenDO.getConsumerKey(), e);

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/TokenValidationHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/TokenValidationHandler.java
@@ -687,8 +687,8 @@ public class TokenValidationHandler {
                 appResidentTenantDomain = IdentityTenantUtil.getTenantDomain(appResidentTenantId);
                 OAuthAppDO oAuthAppDO = OAuth2Util.getAppInformationByClientId(accessTokenDO.getConsumerKey(),
                         appResidentTenantDomain);
-                omitUsernameInIntrospectionRespForAppTokens = oAuthAppDO
-                        .isOmitUsernameInIntrospectionRespForAppTokens();
+                omitUsernameInIntrospectionRespForAppTokens = Boolean.TRUE.equals(oAuthAppDO
+                        .isOmitUsernameInIntrospectionRespForAppTokens());
             } else {
                 throw new IdentityOAuth2ServerException("Invalid tenant domain found in access token issue for"
                         + " client id: " + accessTokenDO.getConsumerKey());

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/validators/TokenValidationHandlerTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/validators/TokenValidationHandlerTest.java
@@ -44,11 +44,9 @@ import org.wso2.carbon.identity.common.testng.WithCarbonHome;
 import org.wso2.carbon.identity.core.util.IdentityDatabaseUtil;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
-import org.wso2.carbon.identity.oauth.OAuthAdminServiceImpl;
 import org.wso2.carbon.identity.oauth.cache.AppInfoCache;
 import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
 import org.wso2.carbon.identity.oauth.dao.OAuthAppDO;
-import org.wso2.carbon.identity.oauth.dto.OAuthConsumerAppDTO;
 import org.wso2.carbon.identity.oauth.internal.OAuthComponentServiceHolder;
 import org.wso2.carbon.identity.oauth.tokenprocessor.PlainTextPersistenceProcessor;
 import org.wso2.carbon.identity.oauth.tokenprocessor.TokenProvider;
@@ -142,12 +140,6 @@ public class TokenValidationHandlerTest {
     private IdentityProvider identityProvider;
     @Mock
     private FederatedAuthenticatorConfig federatedAuthenticatorConfig = new FederatedAuthenticatorConfig();
-    @Mock
-    OAuthComponentServiceHolder mockOAuthComponentServiceHolder;
-    @Mock
-    OAuthConsumerAppDTO mockedOAuthConsumerAppDTO;
-    @Mock
-    OAuthAdminServiceImpl mockedOAuthAdminService;
     private MockedStatic<LoggerUtils> loggerUtils;
 
     @BeforeMethod
@@ -308,6 +300,7 @@ public class TokenValidationHandlerTest {
                 tokenBinding.setBindingReference("test_binding_reference");
                 tokenBinding.setBindingValue("R4Hj_0nNdIzVvPdCdsWlxNKm6a74cszp4Za4M1iE8P9");
                 accessTokenDO.setTokenBinding(tokenBinding);
+                accessTokenDO.setAppResidentTenantId(-1234);
 
                 PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain("carbon.super");
                 TokenProvider tokenProvider = Mockito.mock(TokenProvider.class);
@@ -327,46 +320,38 @@ public class TokenValidationHandlerTest {
                 OAuthAppDO oAuthAppDO = new OAuthAppDO();
                 oAuthAppDO.setTokenType("Default");
                 oAuthAppDO.setApplicationName("testApp");
+                oAuthAppDO.setOmitUsernameInIntrospectionRespForAppTokens(omitUsernameInIntrospectionRespAppConfig);
                 AppInfoCache appInfoCache = AppInfoCache.getInstance();
                 appInfoCache.addToCache("testConsumerKey", oAuthAppDO);
                 oAuth2TokenValidationRequestDTO.setAccessToken(accessToken);
 
-                try (MockedStatic<OAuthComponentServiceHolder> oAuthComponentServiceHolder =
-                             mockStatic(OAuthComponentServiceHolder.class)) {
-                    when(OAuthComponentServiceHolder.getInstance()).thenReturn(mockOAuthComponentServiceHolder);
-                    lenient().when(mockOAuthComponentServiceHolder.getoAuthAdminService())
-                            .thenReturn(mockedOAuthAdminService);
-                    lenient().when(mockedOAuthAdminService.getOAuthApplicationData(anyString(), anyString()))
-                            .thenReturn(mockedOAuthConsumerAppDTO);
-                    lenient().when(mockedOAuthConsumerAppDTO.isOmitUsernameInIntrospectionRespForAppTokens())
-                            .thenReturn(omitUsernameInIntrospectionRespAppConfig);
+                oAuth2Util.when(() -> OAuth2Util.getAppInformationByClientId(anyString(), anyString()))
+                        .thenReturn(oAuthAppDO);
+                // Mock server level config value.
+                when(OAuthServerConfiguration.getInstance()).thenReturn(mockOAuthServerConfiguration);
+                lenient().when(mockOAuthServerConfiguration
+                                .isRemoveUsernameFromIntrospectionResponseForAppTokensEnabled())
+                        .thenReturn(omitUsernameInIntrospectionRespServerConfig);
 
-                    // Mock server level config value.
-                    when(OAuthServerConfiguration.getInstance()).thenReturn(mockOAuthServerConfiguration);
-                    lenient().when(mockOAuthServerConfiguration
-                            .isRemoveUsernameFromIntrospectionResponseForAppTokensEnabled())
-                            .thenReturn(omitUsernameInIntrospectionRespServerConfig);
+                oAuth2Util.when(OAuth2Util::getPersistenceProcessor)
+                        .thenReturn(new PlainTextPersistenceProcessor());
+                oAuth2Util.when(() -> OAuth2Util.getAppInformationByAccessTokenDO(any())).thenReturn(oAuthAppDO);
+                oAuth2Util.when(() -> OAuth2Util.getAccessTokenExpireMillis(any(), Mockito.anyBoolean()))
+                        .thenReturn(1000L);
 
-                    oAuth2Util.when(OAuth2Util::getPersistenceProcessor)
-                            .thenReturn(new PlainTextPersistenceProcessor());
-                    oAuth2Util.when(() -> OAuth2Util.getAppInformationByAccessTokenDO(any())).thenReturn(oAuthAppDO);
-                    oAuth2Util.when(() -> OAuth2Util.getAccessTokenExpireMillis(any(), Mockito.anyBoolean()))
-                            .thenReturn(1000L);
-
-                    OAuth2IntrospectionResponseDTO oAuth2IntrospectionResponseDTO = tokenValidationHandler
-                            .buildIntrospectionResponse(oAuth2TokenValidationRequestDTO);
-                    assertNotNull(oAuth2IntrospectionResponseDTO);
-                    assertEquals(oAuth2IntrospectionResponseDTO.getBindingType(),
-                            OAuth2Constants.TokenBinderType.CERTIFICATE_BASED_TOKEN_BINDER);
-                    assertEquals(oAuth2IntrospectionResponseDTO.getBindingReference(), "test_binding_reference");
-                    assertEquals(oAuth2IntrospectionResponseDTO.getCnfBindingValue(),
-                            "R4Hj_0nNdIzVvPdCdsWlxNKm6a74cszp4Za4M1iE8P9");
-                    if (omitUsernameInIntrospectionRespAppConfig && omitUsernameInIntrospectionRespServerConfig &&
-                            Objects.equals(tokenTypeData, "APPLICATION")) {
-                        assertNull(oAuth2IntrospectionResponseDTO.getUsername());
-                    } else {
-                        assertEquals(oAuth2IntrospectionResponseDTO.getUsername(), authzUser.getUserName());
-                    }
+                OAuth2IntrospectionResponseDTO oAuth2IntrospectionResponseDTO = tokenValidationHandler
+                        .buildIntrospectionResponse(oAuth2TokenValidationRequestDTO);
+                assertNotNull(oAuth2IntrospectionResponseDTO);
+                assertEquals(oAuth2IntrospectionResponseDTO.getBindingType(),
+                        OAuth2Constants.TokenBinderType.CERTIFICATE_BASED_TOKEN_BINDER);
+                assertEquals(oAuth2IntrospectionResponseDTO.getBindingReference(), "test_binding_reference");
+                assertEquals(oAuth2IntrospectionResponseDTO.getCnfBindingValue(),
+                        "R4Hj_0nNdIzVvPdCdsWlxNKm6a74cszp4Za4M1iE8P9");
+                if (omitUsernameInIntrospectionRespAppConfig && omitUsernameInIntrospectionRespServerConfig &&
+                        Objects.equals(tokenTypeData, "APPLICATION")) {
+                    assertNull(oAuth2IntrospectionResponseDTO.getUsername());
+                } else {
+                    assertEquals(oAuth2IntrospectionResponseDTO.getUsername(), authzUser.getUserName());
                 }
             }
         }


### PR DESCRIPTION
### Proposed changes in this pull request
When retrieving an application, use the tenant domain specified in the access token, instead of the user's tenant domain.
