### PR TITLE
Use KeyStoreManager to get primary keystore

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/jwks/JwksEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/jwks/JwksEndpoint.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2015-2024, WSO2 LLC. (http://www.wso2.com).
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -38,10 +38,8 @@ import org.wso2.carbon.identity.oauth.common.OAuthConstants;
 import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
-import org.wso2.carbon.utils.CarbonUtils;
 import org.wso2.carbon.utils.security.KeystoreUtils;
 
-import java.io.FileInputStream;
 import java.security.KeyStore;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateEncodingException;
@@ -66,8 +64,6 @@ public class JwksEndpoint {
 
     private static final Log log = LogFactory.getLog(JwksEndpoint.class);
     private static final String KEY_USE = "sig";
-    private static final String SECURITY_KEY_STORE_LOCATION = "Security.KeyStore.Location";
-    private static final String SECURITY_KEY_STORE_PW = "Security.KeyStore.Password";
     private static final String KEYS = "keys";
     private static final String ADD_PREVIOUS_VERSION_KID = "JWTValidatorConfigs.JWKSEndpoint.AddPreviousVersionKID";
     private static final String ENABLE_X5C_IN_RESPONSE = "JWTValidatorConfigs.JWKSEndpoint.EnableX5CInResponse";
@@ -80,15 +76,13 @@ public class JwksEndpoint {
     public String jwks() {
 
         String tenantDomain = getTenantDomain();
-        String keystorePath = CarbonUtils.getServerConfiguration().getFirstProperty(SECURITY_KEY_STORE_LOCATION);
 
-        try (FileInputStream file = new FileInputStream(keystorePath)) {
+        try {
             final KeyStore keystore;
             List<CertificateInfo> certificateInfoList = new ArrayList<>();
             if (MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equalsIgnoreCase(tenantDomain)) {
-                keystore = KeyStore.getInstance(KeyStore.getDefaultType());
-                String password = CarbonUtils.getServerConfiguration().getFirstProperty(SECURITY_KEY_STORE_PW);
-                keystore.load(file, password.toCharArray());
+                KeyStoreManager keyStoreManager = KeyStoreManager.getInstance(MultitenantConstants.SUPER_TENANT_ID);
+                keystore = keyStoreManager.getPrimaryKeyStore();
             } else {
                 try {
                     int tenantId = IdentityTenantUtil.getTenantId(tenantDomain);

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpointTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpointTest.java
@@ -351,11 +351,15 @@ public class OAuth2AuthzEndpointTest extends TestOAuthEndpointBase {
         initMocks(this);
         identityDatabaseUtil = mockStatic(IdentityDatabaseUtil.class);
         mockDatabase(identityDatabaseUtil);
+        IdentityEventService identityEventService = mock(IdentityEventService.class);
+        CentralLogMgtServiceComponentHolder.getInstance().setIdentityEventService(identityEventService);
     }
 
     @AfterClass
     public void tearDown() throws Exception {
+
         super.cleanData();
+        CentralLogMgtServiceComponentHolder.getInstance().setIdentityEventService(null);
     }
 
     @AfterMethod

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/jwks/JwksEndpointTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/jwks/JwksEndpointTest.java
@@ -165,12 +165,6 @@ public class JwksEndpointTest {
                  MockedStatic<IdentityUtil> identityUtil = mockStatic(IdentityUtil.class)) {
 
                 carbonUtils.when(CarbonUtils::getServerConfiguration).thenReturn(serverConfiguration);
-                when(serverConfiguration.getFirstProperty("Security.KeyStore.Location")).thenReturn(
-                        keystorePath.toString());
-                lenient().when(serverConfiguration.getFirstProperty("Security.KeyStore.Password"))
-                        .thenReturn("wso2carbon");
-                lenient().when(serverConfiguration.getFirstProperty("Security.KeyStore.KeyAlias"))
-                        .thenReturn("wso2carbon");
 
                 ThreadLocal<Map<String, Object>> threadLocalProperties = new ThreadLocal() {
                     protected Map<String, Object> initialValue() {

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/jwks/JwksEndpointTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/jwks/JwksEndpointTest.java
@@ -62,7 +62,6 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mockStatic;
-import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/jwks/JwksEndpointTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/jwks/JwksEndpointTest.java
@@ -221,6 +221,8 @@ public class JwksEndpointTest {
                 keyStoreManager.when(() -> KeyStoreManager.getInstance(anyInt())).thenReturn(mockKeyStoreManager);
                 lenient().when(mockKeyStoreManager.getKeyStore("foo-com.jks")).thenReturn(
                         getKeyStoreFromFile("foo-com.jks", "foo.com"));
+                lenient().when(mockKeyStoreManager.getPrimaryKeyStore()).thenReturn(
+                        getKeyStoreFromFile("wso2carbon.jks", "wso2carbon"));
                 identityUtil.when(() -> IdentityUtil.getProperty(ENABLE_X5C_IN_RESPONSE)).thenReturn("true");
 
                 String result = jwksEndpoint.jwks();

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/saml/SAML2BearerGrantHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/saml/SAML2BearerGrantHandler.java
@@ -1464,13 +1464,13 @@ public class SAML2BearerGrantHandler extends AbstractAuthorizationGrantHandler {
 
         } catch (FileNotFoundException e) {
             throw new IdentityOAuth2Exception("Unable to locate SAML sign keystore.", e);
-        } catch (IOException | NoSuchProviderException e) {
+        } catch (IOException e) {
             throw new IdentityOAuth2Exception("Unable to read SAML sign keystore.", e);
         } catch (CertificateException e) {
             throw new IdentityOAuth2Exception("Unable to read certificate from SAML sign keystore.", e);
         } catch (NoSuchAlgorithmException e) {
             throw new IdentityOAuth2Exception("Unable to load algorithm.", e);
-        } catch (KeyStoreException e) {
+        } catch (KeyStoreException | NoSuchProviderException e) {
             throw new IdentityOAuth2Exception("Unable to load SAML sign keystore.", e);
         }
     }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/saml/SAML2BearerGrantHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/saml/SAML2BearerGrantHandler.java
@@ -84,6 +84,7 @@ import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
 import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.carbon.user.core.util.UserCoreUtil;
 import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
+import org.wso2.carbon.utils.security.KeystoreUtils;
 
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -92,6 +93,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
@@ -1447,7 +1449,7 @@ public class SAML2BearerGrantHandler extends AbstractAuthorizationGrantHandler {
                 .getFirstProperty(SECURITY_SAML_SIGN_KEY_STORE_LOCATION);
         try (FileInputStream smalKeystoreFile = new FileInputStream(keyStoreLocation)) {
             String keyStoreType = ServerConfiguration.getInstance().getFirstProperty(SECURITY_SAML_SIGN_KEY_STORE_TYPE);
-            KeyStore keyStore = KeyStore.getInstance(keyStoreType);
+            KeyStore keyStore = KeystoreUtils.getKeystoreInstance(keyStoreType);
 
             char[] keyStorePassword = ServerConfiguration.getInstance()
                     .getFirstProperty(SECURITY_SAML_SIGN_KEY_STORE_PASSWORD).toCharArray();
@@ -1462,7 +1464,7 @@ public class SAML2BearerGrantHandler extends AbstractAuthorizationGrantHandler {
 
         } catch (FileNotFoundException e) {
             throw new IdentityOAuth2Exception("Unable to locate SAML sign keystore.", e);
-        } catch (IOException e) {
+        } catch (IOException | NoSuchProviderException e) {
             throw new IdentityOAuth2Exception("Unable to read SAML sign keystore.", e);
         } catch (CertificateException e) {
             throw new IdentityOAuth2Exception("Unable to read certificate from SAML sign keystore.", e);

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/HttpClientUtil.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/HttpClientUtil.java
@@ -42,6 +42,7 @@ import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.device.constants.Constants;
 import org.wso2.carbon.utils.CarbonUtils;
+import org.wso2.carbon.utils.security.KeystoreUtils;
 
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -51,6 +52,7 @@ import java.security.KeyManagementException;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
 import java.security.cert.CertificateException;
 
 import javax.net.ssl.SSLContext;
@@ -148,7 +150,7 @@ public class HttpClientUtil {
         String keyStorePassword = CarbonUtils.getServerConfiguration()
                 .getFirstProperty(Constants.TRUSTSTORE_PASSWORD);
         try {
-            KeyStore trustStore = KeyStore.getInstance(Constants.TRUSTSTORE_TYPE);
+            KeyStore trustStore = KeystoreUtils.getKeystoreInstance(Constants.TRUSTSTORE_TYPE);
             trustStore.load(new FileInputStream(keyStorePath), keyStorePassword.toCharArray());
             sslContext = SSLContexts.custom().loadTrustMaterial(trustStore).build();
 
@@ -164,7 +166,7 @@ public class HttpClientUtil {
             }
 
             return new SSLConnectionSocketFactory(sslContext, hostnameVerifier);
-        } catch (KeyStoreException e) {
+        } catch (KeyStoreException | NoSuchProviderException e) {
             throw new IdentityOAuth2Exception("Failed to read from Key Store. ", e);
         } catch (IOException e) {
             throw new IdentityOAuth2Exception("Key Store not found in " + keyStorePath, e);

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/authz/AuthorizationHandlerManagerTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/authz/AuthorizationHandlerManagerTest.java
@@ -17,6 +17,7 @@ package org.wso2.carbon.identity.oauth2.authz;
 
 import org.apache.oltu.oauth2.common.error.OAuthError;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
@@ -24,10 +25,12 @@ import org.testng.annotations.Test;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
 import org.wso2.carbon.identity.application.common.model.ServiceProvider;
 import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
+import org.wso2.carbon.identity.central.log.mgt.internal.CentralLogMgtServiceComponentHolder;
 import org.wso2.carbon.identity.common.testng.WithCarbonHome;
 import org.wso2.carbon.identity.common.testng.WithH2Database;
 import org.wso2.carbon.identity.common.testng.WithRealmService;
 import org.wso2.carbon.identity.core.internal.IdentityCoreServiceDataHolder;
+import org.wso2.carbon.identity.event.services.IdentityEventService;
 import org.wso2.carbon.identity.oauth.internal.OAuthComponentServiceHolder;
 import org.wso2.carbon.identity.oauth2.TestConstants;
 import org.wso2.carbon.identity.oauth2.TestUtil;
@@ -57,6 +60,8 @@ public class AuthorizationHandlerManagerTest extends IdentityBaseTest {
     @BeforeClass
     public void setUp() throws Exception {
 
+        IdentityEventService identityEventService = mock(IdentityEventService.class);
+        CentralLogMgtServiceComponentHolder.getInstance().setIdentityEventService(identityEventService);
         applicationManagementService = mock(ApplicationManagementService.class);
         OAuth2ServiceComponentHolder.setApplicationMgtService(applicationManagementService);
         serviceProvider = mock(ServiceProvider.class);
@@ -65,6 +70,12 @@ public class AuthorizationHandlerManagerTest extends IdentityBaseTest {
         when(applicationManagementService.getServiceProviderByClientId(anyString(), anyString(), anyString()))
                 .thenReturn(serviceProvider);
         authorizationHandlerManager = AuthorizationHandlerManager.getInstance();
+    }
+
+    @AfterClass
+    public void tearDown() {
+
+        CentralLogMgtServiceComponentHolder.getInstance().setIdentityEventService(null);
     }
 
     @BeforeMethod

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/authz/handlers/AbstractResponseTypeHandlerTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/authz/handlers/AbstractResponseTypeHandlerTest.java
@@ -20,17 +20,23 @@ package org.wso2.carbon.identity.oauth2.authz.handlers;
 
 import org.apache.oltu.oauth2.common.message.types.ResponseType;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
+import org.wso2.carbon.identity.central.log.mgt.internal.CentralLogMgtServiceComponentHolder;
 import org.wso2.carbon.identity.common.testng.WithCarbonHome;
 import org.wso2.carbon.identity.common.testng.WithRealmService;
+import org.wso2.carbon.identity.event.services.IdentityEventService;
 import org.wso2.carbon.identity.oauth.dao.OAuthAppDO;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.authz.OAuthAuthzReqMessageContext;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2AuthorizeReqDTO;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2AuthorizeRespDTO;
+
+import static org.mockito.Mockito.mock;
 
 /**
  * Unit test cases covering AbstractResponseTypeHandler
@@ -43,6 +49,19 @@ import org.wso2.carbon.identity.oauth2.dto.OAuth2AuthorizeRespDTO;
 public class AbstractResponseTypeHandlerTest {
 
     private AbstractResponseTypeHandler abstractResponseTypeHandler;
+
+    @BeforeClass
+    public void setUpMocks() {
+
+        IdentityEventService identityEventService = mock(IdentityEventService.class);
+        CentralLogMgtServiceComponentHolder.getInstance().setIdentityEventService(identityEventService);
+    }
+
+    @AfterClass
+    public void tearDown() {
+
+        CentralLogMgtServiceComponentHolder.getInstance().setIdentityEventService(null);
+    }
 
     @BeforeMethod
     public void setUp() throws Exception {

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/authz/handlers/CodeResponseTypeHandlerTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/authz/handlers/CodeResponseTypeHandlerTest.java
@@ -25,9 +25,11 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
+import org.wso2.carbon.identity.central.log.mgt.internal.CentralLogMgtServiceComponentHolder;
 import org.wso2.carbon.identity.common.testng.WithCarbonHome;
 import org.wso2.carbon.identity.common.testng.WithH2Database;
 import org.wso2.carbon.identity.common.testng.WithRealmService;
+import org.wso2.carbon.identity.event.services.IdentityEventService;
 import org.wso2.carbon.identity.oauth.IdentityOAuthAdminException;
 import org.wso2.carbon.identity.oauth.cache.AppInfoCache;
 import org.wso2.carbon.identity.oauth.common.OAuthConstants;
@@ -39,6 +41,8 @@ import org.wso2.carbon.identity.oauth2.authz.OAuthAuthzReqMessageContext;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2AuthorizeReqDTO;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2AuthorizeRespDTO;
 import org.wso2.carbon.identity.oauth2.internal.OAuth2ServiceComponentHolder;
+
+import static org.mockito.Mockito.mock;
 
 /**
  * Test class covering CodeResponseTypeHandler
@@ -61,11 +65,16 @@ public class CodeResponseTypeHandlerTest {
 
     @BeforeClass
     public void init() throws IdentityOAuthAdminException {
+
+        IdentityEventService identityEventService = mock(IdentityEventService.class);
+        CentralLogMgtServiceComponentHolder.getInstance().setIdentityEventService(identityEventService);
         new OAuthAppDAO().addOAuthApplication(getDefaultOAuthAppDO());
     }
 
     @AfterClass
     public void clear() throws IdentityOAuthAdminException {
+
+        CentralLogMgtServiceComponentHolder.getInstance().setIdentityEventService(null);
         new OAuthAppDAO().removeConsumerApplication(TEST_CONSUMER_KEY);
     }
 
@@ -78,6 +87,7 @@ public class CodeResponseTypeHandlerTest {
         authenticatedUser.setUserName("testUser");
         authenticatedUser.setTenantDomain("carbon.super");
         authenticatedUser.setUserStoreDomain("PRIMARY");
+        authenticatedUser.setUserId("1234");
         authorizationReqDTO.setUser(authenticatedUser);
         authorizationReqDTO.setResponseType(OAuthConstants.GrantTypes.TOKEN);
         authAuthzReqMessageContext

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AbstractAuthorizationGrantHandlerTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AbstractAuthorizationGrantHandlerTest.java
@@ -20,7 +20,8 @@ package org.wso2.carbon.identity.oauth2.token.handlers.grant;
 
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.testng.annotations.AfterMethod;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -30,10 +31,12 @@ import org.wso2.carbon.identity.action.execution.model.ActionExecutionStatus;
 import org.wso2.carbon.identity.action.execution.model.ActionType;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
 import org.wso2.carbon.identity.base.IdentityException;
+import org.wso2.carbon.identity.central.log.mgt.internal.CentralLogMgtServiceComponentHolder;
 import org.wso2.carbon.identity.common.testng.WithCarbonHome;
 import org.wso2.carbon.identity.common.testng.WithH2Database;
 import org.wso2.carbon.identity.common.testng.WithRealmService;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.event.services.IdentityEventService;
 import org.wso2.carbon.identity.oauth.IdentityOAuthAdminException;
 import org.wso2.carbon.identity.oauth.common.GrantType;
 import org.wso2.carbon.identity.oauth.common.OAuthConstants;
@@ -60,6 +63,7 @@ import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
@@ -125,9 +129,17 @@ public class AbstractAuthorizationGrantHandlerTest {
 
     }
 
-    @AfterMethod
+    @BeforeClass
+    public void setUpMocks() {
+
+        IdentityEventService identityEventService = mock(IdentityEventService.class);
+        CentralLogMgtServiceComponentHolder.getInstance().setIdentityEventService(identityEventService);
+    }
+
+    @AfterClass
     public void tearDown() {
 
+        CentralLogMgtServiceComponentHolder.getInstance().setIdentityEventService(null);
     }
 
     @DataProvider(name = "IssueDataProvider")

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/openidconnect/OIDCRequestObjectUtilTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/openidconnect/OIDCRequestObjectUtilTest.java
@@ -24,6 +24,8 @@ import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.testng.MockitoTestNGListener;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Listeners;
@@ -81,6 +83,19 @@ public class OIDCRequestObjectUtilTest {
 
     @Mock
     private CentralLogMgtServiceComponentHolder centralLogMgtServiceComponentHolderMock;
+
+    @BeforeClass
+    public void setUpMocks() {
+
+        IdentityEventService identityEventService = mock(IdentityEventService.class);
+        CentralLogMgtServiceComponentHolder.getInstance().setIdentityEventService(identityEventService);
+    }
+
+    @AfterClass
+    public void tearDown() {
+
+        CentralLogMgtServiceComponentHolder.getInstance().setIdentityEventService(null);
+    }
 
     @BeforeTest
     public void setUp() throws Exception {

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/openidconnect/OpenIDConnectClaimFilterImplTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/openidconnect/OpenIDConnectClaimFilterImplTest.java
@@ -20,6 +20,7 @@ package org.wso2.carbon.identity.openidconnect;
 
 import org.mockito.Mockito;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -31,12 +32,14 @@ import org.wso2.carbon.identity.application.common.IdentityApplicationManagement
 import org.wso2.carbon.identity.application.common.model.ServiceProvider;
 import org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants;
 import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
+import org.wso2.carbon.identity.central.log.mgt.internal.CentralLogMgtServiceComponentHolder;
 import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
 import org.wso2.carbon.identity.claim.metadata.mgt.model.ExternalClaim;
 import org.wso2.carbon.identity.common.testng.WithCarbonHome;
 import org.wso2.carbon.identity.common.testng.WithH2Database;
 import org.wso2.carbon.identity.common.testng.WithRealmService;
 import org.wso2.carbon.identity.common.testng.WithRegistry;
+import org.wso2.carbon.identity.event.services.IdentityEventService;
 import org.wso2.carbon.identity.oauth.dto.ScopeDTO;
 import org.wso2.carbon.identity.oauth2.TestConstants;
 import org.wso2.carbon.identity.oauth2.internal.OAuth2ServiceComponentHolder;
@@ -77,6 +80,8 @@ public class OpenIDConnectClaimFilterImplTest {
     @BeforeClass
     public void setUp() throws Exception {
 
+        IdentityEventService identityEventService = mock(IdentityEventService.class);
+        CentralLogMgtServiceComponentHolder.getInstance().setIdentityEventService(identityEventService);
         openIDConnectClaimFilter = new OpenIDConnectClaimFilterImpl();
         ServiceProvider serviceProvider = new ServiceProvider();
         ssoConsentService = mock(SSOConsentServiceImpl.class);
@@ -101,6 +106,12 @@ public class OpenIDConnectClaimFilterImplTest {
         List claimsWithConsent = getClaimsWithConsent();
         when(ssoConsentService.getClaimsWithConsents(any(), any())).thenReturn(claimsWithConsent);
 
+    }
+
+    @AfterClass
+    public void tearDown() {
+
+        CentralLogMgtServiceComponentHolder.getInstance().setIdentityEventService(null);
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -926,9 +926,9 @@
         <apache.felix.scr.ds.annotations.version>1.2.4</apache.felix.scr.ds.annotations.version>
 
         <!-- Carbon kernel version -->
-        <carbon.kernel.version>4.9.23</carbon.kernel.version>
-        <carbon.kernel.feature.version>4.9.7</carbon.kernel.feature.version>
-        <carbon.kernel.imp.pkg.version.range>[4.5.0, 5.0.0)</carbon.kernel.imp.pkg.version.range>
+        <carbon.kernel.version>4.10.22</carbon.kernel.version>
+        <carbon.kernel.feature.version>4.10.22</carbon.kernel.feature.version>
+        <carbon.kernel.imp.pkg.version.range>[4.10.22, 5.0.0)</carbon.kernel.imp.pkg.version.range>
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!-- Carbon Identity Framework version -->


### PR DESCRIPTION
### Proposed changes in this pull request

- Use KeyStoreManager to get primary keystore and internal keystore instead of reading the file again.

### Related PRs
- https://github.com/wso2/carbon-kernel/pull/4059

### Related Issues
- https://github.com/wso2/product-is/issues/18466
- https://github.com/wso2/product-is/issues/19506
