### PR TITLE
Always replace access token attributes with user attribute for old apps.

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImpl.java
@@ -1010,8 +1010,7 @@ public class OAuthAdminServiceImpl {
                 // 2. The AT claims separation is not enabled at app level.
                 // 3. The access token claims are empty.
                 try {
-                    if (!isAccessTokenClaimsSeparationEnabledForApp(oAuthAppDO.getOauthConsumerKey(),
-                            tenantDomain) && oAuthAppDO.getAccessTokenClaims().length == 0) {
+                    if (!isAccessTokenClaimsSeparationEnabledForApp(oAuthAppDO.getOauthConsumerKey(), tenantDomain)) {
                         // Add requested claims as access token claims.
                         addAccessTokenClaims(oAuthAppDO, tenantDomain);
                     }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImpl.java
@@ -1008,7 +1008,6 @@ public class OAuthAdminServiceImpl {
                 // We only trigger the access token claims migration if the following conditions are met.
                 // 1. The AT claims separation is enabled at server level.
                 // 2. The AT claims separation is not enabled at app level.
-                // 3. The access token claims are empty.
                 try {
                     if (!isAccessTokenClaimsSeparationEnabledForApp(oAuthAppDO.getOauthConsumerKey(), tenantDomain)) {
                         // Add requested claims as access token claims.


### PR DESCRIPTION
### Improvement
With this change when upgrading an application, always set the access token attributes as user attributes.

Previous behavior:
- Create new app -> add access token attribute -> downgrade -> add new user attributes -> upgrade
    -  access token attribute = old access token attribute

New behavior:
- Create new app -> add access token attribute -> downgrade -> add new user attributes -> upgrade
    -  access token attribute = user attributes

Related issues:
- https://github.com/wso2/product-is/issues/20880
