### PR TITLE
Fix hybrid flow migration issue

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
+++ b/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
@@ -620,6 +620,7 @@ public final class OAuthConstants {
         public static final String TOKEN_TYPE = "tokenType";
         public static final String HYBRID_FLOW_ENABLED = "hybridFlowEnabled";
         public static final String HYBRID_FLOW_RESPONSE_TYPE = "hybridFlowResponseType";
+        public static final String HYBRID_FLOW_CODE_ID_TOKEN_TOKEN = "code id_token token";
         public static final String BYPASS_CLIENT_CREDENTIALS = "bypassClientCredentials";
         public static final String RENEW_REFRESH_TOKEN = "renewRefreshToken";
         public static final String TOKEN_BINDING_TYPE = "tokenBindingType";

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
@@ -324,6 +324,10 @@ public class OAuthServerConfiguration {
     private List<String> supportedTokenEndpointSigningAlgorithms = new ArrayList<>();
     private Boolean roleBasedScopeIssuerEnabledConfig = false;
     private String scopeMetadataExtensionImpl = null;
+    private static final List<String> ALLOWED_HYBRID_RESPONSE_TYPES = Arrays.asList("code token",
+            "code id_token", "code id_token token");
+    private List<String> configuredHybridResponseTypes = new ArrayList<>();
+
 
     private final List<String> restrictedQueryParameters = new ArrayList<>();
 
@@ -876,6 +880,11 @@ public class OAuthServerConfiguration {
     public boolean useRetainOldAccessTokens() {
 
         return Boolean.TRUE.toString().equalsIgnoreCase(retainOldAccessTokens);
+    }
+
+    public List<String> getConfiguredHybridResponseTypes() {
+
+        return configuredHybridResponseTypes;
     }
 
     public boolean isTokenCleanupEnabled() {
@@ -2707,6 +2716,12 @@ public class OAuthServerConfiguration {
                 }
                 if (responseTypeName != null && !"".equals(responseTypeName) &&
                         responseTypeHandlerImplClass != null && !"".equals(responseTypeHandlerImplClass)) {
+
+                    // check for the configured hybrid response type
+                    if (ALLOWED_HYBRID_RESPONSE_TYPES.contains(responseTypeName)) {
+                        configuredHybridResponseTypes.add(responseTypeName);
+                    }
+
                     supportedResponseTypeClassNames.put(responseTypeName, responseTypeHandlerImplClass);
                     OMElement responseTypeValidatorClassNameElement = supportedResponseTypeElement
                             .getFirstChildWithName(

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dao/OAuthAppDAO.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dao/OAuthAppDAO.java
@@ -79,6 +79,7 @@ import static org.wso2.carbon.identity.oauth.common.OAuthConstants.ENABLE_CLAIMS
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCConfigProperties.BACK_CHANNEL_LOGOUT_URL;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCConfigProperties.BYPASS_CLIENT_CREDENTIALS;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCConfigProperties.FRONT_CHANNEL_LOGOUT_URL;
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCConfigProperties.HYBRID_FLOW_CODE_ID_TOKEN_TOKEN;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCConfigProperties.HYBRID_FLOW_ENABLED;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCConfigProperties.HYBRID_FLOW_RESPONSE_TYPE;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCConfigProperties.ID_TOKEN_ENCRYPTED;
@@ -2007,14 +2008,26 @@ public class OAuthAppDAO {
                     Boolean.parseBoolean(isAccessTokenClaimsSeparationEnabled));
         }
 
-        boolean hybridFlowEnabled = Boolean.parseBoolean(getFirstPropertyValue(spOIDCProperties,
-                HYBRID_FLOW_ENABLED));
-        oauthApp.setHybridFlowEnabled(hybridFlowEnabled);
+        String hybridFlowEnabledProperty = getFirstPropertyValue(spOIDCProperties, HYBRID_FLOW_ENABLED);
+        if (hybridFlowEnabledProperty == null) {
+            // This application doesn't have hybridFlowEnabled property, hence providing the previous behaviour.
+            // which is enabling the hybrid flow with all allowed response types.
+            if (LOG.isDebugEnabled()) {
+                LOG.debug(String.format("This application with consumer key %s doesn't have hybridFlowEnabled " +
+                        "property, hence providing the previous behaviour, which is enabling the hybrid flow with " +
+                        "all allowed response types.", oauthApp.getOauthConsumerKey()));
+            }
+            oauthApp.setHybridFlowEnabled(true);
+            oauthApp.setHybridFlowResponseType(HYBRID_FLOW_CODE_ID_TOKEN_TOKEN);
+        } else {
+            boolean hybridFlowEnabled = Boolean.parseBoolean(hybridFlowEnabledProperty);
+            oauthApp.setHybridFlowEnabled(hybridFlowEnabled);
 
-        String hybridFlowResponseType = getFirstPropertyValue(spOIDCProperties,
-                OAuthConstants.OIDCConfigProperties.HYBRID_FLOW_RESPONSE_TYPE);
+            String hybridFlowResponseType = getFirstPropertyValue(spOIDCProperties,
+                    OAuthConstants.OIDCConfigProperties.HYBRID_FLOW_RESPONSE_TYPE);
 
-        oauthApp.setHybridFlowResponseType(hybridFlowResponseType);
+            oauthApp.setHybridFlowResponseType(hybridFlowResponseType);
+        }
     }
 
     private String getFirstPropertyValue(Map<String, List<String>> propertyMap, String key) {

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/dao/OAuthAppDAOTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/dao/OAuthAppDAOTest.java
@@ -834,6 +834,7 @@ public class OAuthAppDAOTest extends TestOAuthDAOBase {
                 assertNotNull(oAuthAppDO);
                 assertEquals(oAuthAppDO.isHybridFlowEnabled(), hybridFlowEnabledExpected);
                 assertEquals(oAuthAppDO.getHybridFlowResponseType(), hybridFlowResponseTypeExpected);
+                appDAO.removeConsumerApplication(CONSUMER_KEY);
             }
         } finally {
             resetPrivilegedCarbonContext();
@@ -885,6 +886,7 @@ public class OAuthAppDAOTest extends TestOAuthDAOBase {
                 assertNotNull(oAuthAppDO);
                 assertEquals(oAuthAppDO.isHybridFlowEnabled(), hybridFlowEnabledExpected);
                 assertEquals(oAuthAppDO.getHybridFlowResponseType(), hybridFlowResponseTypeExpected);
+                appDAO.removeConsumerApplication(CONSUMER_KEY);
             }
         } finally {
             resetPrivilegedCarbonContext();


### PR DESCRIPTION
### Issue
Issue : https://github.com/wso2/product-is/issues/21140

### Proposed fix

Before the fix https://github.com/wso2/product-is/issues/20331, applications don't have hybrid flow enabled properties, hence according to the [logic](https://github.com/wso2-extensions/identity-inbound-auth-oauth/blob/55569c209703516765622720bcbd13f3d3cb893c/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dao/OAuthAppDAO.java#L2010) hybrid flow is disabled which causes the Backward Incompatibility.

Now with added new fix, if the property is missing which means the application doesn't have hybridFlowEnabled property(probably an application created before the fix), hence providing the previous behaviour, which is enabling the hybrid flow with all allowed response types.

Debug Log:
```
[2024-09-23 00:35:00,092] [03c5c187-bac3-44c3-8539-0146f38ac019]  DEBUG {org.wso2.carbon.identity.oauth.dao.OAuthAppDAO} - This application with consumer key 70_x1i8nTwzO7qvf82CNdhZvnrEa doesn't have hybridFlowEnabled property, hence providing the previous behaviour, which is enabling the hybrid flow with all allowed response types.
```

- [x] Unit test for Creation
- [x] Unit test for Migrated App

### Tested Scenarios

- Migrated App
  - [x] Try _code token_, _code id_token_, _code id_token token_ response types and get expected results.
  - [x] Disable Hybrid flow - working as expected.
  - [x] Try Hybrid flow after disabling the feature - working as expected.
  - [x] Try Hybrid flow after disabling the server config feature .


- New App
  - [x] Try _code token_, _code id_token_, _code id_token token_ response types after configuring a selected response type and get expected results. - only configured response type will get successful response.
  - [x] Disable Hybrid flow - working as expected.
  - [x] Try Hybrid flow after disabling the feature - working as expected.

- Working with Server Configuration for existing apps

We have a sever wide config to enable/disable specific response types. current application configuration logic won't support this server wide config (If some disable a response type in server config, he/she still can configure it via UI). This logic partially fix this issue.

- If all hybrid flow response types are disabled, then application hybrid flow configuration also disabled.
- If one hybrid flow response types is enabled, then application hybrid flow configuration is enabled and configured response type will be set on application retrieval.
- If more than one hybrid flow response types are enabled, then application hybrid flow configuration is enabled and configured response type will be "code id_token token". Currently DAO allows to have one string for configured hybrid flow response types so I went for this option to preserve the backward compatibility. But we need to fix it in seperate effort.

### UI
Following is the UI for the migrated app regarding hybrid flow.

<img width="914" alt="Screenshot 2024-09-23 at 12 32 25" src="https://github.com/user-attachments/assets/8f9403ba-1073-43a8-8172-797945f83a9e">


UI when the hybrid flow is disabled via server config.

<img width="914" alt="Screenshot 2024-09-24 at 12 04 22" src="https://github.com/user-attachments/assets/2c634949-bd0d-40df-890b-2c6b9097bb37">

UI when only code id_token is enabled via server config. (code token and code id_token token is disabeld)
<img width="914" alt="Screenshot 2024-09-24 at 12 07 29" src="https://github.com/user-attachments/assets/18f228c2-5cd8-450a-8333-9f6461a08fe6">


