### PR TITLE
Fix resolving expires_in claim name after Pre Issue Access Token Execution

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/action/PreIssueAccessTokenResponseProcessor.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/action/PreIssueAccessTokenResponseProcessor.java
@@ -144,7 +144,7 @@ public class PreIssueAccessTokenResponseProcessor implements ActionExecutionResp
 
         tokenMessageContext.setScope(responseAccessToken.getScopes().toArray(new String[0]));
 
-        String expiresInClaimName = CLAIMS_PATH_PREFIX + AccessToken.ClaimNames.EXPIRES_IN.getName();
+        String expiresInClaimName = AccessToken.ClaimNames.EXPIRES_IN.getName();
         responseAccessToken.getClaims().stream()
                 .filter(claim -> expiresInClaimName.equals(claim.getName()))
                 .findFirst()
@@ -533,10 +533,8 @@ public class PreIssueAccessTokenResponseProcessor implements ActionExecutionResp
         }
 
         responseAccessToken.getClaims().removeIf(
-                claim -> claim.getName()
-                        .equals(CLAIMS_PATH_PREFIX + AccessToken.ClaimNames.EXPIRES_IN.getName()));
-        responseAccessToken.addClaim(CLAIMS_PATH_PREFIX + AccessToken.ClaimNames.EXPIRES_IN.getName(),
-                expiresIn);
+                claim -> claim.getName().equals(AccessToken.ClaimNames.EXPIRES_IN.getName()));
+        responseAccessToken.addClaim(AccessToken.ClaimNames.EXPIRES_IN.getName(), expiresIn);
         return new OperationExecutionResult(operation, OperationExecutionResult.Status.SUCCESS,
                 "Expiry time updated.");
     }


### PR DESCRIPTION
### Proposed changes in this pull request
- There was an issue in resolving claim name of the `expires_in` claim value. Previously it was added as a claim where the claim name was `/accessToken/claims/expires_in`. But due to that reason it was considered as an custom claim and then added to the token claims. 
- By this PR that issue will be resolved.

### Related Issue:
- https://github.com/wso2/product-is/issues/20739