### PR TITLE
Support new action invocation status.

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/action/PreIssueAccessTokenResponseProcessor.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/action/PreIssueAccessTokenResponseProcessor.java
@@ -30,6 +30,7 @@ import org.wso2.carbon.identity.action.execution.exception.ActionExecutionRespon
 import org.wso2.carbon.identity.action.execution.model.ActionExecutionStatus;
 import org.wso2.carbon.identity.action.execution.model.ActionInvocationErrorResponse;
 import org.wso2.carbon.identity.action.execution.model.ActionInvocationFailureResponse;
+import org.wso2.carbon.identity.action.execution.model.ActionInvocationIncompleteResponse;
 import org.wso2.carbon.identity.action.execution.model.ActionInvocationSuccessResponse;
 import org.wso2.carbon.identity.action.execution.model.ActionType;
 import org.wso2.carbon.identity.action.execution.model.Error;
@@ -37,6 +38,7 @@ import org.wso2.carbon.identity.action.execution.model.ErrorStatus;
 import org.wso2.carbon.identity.action.execution.model.Event;
 import org.wso2.carbon.identity.action.execution.model.FailedStatus;
 import org.wso2.carbon.identity.action.execution.model.Failure;
+import org.wso2.carbon.identity.action.execution.model.Incomplete;
 import org.wso2.carbon.identity.action.execution.model.PerformableOperation;
 import org.wso2.carbon.identity.action.execution.model.Success;
 import org.wso2.carbon.identity.action.execution.model.SuccessStatus;
@@ -161,6 +163,15 @@ public class PreIssueAccessTokenResponseProcessor implements ActionExecutionResp
                 LOG.debug("Error occurred while logging operation execution results.", e);
             }
         }
+    }
+    
+    @Override
+    public ActionExecutionStatus<Incomplete> processIncompleteResponse(Map<String, Object> eventContext,
+            Event actionEvent, ActionInvocationIncompleteResponse incompleteResponse) throws
+            ActionExecutionResponseProcessorException {
+
+        throw new UnsupportedOperationException(
+                "The INCOMPLETE status is not supported for the action type: " + getSupportedActionType());
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -944,7 +944,7 @@
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!-- Carbon Identity Framework version -->
-        <carbon.identity.framework.version>7.7.49</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.7.71</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.25.234, 8.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
         <identity.oauth.xacml.version.range>[2.0.0, 3.0.0)</identity.oauth.xacml.version.range>


### PR DESCRIPTION
Issue: 
- https://github.com/wso2/product-is/issues/22165

With this PR, the following improvement is incorporated into the action execution core:
- A new INCOMPLETE action invocation status is introduced with https://github.com/wso2/carbon-identity-framework/pull/6262. This PR overrides the processIncompleteResponse(Map<String, Object> eventContext, Event actionEvent, ActionInvocationIncompleteResponse incompleteResponse) method in the ActionExecutionStatus<Incomplete> class. Within this method, an UnsupportedOperationException is thrown because the INCOMPLETE state is not acceptable for pre-issue access tokens.