### PR TITLE
Remove unnecessary authentication requirement for /authorize GET API

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
@@ -332,23 +332,6 @@ public class OAuth2AuthzEndpoint {
             return handleIdentityException(request, e);
         }
 
-        // Perform request authentication for API based auth flow.
-        if (OAuth2Util.isApiBasedAuthenticationFlow(request)) {
-            OAuthClientAuthnContext oAuthClientAuthnContext = getClientAuthnContext(request);
-            if (!oAuthClientAuthnContext.isAuthenticated()) {
-                return handleAuthFailureResponse(oAuthClientAuthnContext);
-            }
-
-            ClientAttestationContext clientAttestationContext = getClientAttestationContext(request);
-            if (clientAttestationContext.isAttestationEnabled() && !clientAttestationContext.isAttested()) {
-                return handleAttestationFailureResponse(clientAttestationContext);
-            }
-
-            if (!OAuth2Util.isApiBasedAuthSupportedGrant(request)) {
-                return handleUnsupportedGrantForApiBasedAuth();
-            }
-        }
-
         try {
             // Start tenant domain flow if the tenant configuration is not enabled.
             if (!IdentityTenantUtil.isTenantedSessionsEnabled()) {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/client/authentication/PublicClientAuthenticator.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/client/authentication/PublicClientAuthenticator.java
@@ -215,12 +215,6 @@ public class PublicClientAuthenticator extends AbstractOAuthClientAuthenticator 
 
         Map<String, String> stringContent = getBodyParameters(params);
         String clientId = stringContent.get(OAuth.OAUTH_CLIENT_ID);
-        /* With API based authentication, client authentication is provided for the authorization endpoint.
-         When calling /GET authorization ep, the client ID is not available in the request body.
-         Hence, the client ID is extracted from the request parameter.*/
-        if (StringUtils.isBlank(clientId) && isApiBasedAuthenticationFlow(request)) {
-            clientId = request.getParameter(OAuth.OAUTH_CLIENT_ID);
-        }
         context.setClientId(clientId);
     }
 


### PR DESCRIPTION
### Proposed changes in this pull request

`GET /authorize API` doesn't required any authentication as the information passed for the endpoint is exposed through the network.