### PR TITLE
Fix Pre Issue Access Token action execution issue when previous token grant type is refresh_token

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/RefreshGrantHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/RefreshGrantHandler.java
@@ -722,7 +722,8 @@ public class RefreshGrantHandler extends AbstractAuthorizationGrantHandler {
         return OAuthComponentServiceHolder.getInstance().getActionExecutorService()
                 .isExecutionEnabled(ActionType.PRE_ISSUE_ACCESS_TOKEN) &&
                 (OAuthConstants.GrantTypes.AUTHORIZATION_CODE.equals(grantType) ||
-                        OAuthConstants.GrantTypes.PASSWORD.equals(grantType)) &&
+                        OAuthConstants.GrantTypes.PASSWORD.equals(grantType) ||
+                        OAuthConstants.GrantTypes.REFRESH_TOKEN.equals(grantType)) &&
                 JWT_TOKEN_TYPE.equals(oAuthAppBean.getTokenType());
     }
 


### PR DESCRIPTION
### Proposed changes in this pull request
- When the previous token is also taken from the `refresh_token` grant type, the action execution didn't happen since it only checked the `authorization_code` and `password` grant types. Due to that reason action execution not performed after the first refresh of the token.
- Modified action execution triggering logic to allow tokens with grant_type `refresh_token` in RefreshGrantHandler. After this action will be triggered for the refreshing a token issued by refresh_token grant.


### When should this PR be merged
- Soon


### Follow up actions
- Bump version in Product
