### PR TITLE
[Clean Up] Clean OIDC session code v1

### DIFF
--- a/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/backchannellogout/ClaimProviderImpl.java
+++ b/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/backchannellogout/ClaimProviderImpl.java
@@ -48,7 +48,7 @@ import javax.ws.rs.core.HttpHeaders;
  */
 public class ClaimProviderImpl implements ClaimProvider {
 
-    private static final Log log = LogFactory.getLog(ClaimProviderImpl.class);
+    private static final Log LOG = LogFactory.getLog(ClaimProviderImpl.class);
 
     @Override
     public Map<String, Object> getAdditionalClaims(OAuthAuthzReqMessageContext oAuthAuthzReqMessageContext,
@@ -61,15 +61,11 @@ public class ClaimProviderImpl implements ClaimProvider {
         if (previousSession == null) {
             // If there is no previous browser session, generate new sid value.
             claimValue = UUID.randomUUID().toString();
-            if (log.isDebugEnabled()) {
-                log.debug("sid claim is generated for auth request. ");
-            }
+            LOG.debug("sid claim is generated for auth request.");
         } else {
             // Previous browser session exists, get sid claim from OIDCSessionState.
             claimValue = previousSession.getSidClaim();
-            if (log.isDebugEnabled()) {
-                log.debug("sid claim is found in the session state");
-            }
+            LOG.debug("sid claim is found in the session state.");
         }
         additionalClaims.put(OAuthConstants.OIDCClaims.SESSION_ID_CLAIM, claimValue);
         oAuth2AuthorizeRespDTO.setOidcSessionId(claimValue);
@@ -104,16 +100,12 @@ public class ClaimProviderImpl implements ClaimProvider {
                 claimValue = previousSession.getSidClaim();
             }
         } else {
-            if (log.isDebugEnabled()) {
-                log.debug("AccessCode is null. Possibly a back end grant");
-            }
+            LOG.debug("AccessCode is null. Possibly a back end grant");
             return additionalClaims;
         }
 
         if (claimValue != null) {
-            if (log.isDebugEnabled()) {
-                log.debug("sid claim is found in the session state");
-            }
+            LOG.debug("sid claim is found in the session state");
             additionalClaims.put("sid", claimValue);
         }
         return additionalClaims;
@@ -122,7 +114,7 @@ public class ClaimProviderImpl implements ClaimProvider {
     /**
      * Return previousSessionState using opbs cookie.
      *
-     * @param oAuthAuthzReqMessageContext
+     * @param oAuthAuthzReqMessageContext OAuthAuthzReqMessageContext.
      * @return OIDCSession state
      */
     private OIDCSessionState getSessionState(OAuthAuthzReqMessageContext oAuthAuthzReqMessageContext) {
@@ -131,10 +123,9 @@ public class ClaimProviderImpl implements ClaimProvider {
         if (cookies != null) {
             for (Cookie cookie : cookies) {
                 if (OIDCSessionConstants.OPBS_COOKIE_ID.equals(cookie.getName())) {
-                    OIDCSessionState previousSessionState = OIDCSessionManagementUtil.getSessionManager()
+                    return OIDCSessionManagementUtil.getSessionManager()
                             .getOIDCSessionState(cookie.getValue(), oAuthAuthzReqMessageContext.
                                     getAuthorizationReqDTO().getLoggedInTenantDomain());
-                    return previousSessionState;
                 }
             }
         }

--- a/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/backchannellogout/DefaultLogoutTokenBuilder.java
+++ b/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/backchannellogout/DefaultLogoutTokenBuilder.java
@@ -70,7 +70,7 @@ import static org.wso2.carbon.identity.oauth2.util.OAuth2Util.getResidentIdpEnti
  */
 public class DefaultLogoutTokenBuilder implements LogoutTokenBuilder {
 
-    private static final Log log = LogFactory.getLog(DefaultLogoutTokenBuilder.class);
+    private static final Log LOG = LogFactory.getLog(DefaultLogoutTokenBuilder.class);
     private OAuthServerConfiguration config = null;
     private JWSAlgorithm signatureAlgorithm = null;
     private static final String OPENID_IDP_ENTITY_ID = "IdPEntityId";
@@ -85,6 +85,7 @@ public class DefaultLogoutTokenBuilder implements LogoutTokenBuilder {
     }
 
     @Override
+    @Deprecated
     public Map<String, String> buildLogoutToken(HttpServletRequest request)
             throws IdentityOAuth2Exception, InvalidOAuthClientException {
 
@@ -102,8 +103,8 @@ public class DefaultLogoutTokenBuilder implements LogoutTokenBuilder {
                     try {
                         oAuthAppDO = getOAuthAppDO(clientID);
                     } catch (InvalidOAuthClientException e) {
-                        if (log.isDebugEnabled()) {
-                            log.debug("The application with client id: " + clientID
+                        if (LOG.isDebugEnabled()) {
+                            LOG.debug("The application with client id: " + clientID
                                     + " does not exists. This application may be deleted after"
                                     + " this session is created. So skipping it in logout token list.", e);
                         }
@@ -154,8 +155,8 @@ public class DefaultLogoutTokenBuilder implements LogoutTokenBuilder {
         try {
             oAuthAppDO = getOAuthAppDO(clientID);
         } catch (InvalidOAuthClientException e) {
-            if (log.isDebugEnabled()) {
-                log.debug("The application with client id: " + clientID
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("The application with client id: " + clientID
                         + " does not exists. This application may be deleted after"
                         + " this session is created. So skipping it in logout token list.", e);
             }
@@ -169,8 +170,8 @@ public class DefaultLogoutTokenBuilder implements LogoutTokenBuilder {
                     getSigningTenantDomain(oAuthAppDO)).serialize();
             logoutTokenList.put(logoutToken, backChannelLogoutUrl);
 
-            if (log.isDebugEnabled()) {
-                log.debug("Logout token created for the client: " + clientID);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Logout token created for the client: " + clientID);
             }
         }
     }
@@ -231,21 +232,21 @@ public class DefaultLogoutTokenBuilder implements LogoutTokenBuilder {
                     JWT decryptedIDToken = OIDCSessionManagementUtil.decryptWithRSA(tenantDomain, idToken);
                     clientId = OIDCSessionManagementUtil.extractClientIDFromDecryptedIDToken(decryptedIDToken);
                 } catch (ParseException e) {
-                    if (log.isDebugEnabled()) {
-                        log.debug("Error in extracting the client ID from the ID token : " + idToken);
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("Error in extracting the client ID from the ID token : " + idToken);
                     }
                 }
                 return clientId;
             }
             clientId = getClientIdFromIDTokenHint(idToken);
         } else {
-            log.debug("IdTokenHint is not found in the request ");
+            LOG.debug("IdTokenHint is not found in the request ");
             return null;
         }
         if (validateIdTokenHint(clientId, idToken)) {
             return clientId;
         } else {
-            log.debug("Id Token is not valid");
+            LOG.debug("Id Token is not valid");
             return null;
         }
     }
@@ -309,16 +310,6 @@ public class DefaultLogoutTokenBuilder implements LogoutTokenBuilder {
 
         String sidClaim = sessionState.getSidClaim();
         return sidClaim;
-    }
-
-    private IdentityProvider getResidentIdp(String tenantDomain) throws IdentityOAuth2Exception {
-
-        try {
-            return IdentityProviderManager.getInstance().getResidentIdP(tenantDomain);
-        } catch (IdentityProviderManagementException e) {
-            String errorMsg = String.format(ERROR_GET_RESIDENT_IDP, tenantDomain);
-            throw new IdentityOAuth2Exception(errorMsg, e);
-        }
     }
 
     /**
@@ -428,8 +419,8 @@ public class DefaultLogoutTokenBuilder implements LogoutTokenBuilder {
             try {
                 clientId = extractClientFromIdToken(idTokenHint);
             } catch (ParseException e) {
-                if (log.isDebugEnabled()) {
-                    log.debug("Error while decoding the ID Token Hint: " + idTokenHint, e);
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Error while decoding the ID Token Hint: " + idTokenHint, e);
                 }
             }
         }
@@ -482,12 +473,12 @@ public class DefaultLogoutTokenBuilder implements LogoutTokenBuilder {
 
             return signedJWT.verify(verifier);
         } catch (JOSEException | ParseException e) {
-            if (log.isDebugEnabled()) {
-                log.debug("Error occurred while validating id token signature.", e);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Error occurred while validating id token signature.", e);
             }
             return false;
         } catch (Exception e) {
-            log.error("Error occurred while validating id token signature.", e);
+            LOG.error("Error occurred while validating id token signature.", e);
             return false;
         }
     }

--- a/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/backchannellogout/DefaultLogoutTokenBuilder.java
+++ b/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/backchannellogout/DefaultLogoutTokenBuilder.java
@@ -30,7 +30,6 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.base.MultitenantConstants;
 import org.wso2.carbon.core.util.KeyStoreManager;
-import org.wso2.carbon.identity.application.common.model.IdentityProvider;
 import org.wso2.carbon.identity.core.ServiceURLBuilder;
 import org.wso2.carbon.identity.core.URLBuilderException;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
@@ -42,8 +41,6 @@ import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 import org.wso2.carbon.identity.oidc.session.OIDCSessionConstants;
 import org.wso2.carbon.identity.oidc.session.OIDCSessionState;
 import org.wso2.carbon.identity.oidc.session.util.OIDCSessionManagementUtil;
-import org.wso2.carbon.idp.mgt.IdentityProviderManagementException;
-import org.wso2.carbon.idp.mgt.IdentityProviderManager;
 import org.wso2.carbon.utils.security.KeystoreUtils;
 
 import java.security.interfaces.RSAPublicKey;

--- a/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/backchannellogout/LogoutRequestSender.java
+++ b/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/backchannellogout/LogoutRequestSender.java
@@ -51,7 +51,7 @@ import javax.servlet.http.HttpServletRequest;
  */
 public class LogoutRequestSender {
 
-    private static final Log log = LogFactory.getLog(LogoutRequestSender.class);
+    private static final Log LOG = LogFactory.getLog(LogoutRequestSender.class);
     private static ExecutorService threadPool = Executors.newFixedThreadPool(2);
     private static LogoutRequestSender instance = new LogoutRequestSender();
     private static final String LOGOUT_TOKEN = "logout_token";
@@ -85,7 +85,7 @@ public class LogoutRequestSender {
         if (opbsCookie != null) {
             sendLogoutRequests(opbsCookie.getValue());
         } else {
-            log.error("No opbscookie exists in the request");
+            LOG.error("No opbscookie exists in the request");
         }
     }
 
@@ -118,11 +118,8 @@ public class LogoutRequestSender {
             for (Map.Entry<String, String> logoutTokenMap : logoutTokenList.entrySet()) {
                 String logoutToken = logoutTokenMap.getKey();
                 String bcLogoutUrl = logoutTokenMap.getValue();
+                LOG.debug("A logoutReqSenderTask will be assigned to the thread pool");
                 threadPool.submit(new LogoutReqSenderTask(logoutToken, bcLogoutUrl));
-                if (log.isDebugEnabled()) {
-                    log.debug("A logoutReqSenderTask is assigned to the thread pool");
-
-                }
             }
         }
     }
@@ -140,10 +137,10 @@ public class LogoutRequestSender {
             DefaultLogoutTokenBuilder logoutTokenBuilder = new DefaultLogoutTokenBuilder();
             logoutTokenList = logoutTokenBuilder.buildLogoutToken(opbsCookie, tenantDomain);
         } catch (IdentityOAuth2Exception e) {
-            log.error("Error while initializing " + DefaultLogoutTokenBuilder.class, e);
+            LOG.error("Error while initializing " + DefaultLogoutTokenBuilder.class, e);
         } catch (InvalidOAuthClientException e) {
-            if (log.isDebugEnabled()) {
-                log.debug("Error while obtaining logout token list for the obpsCookie: " + opbsCookie +
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Error while obtaining logout token list for the obpsCookie: " + opbsCookie +
                                 "& tenant domain: " + tenantDomain, e);
             }
         }
@@ -169,8 +166,8 @@ public class LogoutRequestSender {
         @Override
         public void run() {
 
-            if (log.isDebugEnabled()) {
-                log.debug("Starting backchannel logout request to: " + backChannelLogouturl);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Starting backchannel logout request to: " + backChannelLogouturl);
             }
 
             List<NameValuePair> logoutReqParams = new ArrayList<NameValuePair>();
@@ -194,15 +191,15 @@ public class LogoutRequestSender {
                 try {
                     httpPost.setEntity(new UrlEncodedFormEntity(logoutReqParams));
                 } catch (UnsupportedEncodingException e) {
-                    log.error("Error while sending logout token", e);
+                    LOG.error("Error while sending logout token", e);
                 }
                 HttpResponse response = httpClient.execute(httpPost);
-                if (log.isDebugEnabled()) {
-                    log.debug("Backchannel logout response: " + response.getStatusLine());
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Backchannel logout response: " + response.getStatusLine());
                 }
 
             } catch (IOException e) {
-                log.error("Error sending logout requests to: " + backChannelLogouturl, e);
+                LOG.error("Error sending logout requests to: " + backChannelLogouturl, e);
             }
         }
     }


### PR DESCRIPTION
### Proposed changes in this pull request
1. Log is a static final variable, so it should be "LOG" not "log".
2. Clean some un used code.
3. Checking for debug enabled is redundent, but improve performance if the logging message contains computations. But if there is no computations, no concatinations then checking debug enabled affect the performance. Hence I selectively remove debug enabled checks if the message is simple.