### PR TITLE
Exclude username in password grant error message using OAuth config

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/PasswordGrantHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/PasswordGrantHandler.java
@@ -239,16 +239,8 @@ public class PasswordGrantHandler extends AbstractAuthorizationGrantHandler {
                 if (isPublishPasswordGrantLoginEnabled) {
                     publishAuthenticationData(tokenReq, false, serviceProvider);
                 }
-                if (MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equalsIgnoreCase(MultitenantUtils.getTenantDomain
-                        (tokenReq.getResourceOwnerUsername()))) {
-                    throw new IdentityOAuth2Exception("Authentication failed for " + tenantAwareUserName);
-                }
-                username = tokenReq.getResourceOwnerUsername();
-                if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled()) {
-                    // For tenant qualified urls, no need to send fully qualified username in response.
-                    username = tenantAwareUserName;
-                }
-                throw new IdentityOAuth2Exception("Authentication failed for " + username);
+
+                throw new IdentityOAuth2Exception("Authentication failed");
             }
         } catch (UserStoreClientException e) {
             if (isPublishPasswordGrantLoginEnabled) {
@@ -287,7 +279,7 @@ public class PasswordGrantHandler extends AbstractAuthorizationGrantHandler {
             if (log.isDebugEnabled()) {
                 log.debug(message, e);
             }
-            throw new IdentityOAuth2Exception(message);
+            throw new IdentityOAuth2Exception("Authentication failed");
         } finally {
             UserCoreUtil.removeUserMgtContextInThreadLocal();
             if (log.isDebugEnabled()) {


### PR DESCRIPTION
## Purpose
- This will remove the username from Token API Error response with the password grant type
- Related Issues - https://github.com/wso2/api-manager/issues/3396