### PR TITLE
Fix application branding not being applied on consent page.

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/model/Constants.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/model/Constants.java
@@ -49,6 +49,7 @@ public class Constants {
     public static final String X509 = "X.509";
     public static final String SHA1 = "SHA-1";
     public static final String SHA256 = "SHA-256";
+    public static final String SERVICE_PROVIDER_ID = "spId";
 
 
     //JWS is consists of three parts seperated by 2 '.'s as JOSE header, JWS payload, JWS signature


### PR DESCRIPTION
### Proposed changes in this pull request

Application branding is not being applied to the consent page. This is due to the lack of `spId` query parameter in the url.
This URL is generated at the authorize endpoint. This PR fixes this issue by adding the `spId` query parameter to the redirect url if it is sent to the authorize endpoint as a request parameter. This ensures the `spId` param is only added for the authorize requests that  are initiated including the `spId` parameter. 

### Related PR 
- https://github.com/wso2-enterprise/asgardeo-product/issues/26734
