### PR TITLE
Property "renew_token_without_revoking_existing" not being honored causing stuck threads

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
+++ b/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
@@ -117,6 +117,8 @@ public final class OAuthConstants {
 
     public static final String READ_AMR_VALUE_FROM_IDP = "OAuth.ReplaceDefaultAMRValuesWithIDPSentValues";
 
+    public static final String OAUTH_APP = "OAuthAppDO";
+
     public static final String CNF = "cnf";
     public static final String MTLS_AUTH_HEADER = "MutualTLS.ClientCertificateHeader";
     public static final String BEGIN_CERT = "-----BEGIN CERTIFICATE-----";

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/model/TokenIssuerDO.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/model/TokenIssuerDO.java
@@ -32,6 +32,7 @@ package org.wso2.carbon.identity.oauth2.model;
 public class TokenIssuerDO {
 
     private String tokenType;
+    private String accessTokenType;
     private String tokenImplClass;
     private boolean persistAccessTokenAlias;
 
@@ -49,12 +50,44 @@ public class TokenIssuerDO {
     public TokenIssuerDO() {
     }
 
+    /**
+     * @deprecated Use {@link #getAccessTokenType()} instead.
+     */
+    @Deprecated
     public String getTokenType() {
         return tokenType;
     }
 
+    /**
+     * @deprecated Use {@link #setAccessTokenType(String)} instead.
+     */
+    @Deprecated
     public void setTokenType(String tokenType) {
         this.tokenType = tokenType;
+    }
+
+    /**
+     * Get the token issuer name.
+     * @return the token issuer name
+     */
+    public String getTokenIssuerName() {
+        return tokenType;
+    }
+
+    /**
+     * Set the token issuer name.
+     * @param tokenIssuerName the token issuer name to set
+     */
+    public void setTokenIssuerName(String tokenIssuerName) {
+        this.tokenType = tokenIssuerName;
+    }
+
+    public String getAccessTokenType() {
+        return accessTokenType;
+    }
+
+    public void setAccessTokenType(String accessTokenType) {
+        this.accessTokenType = accessTokenType;
     }
 
     public String getTokenImplClass() {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AbstractAuthorizationGrantHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AbstractAuthorizationGrantHandler.java
@@ -103,9 +103,6 @@ public abstract class AbstractAuthorizationGrantHandler implements Authorization
     protected static final int SECONDS_TO_MILISECONDS_FACTOR = 1000;
     private boolean isHashDisabled = OAuth2Util.isHashDisabled();
 
-    private static final boolean renewWithoutRevokingExistingEnabled = Boolean.parseBoolean(IdentityUtil.
-            getProperty(RENEW_TOKEN_WITHOUT_REVOKING_EXISTING_ENABLE_CONFIG));
-
     @Override
     public void init() throws IdentityOAuth2Exception {
         callbackManager = new OAuthCallbackManager();
@@ -192,7 +189,7 @@ public abstract class AbstractAuthorizationGrantHandler implements Authorization
             based on the config.
             */
             boolean isJWTAndRenewEnabled = (JWT.equalsIgnoreCase(tokenIssuerName) || JWT.equalsIgnoreCase(tokenType))
-                    && renewWithoutRevokingExistingEnabled;
+                    && getRenewWithoutRevokingExistingStatus();
             boolean isGrantTypeAllowed = OAuth2ServiceComponentHolder.getJwtRenewWithoutRevokeAllowedGrantTypes()
                     .contains(tokReqMsgCtx.getOauth2AccessTokenReqDTO().getGrantType());
 
@@ -244,6 +241,13 @@ public abstract class AbstractAuthorizationGrantHandler implements Authorization
             return generateNewAccessToken(tokReqMsgCtx, scope, consumerKey, existingTokenBean, true,
                     oauthTokenIssuer);
         }
+    }
+
+    private boolean getRenewWithoutRevokingExistingStatus() {
+
+        return Boolean.parseBoolean(IdentityUtil.
+                getProperty(RENEW_TOKEN_WITHOUT_REVOKING_EXISTING_ENABLE_CONFIG));
+
     }
 
     private void setDetailsToMessageContext(OAuthTokenReqMessageContext tokReqMsgCtx, AccessTokenDO existingToken) {
@@ -1242,7 +1246,8 @@ public abstract class AbstractAuthorizationGrantHandler implements Authorization
         }
 
         if (JWT.equalsIgnoreCase(tokenIssuerName) || JWT.equalsIgnoreCase(tokenType)) {
-            if (renewWithoutRevokingExistingEnabled && tokReqMsgCtx != null && (tokReqMsgCtx.getTokenBinding() == null
+            if (getRenewWithoutRevokingExistingStatus() && tokReqMsgCtx != null
+                    && (tokReqMsgCtx.getTokenBinding() == null
                     || StringUtils.isBlank(tokReqMsgCtx.getTokenBinding().getBindingReference()))) {
                 if (OAuth2ServiceComponentHolder.getJwtRenewWithoutRevokeAllowedGrantTypes()
                         .contains(tokReqMsgCtx.getOauth2AccessTokenReqDTO().getGrantType())) {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AbstractAuthorizationGrantHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AbstractAuthorizationGrantHandler.java
@@ -81,10 +81,13 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.function.Consumer;
 
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OAUTH_APP;
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.RENEW_TOKEN_WITHOUT_REVOKING_EXISTING_ENABLE_CONFIG;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.TokenBindings.NONE;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.TokenStates.TOKEN_STATE_ACTIVE;
 import static org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration.JWT_TOKEN_TYPE;
 import static org.wso2.carbon.identity.oauth2.util.OAuth2Util.EXTENDED_REFRESH_TOKEN_DEFAULT_TIME;
+import static org.wso2.carbon.identity.oauth2.util.OAuth2Util.JWT;
 
 /**
  * Abstract authorization grant handler.
@@ -99,6 +102,9 @@ public abstract class AbstractAuthorizationGrantHandler implements Authorization
     protected static final String EXISTING_TOKEN_ISSUED = "existingTokenUsed";
     protected static final int SECONDS_TO_MILISECONDS_FACTOR = 1000;
     private boolean isHashDisabled = OAuth2Util.isHashDisabled();
+
+    private static final boolean renewWithoutRevokingExistingEnabled = Boolean.parseBoolean(IdentityUtil.
+            getProperty(RENEW_TOKEN_WITHOUT_REVOKING_EXISTING_ENABLE_CONFIG));
 
     @Override
     public void init() throws IdentityOAuth2Exception {
@@ -171,6 +177,37 @@ public abstract class AbstractAuthorizationGrantHandler implements Authorization
 
         synchronized ((consumerKey + ":" + authorizedUserId + ":" + scope + ":" + tokenBindingReference).intern()) {
             AccessTokenDO existingTokenBean = null;
+
+            OAuthAppDO oAuthAppDO = (OAuthAppDO) tokReqMsgCtx.getProperty(OAUTH_APP);
+            String tokenIssuerName = (oAuthAppDO != null) ? oAuthAppDO.getTokenType() : null;
+            String tokenType = null;
+            if (tokenIssuerName != null) {
+                tokenType = OAuthServerConfiguration.getInstance().getSupportedTokenIssuers()
+                        .get(tokenIssuerName).getAccessTokenType();
+            }
+
+            /*
+            Check if the token type is JWT and renew without revoking existing tokens is enabled.
+            Additionally, ensure that the grant type used for the token request is allowed to renew without revoke,
+            based on the config.
+            */
+            boolean isJWTAndRenewEnabled = (JWT.equalsIgnoreCase(tokenIssuerName) || JWT.equalsIgnoreCase(tokenType))
+                    && renewWithoutRevokingExistingEnabled;
+            boolean isGrantTypeAllowed = OAuth2ServiceComponentHolder.getJwtRenewWithoutRevokeAllowedGrantTypes()
+                    .contains(tokReqMsgCtx.getOauth2AccessTokenReqDTO().getGrantType());
+
+            if (isJWTAndRenewEnabled && isGrantTypeAllowed) {
+                /*
+                If the application does not have a token binding type (i.e., no specific binding type is set),
+                binding reference will be randomly generated UUID, in that case we can generate a new access token
+                without looking up the existing tokens in the token table.
+                */
+                if (oAuthAppDO.getTokenBindingType() == null) {
+                    return generateNewAccessToken(tokReqMsgCtx, scope, consumerKey, existingTokenBean,
+                            false, oauthTokenIssuer);
+                }
+            }
+
             if (isHashDisabled) {
                 existingTokenBean = getExistingToken(tokReqMsgCtx,
                         getOAuthCacheKey(scope, consumerKey, authorizedUserId, authenticatedIDP,
@@ -1176,16 +1213,60 @@ public abstract class AbstractAuthorizationGrantHandler implements Authorization
      */
     protected String getTokenBindingReference(OAuthTokenReqMessageContext tokReqMsgCtx) {
 
-        if (tokReqMsgCtx.getTokenBinding() == null) {
-            if (log.isDebugEnabled()) {
-                log.debug("Token binding data is null.");
+        /**
+         * If OAuth.JWT.RenewTokenWithoutRevokingExisting is enabled from configurations, and current token
+         * binding is null,then we will add a new token binding (request binding) to the token binding with
+         * a value of a random UUID.
+         * The purpose of this new token binding type is to add a random value to the token binding so that
+         * "User, Application, Scope, Binding" combination will be unique for each token.
+         * Previously, if a token issue request come for the same combination of "User, Application, Scope, Binding",
+         * the existing JWT token will be revoked and issue a new token. but with this way, we can issue new tokens
+         * without revoking the old ones.
+         *
+         * Add following configuration to deployment.toml file to enable this feature.
+         *     [oauth.jwt.renew_token_without_revoking_existing]
+         *     enable = true
+         *
+         * By default, the allowed grant type for this feature is "client_credentials". If you need to enable for
+         * other grant types, add the following configuration to deployment.toml file.
+         *     [oauth.jwt.renew_token_without_revoking_existing]
+         *     enable = true
+         *     allowed_grant_types = ["client_credentials","password", ...]
+         */
+        OAuthAppDO oAuthAppDO = (OAuthAppDO) tokReqMsgCtx.getProperty(OAUTH_APP);
+        String tokenIssuerName = (oAuthAppDO != null) ? oAuthAppDO.getTokenType() : null;
+        String tokenType = null;
+        if (tokenIssuerName != null) {
+            tokenType = OAuthServerConfiguration.getInstance().getSupportedTokenIssuers()
+                    .get(tokenIssuerName).getAccessTokenType();
+        }
+
+        if (JWT.equalsIgnoreCase(tokenIssuerName) || JWT.equalsIgnoreCase(tokenType)) {
+            if (renewWithoutRevokingExistingEnabled && tokReqMsgCtx != null && (tokReqMsgCtx.getTokenBinding() == null
+                    || StringUtils.isBlank(tokReqMsgCtx.getTokenBinding().getBindingReference()))) {
+                if (OAuth2ServiceComponentHolder.getJwtRenewWithoutRevokeAllowedGrantTypes()
+                        .contains(tokReqMsgCtx.getOauth2AccessTokenReqDTO().getGrantType())) {
+                    return UUID.randomUUID().toString();
+                }
+                return NONE;
             }
+        }
+        return getExistingTokenBindingReference(tokReqMsgCtx);
+    }
+
+    /**
+     * Retrieves the existing token binding reference if available, otherwise returns NONE.
+     *
+     * @param tokReqMsgCtx OAuthTokenReqMessageContext.
+     * @return token binding reference.
+     */
+    private String getExistingTokenBindingReference(OAuthTokenReqMessageContext tokReqMsgCtx) {
+
+        if (tokReqMsgCtx == null || tokReqMsgCtx.getTokenBinding() == null) {
             return NONE;
         }
-        if (StringUtils.isBlank(tokReqMsgCtx.getTokenBinding().getBindingReference())) {
-            return NONE;
-        }
-        return tokReqMsgCtx.getTokenBinding().getBindingReference();
+        String bindingReference = tokReqMsgCtx.getTokenBinding().getBindingReference();
+        return StringUtils.isBlank(bindingReference) ? NONE : bindingReference;
     }
 
     /**


### PR DESCRIPTION
### Proposed changes in this pull request
- Skip checking for existing token when `renew_without_revoking_existing` is enabled, the binding type is set to "none," and generate a random UUID as the binding reference. This avoids thread stuck issues.
- Support for reading the token type from the following `Deployment.toml` configurations and correctly retrieves the token type to initialize the "renew_token_without_revoking_existing" flow.

```
//Adding custom token issuers
[[oauth.extensions.token_types]]
name = "CustomTokenIssuer"
issuer = "org.wso2.carbon.identity.extensions.CustomJWTTokenIssuer"
persist_access_token_alias = true
type = "jwt"

//Changing the default token issuer
[oauth.extensions]
token_generator = "org.wso2.carbon.identity.extensions.CustomJWTTokenIssuer"
token_type = "jwt"
```
#### Resolves
- https://github.com/wso2/product-is/issues/20994
- https://github.com/wso2/product-is/issues/21122
- https://github.com/wso2/product-is/issues/21355

### When should this PR be merged

This PR should be merged after merging the following PR.
- https://github.com/wso2/carbon-identity-framework/pull/6126