### PR TITLE
Fix DCR PUT request not updating application role audience

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/service/DCRMServiceTest.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/service/DCRMServiceTest.java
@@ -108,6 +108,7 @@ public class DCRMServiceTest {
     private String dummyCallbackUrl = "dummyCallbackUrl";
     private final String dummyTemplateName = "dummyTemplateName";
     private final String dummyBackchannelLogoutUri = "http://backchannel.com/";
+    private static final String ORG_ROLE_AUDIENCE = "organization";
 
     @Mock
     private OAuthConsumerAppDTO dto;
@@ -1007,6 +1008,7 @@ public class DCRMServiceTest {
         assertEquals(application.getClientId(), dummyConsumerKey);
         assertEquals(application.getClientName(), dummyClientName);
         assertEquals(application.getClientSecret(), dummyConsumerSecret);
+        assertEquals(application.getExtAllowedAudience(), roleAudience);
     }
 
     @Test


### PR DESCRIPTION
This PR fixes an issue in the DCR PUT implementation where the application role audience value was not persisted to the database.

### Changes

- Added logic to store the application role audience during DCR updates.
- Earlier if the client name is not is the request the SP is not updated, thats not correct, hence moving the update SP section outside the if block.
- Improved unit tests to assert the application role audience update.

### Issue

https://github.com/wso2/product-is/issues/21627