### PR TITLE
Improve user authorization check when accessing org is different from resident org

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/AuthzUtil.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/AuthzUtil.java
@@ -255,7 +255,13 @@ public class AuthzUtil {
 
         // Application id is not required for basic authentication flow.
         List<String> roleIds = getUserRoles(authenticatedUser, null);
-        List<String> permissions = getAssociatedScopesForRoles(roleIds, authenticatedUser.getTenantDomain());
+        String tenantDomain = authenticatedUser.getTenantDomain();
+        if (StringUtils.isNotBlank(authenticatedUser.getAccessingOrganization()) &&
+                !authenticatedUser.getAccessingOrganization().
+                        equals(authenticatedUser.getUserResidentOrganization())) {
+            tenantDomain = getAccessingTenantDomain(authenticatedUser);
+        }
+        List<String> permissions = getAssociatedScopesForRoles(roleIds, tenantDomain);
         if (OAuthServerConfiguration.getInstance().isUseLegacyPermissionAccessForUserBasedAuth()) {
             // Handling backward compatibility for previous access level.
             List<String> internalScopes = getInternalScopes(authenticatedUser.getTenantDomain());


### PR DESCRIPTION
### Proposed changes in this pull request

- $subject
- Part of the fix for : https://github.com/wso2/product-is/issues/21208
- From this change if the authenticated user contains a different accessing organization than the resident organization, then the authorization check will be happen against the accessing organization.
- This is a supportive implementation for https://github.com/wso2-extensions/identity-carbon-auth-rest/pull/299 and the new implementation will be executed from [1].

[1] https://github.com/wso2-extensions/identity-carbon-auth-rest/blob/9eb3d1380f3af32c35de98591dd2c5a5bb728026/components/org.wso2.carbon.identity.authz.service/src/main/java/org/wso2/carbon/identity/authz/service/handler/AuthorizationHandler.java#L109

-

### When should this PR be merged

This PR needs to be merged before merging https://github.com/wso2-extensions/identity-carbon-auth-rest/pull/299