### PR TITLE
Bump framework version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -932,7 +932,7 @@
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!-- Carbon Identity Framework version -->
-        <carbon.identity.framework.version>7.5.46</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.5.59</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.25.234, 8.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 


### PR DESCRIPTION
#### Description
This PR bumps the carbon-identity-framework version to `7.5.59`.