### PR TITLE
Refactor pre issue access token action request object

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/action/model/TokenRequest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/action/model/TokenRequest.java
@@ -18,12 +18,12 @@
 
 package org.wso2.carbon.identity.oauth.action.model;
 
+import org.wso2.carbon.identity.action.execution.model.Header;
+import org.wso2.carbon.identity.action.execution.model.Param;
 import org.wso2.carbon.identity.action.execution.model.Request;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 /**
  * This class models the request at a pre issue access token trigger.
@@ -72,8 +72,8 @@ public class TokenRequest extends Request {
      */
     public static class Builder {
 
-        private final Map<String, String[]> additionalHeaders = new HashMap<>();
-        private final Map<String, String[]> additionalParams = new HashMap<>();
+        private final List<Header> additionalHeaders = new ArrayList<>();
+        private final List<Param> additionalParams = new ArrayList<>();
         private String clientId;
         private String grantType;
         private String redirectUri;
@@ -103,15 +103,15 @@ public class TokenRequest extends Request {
             return this;
         }
 
-        public Builder addAdditionalHeader(String key, String[] value) {
+        public Builder addAdditionalHeader(String name, String[] value) {
 
-            this.additionalHeaders.put(key, value);
+            this.additionalHeaders.add(new Header(name, value));
             return this;
         }
 
-        public Builder addAdditionalParam(String key, String[] value) {
+        public Builder addAdditionalParam(String name, String[] value) {
 
-            this.additionalParams.put(key, value);
+            this.additionalParams.add(new Param(name, value));
             return this;
         }
 

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/action/PreIssueAccessTokenRequestBuilderTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/action/PreIssueAccessTokenRequestBuilderTest.java
@@ -1,0 +1,416 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth.action;
+
+import org.apache.commons.codec.binary.Base64;
+import org.mockito.MockedStatic;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.action.execution.exception.ActionExecutionRequestBuilderException;
+import org.wso2.carbon.identity.action.execution.model.ActionExecutionRequest;
+import org.wso2.carbon.identity.action.execution.model.ActionType;
+import org.wso2.carbon.identity.action.execution.model.AllowedOperation;
+import org.wso2.carbon.identity.action.execution.model.Header;
+import org.wso2.carbon.identity.action.execution.model.Operation;
+import org.wso2.carbon.identity.action.execution.model.Param;
+import org.wso2.carbon.identity.action.execution.model.Tenant;
+import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.oauth.action.model.AccessToken;
+import org.wso2.carbon.identity.oauth.action.model.PreIssueAccessTokenEvent;
+import org.wso2.carbon.identity.oauth.action.model.TokenRequest;
+import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
+import org.wso2.carbon.identity.oauth.dao.OAuthAppDO;
+import org.wso2.carbon.identity.oauth2.dto.OAuth2AccessTokenReqDTO;
+import org.wso2.carbon.identity.oauth2.model.HttpRequestHeader;
+import org.wso2.carbon.identity.oauth2.model.RequestParameter;
+import org.wso2.carbon.identity.oauth2.token.OAuthTokenReqMessageContext;
+import org.wso2.carbon.identity.oauth2.token.handlers.grant.AuthorizationGrantHandler;
+import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
+import org.wso2.carbon.identity.openidconnect.CustomClaimsCallbackHandler;
+import org.wso2.carbon.identity.openidconnect.util.ClaimHandlerUtil;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+
+/**
+ * Unit test class for PreIssueAccessTokenRequestBuilder class.
+ */
+public class PreIssueAccessTokenRequestBuilderTest {
+
+    private PreIssueAccessTokenRequestBuilder preIssueAccessTokenRequestBuilder;
+
+    private MockedStatic<ClaimHandlerUtil> claimHandlerUtilMockedStatic;
+    private MockedStatic<OAuthServerConfiguration> oAuthServerConfiguration;
+    private MockedStatic<IdentityTenantUtil> identityTenantUtilMockedStatic;
+    private MockedStatic<OAuth2Util> oAuth2UtilMockedStatic;
+
+    private static final String CLIENT_ID_TEST = "test-client-id";
+    private static final String CLIENT_SECRET_TEST = "test-client-secret";
+    private static final String GRANT_TYPE_TEST = "password";
+    private static final String TENANT_DOMAIN_TEST = "carbon.super";
+    private static final int TENANT_ID_TEST = 1234;
+    private static final String USER_ID_TEST = "user-123";
+    private static final String USERNAME_TEST = "testUser";
+    private static final String PASSWORD_TEST = "test@123";
+    private static final String USER_STORE_TEST = "PRIMARY";
+    private static final String TEST_URL = "https://test.com/oauth2/token";
+    private static final String AUDIENCE_TEST = "audience1";
+
+    @BeforeClass
+    public void setUp() {
+
+        preIssueAccessTokenRequestBuilder = new PreIssueAccessTokenRequestBuilder();
+
+        OAuthServerConfiguration mockOAuthServerConfiguration = mock(OAuthServerConfiguration.class);
+        oAuthServerConfiguration = mockStatic(OAuthServerConfiguration.class);
+        oAuthServerConfiguration.when(OAuthServerConfiguration::getInstance).thenReturn(mockOAuthServerConfiguration);
+        oAuth2UtilMockedStatic = mockStatic(OAuth2Util.class);
+        OAuthAppDO oAuthAppDO = mock(OAuthAppDO.class);
+        oAuth2UtilMockedStatic.when(() -> OAuth2Util.getAppInformationByClientId(CLIENT_ID_TEST, TENANT_DOMAIN_TEST))
+                .thenReturn(oAuthAppDO);
+        oAuth2UtilMockedStatic.when(() -> OAuth2Util.getIdTokenIssuer(TENANT_DOMAIN_TEST)).thenReturn(TEST_URL);
+        doReturn(new String[]{AUDIENCE_TEST}).when(oAuthAppDO).getAudiences();
+        doReturn(CLIENT_ID_TEST).when(oAuthAppDO).getOauthConsumerKey();
+        oAuth2UtilMockedStatic.when(() -> OAuth2Util.getOIDCAudience(CLIENT_ID_TEST, oAuthAppDO)).
+                thenReturn(new LinkedList<>(Collections.singleton(AUDIENCE_TEST)));
+        oAuth2UtilMockedStatic.when(OAuth2Util::isPairwiseSubEnabledForAccessTokens).thenReturn(false);
+        AuthenticatedUser authenticatedUser = mock(AuthenticatedUser.class);
+        doReturn(USER_ID_TEST).when(authenticatedUser).getAuthenticatedSubjectIdentifier();
+
+        claimHandlerUtilMockedStatic = mockStatic(ClaimHandlerUtil.class);
+        CustomClaimsCallbackHandler customClaimsCallbackHandler = mock(CustomClaimsCallbackHandler.class);
+        claimHandlerUtilMockedStatic.when(() -> ClaimHandlerUtil.getClaimsCallbackHandler(oAuthAppDO)).
+                thenReturn(customClaimsCallbackHandler);
+
+        identityTenantUtilMockedStatic = mockStatic(IdentityTenantUtil.class);
+        identityTenantUtilMockedStatic.when(() -> IdentityTenantUtil.getTenantId(TENANT_DOMAIN_TEST))
+                .thenReturn(TENANT_ID_TEST);
+
+        AuthorizationGrantHandler authorizationGrantHandler = mock(AuthorizationGrantHandler.class);
+        Map<String, AuthorizationGrantHandler> mockGrantTypesMap = new HashMap<>();
+        mockGrantTypesMap.put(GRANT_TYPE_TEST, authorizationGrantHandler);
+        oAuthServerConfiguration.when(() -> OAuthServerConfiguration.getInstance().getSupportedGrantTypes()).
+                thenReturn(mockGrantTypesMap);
+
+    }
+
+    @AfterClass
+    public void tearDown() {
+
+        preIssueAccessTokenRequestBuilder = null;
+        oAuth2UtilMockedStatic.close();
+        oAuthServerConfiguration.close();
+        claimHandlerUtilMockedStatic.close();
+        identityTenantUtilMockedStatic.close();
+    }
+
+    @Test
+    public void testGetSupportedActionType() {
+
+        ActionType actionType = preIssueAccessTokenRequestBuilder.getSupportedActionType();
+        Assert.assertEquals(actionType, ActionType.PRE_ISSUE_ACCESS_TOKEN);
+    }
+
+    @DataProvider(name = "BuildTokenRequestMessageContext")
+    public Object[][] buildTokenRequestMessageContext() {
+
+        return new Object[][]{
+                {mockTokenMessageContext()},
+        };
+    }
+
+    @Test(dataProvider = "BuildTokenRequestMessageContext")
+    public void testBuildActionExecutionRequest(Map<String, Object> eventContext)
+            throws ActionExecutionRequestBuilderException {
+
+        ActionExecutionRequest actionExecutionRequest = preIssueAccessTokenRequestBuilder.
+                buildActionExecutionRequest(eventContext);
+        Assert.assertNotNull(actionExecutionRequest);
+        Assert.assertEquals(actionExecutionRequest.getActionType(), ActionType.PRE_ISSUE_ACCESS_TOKEN);
+        assertEvent((PreIssueAccessTokenEvent) actionExecutionRequest.getEvent(), getExpectedEvent());
+        assertAllowedOperations(actionExecutionRequest.getAllowedOperations(), getExpectedAllowedOperations());
+    }
+
+    /**
+     * Assert that the actual event matches the expected event.
+     *
+     * @param actualEvent The actual PreIssueAccessTokenEvent.
+     * @param expectedEvent The expected PreIssueAccessTokenEvent.
+     */
+
+    private void assertEvent(PreIssueAccessTokenEvent actualEvent, PreIssueAccessTokenEvent expectedEvent) {
+
+        Assert.assertEquals(expectedEvent.getTenant().getId(), actualEvent.getTenant().getId());
+        assertAccessToken(actualEvent.getAccessToken(), expectedEvent.getAccessToken());
+        assertRequest((TokenRequest) actualEvent.getRequest(), (TokenRequest) expectedEvent.getRequest());
+    }
+
+    /**
+     * Assert that the actual access token matches the expected access token.
+     *
+     * @param actualAccessToken The actual AccessToken.
+     * @param expectedAccessToken The expected AccessToken.
+     */
+
+    private static void assertAccessToken(AccessToken actualAccessToken, AccessToken expectedAccessToken) {
+
+        Assert.assertEquals(actualAccessToken.getClaims().size(), expectedAccessToken.getClaims().size());
+        for (int i = 0; i < expectedAccessToken.getClaims().size(); i++) {
+            AccessToken.Claim actualClaim = actualAccessToken.getClaims().get(i);
+            AccessToken.Claim expectedClaim = expectedAccessToken.getClaims().get(i);
+            Assert.assertEquals(actualClaim.getName(), expectedClaim.getName());
+            Assert.assertEquals(actualClaim.getValue(), expectedClaim.getValue());
+        }
+        Assert.assertEquals(actualAccessToken.getScopes().size(), expectedAccessToken.getScopes().size());
+        for (int i = 0; i < expectedAccessToken.getScopes().size(); i++) {
+            String actualScope = expectedAccessToken.getScopes().get(i);
+            String expectedScope = expectedAccessToken.getScopes().get(i);
+            Assert.assertEquals(actualScope, expectedScope);
+        }
+    }
+
+    /**
+     * Assert that the actual token request matches the expected token request.
+     *
+     * @param actualRequest The actual TokenRequest.
+     * @param expectedRequest The expected TokenRequest.
+     */
+    private static void assertRequest(TokenRequest actualRequest, TokenRequest expectedRequest) {
+
+        Assert.assertEquals(actualRequest.getClientId(), expectedRequest.getClientId());
+        Assert.assertEquals(actualRequest.getGrantType(), expectedRequest.getGrantType());
+        Assert.assertEquals(actualRequest.getScopes().size(), expectedRequest.getScopes().size());
+        for (int i = 0; i < expectedRequest.getScopes().size(); i++) {
+            Assert.assertEquals(actualRequest.getScopes().get(i), expectedRequest.getScopes().get(i));
+        }
+        Assert.assertEquals(actualRequest.getAdditionalHeaders().size(), expectedRequest.getAdditionalHeaders().size());
+        for (int i = 0; i < expectedRequest.getAdditionalHeaders().size(); i++) {
+            Header actualAdditionalHeader = actualRequest.getAdditionalHeaders().get(i);
+            Header expectedAdditionalHeader = expectedRequest.getAdditionalHeaders().get(i);
+            Assert.assertEquals(actualAdditionalHeader.getName(), expectedAdditionalHeader.getName());
+            Assert.assertEquals(actualAdditionalHeader.getValue(), expectedAdditionalHeader.getValue());
+        }
+        Assert.assertEquals(actualRequest.getAdditionalParams().size(), expectedRequest.getAdditionalParams().size());
+        for (int i = 0; i < expectedRequest.getAdditionalParams().size(); i++) {
+            Param actualAdditionalParam = actualRequest.getAdditionalParams().get(i);
+            Param expectedAdditionalParam = expectedRequest.getAdditionalParams().get(i);
+            Assert.assertEquals(actualAdditionalParam.getName(), expectedAdditionalParam.getName());
+            Assert.assertEquals(actualAdditionalParam.getValue(), expectedAdditionalParam.getValue());
+        }
+    }
+
+    /**
+     * Assert that the actual allowed operations match the expected allowed operations.
+     *
+     * @param actual List of actual AllowedOperation.
+     * @param expected List of expected AllowedOperation.
+     */
+    private void assertAllowedOperations(List<AllowedOperation> actual, List<AllowedOperation> expected) {
+
+        Assert.assertEquals(actual.size(), expected.size());
+        for (int i = 0; i < expected.size(); i++) {
+            AllowedOperation expectedOperation = expected.get(i);
+            AllowedOperation actualOperation = actual.get(i);
+            Assert.assertEquals(expectedOperation.getOp(), actualOperation.getOp());
+            Assert.assertEquals(expectedOperation.getPaths().size(), actualOperation.getPaths().size());
+            for (int j = 0; j < expectedOperation.getPaths().size(); j++) {
+                Assert.assertEquals(expectedOperation.getPaths().get(j), actualOperation.getPaths().get(j));
+            }
+        }
+    }
+
+    /**
+     * Mock the token message context for testing.
+     *
+     * @return A map representing the event context.
+     */
+    private Map<String, Object> mockTokenMessageContext() {
+
+        Map<String, Object> eventContext = new HashMap<>();
+
+        OAuth2AccessTokenReqDTO tokenReqDTO = mockTokenRequestDTO();
+        AuthenticatedUser authenticatedUser = mockAuthenticatedUser();
+        OAuthTokenReqMessageContext tokenMessageContext = mockMessageContext(tokenReqDTO, authenticatedUser);
+        eventContext.put("tokenMessageContext", tokenMessageContext);
+
+        return eventContext;
+    }
+
+    /**
+     * Mock the OAuth2 access token request DTO.
+     *
+     * @return OAuth2AccessTokenReqDTO containing mock token request data.
+     */
+    private OAuth2AccessTokenReqDTO mockTokenRequestDTO() {
+
+        OAuth2AccessTokenReqDTO tokenReqDTO = new OAuth2AccessTokenReqDTO();
+        tokenReqDTO.setClientId(CLIENT_ID_TEST);
+        tokenReqDTO.setClientSecret(CLIENT_SECRET_TEST);
+        tokenReqDTO.setGrantType(GRANT_TYPE_TEST);
+        tokenReqDTO.setTenantDomain(TENANT_DOMAIN_TEST);
+        tokenReqDTO.setResourceOwnerUsername(USERNAME_TEST);
+        tokenReqDTO.setResourceOwnerPassword(PASSWORD_TEST);
+        tokenReqDTO.setScope(new String[]{"scope1", "scope2"});
+        HttpRequestHeader[] requestHeaders = new HttpRequestHeader[]{
+                new HttpRequestHeader("authorization",
+                        getBase64EncodedString(CLIENT_ID_TEST, CLIENT_SECRET_TEST)),
+                new HttpRequestHeader("accept", "application/json")
+        };
+        tokenReqDTO.setHttpRequestHeaders(requestHeaders);
+        RequestParameter[] requestParameters = new RequestParameter[] {
+                new RequestParameter("grant_type", GRANT_TYPE_TEST),
+                new RequestParameter("username", USERNAME_TEST),
+                new RequestParameter("password", PASSWORD_TEST),
+                new RequestParameter("scope", "scope1", "scope2")
+        };
+        tokenReqDTO.setRequestParameters(requestParameters);
+        return tokenReqDTO;
+    }
+
+    /**
+     * Mock an authenticated user.
+     *
+     * @return AuthenticatedUser object containing mock user data.
+     */
+    private static AuthenticatedUser mockAuthenticatedUser() {
+
+        AuthenticatedUser authenticatedUser = new AuthenticatedUser();
+        authenticatedUser.setUserName(USERNAME_TEST);
+        authenticatedUser.setUserStoreDomain(USER_STORE_TEST);
+        authenticatedUser.setUserId(USER_ID_TEST);
+        authenticatedUser.setAuthenticatedSubjectIdentifier(USER_ID_TEST);
+        return authenticatedUser;
+    }
+
+    /**
+     * Mock the OAuthTokenReqMessageContext for testing.
+     *
+     * @param tokenReqDTO The OAuth2AccessTokenReqDTO used in the message context.
+     * @param authenticatedUser The authenticated user for the request.
+     * @return OAuthTokenReqMessageContext with mock data.
+     */
+    private static OAuthTokenReqMessageContext mockMessageContext(OAuth2AccessTokenReqDTO tokenReqDTO,
+                                                                  AuthenticatedUser authenticatedUser) {
+
+        OAuthTokenReqMessageContext tokenMessageContext = new OAuthTokenReqMessageContext(tokenReqDTO);
+        tokenMessageContext.setAuthorizedUser(authenticatedUser);
+        tokenMessageContext.setScope(new String[]{"scope1", "scope2"});
+
+        tokenMessageContext.setPreIssueAccessTokenActionsExecuted(false);
+        tokenMessageContext.setAudiences(Collections.singletonList(AUDIENCE_TEST));
+
+        tokenMessageContext.addProperty("USER_TYPE", "APPLICATION_USER");
+        tokenMessageContext.setValidityPeriod(3600000L);
+        return tokenMessageContext;
+    }
+
+    /**
+     * Get the expected PreIssueAccessTokenEvent for testing.
+     *
+     * @return PreIssueAccessTokenEvent representing the expected event.
+     */
+    private PreIssueAccessTokenEvent getExpectedEvent() {
+
+        PreIssueAccessTokenEvent.Builder eventBuilder = new PreIssueAccessTokenEvent.Builder();
+        eventBuilder.tenant(new Tenant(String.valueOf(TENANT_ID_TEST), TENANT_DOMAIN_TEST));
+        AccessToken.Builder accessTokenBuilder = new AccessToken.Builder();
+        accessTokenBuilder
+                .addClaim(AccessToken.ClaimNames.ISS.getName(), TEST_URL)
+                .addClaim(AccessToken.ClaimNames.CLIENT_ID.getName(), CLIENT_ID_TEST)
+                .addClaim(AccessToken.ClaimNames.AUTHORIZED_USER_TYPE.getName(), "APPLICATION_USER")
+                .addClaim(AccessToken.ClaimNames.EXPIRES_IN.getName(), 3600L)
+                .addClaim(AccessToken.ClaimNames.AUD.getName(), new LinkedList<>(Collections.singleton(AUDIENCE_TEST)))
+                .addClaim(AccessToken.ClaimNames.SUB.getName(), USER_ID_TEST)
+                .scopes(Arrays.asList("scope1", "scope2"));
+        eventBuilder.accessToken(accessTokenBuilder.build());
+        TokenRequest.Builder requestBuilder = new TokenRequest.Builder();
+        requestBuilder
+                .clientId(CLIENT_ID_TEST)
+                .grantType(GRANT_TYPE_TEST)
+                .scopes(Arrays.asList("scope1", "scope2"))
+                .addAdditionalHeader("authorization",
+                        new String[]{getBase64EncodedString(CLIENT_ID_TEST, CLIENT_SECRET_TEST)})
+                .addAdditionalHeader("accept", new String[]{"application/json"})
+                .addAdditionalParam("grant_type", new String[]{GRANT_TYPE_TEST})
+                .addAdditionalParam("username", new String[]{USERNAME_TEST})
+                .addAdditionalParam("password", new String[]{PASSWORD_TEST})
+                .addAdditionalParam("scope", new String[]{"scope1", "scope2"});
+        eventBuilder.request(requestBuilder.build());
+
+        return eventBuilder.build();
+    }
+
+    /**
+     * Get the expected allowed operations for the action execution request.
+     *
+     * @return List of AllowedOperation representing the expected operations.
+     */
+    private List<AllowedOperation> getExpectedAllowedOperations() {
+
+        List<AllowedOperation> allowedOperations = new ArrayList<>();
+        AllowedOperation addOperation = new AllowedOperation();
+        addOperation.setOp(Operation.ADD);
+        addOperation.setPaths(Arrays.asList(
+                "/accessToken/claims/",
+                "/accessToken/scopes/",
+                "/accessToken/claims/aud/"));
+        AllowedOperation removeOperation = new AllowedOperation();
+        removeOperation.setOp(Operation.REMOVE);
+        removeOperation.setPaths(Arrays.asList(
+                "/accessToken/scopes/",
+                "/accessToken/claims/aud/"));
+        AllowedOperation replaceOperation = new AllowedOperation();
+        replaceOperation.setOp(Operation.REPLACE);
+        replaceOperation.setPaths(Arrays.asList(
+                "/accessToken/scopes/",
+                "/accessToken/claims/aud/",
+                "/accessToken/claims/expires_in"));
+        allowedOperations.add(addOperation);
+        allowedOperations.add(removeOperation);
+        allowedOperations.add(replaceOperation);
+
+        return allowedOperations;
+    }
+
+    /**
+     * Encode the client ID and client secret as a Base64 encoded string.
+     *
+     * @param clientId The client ID.
+     * @param clientSecret The client secret.
+     * @return Base64 encoded string representing client ID and secret.
+     */
+    private String getBase64EncodedString(String clientId, String clientSecret) {
+
+        return new String(Base64.encodeBase64((clientId + ":" + clientSecret).getBytes()));
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -932,7 +932,7 @@
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!-- Carbon Identity Framework version -->
-        <carbon.identity.framework.version>7.5.59</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.5.64</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.25.234, 8.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 

--- a/pom.xml
+++ b/pom.xml
@@ -932,7 +932,7 @@
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!-- Carbon Identity Framework version -->
-        <carbon.identity.framework.version>7.5.46</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.5.59</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.25.234, 8.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 


### PR DESCRIPTION
### Description
This PR updates pre-issue-access-token action request by refactoring `additionalHeaders` and `additionalParams` fields.

Updated request object:
```
{
    "additionalHeaders": [
        {
            "name": "accept",
            "value": [
                "application/json"
            ]
        },
        {
            "name": "cache-control",
            "value": [
                "no-cache"
            ]
        }
    ],
    "additionalParams": [
        {
            "name": "TestParam",
            "value": [
                "test"
            ]
        }
    ],
    "clientId": "r***************************a",
    "grantType": "client_credentials",
    "scopes": [
        "test_scope_1",
        "test_scope_2"
    ]
}
```

### Related Issue:
- https://github.com/wso2/product-is/issues/21305

**When should this PR be merged:**
 - After merging https://github.com/wso2/carbon-identity-framework/pull/6006
