### PR TITLE
Reflect changes of moving IdPSecretsProcessor to the idp component.

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/openidconnect/DefaultIDTokenBuilderTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/openidconnect/DefaultIDTokenBuilderTest.java
@@ -74,10 +74,9 @@ import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 import org.wso2.carbon.identity.openidconnect.dao.ScopeClaimMappingDAOImpl;
 import org.wso2.carbon.identity.openidconnect.internal.OpenIDConnectServiceComponentHolder;
 import org.wso2.carbon.identity.openidconnect.model.RequestedClaim;
-import org.wso2.carbon.identity.secret.mgt.core.IdPSecretsProcessor;
-import org.wso2.carbon.identity.secret.mgt.core.SecretsProcessor;
 import org.wso2.carbon.identity.testutil.ReadCertStoreSampleUtil;
 import org.wso2.carbon.idp.mgt.internal.IdpMgtServiceComponentHolder;
+import org.wso2.carbon.idp.mgt.util.IdPSecretsProcessor;
 import org.wso2.carbon.user.core.service.RealmService;
 
 import java.io.InputStream;
@@ -155,9 +154,7 @@ public class DefaultIDTokenBuilderTest {
         configuration.put("OAuth.OpenIDConnect.IDTokenIssuerID", "https://localhost:9443/oauth2/token");
         configuration.put(OAuthConstants.MTLS_HOSTNAME, "https://mtls.localhost:9443/");
         setPrivateStaticField(IdentityUtil.class, "configuration", configuration);
-        SecretsProcessor<IdentityProvider> identityProviderSecretsProcessor = mock(
-                IdPSecretsProcessor.class);
-        IdpMgtServiceComponentHolder.getInstance().setIdPSecretsProcessorService(identityProviderSecretsProcessor);
+        IdPSecretsProcessor identityProviderSecretsProcessor = mock(IdPSecretsProcessor.class);
         when(identityProviderSecretsProcessor.encryptAssociatedSecrets(any())).thenAnswer(
                 invocation -> invocation.getArguments()[0]);
         when(identityProviderSecretsProcessor.decryptAssociatedSecrets(any())).thenAnswer(

--- a/pom.xml
+++ b/pom.xml
@@ -939,7 +939,7 @@
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!-- Carbon Identity Framework version -->
-        <carbon.identity.framework.version>7.5.106</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.5.115</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.25.234, 8.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 


### PR DESCRIPTION
Issue:
- https://github.com/wso2-enterprise/asgardeo-product/issues/27270

With the PR https://github.com/wso2/carbon-identity-framework/pull/6088, the IdPSecretsProcessor class moved from secret core component to to the org.wso2.carbon.idp.mgt component. 

With this PR, update the usage of the to the IdPSecretsProcessor to accomerdate the above change