### PR TITLE
Fix application branding not being applied on consent page.

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
@@ -228,6 +228,7 @@ import static org.wso2.carbon.identity.openidconnect.model.Constants.MAX_AGE;
 import static org.wso2.carbon.identity.openidconnect.model.Constants.NONCE;
 import static org.wso2.carbon.identity.openidconnect.model.Constants.PROMPT;
 import static org.wso2.carbon.identity.openidconnect.model.Constants.SCOPE;
+import static org.wso2.carbon.identity.openidconnect.model.Constants.SERVICE_PROVIDER_ID;
 import static org.wso2.carbon.identity.openidconnect.model.Constants.STATE;
 
 /**
@@ -1281,6 +1282,8 @@ public class OAuth2AuthzEndpoint {
         try {
             redirectURL = doUserAuthorization(oAuthMessage, oAuthMessage.getSessionDataKeyFromLogin(), sessionState,
                     authorizationResponseDTO);
+            String serviceProviderId = oAuthMessage.getRequest().getParameter(SERVICE_PROVIDER_ID);
+            redirectURL = addServiceProviderIdToRedirectURI(redirectURL, serviceProviderId);
         } catch (OAuthProblemException ex) {
             if (isFormPostOrFormPostJWTResponseMode(oauth2Params.getResponseMode())) {
                 return handleFailedState(oAuthMessage, oauth2Params, ex, authorizationResponseDTO);
@@ -1456,7 +1459,21 @@ public class OAuth2AuthzEndpoint {
         }
         String redirectURL = handleOAuthAuthorizationRequest(oAuthMessage);
         String type = getRequestProtocolType(oAuthMessage);
-
+        try {
+            // Add the service provider id to the redirect URL. This is needed to support application wise branding.
+            String clientId = oAuthMessage.getRequest().getParameter(CLIENT_ID);
+            if (StringUtils.isNotBlank(clientId)) {
+                ServiceProvider serviceProvider = getServiceProvider(clientId);
+                if (serviceProvider != null) {
+                    redirectURL = addServiceProviderIdToRedirectURI(redirectURL,
+                            serviceProvider.getApplicationResourceId());
+                }
+            }
+        } catch (OAuthSystemException e) {
+            // The value is set to be used for branding purposes. Therefore, if an error occurs, the process should
+            // continue without breaking.
+            log.debug("Error while getting the service provider id", e);
+        }
         if (AuthenticatorFlowStatus.SUCCESS_COMPLETED == oAuthMessage.getFlowStatus()) {
             return handleAuthFlowThroughFramework(oAuthMessage, type, redirectURL);
         } else {
@@ -3954,6 +3971,16 @@ public class OAuth2AuthzEndpoint {
                         return Response.status(HttpServletResponse.SC_OK).entity(responseWrapper.getContent()).build();
                     }
                 } else {
+                    try {
+                        String serviceProviderId =
+                                getServiceProvider(oAuthMessage.getRequest().getParameter(CLIENT_ID))
+                                .getApplicationResourceId();
+                        requestWrapper.setParameter(SERVICE_PROVIDER_ID, serviceProviderId);
+                    } catch (Exception e) {
+                        // The value is set to be used for branding purposes. Therefore, if an error occurs,
+                        // the process should continue without breaking.
+                        log.error("Error occurred while getting service provider id.");
+                    }
                     return authorize(requestWrapper, oAuthMessage.getResponse());
                 }
             } else {
@@ -4745,5 +4772,25 @@ public class OAuth2AuthzEndpoint {
         return ApiAuthnUtils.buildResponseForClientError(
                 new AuthServiceClientException(AuthServiceConstants.ErrorMessage.ERROR_INVALID_AUTH_REQUEST.code(),
                         "App native authentication is only supported with code response type."), log);
+    }
+
+    private String addServiceProviderIdToRedirectURI(String redirectURI, String serviceProviderId) {
+
+        if (StringUtils.isNotBlank(redirectURI) && StringUtils.isNotBlank(serviceProviderId)) {
+            try {
+                URI uri = new URI(redirectURI);
+                String query = uri.getRawQuery();
+                if (StringUtils.isNotBlank(query)) {
+                    if (!query.contains(SERVICE_PROVIDER_ID + "=")) {
+                        redirectURI = redirectURI + "&" + SERVICE_PROVIDER_ID + "=" + serviceProviderId;
+                    }
+                } else {
+                    redirectURI = redirectURI + "?" + SERVICE_PROVIDER_ID + "=" + serviceProviderId;
+                }
+            } catch (URISyntaxException e) {
+                log.debug("Error occurred while adding service provider id to redirect URI.", e);
+            }
+        }
+        return redirectURI;
     }
 }

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpointTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpointTest.java
@@ -178,6 +178,7 @@ import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.doAnswer;
@@ -309,6 +310,7 @@ public class OAuth2AuthzEndpointTest extends TestOAuthEndpointBase {
     private static final String OIDC_DIALECT = "http://wso2.org/oidc/claim";
     private static final int MILLISECONDS_PER_SECOND = 1000;
     private static final int TIME_MARGIN_IN_SECONDS = 3000;
+    private static final String INVALID_CLIENT_ID = "invalidId";
 
     private OAuth2AuthzEndpoint oAuth2AuthzEndpoint;
     private Object authzEndpointObject;
@@ -586,6 +588,12 @@ public class OAuth2AuthzEndpointTest extends TestOAuthEndpointBase {
                             .thenReturn(oAuth2ClientValidationResponseDTO);
                     when(oAuth2ClientValidationResponseDTO.isValidClient()).thenReturn(true);
                 }
+
+                ApplicationManagementService appMgtService = mock(ApplicationManagementService.class);
+                OAuth2ServiceComponentHolder.setApplicationMgtService(appMgtService);
+                when(appMgtService.getServiceProviderByClientId(anyString(), any(), anyString())).thenReturn(dummySp);
+                when(appMgtService.getServiceProviderByClientId(eq(INVALID_CLIENT_ID), any(), anyString()))
+                        .thenReturn(null);
 
                 try (MockedConstruction<CommonAuthenticationHandler> mockedConstruction = Mockito.mockConstruction(
                         CommonAuthenticationHandler.class,

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/model/Constants.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/model/Constants.java
@@ -49,6 +49,7 @@ public class Constants {
     public static final String X509 = "X.509";
     public static final String SHA1 = "SHA-1";
     public static final String SHA256 = "SHA-256";
+    public static final String SERVICE_PROVIDER_ID = "spId";
 
 
     //JWS is consists of three parts seperated by 2 '.'s as JOSE header, JWS payload, JWS signature


### PR DESCRIPTION
### Proposed changes in this pull request

Application branding is not being applied to the consent page. This is due to the lack of `spId` query parameter in the url.
This URL is generated at the authorize endpoint. This PR fixes this issue by adding the `spId` query parameter to the redirect url if it is sent to the authorize endpoint as a request parameter. This ensures the `spId` param is only added for the authorize requests that  are initiated including the `spId` parameter. 

### Related PR 
- https://github.com/wso2/product-is/issues/21314