### PR TITLE
Property "renew_token_without_revoking_existing" not being honored causing stuck threads

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
+++ b/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
@@ -117,6 +117,8 @@ public final class OAuthConstants {
 
     public static final String READ_AMR_VALUE_FROM_IDP = "OAuth.ReplaceDefaultAMRValuesWithIDPSentValues";
 
+    public static final String OAUTH_APP = "OAuthAppDO";
+
     public static final String CNF = "cnf";
     public static final String MTLS_AUTH_HEADER = "MutualTLS.ClientCertificateHeader";
     public static final String BEGIN_CERT = "-----BEGIN CERTIFICATE-----";

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/OAuth2Constants.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/OAuth2Constants.java
@@ -34,6 +34,17 @@ public class OAuth2Constants {
         public static final String CLIENT_REQUEST = "client-request";
 
     }
+
+    /**
+     * Constants for token types.
+     */
+    public static class TokenTypes {
+
+        public static final String OPAQUE = "Opaque";
+        public static final String JWT = "jwt";
+
+    }
+
     public static final String GROUPS = "groups";
     public static final String ENTITY_ID = "entity_id";
     public static final String IS_CONSENTED = "is_consented";

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/OAuth2Constants.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/OAuth2Constants.java
@@ -42,7 +42,6 @@ public class OAuth2Constants {
 
         public static final String OPAQUE = "Opaque";
         public static final String JWT = "jwt";
-
     }
 
     public static final String GROUPS = "groups";

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuer.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuer.java
@@ -120,6 +120,12 @@ public class JWTTokenIssuer extends OauthTokenIssuerImpl {
         signatureAlgorithm = mapSignatureAlgorithm(config.getSignatureAlgorithm());
     }
 
+    @Override
+    public String getAccessTokenType() {
+
+        return "JWT";
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuer.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuer.java
@@ -123,7 +123,7 @@ public class JWTTokenIssuer extends OauthTokenIssuerImpl {
     @Override
     public String getAccessTokenType() {
 
-        return "JWT";
+        return JWT_TYP_HEADER_VALUE;
     }
 
     /**

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/OauthTokenIssuer.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/OauthTokenIssuer.java
@@ -99,4 +99,13 @@ public interface OauthTokenIssuer {
     default String issueSubjectToken(OAuthAuthzReqMessageContext oauthAuthzMsgCtx) throws IdentityOAuth2Exception {
         return StringUtils.EMPTY;
     }
+
+    /**
+     * Default method to retrieve the access token type
+     *
+     * @return The type of the token (e.g., "JWT" or "Opaque").
+     */
+    default String getAccessTokenType() {
+        return "Opaque";
+    }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/OauthTokenIssuer.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/OauthTokenIssuer.java
@@ -24,6 +24,8 @@ import org.apache.oltu.oauth2.common.exception.OAuthSystemException;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.authz.OAuthAuthzReqMessageContext;
 
+import static org.wso2.carbon.identity.oauth2.OAuth2Constants.TokenTypes.OPAQUE;
+
 /**
  * OAuth 2 access token issuer.
  */
@@ -106,6 +108,7 @@ public interface OauthTokenIssuer {
      * @return The type of the token (e.g., "JWT" or "Opaque").
      */
     default String getAccessTokenType() {
-        return "Opaque";
+
+        return OPAQUE;
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AbstractAuthorizationGrantHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AbstractAuthorizationGrantHandler.java
@@ -1241,7 +1241,7 @@ public abstract class AbstractAuthorizationGrantHandler implements Authorization
                     "Error while retrieving oauth issuer for the app with clientId: " + consumerKey, e);
         }
 
-        String tokenType =  oauthTokenIssuer.getAccessTokenType();
+        String tokenType = oauthTokenIssuer.getAccessTokenType();
 
         if (JWT.equalsIgnoreCase(tokenType)) {
             if (getRenewWithoutRevokingExistingStatus()

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AbstractAuthorizationGrantHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AbstractAuthorizationGrantHandler.java
@@ -736,7 +736,6 @@ public abstract class AbstractAuthorizationGrantHandler implements Authorization
 
         return Boolean.parseBoolean(IdentityUtil.
                 getProperty(RENEW_TOKEN_WITHOUT_REVOKING_EXISTING_ENABLE_CONFIG));
-
     }
 
     private String getNewAccessToken(OAuthTokenReqMessageContext tokReqMsgCtx, OauthTokenIssuer oauthTokenIssuer)

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AbstractAuthorizationGrantHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AbstractAuthorizationGrantHandler.java
@@ -81,10 +81,13 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.function.Consumer;
 
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OAUTH_APP;
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.RENEW_TOKEN_WITHOUT_REVOKING_EXISTING_ENABLE_CONFIG;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.TokenBindings.NONE;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.TokenStates.TOKEN_STATE_ACTIVE;
 import static org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration.JWT_TOKEN_TYPE;
 import static org.wso2.carbon.identity.oauth2.util.OAuth2Util.EXTENDED_REFRESH_TOKEN_DEFAULT_TIME;
+import static org.wso2.carbon.identity.oauth2.util.OAuth2Util.JWT;
 
 /**
  * Abstract authorization grant handler.
@@ -171,6 +174,29 @@ public abstract class AbstractAuthorizationGrantHandler implements Authorization
 
         synchronized ((consumerKey + ":" + authorizedUserId + ":" + scope + ":" + tokenBindingReference).intern()) {
             AccessTokenDO existingTokenBean = null;
+
+            OAuthAppDO oAuthAppDO = (OAuthAppDO) tokReqMsgCtx.getProperty(OAUTH_APP);
+            String tokenType = oauthTokenIssuer.getAccessTokenType();
+
+            /*
+            Check if the token type is JWT and renew without revoking existing tokens is enabled.
+            Additionally, ensure that the grant type used for the token request is allowed to renew without revoke,
+            based on the config.
+            */
+            if (JWT.equalsIgnoreCase(tokenType) && getRenewWithoutRevokingExistingStatus() &&
+                    OAuth2ServiceComponentHolder.getJwtRenewWithoutRevokeAllowedGrantTypes()
+                            .contains(tokReqMsgCtx.getOauth2AccessTokenReqDTO().getGrantType())) {
+                /*
+                If the application does not have a token binding type (i.e., no specific binding type is set),
+                binding reference will be randomly generated UUID, in that case we can generate a new access token
+                without looking up the existing tokens in the token table.
+                */
+                if (oAuthAppDO.getTokenBindingType() == null) {
+                    return generateNewAccessToken(tokReqMsgCtx, scope, consumerKey, existingTokenBean,
+                            false, oauthTokenIssuer);
+                }
+            }
+
             if (isHashDisabled) {
                 existingTokenBean = getExistingToken(tokReqMsgCtx,
                         getOAuthCacheKey(scope, consumerKey, authorizedUserId, authenticatedIDP,
@@ -706,6 +732,13 @@ public abstract class AbstractAuthorizationGrantHandler implements Authorization
         }
     }
 
+    private boolean getRenewWithoutRevokingExistingStatus() {
+
+        return Boolean.parseBoolean(IdentityUtil.
+                getProperty(RENEW_TOKEN_WITHOUT_REVOKING_EXISTING_ENABLE_CONFIG));
+
+    }
+
     private String getNewAccessToken(OAuthTokenReqMessageContext tokReqMsgCtx, OauthTokenIssuer oauthTokenIssuer)
             throws IdentityOAuth2Exception {
         try {
@@ -1137,7 +1170,8 @@ public abstract class AbstractAuthorizationGrantHandler implements Authorization
         return OAuthServerConfiguration.getInstance().isTokenRenewalPerRequestEnabled();
     }
 
-    private void clearExistingTokenFromCache(OAuthTokenReqMessageContext tokenMsgCtx, AccessTokenDO existingTokenBean) {
+    private void clearExistingTokenFromCache(OAuthTokenReqMessageContext tokenMsgCtx, AccessTokenDO existingTokenBean)
+            throws IdentityOAuth2Exception {
 
         if (cacheEnabled) {
             String tokenBindingReference = getTokenBindingReference(tokenMsgCtx);
@@ -1174,18 +1208,68 @@ public abstract class AbstractAuthorizationGrantHandler implements Authorization
      * @param tokReqMsgCtx OAuthTokenReqMessageContext.
      * @return token binding reference.
      */
-    protected String getTokenBindingReference(OAuthTokenReqMessageContext tokReqMsgCtx) {
+    protected String getTokenBindingReference(OAuthTokenReqMessageContext tokReqMsgCtx)
+            throws IdentityOAuth2Exception {
 
-        if (tokReqMsgCtx.getTokenBinding() == null) {
-            if (log.isDebugEnabled()) {
-                log.debug("Token binding data is null.");
+        /**
+         * If OAuth.JWT.RenewTokenWithoutRevokingExisting is enabled from configurations, and current token
+         * binding is null,then we will add a new token binding (request binding) to the token binding with
+         * a value of a random UUID.
+         * The purpose of this new token binding type is to add a random value to the token binding so that
+         * "User, Application, Scope, Binding" combination will be unique for each token.
+         * Previously, if a token issue request come for the same combination of "User, Application, Scope, Binding",
+         * the existing JWT token will be revoked and issue a new token. but with this way, we can issue new tokens
+         * without revoking the old ones.
+         *
+         * Add following configuration to deployment.toml file to enable this feature.
+         *     [oauth.jwt.renew_token_without_revoking_existing]
+         *     enable = true
+         *
+         * By default, the allowed grant type for this feature is "client_credentials". If you need to enable for
+         * other grant types, add the following configuration to deployment.toml file.
+         *     [oauth.jwt.renew_token_without_revoking_existing]
+         *     enable = true
+         *     allowed_grant_types = ["client_credentials","password", ...]
+         */
+        String consumerKey = tokReqMsgCtx.getOauth2AccessTokenReqDTO().getClientId();
+        OauthTokenIssuer oauthTokenIssuer;
+
+        try {
+            oauthTokenIssuer = OAuth2Util.getOAuthTokenIssuerForOAuthApp(consumerKey);
+        } catch (InvalidOAuthClientException | IdentityOAuth2Exception e) {
+            throw new IdentityOAuth2Exception(
+                    "Error while retrieving oauth issuer for the app with clientId: " + consumerKey, e);
+        }
+
+        String tokenType =  oauthTokenIssuer.getAccessTokenType();
+
+        if (JWT.equalsIgnoreCase(tokenType)) {
+            if (getRenewWithoutRevokingExistingStatus()
+                    && tokReqMsgCtx != null && (tokReqMsgCtx.getTokenBinding() == null
+                    || StringUtils.isBlank(tokReqMsgCtx.getTokenBinding().getBindingReference()))) {
+                if (OAuth2ServiceComponentHolder.getJwtRenewWithoutRevokeAllowedGrantTypes()
+                        .contains(tokReqMsgCtx.getOauth2AccessTokenReqDTO().getGrantType())) {
+                    return UUID.randomUUID().toString();
+                }
+                return NONE;
             }
+        }
+        return getExistingTokenBindingReference(tokReqMsgCtx);
+    }
+
+    /**
+     * Retrieves the existing token binding reference if available, otherwise returns NONE.
+     *
+     * @param tokReqMsgCtx OAuthTokenReqMessageContext.
+     * @return token binding reference.
+     */
+    private String getExistingTokenBindingReference(OAuthTokenReqMessageContext tokReqMsgCtx) {
+
+        if (tokReqMsgCtx == null || tokReqMsgCtx.getTokenBinding() == null) {
             return NONE;
         }
-        if (StringUtils.isBlank(tokReqMsgCtx.getTokenBinding().getBindingReference())) {
-            return NONE;
-        }
-        return tokReqMsgCtx.getTokenBinding().getBindingReference();
+        String bindingReference = tokReqMsgCtx.getTokenBinding().getBindingReference();
+        return StringUtils.isBlank(bindingReference) ? NONE : bindingReference;
     }
 
     /**

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AbstractAuthorizationGrantHandlerTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AbstractAuthorizationGrantHandlerTest.java
@@ -19,6 +19,7 @@
 package org.wso2.carbon.identity.oauth2.token.handlers.grant;
 
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.MockitoAnnotations;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -36,6 +37,7 @@ import org.wso2.carbon.identity.common.testng.WithCarbonHome;
 import org.wso2.carbon.identity.common.testng.WithH2Database;
 import org.wso2.carbon.identity.common.testng.WithRealmService;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.event.services.IdentityEventService;
 import org.wso2.carbon.identity.oauth.IdentityOAuthAdminException;
 import org.wso2.carbon.identity.oauth.common.GrantType;
@@ -47,11 +49,17 @@ import org.wso2.carbon.identity.oauth.dao.OAuthAppDO;
 import org.wso2.carbon.identity.oauth.internal.OAuthComponentServiceHolder;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.TestConstants;
+import org.wso2.carbon.identity.oauth2.dao.AccessTokenDAOImpl;
+import org.wso2.carbon.identity.oauth2.dao.OAuthTokenPersistenceFactory;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2AccessTokenReqDTO;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2AccessTokenRespDTO;
 import org.wso2.carbon.identity.oauth2.internal.OAuth2ServiceComponentHolder;
 import org.wso2.carbon.identity.oauth2.model.AccessTokenDO;
+import org.wso2.carbon.identity.oauth2.token.JWTTokenIssuer;
 import org.wso2.carbon.identity.oauth2.token.OAuthTokenReqMessageContext;
+import org.wso2.carbon.identity.oauth2.token.OauthTokenIssuer;
+import org.wso2.carbon.identity.oauth2.token.bindings.TokenBinding;
+import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 import org.wso2.carbon.identity.oauth2.validators.OAuth2ScopeHandler;
 
 import java.util.Collections;
@@ -63,7 +71,9 @@ import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
@@ -142,6 +152,58 @@ public class AbstractAuthorizationGrantHandlerTest {
         CentralLogMgtServiceComponentHolder.getInstance().setIdentityEventService(null);
     }
 
+    @Test(dataProvider = "IssueWithRenewDataProvider", expectedExceptions = IdentityOAuth2Exception.class)
+    public void testIssueWithRenewWithoutRevokingExistingEnabled
+            (boolean cacheEnabled, boolean cacheEntryAvailable, long cachedTokenValidity,
+             long cachedRefreshTokenValidity, long dbTokenValidity, long dbRefreshTokenValidity,
+             boolean dbEntryAvailable, String dbTokenState, boolean tokenLoggable, boolean isIDPIdColumnEnabled,
+             boolean setBindingReference) throws Exception {
+
+        OAuth2ServiceComponentHolder.setIDPIdColumnEnabled(isIDPIdColumnEnabled);
+
+        Map<String, AuthorizationGrantHandler> supportedGrantTypes = new HashMap<>();
+        supportedGrantTypes.put("refresh_token", refreshGrantHandler);
+
+        OAuth2AccessTokenReqDTO oAuth2AccessTokenReqDTO = new OAuth2AccessTokenReqDTO();
+        oAuth2AccessTokenReqDTO.setClientId(clientId);
+        oAuth2AccessTokenReqDTO.setGrantType(PASSWORD_GRANT);  // Ensure the grant type is valid for renewal
+
+        OAuthTokenReqMessageContext tokReqMsgCtx = new OAuthTokenReqMessageContext(oAuth2AccessTokenReqDTO);
+        tokReqMsgCtx.setAuthorizedUser(authenticatedUser);
+        tokReqMsgCtx.setScope(new String[]{"scope1", "scope2"});
+
+        tokReqMsgCtx.addProperty("OAuthAppDO", oAuthAppDO);
+
+        TokenBinding tokenBinding = new TokenBinding();
+        if (setBindingReference) {
+            tokenBinding.setBindingReference("bindingReference");
+        }
+        tokReqMsgCtx.setTokenBinding(tokenBinding);
+
+        // Mocking static methods using try-with-resources
+        try (MockedStatic<IdentityUtil> identityUtil = mockStatic(IdentityUtil.class);
+             MockedStatic<OAuth2Util> oauth2Util = mockStatic(OAuth2Util.class)) {
+
+            identityUtil.when(() -> IdentityUtil.getProperty(anyString()))
+                    .thenReturn(Boolean.TRUE.toString());
+
+            OAuthComponentServiceHolder.getInstance().setActionExecutorService(mockActionExecutionService);
+            OAuthTokenPersistenceFactory persistenceFactory = mock(OAuthTokenPersistenceFactory.class);
+            when(persistenceFactory.getAccessTokenDAO()).thenReturn(new AccessTokenDAOImpl());
+
+            OauthTokenIssuer oauthTokenIssuer = mock(JWTTokenIssuer.class);
+            when(oauthTokenIssuer.getAccessTokenType()).thenReturn("jwt");
+            oauth2Util.when(() -> OAuth2Util.getOAuthTokenIssuerForOAuthApp(clientId)).thenReturn(oauthTokenIssuer);
+            oauth2Util.when(() -> OAuth2Util.getAppInformationByClientId(clientId)).thenReturn(oAuthAppDO);
+
+            // Set allowed grant types (ensure PASSWORD_GRANT is allowed for renewal)
+            OAuth2ServiceComponentHolder.setJwtRenewWithoutRevokeAllowedGrantTypes(
+                    Collections.singletonList("password")); // This allows PASSWORD_GRANT
+
+            OAuth2AccessTokenRespDTO tokenRespDTO = handler.issue(tokReqMsgCtx);
+        }
+    }
+
     @DataProvider(name = "IssueDataProvider")
     public Object[][] issueDataProvider() {
         return new Object[][] {
@@ -172,6 +234,14 @@ public class AbstractAuthorizationGrantHandlerTest {
                 {true, false, 0L, 0L, 0L, 3600L, true, TOKEN_STATE_ACTIVE, true, false},
                 {true, true, 0L, 0L, -1L, 3600L, true, TOKEN_STATE_ACTIVE, true, true},
                 {false, true, 0L, 0L, -1L, 3600L, true, TOKEN_STATE_ACTIVE, true, false}};
+    }
+
+    @DataProvider(name = "IssueWithRenewDataProvider")
+    public Object[][] issueWithRenewDataProvider() {
+        return new Object[][]{
+                {true, true, 3600L, 3600L, 0L, 0L, false, TOKEN_STATE_ACTIVE, false, true, true},
+                {true, true, 3600L, 3600L, 0L, 0L, false, TOKEN_STATE_ACTIVE, false, true, false}
+        };
     }
 
     @Test(dataProvider = "IssueDataProvider")


### PR DESCRIPTION
### Proposed changes in this pull request

- This PR addresses issues related to token renewal and token type handling to enhance the stability and configurability of the token issuance process. When the `renew_without_revoking_existing` flag is enabled and the binding type is set to "none," the implementation now skips checking for existing tokens. Instead, it generates a random UUID as the binding reference, which helps to prevent thread-stuck issues in high-concurrency scenarios.

- A new approach is introduced for retrieving the token type from custom token issuers. The OauthTokenIssuer interface now includes a default method, `getAccessTokenType()`, which returns "Opaque" by default. In the JWTTokenIssuer class, this method is overridden to return "JWT." This allows the system to correctly identify the token type without requiring additional configurations, making the implementation more flexible and easier to extend.

### Related Issues
- https://github.com/wso2/product-is/issues/20994
- https://github.com/wso2/product-is/issues/21122
- https://github.com/wso2/product-is/issues/21355

### Follow up actions
Update the migration documentation to reflect the changes in token type handling. Specifically, note that a previously used Deployment.toml configuration for specifying the token type is no longer required, and custom JWT issuers that do not extend the `JWTTokenIssuer` class must override the getter method to specify the token type explicitly. Similarly, if implementing the OauthTokenIssuer interface, the method must be overridden to ensure compatibility. 
