### PR TITLE
[Public] Fix accepting user credentials in query parameters

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
+++ b/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
@@ -251,6 +251,9 @@ public final class OAuthConstants {
         public static final String STATE = "state";
         public static final String RESPONSE_TYPE = "response_type";
         public static final String REQUEST = "request";
+        public static final String USERNAME = "username";
+        public static final String PASSWORD = "password";
+        public static final String CLIENT_SECRET = "client_secret";
 
         private OAuth20Params() {
 

--- a/pom.xml
+++ b/pom.xml
@@ -839,7 +839,7 @@
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!-- Carbon Identity Framework version -->
-        <carbon.identity.framework.version>5.25.716</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.25.717</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.17.5, 6.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 

--- a/pom.xml
+++ b/pom.xml
@@ -839,7 +839,7 @@
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!-- Carbon Identity Framework version -->
-        <carbon.identity.framework.version>5.25.711</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.25.716</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.17.5, 6.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 


### PR DESCRIPTION
Front-port: https://github.com/wso2-support/identity-inbound-auth-oauth/pull/1618

### Purpose
This PR prevents processing sensitive data (eg: username, password, client secret) sent as query parameters in requests by checking for their availability in the query string part of the request.