### PR TITLE
Treat the ID token signature validation failure as client error instead of generic error which will be logged as server error later

### DIFF
--- a/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/servlet/OIDCLogoutServlet.java
+++ b/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/servlet/OIDCLogoutServlet.java
@@ -1108,7 +1108,7 @@ public class OIDCLogoutServlet extends HttpServlet {
             return OIDCSessionManagementUtil.extractClientIDFromDecryptedIDToken(decryptedIDToken);
         } else {
             if (!validateIdToken(idToken)) {
-                throw new IdentityOAuth2Exception(OAuth2ErrorCodes.OAuth2SubErrorCodes.INVALID_ID_TOKEN,
+                throw new IdentityOAuth2ClientException(OAuth2ErrorCodes.OAuth2SubErrorCodes.INVALID_ID_TOKEN,
                         "ID token signature validation failed.");
             }
             return extractClientFromIdToken(idToken);


### PR DESCRIPTION
### Proposed changes in this pull request

In the OIDC logout request, The ID token signature validation failure is not required to be handled as server error and log the error. It should be a client error as the id token is sent by the client apps, along with OIDC logout request.

The failure should have been handled by this exception block [1], but it is being handled from this exception block[2].

[1] - https://github.com/wso2-extensions/identity-inbound-auth-oauth/blob/master/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/servlet/OIDCLogoutServlet.java#L244~L251
[2] - https://github.com/wso2-extensions/identity-inbound-auth-oauth/blob/master/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/servlet/OIDCLogoutServlet.java#L252~L255
