### PR TITLE
Allow OAuth2 application management through DCR in sub organizations

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.dcr/pom.xml
+++ b/components/org.wso2.carbon.identity.oauth.dcr/pom.xml
@@ -126,7 +126,10 @@
             <groupId>org.wso2.carbon.identity.framework</groupId>
             <artifactId>org.wso2.carbon.identity.configuration.mgt.core</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>org.wso2.carbon.identity.organization.management.core</groupId>
+            <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
+        </dependency>
     </dependencies>
 
     <build>
@@ -165,6 +168,8 @@
                             org.wso2.carbon.identity.application.common.model;version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.application.mgt.*;version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.application.authentication.framework.*;version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.organization.management.service; version="${carbon.identity.organization.management.core.version.range}",
+                            org.wso2.carbon.identity.organization.management.service.exception; version="${carbon.identity.organization.management.core.version.range}",
                             javax.servlet.http; version="${imp.pkg.version.javax.servlet}",
                             org.wso2.carbon.user.api; version="${carbon.user.api.imp.pkg.version.range}",
                             org.wso2.carbon.identity.oauth.*;version="${identity.inbound.auth.oauth.imp.pkg.version.range}",

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/DCRMConstants.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/DCRMConstants.java
@@ -60,7 +60,8 @@ public class DCRMConstants {
         SIGNATURE_VALIDATION_FAILED("Signature validation failed for the software statement"),
         MANDATORY_SOFTWARE_STATEMENT("Mandatory software statement is missing"),
         FAILED_TO_READ_SSA("Error occurred while reading the software statement"),
-        ADDITIONAL_ATTRIBUTE_ERROR("Error occurred while handling additional attributes");
+        ADDITIONAL_ATTRIBUTE_ERROR("Error occurred while handling additional attributes"),
+        FAILED_TO_RESOLVE_TENANT_DOMAIN("Error while resolving tenant domain from the organization id: %s");
 
         private final String message;
         private final String errorCode;

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/internal/DCRDataHolder.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/internal/DCRDataHolder.java
@@ -23,6 +23,7 @@ import org.wso2.carbon.identity.configuration.mgt.core.ConfigurationManager;
 import org.wso2.carbon.identity.oauth.dcr.handler.RegistrationHandler;
 import org.wso2.carbon.identity.oauth.dcr.handler.UnRegistrationHandler;
 import org.wso2.carbon.identity.oauth2.token.bindings.TokenBinder;
+import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -33,7 +34,6 @@ import java.util.List;
  * This was deprecated as part of deprecating the legacy identity/register DCR endpoint.
  * The recommendation is to use /identity/oauth2/dcr/v1.1 instead.
  */
-@Deprecated
 public class DCRDataHolder {
 
     private static DCRDataHolder thisInstance = new DCRDataHolder();
@@ -42,6 +42,7 @@ public class DCRDataHolder {
     private List<UnRegistrationHandler> unRegistrationHandlerList = new ArrayList<>();
     private List<TokenBinder> tokenBinders = new ArrayList<>();
     private ConfigurationManager configurationManager;
+    private OrganizationManager organizationManager;
 
     private DCRDataHolder() {
 
@@ -110,5 +111,15 @@ public class DCRDataHolder {
     public void setConfigurationManager(ConfigurationManager configurationManager) {
 
         this.configurationManager = configurationManager;
+    }
+
+    public OrganizationManager getOrganizationManager() {
+
+        return organizationManager;
+    }
+
+    public void setOrganizationManager(OrganizationManager organizationManager) {
+
+        this.organizationManager = organizationManager;
     }
 }

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/internal/DCRServiceComponent.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/internal/DCRServiceComponent.java
@@ -42,6 +42,7 @@ import org.wso2.carbon.identity.oauth.dcr.handler.UnRegistrationHandler;
 import org.wso2.carbon.identity.oauth.dcr.processor.DCRProcessor;
 import org.wso2.carbon.identity.oauth.dcr.service.DCRMService;
 import org.wso2.carbon.identity.oauth2.token.bindings.TokenBinder;
+import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
 
 /**
  * OAuth DCRM service component.
@@ -52,7 +53,6 @@ import org.wso2.carbon.identity.oauth2.token.bindings.TokenBinder;
         name = "identity.oauth.dcr",
         immediate = true
 )
-@Deprecated
 public class DCRServiceComponent {
 
     private static final Log log = LogFactory.getLog(DCRServiceComponent.class);
@@ -253,5 +253,24 @@ public class DCRServiceComponent {
 
         log.debug("Unregistering the ConfigurationManager in DCR Service Component.");
         DCRDataHolder.getInstance().setConfigurationManager(null);
+    }
+
+    @Reference(
+            name = "organization.service",
+            service = OrganizationManager.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetOrganizationManager"
+    )
+    protected void setOrganizationManager(OrganizationManager organizationManager) {
+
+        DCRDataHolder.getInstance().setOrganizationManager(organizationManager);
+        log.debug("Set the organization management service.");
+    }
+
+    protected void unsetOrganizationManager(OrganizationManager organizationManager) {
+
+        DCRDataHolder.getInstance().setOrganizationManager(null);
+        log.debug("Unset organization management service.");
     }
 }

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/util/DCRMUtils.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/util/DCRMUtils.java
@@ -37,7 +37,6 @@ import static org.wso2.carbon.identity.oauth.dcr.util.DCRConstants.APP_NAME_VALI
  * This was deprecated as part of deprecating the legacy identity/register DCR endpoint.
  * The recommendation is to use /identity/oauth2/dcr/v1.1 instead.
  */
-@Deprecated
 public class DCRMUtils {
 
     private static final Log log = LogFactory.getLog(DCRMUtils.class);

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/service/DCRMServiceTest.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/service/DCRMServiceTest.java
@@ -199,12 +199,12 @@ public class DCRMServiceTest {
     public void getApplicationNullDTOTest(String dtoStatus) throws Exception {
 
         if (dtoStatus == null) {
-            when(mockOAuthAdminService.getOAuthApplicationData(dummyConsumerKey)).thenReturn(null);
+            when(mockOAuthAdminService.getOAuthApplicationData(dummyConsumerKey, dummyTenantDomain)).thenReturn(null);
             lenient().when(mockOAuthAdminService.getAllOAuthApplicationData()).thenReturn(new OAuthConsumerAppDTO[0]);
         } else {
             OAuthConsumerAppDTO dto = new OAuthConsumerAppDTO();
             dto.setApplicationName("");
-            when(mockOAuthAdminService.getOAuthApplicationData(dummyConsumerKey)).thenReturn(dto);
+            when(mockOAuthAdminService.getOAuthApplicationData(dummyConsumerKey, dummyTenantDomain)).thenReturn(dto);
             lenient().when(mockOAuthAdminService.getAllOAuthApplicationData())
                     .thenReturn(new OAuthConsumerAppDTO[]{dto});
         }
@@ -222,7 +222,7 @@ public class DCRMServiceTest {
     public void getApplicationDTOTestWithIOAException() throws Exception {
 
         doThrow(new IdentityOAuthAdminException("")).when(mockOAuthAdminService)
-                .getOAuthApplicationData(dummyConsumerKey);
+                .getOAuthApplicationData(dummyConsumerKey, dummyTenantDomain);
         lenient().when(mockOAuthAdminService.getAllOAuthApplicationData()).thenReturn(new OAuthConsumerAppDTO[0]);
         setInternalState(dcrmService, "oAuthAdminService", mockOAuthAdminService);
 
@@ -239,7 +239,7 @@ public class DCRMServiceTest {
     public void getApplicationDTOTestWithIOCException() throws Exception {
 
         doThrow(new IdentityOAuthAdminException("", new InvalidOAuthClientException(""))).when(mockOAuthAdminService)
-                .getOAuthApplicationData(dummyConsumerKey);
+                .getOAuthApplicationData(dummyConsumerKey, dummyTenantDomain);
         lenient().when(mockOAuthAdminService.getAllOAuthApplicationData()).thenReturn(new OAuthConsumerAppDTO[0]);
         setInternalState(dcrmService, "oAuthAdminService", mockOAuthAdminService);
 
@@ -256,7 +256,7 @@ public class DCRMServiceTest {
     public void getApplicationDTOTestUserUnauthorized() throws Exception {
 
         setInternalState(dcrmService, "oAuthAdminService", mockOAuthAdminService);
-        when(mockOAuthAdminService.getOAuthApplicationData(dummyConsumerKey)).thenReturn(dto);
+        when(mockOAuthAdminService.getOAuthApplicationData(dummyConsumerKey, dummyTenantDomain)).thenReturn(dto);
         when(dto.getApplicationName()).thenReturn(dummyClientName);
 
         try {
@@ -276,7 +276,7 @@ public class DCRMServiceTest {
             UserStoreException, NoSuchFieldException, IllegalAccessException {
 
         setInternalState(dcrmService, "oAuthAdminService", mockOAuthAdminService);
-        when(mockOAuthAdminService.getOAuthApplicationData(dummyConsumerKey)).thenReturn(dto);
+        when(mockOAuthAdminService.getOAuthApplicationData(dummyConsumerKey, dummyTenantDomain)).thenReturn(dto);
         when(dto.getApplicationName()).thenReturn(dummyClientName);
 
         try {
@@ -304,7 +304,7 @@ public class DCRMServiceTest {
         dto.setCallbackUrl(dummyCallbackUrl);
         dto.setUsername(dummyUserName.concat("@").concat(dummyTenantDomain));
 
-        when(mockOAuthAdminService.getOAuthApplicationData(dummyConsumerKey)).thenReturn(dto);
+        when(mockOAuthAdminService.getOAuthApplicationData(dummyConsumerKey, dummyTenantDomain)).thenReturn(dto);
         setInternalState(dcrmService, "oAuthAdminService", mockOAuthAdminService);
         PrivilegedCarbonContext.getThreadLocalCarbonContext().setUserRealm(mockedUserRealm);
         when(mockedUserRealm.getUserStoreManager()).thenReturn(mockedUserStoreManager);
@@ -328,7 +328,8 @@ public class DCRMServiceTest {
     public void validateRequestTenantDomainTestWitInvalidOAuthClientException()
             throws IdentityOAuth2Exception, InvalidOAuthClientException {
 
-        when(OAuth2Util.getTenantDomainOfOauthApp(dummyConsumerKey)).thenThrow(new InvalidOAuthClientException(""));
+        when(OAuth2Util.getTenantDomainOfOauthApp(dummyConsumerKey, dummyTenantDomain)).
+                thenThrow(new InvalidOAuthClientException(""));
         try {
             dcrmService.getApplication(dummyConsumerKey);
         } catch (DCRMException ex) {
@@ -343,7 +344,8 @@ public class DCRMServiceTest {
     public void validateRequestTenantDomainTestWitIdentityOAuth2Exception()
             throws IdentityOAuth2Exception, InvalidOAuthClientException {
 
-        when(OAuth2Util.getTenantDomainOfOauthApp(dummyConsumerKey)).thenThrow(new IdentityOAuth2Exception(""));
+        when(OAuth2Util.getTenantDomainOfOauthApp(dummyConsumerKey, dummyTenantDomain)).
+                thenThrow(new IdentityOAuth2Exception(""));
         try {
             dcrmService.getApplication(dummyConsumerKey);
         } catch (DCRMException ex) {
@@ -535,7 +537,7 @@ public class DCRMServiceTest {
         applicationRegistrationRequest.setGrantTypes(dummyGrantTypes);
         applicationRegistrationRequest.setConsumerKey(dummyConsumerKey);
         setInternalState(dcrmService, "oAuthAdminService", mockOAuthAdminService);
-        when(mockOAuthAdminService.getOAuthApplicationData(dummyConsumerKey))
+        when(mockOAuthAdminService.getOAuthApplicationData(dummyConsumerKey, dummyTenantDomain))
                 .thenReturn(dto);
         when(dto.getApplicationName()).thenReturn(dummyClientName);
 
@@ -915,7 +917,8 @@ public class DCRMServiceTest {
         setInternalState(dcrmService, "oAuthAdminService", mockOAuthAdminService);
 
         IdentityOAuthAdminException identityOAuthAdminException = mock(IdentityOAuthAdminException.class);
-        doThrow(identityOAuthAdminException).when(mockOAuthAdminService).getOAuthApplicationData(dummyConsumerKey);
+        doThrow(identityOAuthAdminException).when(mockOAuthAdminService).getOAuthApplicationData(dummyConsumerKey,
+                dummyTenantDomain);
         try {
             dcrmService.registerApplication(applicationRegistrationRequest);
         } catch (IdentityException ex) {
@@ -974,7 +977,7 @@ public class DCRMServiceTest {
         lenient().when(mockOAuthAdminService
                 .getOAuthApplicationDataByAppName(dummyClientName)).thenReturn(oAuthConsumerApp);
         lenient().when(mockOAuthAdminService
-                .getOAuthApplicationData("dummyConsumerKey")).thenReturn(oAuthConsumerApp);
+                .getOAuthApplicationData("dummyConsumerKey", dummyTenantDomain)).thenReturn(oAuthConsumerApp);
         lenient().when(mockOAuthAdminService.getAllOAuthApplicationData())
                 .thenReturn(new OAuthConsumerAppDTO[]{oAuthConsumerApp});
         lenient().when(mockOAuthAdminService.registerAndRetrieveOAuthApplicationData(any(OAuthConsumerAppDTO.class))).
@@ -1107,7 +1110,7 @@ public class DCRMServiceTest {
         dto.setCallbackUrl(dummyCallbackUrl);
         dto.setUsername(dummyUserName.concat("@").concat(dummyTenantDomain));
 
-        when(mockOAuthAdminService.getOAuthApplicationData(dummyConsumerKey)).thenReturn(dto);
+        when(mockOAuthAdminService.getOAuthApplicationData(dummyConsumerKey, dummyTenantDomain)).thenReturn(dto);
         setInternalState(dcrmService, "oAuthAdminService", mockOAuthAdminService);
 
         ServiceProvider serviceProvider = new ServiceProvider();

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthAdminService.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthAdminService.java
@@ -89,6 +89,24 @@ public class OAuthAdminService extends AbstractAdmin {
     }
 
     /**
+     * Get OAuth application data by the consumer key and tenant domain.
+     *
+     * @param consumerKey Consumer Key.
+     * @param tenantDomain Tenant Domain.
+     * @return <code>OAuthConsumerAppDTO</code> with application information.
+     * @throws IdentityOAuthAdminException Error when reading application information from persistence store.
+     */
+    public OAuthConsumerAppDTO getOAuthApplicationData(String consumerKey, String tenantDomain)
+            throws IdentityOAuthAdminException {
+
+        try {
+            return oAuthAdminServiceImpl.getOAuthApplicationData(consumerKey, tenantDomain);
+        } catch (IdentityOAuthAdminException ex) {
+            throw handleError(ex);
+        }
+    }
+
+    /**
      * Get OAuth application data by the application name.
      *
      * @param appName OAuth application name.

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/authz/AuthorizationHandlerManagerTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/authz/AuthorizationHandlerManagerTest.java
@@ -16,6 +16,7 @@
 package org.wso2.carbon.identity.oauth2.authz;
 
 import org.apache.oltu.oauth2.common.error.OAuthError;
+import org.mockito.MockedStatic;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -37,11 +38,13 @@ import org.wso2.carbon.identity.oauth2.TestUtil;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2AuthorizeReqDTO;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2AuthorizeRespDTO;
 import org.wso2.carbon.identity.oauth2.internal.OAuth2ServiceComponentHolder;
+import org.wso2.carbon.identity.oauth2.util.AuthzUtil;
 import org.wso2.carbon.identity.testutil.IdentityBaseTest;
 import org.wso2.carbon.user.api.UserStoreException;
 
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
 @WithCarbonHome
@@ -56,6 +59,7 @@ public class AuthorizationHandlerManagerTest extends IdentityBaseTest {
     private AuthorizationHandlerManager authorizationHandlerManager;
     private OAuth2AuthorizeReqDTO authzReqDTO = new OAuth2AuthorizeReqDTO();
     private ServiceProvider serviceProvider;
+    private MockedStatic<AuthzUtil> mockedAuthzUtil;
 
     @BeforeClass
     public void setUp() throws Exception {
@@ -70,12 +74,16 @@ public class AuthorizationHandlerManagerTest extends IdentityBaseTest {
         when(applicationManagementService.getServiceProviderByClientId(anyString(), anyString(), anyString()))
                 .thenReturn(serviceProvider);
         authorizationHandlerManager = AuthorizationHandlerManager.getInstance();
+        mockedAuthzUtil = mockStatic(AuthzUtil.class);
+        mockedAuthzUtil.when(AuthzUtil::isLegacyAuthzRuntime).thenReturn(false);
     }
 
     @AfterClass
     public void tearDown() {
 
         CentralLogMgtServiceComponentHolder.getInstance().setIdentityEventService(null);
+        mockedAuthzUtil.close();
+
     }
 
     @BeforeMethod

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/authz/handlers/CodeResponseTypeHandlerTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/authz/handlers/CodeResponseTypeHandlerTest.java
@@ -18,6 +18,8 @@
 
 package org.wso2.carbon.identity.oauth2.authz.handlers;
 
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -41,8 +43,10 @@ import org.wso2.carbon.identity.oauth2.authz.OAuthAuthzReqMessageContext;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2AuthorizeReqDTO;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2AuthorizeRespDTO;
 import org.wso2.carbon.identity.oauth2.internal.OAuth2ServiceComponentHolder;
+import org.wso2.carbon.identity.oauth2.util.AuthzUtil;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 
 /**
  * Test class covering CodeResponseTypeHandler
@@ -62,6 +66,7 @@ public class CodeResponseTypeHandlerTest {
 
     OAuthAuthzReqMessageContext authAuthzReqMessageContext;
     OAuth2AuthorizeReqDTO authorizationReqDTO;
+    private MockedStatic<AuthzUtil> mockedAuthzUtil;
 
     @BeforeClass
     public void init() throws IdentityOAuthAdminException {
@@ -69,6 +74,9 @@ public class CodeResponseTypeHandlerTest {
         IdentityEventService identityEventService = mock(IdentityEventService.class);
         CentralLogMgtServiceComponentHolder.getInstance().setIdentityEventService(identityEventService);
         new OAuthAppDAO().addOAuthApplication(getDefaultOAuthAppDO());
+        Mockito.clearAllCaches();
+        mockedAuthzUtil = mockStatic(AuthzUtil.class);
+        mockedAuthzUtil.when(AuthzUtil::isLegacyAuthzRuntime).thenReturn(false);
     }
 
     @AfterClass
@@ -76,6 +84,7 @@ public class CodeResponseTypeHandlerTest {
 
         CentralLogMgtServiceComponentHolder.getInstance().setIdentityEventService(null);
         new OAuthAppDAO().removeConsumerApplication(TEST_CONSUMER_KEY);
+        mockedAuthzUtil.close();
     }
 
     @BeforeMethod

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AbstractAuthorizationGrantHandlerTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AbstractAuthorizationGrantHandlerTest.java
@@ -20,6 +20,7 @@ package org.wso2.carbon.identity.oauth2.token.handlers.grant;
 
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -59,6 +60,7 @@ import org.wso2.carbon.identity.oauth2.token.JWTTokenIssuer;
 import org.wso2.carbon.identity.oauth2.token.OAuthTokenReqMessageContext;
 import org.wso2.carbon.identity.oauth2.token.OauthTokenIssuer;
 import org.wso2.carbon.identity.oauth2.token.bindings.TokenBinding;
+import org.wso2.carbon.identity.oauth2.util.AuthzUtil;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 import org.wso2.carbon.identity.oauth2.validators.OAuth2ScopeHandler;
 
@@ -104,6 +106,7 @@ public class AbstractAuthorizationGrantHandlerTest {
             "org.wso2.carbon.identity.oauth.callback.DefaultCallbackHandler";
     private static final String PASSWORD_GRANT = "password";
     private OAuthAppDO oAuthAppDO;
+    private MockedStatic<AuthzUtil> mockedAuthzUtil;
 
     @BeforeMethod
     public void setUp() throws IdentityOAuth2Exception, IdentityOAuthAdminException, ActionExecutionException {
@@ -144,12 +147,16 @@ public class AbstractAuthorizationGrantHandlerTest {
 
         IdentityEventService identityEventService = mock(IdentityEventService.class);
         CentralLogMgtServiceComponentHolder.getInstance().setIdentityEventService(identityEventService);
+        Mockito.clearAllCaches();
+        mockedAuthzUtil = mockStatic(AuthzUtil.class);
+        mockedAuthzUtil.when(AuthzUtil::isLegacyAuthzRuntime).thenReturn(false);
     }
 
     @AfterClass
     public void tearDown() {
 
         CentralLogMgtServiceComponentHolder.getInstance().setIdentityEventService(null);
+        mockedAuthzUtil.close();
     }
 
     @Test(dataProvider = "IssueWithRenewDataProvider", expectedExceptions = IdentityOAuth2Exception.class)

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/util/OAuth2UtilTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/util/OAuth2UtilTest.java
@@ -2232,12 +2232,13 @@ public class OAuth2UtilTest {
             appDO.setTokenType(tokenType);
 
             AppInfoCache mockAppInfoCache = mock(AppInfoCache.class);
-            when(mockAppInfoCache.getValueFromCache(clientId)).thenReturn(appDO);
+            when(mockAppInfoCache.getValueFromCache(clientId, clientTenantDomain)).thenReturn(appDO);
 
             appInfoCache.when(AppInfoCache::getInstance).thenReturn(mockAppInfoCache);
 
             OauthTokenIssuer oauthTokenIssuer = mock(OauthTokenIssuer.class);
             when(oauthServerConfigurationMock.getIdentityOauthTokenIssuer()).thenReturn(oauthTokenIssuer);
+            identityTenantUtil.when(IdentityTenantUtil::resolveTenantDomain).thenReturn(clientTenantDomain);
             assertEquals(OAuth2Util.getOAuthTokenIssuerForOAuthApp(clientId), oauthTokenIssuer);
         }
     }
@@ -2247,11 +2248,12 @@ public class OAuth2UtilTest {
 
         try (MockedStatic<AppInfoCache> appInfoCache = mockStatic(AppInfoCache.class)) {
             AppInfoCache mockAppInfoCache = mock(AppInfoCache.class);
-            when(mockAppInfoCache.getValueFromCache(clientId)).
+            when(mockAppInfoCache.getValueFromCache(clientId, clientTenantDomain)).
                     thenAnswer(i -> {
                         throw new IdentityOAuth2Exception("IdentityOAuth2Exception");
                     });
             appInfoCache.when(AppInfoCache::getInstance).thenReturn(mockAppInfoCache);
+            identityTenantUtil.when(IdentityTenantUtil::resolveTenantDomain).thenReturn(clientTenantDomain);
 
             try {
                 OAuth2Util.getOAuthTokenIssuerForOAuthApp(clientId);
@@ -2603,7 +2605,7 @@ public class OAuth2UtilTest {
         appDO.setUser(user);
 
         AppInfoCache mockAppInfoCache = mock(AppInfoCache.class);
-        lenient().when(mockAppInfoCache.getValueFromCache(clientId)).thenReturn(appDO);
+        lenient().when(mockAppInfoCache.getValueFromCache(clientId, SUPER_TENANT_DOMAIN_NAME)).thenReturn(appDO);
         appInfoCache.when(AppInfoCache::getInstance).thenReturn(mockAppInfoCache);
     }
 
@@ -2612,7 +2614,7 @@ public class OAuth2UtilTest {
 
         try (MockedStatic<AppInfoCache> appInfoCache = mockStatic(AppInfoCache.class)) {
             AppInfoCache mockAppInfoCache = mock(AppInfoCache.class);
-            when(mockAppInfoCache.getValueFromCache(clientId)).
+            when(mockAppInfoCache.getValueFromCache(clientId, SUPER_TENANT_DOMAIN_NAME)).
                     thenAnswer(i -> {
                         throw new InvalidOAuthClientException("InvalidOAuthClientException");
                     });

--- a/pom.xml
+++ b/pom.xml
@@ -938,7 +938,7 @@
         <apache.felix.scr.ds.annotations.version>1.2.4</apache.felix.scr.ds.annotations.version>
 
         <!-- Carbon kernel version -->
-        <carbon.kernel.version>4.10.22</carbon.kernel.version>
+        <carbon.kernel.version>4.10.26</carbon.kernel.version>
         <carbon.kernel.feature.version>4.10.22</carbon.kernel.feature.version>
         <carbon.kernel.imp.pkg.version.range>[4.10.22, 5.0.0)</carbon.kernel.imp.pkg.version.range>
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>


### PR DESCRIPTION
### Proposed changes in this pull request

- $subject
- Improvement for : https://github.com/wso2/product-is/issues/21208
- OAuth2 application management will be allowed through the DCR endpoint.
`/t/{tenant-domain}/o/{org-id}/api/identity/oauth2/dcr/v1.1/register`
- This change contains the following improvements in the sub organization level
   - OAuth2 application creation
   - OAuth2 application get by client id
   - OAuth2 application get by client / application name
   - OAuth2 application update by client id
   - OAuth2 application delete by client id
- Contains some supportive method improvements to the aforementioned main operations.

### When should this PR be merged

- Need a kernel level improvement to be merged first and release a kernel version : https://github.com/wso2/carbon-kernel/pull/4104