### PR TITLE
Improve device code not exists error description

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/device/errorcodes/DeviceErrorCodes.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/device/errorcodes/DeviceErrorCodes.java
@@ -50,6 +50,7 @@ public class DeviceErrorCodes {
         public static final String SLOW_DOWN = "Forbidden";
         public static final String AUTHORIZATION_PENDING = "Precondition required";
         public static final String EXPIRED_TOKEN = "Forbidden";
+        public static final String NOT_EXIST = "The provided device code is not registered or is invalid.";
 
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/device/grant/DeviceFlowGrant.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/device/grant/DeviceFlowGrant.java
@@ -100,7 +100,8 @@ public class DeviceFlowGrant extends AbstractAuthorizationGrantHandler {
 
         Date date = new Date();
         if (Constants.NOT_EXIST.equals(deviceStatus)) {
-            throw new IdentityOAuth2Exception(DeviceErrorCodes.INVALID_REQUEST, DeviceErrorCodes.INVALID_REQUEST);
+            throw new IdentityOAuth2Exception(DeviceErrorCodes.INVALID_REQUEST,
+                    DeviceErrorCodes.SubDeviceErrorCodesDescriptions.NOT_EXIST);
         } else if (Constants.EXPIRED.equals(deviceStatus) || isExpiredDeviceCode(deviceFlowDO, date)) {
             throw new IdentityOAuth2Exception(DeviceErrorCodes.SubDeviceErrorCodes.EXPIRED_TOKEN,
                     DeviceErrorCodes.SubDeviceErrorCodesDescriptions.EXPIRED_TOKEN);


### PR DESCRIPTION
### Proposed changes in this pull request
With current impl, following is the error code for device_code not exist.
```json
{
    "error_description": "invalid_request",
    "error": "invalid_request"
}
```

Above description can be improved with this pr.
```json
{
    "error_description": "The provided device code is not registered or is invalid.",
    "error": "invalid_request"
}
```