### PR TITLE
Improve request object clean up logic to avoid unnecessary delete requests

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/pom.xml
+++ b/components/org.wso2.carbon.identity.oauth/pom.xml
@@ -406,6 +406,7 @@
                             org.apache.commons.collections.map; version="${commons-collections.wso2.osgi.version.range}",
                             org.apache.commons.lang; version="${commons-lang.wso2.osgi.version.range}",
                             org.apache.commons.logging; version="${commons-logging.osgi.version.range}",
+                            org.apache.commons.collections; version="${commons-collections.wso2.osgi.version.range}",
 
                             com.google.gdata.client.authn.oauth; version="${gdata-core.imp.pkg.version.range}",
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthUtil.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthUtil.java
@@ -690,7 +690,7 @@ public final class OAuthUtil {
                                 authorizationCode.getAuthorizationCode())));
                 OAuthTokenPersistenceFactory.getInstance().getAuthorizationCodeDAO()
                         .updateAuthorizationCodeState(authorizationCode.getAuthorizationCode(),
-                                OAuthConstants.AuthorizationCodeState.REVOKED);
+                                authorizationCode.getAuthzCodeId(), OAuthConstants.AuthorizationCodeState.REVOKED);
             }
         } catch (IdentityOAuth2Exception e) {
             String errorMsg = "Error occurred while revoking authorization codes for user: " + username;

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dao/AccessTokenDAOImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dao/AccessTokenDAOImpl.java
@@ -19,6 +19,7 @@
 package org.wso2.carbon.identity.oauth2.dao;
 
 import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
@@ -1514,10 +1515,12 @@ public class AccessTokenDAOImpl extends AbstractOAuthDAO implements AccessTokenD
                 }
                 ps.executeBatch();
                 IdentityDatabaseUtil.commitTransaction(connection);
-                // To revoke request objects which have persisted against the access token.
-                OAuth2TokenUtil.postUpdateAccessTokens(Arrays.asList(tokens), OAuthConstants.TokenStates.
-                        TOKEN_STATE_REVOKED);
                 if (isTokenCleanupFeatureEnabled) {
+                    if (connection.getMetaData().getDriverName().contains("Microsoft")) {
+                        /* When token is deleted, the request objects get on delete cascade except for the SQL server.
+                        Hence, invoke the event listener to revoke the request objects.*/
+                        revokeRequestObjectEntries(Arrays.asList(tokens));
+                    }
                     oldTokenCleanupObject.cleanupTokensInBatch(oldTokens, connection);
                 }
             } catch (SQLException e) {
@@ -1545,14 +1548,13 @@ public class AccessTokenDAOImpl extends AbstractOAuthDAO implements AccessTokenD
 
 
                 if (isTokenCleanupFeatureEnabled) {
+                    if (connection.getMetaData().getDriverName().contains("Microsoft")) {
+                        /* When token is deleted, the request objects get on delete cascade except for the SQL server.
+                        Hence, invoke the event listener to revoke the request objects.*/
+                        revokeRequestObjectEntries(Arrays.asList(tokens));
+                    }
                     oldTokenCleanupObject.cleanupTokenByTokenValue(
                             getHashingPersistenceProcessor().getProcessedAccessTokenIdentifier(tokens[0]), connection);
-                    /* When token is deleted, the request objects get on delete cascade except for the SQL server.
-                        Hence, invoke the event listener to revoke the request objects.*/
-                    if (connection.getMetaData().getDriverName().contains("Microsoft")) {
-                        OAuth2TokenUtil.postUpdateAccessTokens(Arrays.asList(tokens), OAuthConstants.TokenStates.
-                                TOKEN_STATE_REVOKED);
-                    }
                 }
             } catch (SQLException e) {
                 // IdentityDatabaseUtil.rollbackTransaction(connection);
@@ -1618,13 +1620,13 @@ public class AccessTokenDAOImpl extends AbstractOAuthDAO implements AccessTokenD
                 }
                 accessTokenId.add(getTokenIdByAccessToken(token));
             }
-            // To revoke request objects which have persisted against the access token.
-            if (accessTokenId.size() > 0) {
-                OAuth2TokenUtil.postUpdateAccessTokens(accessTokenId, OAuthConstants.TokenStates.
-                        TOKEN_STATE_REVOKED);
-            }
 
             if (isTokenCleanupFeatureEnabled) {
+                if (connection.getMetaData().getDriverName().contains("Microsoft")) {
+                    /* When token is deleted, the request objects get on delete cascade except for the SQL server.
+                    Hence, invoke the event listener to revoke the request objects.*/
+                    revokeRequestObjectEntries(accessTokenId);
+                }
                 for (String token : tokens) {
                     oldTokenCleanupObject.cleanupTokenByTokenValue(
                             getHashingPersistenceProcessor().getProcessedAccessTokenIdentifier(token), connection);
@@ -3330,5 +3332,16 @@ public class AccessTokenDAOImpl extends AbstractOAuthDAO implements AccessTokenD
             throw new IdentityOAuth2Exception("Error occurred while resolving root tenant domain by organization ID: " +
                     organizationId, e);
         }
+    }
+
+    /* When token is deleted, the request objects get on delete cascade except for the SQL server.
+       Hence, invoke the event listener to revoke the request objects.*/
+    private void revokeRequestObjectEntries(List<String> tokens) throws IdentityOAuth2Exception {
+
+        if (CollectionUtils.isEmpty(tokens)) {
+            return;
+        }
+        OAuth2TokenUtil.postUpdateAccessTokens(tokens, OAuthConstants.TokenStates.
+                TOKEN_STATE_REVOKED);
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dao/AuthorizationCodeDAO.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dao/AuthorizationCodeDAO.java
@@ -66,6 +66,8 @@ public interface AuthorizationCodeDAO {
     AuthorizationCodeValidationResult validateAuthorizationCode(String consumerKey, String authorizationKey)
             throws IdentityOAuth2Exception;
 
+    void updateAuthorizationCodeState(String authzCode, String codeId, String newState) throws IdentityOAuth2Exception;
+
     void updateAuthorizationCodeState(String authzCode, String newState) throws IdentityOAuth2Exception;
 
     void deactivateAuthorizationCode(AuthzCodeDO authzCodeDO) throws

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AuthorizationCodeGrantHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AuthorizationCodeGrantHandler.java
@@ -555,7 +555,7 @@ public class AuthorizationCodeGrantHandler extends AbstractAuthorizationGrantHan
     private void markAsExpired(AuthzCodeDO authzCodeBean) throws IdentityOAuth2Exception {
 
         OAuthTokenPersistenceFactory.getInstance().getAuthorizationCodeDAO()
-                .updateAuthorizationCodeState(authzCodeBean.getAuthorizationCode(),
+                .updateAuthorizationCodeState(authzCodeBean.getAuthorizationCode(), authzCodeBean.getAuthzCodeId(),
                         OAuthConstants.AuthorizationCodeState.EXPIRED);
         if (log.isDebugEnabled()) {
             log.debug("Changed state of authorization code : " + authzCodeBean.getAuthorizationCode() + " to expired");
@@ -599,8 +599,10 @@ public class AuthorizationCodeGrantHandler extends AbstractAuthorizationGrantHan
     }
 
     private void revokeAuthorizationCode(AuthzCodeDO authzCodeBean) throws IdentityOAuth2Exception {
+
         OAuthTokenPersistenceFactory.getInstance().getAuthorizationCodeDAO().updateAuthorizationCodeState(
-                authzCodeBean.getAuthorizationCode(), OAuthConstants.AuthorizationCodeState.REVOKED);
+                authzCodeBean.getAuthorizationCode(), authzCodeBean.getAuthzCodeId(),
+                OAuthConstants.AuthorizationCodeState.REVOKED);
         if (log.isDebugEnabled()) {
             log.debug("Changed state of authorization code : " + authzCodeBean.getAuthorizationCode() + " to revoked");
         }

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/dao/AccessTokenDAOImplTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/dao/AccessTokenDAOImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.org).
+ * Copyright (c) 2024-2025, WSO2 LLC. (http://www.wso2.org).
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -29,14 +29,21 @@ import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 import org.wso2.carbon.identity.common.testng.WithCarbonHome;
 import org.wso2.carbon.identity.core.util.IdentityDatabaseUtil;
+import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.dao.util.DAOUtils;
 
 import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 
 @WithCarbonHome
@@ -51,6 +58,7 @@ public class AccessTokenDAOImplTest {
     public static final String DB_NAME = "AccessTokenDB";
     Connection connection = null;
     private MockedStatic<IdentityDatabaseUtil> identityDatabaseUtil;
+    private MockedStatic<OAuthServerConfiguration> oAuthServerConfiguration;
 
     @BeforeClass
     public void initTest() throws Exception {
@@ -60,13 +68,20 @@ public class AccessTokenDAOImplTest {
         } catch (Exception e) {
             throw new IdentityOAuth2Exception("Error while initializing the data source", e);
         }
-        accessTokenDAO = new AccessTokenDAOImpl();
     }
 
     @BeforeMethod
     public void setUp() throws Exception {
 
         connection = DAOUtils.getConnection(DB_NAME);
+        identityDatabaseUtil = mockStatic(IdentityDatabaseUtil.class);
+        oAuthServerConfiguration = mockStatic(OAuthServerConfiguration.class);
+
+        OAuthServerConfiguration mockOAuthServerConfiguration = mock(OAuthServerConfiguration.class);
+        oAuthServerConfiguration.when(OAuthServerConfiguration::getInstance)
+                .thenReturn(mockOAuthServerConfiguration);
+        when(mockOAuthServerConfiguration.isTokenCleanupEnabled()).thenReturn(true);
+        accessTokenDAO = new AccessTokenDAOImpl();
     }
 
     @AfterMethod
@@ -76,6 +91,7 @@ public class AccessTokenDAOImplTest {
             connection.close();
         }
         identityDatabaseUtil.close();
+        oAuthServerConfiguration.close();
     }
 
     @AfterClass
@@ -88,8 +104,6 @@ public class AccessTokenDAOImplTest {
     public void getSessionIdentifierByTokenId() throws Exception {
 
         connection = DAOUtils.getConnection(DB_NAME);
-        identityDatabaseUtil = mockStatic(IdentityDatabaseUtil.class);
-
         identityDatabaseUtil.when(() -> IdentityDatabaseUtil.getDBConnection(false))
                 .thenReturn(connection);
         assertEquals(accessTokenDAO.getSessionIdentifierByTokenId("2sa9a678f890877856y66e75f605d456"),
@@ -102,5 +116,44 @@ public class AccessTokenDAOImplTest {
         if (dataSource != null) {
             dataSource.close();
         }
+    }
+
+    @Test
+    public void testRevokeAccessTokensIndividually() throws Exception {
+
+        String[] tokens = {};
+        boolean isHashedToken = false;
+
+        Connection mockConnection = mock(Connection.class);
+        DatabaseMetaData mockDatabaseMetaData = mock(DatabaseMetaData.class);
+        when(mockConnection.getMetaData()).thenReturn(mockDatabaseMetaData);
+        when(mockDatabaseMetaData.getDriverName()).thenReturn("Microsoft SQL Server");
+        identityDatabaseUtil.when(IdentityDatabaseUtil::getDBConnection).thenReturn(mockConnection);
+        accessTokenDAO.revokeAccessTokensIndividually(tokens, isHashedToken);
+    }
+
+    @Test
+    public void testRevokeAccessTokensInBatch() throws Exception {
+
+        String[] tokens = {"token1", "token2"};
+        boolean isHashedToken = true;
+
+        Connection mockConnection = mock(Connection.class);
+        PreparedStatement preparedStatement = mock(PreparedStatement.class);
+        ResultSet resultSet = mock(ResultSet.class);
+        when(preparedStatement.executeQuery()).thenReturn(resultSet);
+        when(mockConnection.prepareStatement(anyString())).thenReturn(preparedStatement);
+
+        DatabaseMetaData mockDatabaseMetaData = mock(DatabaseMetaData.class);
+        when(mockConnection.getMetaData()).thenReturn(mockDatabaseMetaData);
+        when(mockDatabaseMetaData.getDriverName()).thenReturn("Microsoft SQL Server");
+        identityDatabaseUtil.when(IdentityDatabaseUtil::getDBConnection).thenReturn(mockConnection);
+
+        OAuthServerConfiguration mockOAuthServerConfiguration = mock(OAuthServerConfiguration.class);
+        oAuthServerConfiguration.when(OAuthServerConfiguration::getInstance)
+                .thenReturn(mockOAuthServerConfiguration);
+        when(mockOAuthServerConfiguration.getHashAlgorithm()).thenReturn("SHA-256");
+
+        accessTokenDAO.revokeAccessTokensInBatch(tokens, isHashedToken);
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/dao/AuthorizationCodeDAOImplTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/dao/AuthorizationCodeDAOImplTest.java
@@ -282,7 +282,7 @@ public class AuthorizationCodeDAOImplTest {
                     .thenAnswer(
                             (Answer<Void>) invocation -> null);
             authorizationCodeDAO.updateAuthorizationCodeState(authzCodeDO1.getAuthorizationCode(),
-                    OAuthConstants.AuthorizationCodeState.REVOKED);
+                    authzCodeDO1.getAuthzCodeId(), OAuthConstants.AuthorizationCodeState.REVOKED);
             Set<String> availableAuthzCodes = new HashSet<>();
             availableAuthzCodes.add(authzCode2);
 

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/dao/AuthorizationCodeDAOImplTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/dao/AuthorizationCodeDAOImplTest.java
@@ -282,7 +282,7 @@ public class AuthorizationCodeDAOImplTest {
                     .thenAnswer(
                             (Answer<Void>) invocation -> null);
             authorizationCodeDAO.updateAuthorizationCodeState(authzCodeDO1.getAuthorizationCode(),
-                    authzCodeDO1.getAuthzCodeId(), OAuthConstants.AuthorizationCodeState.REVOKED);
+                    OAuthConstants.AuthorizationCodeState.REVOKED);
             Set<String> availableAuthzCodes = new HashSet<>();
             availableAuthzCodes.add(authzCode2);
 


### PR DESCRIPTION
### Proposed changes in this pull request

> The request object tables get entries added for the authorization request object flow only. For the normal authorization flows, try to delete from request object tables is a cost.
- [x] Improved authorization code revocation logics to pass the authz code and authz code-id which help to detect the flow is request object flow which help to avoid unnecessary operations. 

> When internal token clean up is disabled, tryin to delete the request objects from the relevant tables are unnecessary. Internal token clean ups are disabled to improve the performance at the runtime, but clean the tables as back office task.
- [x] Call the request object handling for token-ids when internal token clean up is enabled.

> The request object table has foreign key constraints with authz-code and access-token tables with on delete cascade approach except for the mssql database. Hence there is no need to delete the records via an event listener. Only for the MSSQL server databases, we can consider of invoking the listener. But ideally we could have improved it to delete via a trigger.
 - [x] Call the request object handling for token-ids only for mssql database type.

### Related Issues
- https://github.com/wso2/product-is/issues/21598
