### PR TITLE
Fix DCR PUT request not updating application role audience

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/service/DCRMService.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/service/DCRMService.java
@@ -419,6 +419,7 @@ public class DCRMService {
                 AssociatedRolesConfig associatedRolesConfig = new AssociatedRolesConfig();
                 associatedRolesConfig.setAllowedAudience(updateRequest.getExtAllowedAudience().toLowerCase());
                 sp.setAssociatedRolesConfig(associatedRolesConfig);
+                updateServiceProvider(sp, tenantDomain, applicationOwner);
             }
         } catch (IdentityOAuthClientException e) {
             throw new DCRMClientException(DCRMConstants.ErrorCodes.INVALID_CLIENT_METADATA, e.getMessage(), e);

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/service/DCRMServiceTest.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/service/DCRMServiceTest.java
@@ -1004,6 +1004,7 @@ public class DCRMServiceTest {
         assertEquals(application.getClientId(), dummyConsumerKey);
         assertEquals(application.getClientName(), dummyClientName);
         assertEquals(application.getClientSecret(), dummyConsumerSecret);
+        assertEquals(application.getExtAllowedAudience(), roleAudience);
     }
 
     @Test


### PR DESCRIPTION
This PR fixes an issue in the DCR PUT implementation where the application role audience value was not persisted to the database.

### Changes

- Added logic to store the application role audience during DCR updates.
- Improved unit tests to validate the application role audience update.

### Issue

https://github.com/wso2/product-is/issues/21627