### PR TITLE
Fix the issue of password expiry event trigger of PasswordGrantHandler

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/PasswordGrantHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/PasswordGrantHandler.java
@@ -169,6 +169,11 @@ public class PasswordGrantHandler extends AbstractAuthorizationGrantHandler {
         if (log.isDebugEnabled()) {
             log.debug("user " + tokenReq.getResourceOwnerUsername() + " authenticated: " + authenticated);
         }
+        triggerPasswordExpiryValidationEvent(PASSWORD_GRANT_POST_AUTHENTICATION_EVENT, tenantAwareUserName,
+                userTenantDomain, userStoreManager, true);
+        if (log.isDebugEnabled()) {
+            log.debug(PASSWORD_GRANT_POST_AUTHENTICATION_EVENT + " event is triggered");
+        }
         if (authenticated) {
             AuthenticatedUser authenticatedUser =
                     new AuthenticatedUser(authenticationResult.getAuthenticatedUser().get());
@@ -178,11 +183,6 @@ public class PasswordGrantHandler extends AbstractAuthorizationGrantHandler {
             return Optional.of(authenticatedUser);
         }
 
-        triggerPasswordExpiryValidationEvent(PASSWORD_GRANT_POST_AUTHENTICATION_EVENT, tenantAwareUserName,
-                userTenantDomain, userStoreManager, true);
-        if (log.isDebugEnabled()) {
-            log.debug(PASSWORD_GRANT_POST_AUTHENTICATION_EVENT + " event is triggered");
-        }
         return Optional.empty();
     }
 
@@ -387,13 +387,13 @@ public class PasswordGrantHandler extends AbstractAuthorizationGrantHandler {
                 authenticatedUser = authenticateUserAtUserStore(tokenReq, userId, userStoreManager,
                         tenantAwareUserName, isPublishPasswordGrantLoginEnabled, userTenantDomain, serviceProvider);
             }
-            if (authenticatedUser.isPresent()) {
-                return authenticatedUser.get();
-            }
             triggerPasswordExpiryValidationEvent(PASSWORD_GRANT_POST_AUTHENTICATION_EVENT, tenantAwareUserName,
                     userTenantDomain, userStoreManager, false);
             if (log.isDebugEnabled()) {
                 log.debug(PASSWORD_GRANT_POST_AUTHENTICATION_EVENT + " event is triggered");
+            }
+            if (authenticatedUser.isPresent()) {
+                return authenticatedUser.get();
             }
             if (isPublishPasswordGrantLoginEnabled) {
                 publishAuthenticationData(tokenReq, false, serviceProvider);


### PR DESCRIPTION
### Purpose
$subject

### Changes from this PR
- When the password is expired for the user, the password grant handler should return below.
```
{
  "error_description": "Authentication Failed! Password has expired",
  "error": "invalid_grant"
}
```
- But before trigger the triggerPasswordExpiryValidationEvent , the authentictaed user is return in the current implementation. Due to this even though the password is expired, the token is issued for the user.
- To fix this issue, the triggerPasswordExpiryValidationEvent should be triggered before return the authenticated user.

### Related issue

This issue is identified and fixed with https://github.com/wso2/product-is/issues/21890 effort.