### PR TITLE
Handle Null Pointer Exception while trying to delete already deleted Authorized API

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/listener/IdentityOauthEventHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/listener/IdentityOauthEventHandler.java
@@ -243,7 +243,7 @@ public class IdentityOauthEventHandler extends AbstractEventHandler {
                 AuthorizedAPI authorizedAPI = OAuthComponentServiceHolder.getInstance()
                         .getAuthorizedAPIManagementService()
                         .getAuthorizedAPI(appId, apiId, tenantDomain);
-                if (authorizedAPI.getScopes() == null) {
+                if (null == authorizedAPI || authorizedAPI.getScopes() == null) {
                     return;
                 }
                 List<String> removedScopes = authorizedAPI.getScopes().stream()

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/listener/IdentityOauthEventHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/listener/IdentityOauthEventHandler.java
@@ -243,7 +243,7 @@ public class IdentityOauthEventHandler extends AbstractEventHandler {
                 AuthorizedAPI authorizedAPI = OAuthComponentServiceHolder.getInstance()
                         .getAuthorizedAPIManagementService()
                         .getAuthorizedAPI(appId, apiId, tenantDomain);
-                if (null == authorizedAPI || authorizedAPI.getScopes() == null) {
+                if (authorizedAPI == null || authorizedAPI.getScopes() == null) {
                     return;
                 }
                 List<String> removedScopes = authorizedAPI.getScopes().stream()

--- a/pom.xml
+++ b/pom.xml
@@ -939,7 +939,7 @@
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!-- Carbon Identity Framework version -->
-        <carbon.identity.framework.version>7.5.75</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.5.85-SNAPSHOT</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.25.234, 8.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 

--- a/pom.xml
+++ b/pom.xml
@@ -939,7 +939,7 @@
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!-- Carbon Identity Framework version -->
-        <carbon.identity.framework.version>7.5.85-SNAPSHOT</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.5.75</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.25.234, 8.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 


### PR DESCRIPTION
## Purpose
> This PR may resolve https://github.com/wso2/product-is/issues/21260

## Goals
> This PR addresses a NullPointerException that occurs when attempting to delete an already deleted Authorized API.

 **Behavior After Fix:**
> Below are the Sample Request & response.
> **Request [Delete already deleted Authorized API]**
```
curl --location --request DELETE 'https://localhost:9443/api/server/v1/applications/<applcation-id>/authorized-apis/<api-id>' \
--header 'Authorization: Basic <username:password>'
```
> **Response [Delete already deleted Authorized API]**
Response Code - 204
Empty Response Body
