### PR TITLE
Skip OIDC claim handling when OPENID scope not present in the access token grant flow

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuer.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuer.java
@@ -878,6 +878,11 @@ public class JWTTokenIssuer extends OauthTokenIssuerImpl {
             // CC grant doesn't involve a user and hence skipping OIDC claims to CC grant type Access token.
             return jwtClaimsSetBuilder.build();
         }
+        if (tokenReqMessageContext != null &&
+                !Arrays.asList(tokenReqMessageContext.getScope()).contains(OAuthConstants.Scope.OPENID)) {
+            // Skip OIDC claim handling when OPENID scope is not present.
+            return jwtClaimsSetBuilder.build();
+        }
         CustomClaimsCallbackHandler claimsCallBackHandler =
                 OAuthServerConfiguration.getInstance().getOpenIDConnectCustomClaimsCallbackHandler();
         return claimsCallBackHandler.handleCustomClaims(jwtClaimsSetBuilder, tokenReqMessageContext);


### PR DESCRIPTION
### Proposed changes in this pull request

$subject