### PR TITLE
Fix token revoke failure in role update flow for sub org.

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthUtil.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthUtil.java
@@ -1039,7 +1039,8 @@ public final class OAuthUtil {
                             .getTokenManagementDAO().getAllTimeAuthorizedClientIds(authenticatedUser);
 
                 if (role != null && RoleConstants.ORGANIZATION.equals(role.getAudience())) {
-                    clientIds = filterClientIdsWithOrganizationAudience(new ArrayList<>(clientIds), tenantDomain);
+                    clientIds = filterClientIdsWithOrganizationAudience(new ArrayList<>(clientIds),
+                            authenticatedUser.getTenantDomain());
                 }
 
             } catch (IdentityOAuth2Exception e) {


### PR DESCRIPTION
### Purpose
- $subject

### Tests
- Tested the role update flow by removing a role from a user when they already have an access token.
- Screen recording: 

https://github.com/user-attachments/assets/a90c76a2-5b5c-4eda-bace-04c2905b6bd7



