### PR TITLE
Remove commonAuthId cookie if authentication flow failed

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
@@ -369,6 +369,15 @@ public class OAuth2AuthzEndpoint {
                 oauthResponse = handleInitialAuthorizationRequest(oAuthMessage);
             } else if (isAuthenticationResponseFromFramework(oAuthMessage)) {
                 oauthResponse = handleAuthenticationResponse(oAuthMessage);
+                // Remove the commonAuthId cookie if the authentication flow failed.
+                MultivaluedMap<String, Object> responseMetadata = oauthResponse.getMetadata();
+                List<Object> locationHeaders = responseMetadata != null ?
+                        responseMetadata.get(HttpHeaders.LOCATION) : null;
+
+                if (locationHeaders != null && locationHeaders.stream()
+                        .anyMatch(header -> header.toString().contains(OAuth2ErrorCodes.INVALID_REQUEST))) {
+                    FrameworkUtils.removeAuthCookie(request, response);
+                }
             } else if (isConsentResponseFromUser(oAuthMessage)) {
                 oauthResponse = handleResponseFromConsent(oAuthMessage);
             } else {


### PR DESCRIPTION
### Summray
This pull request includes an important change to the `OAuth2AuthzEndpoint` class in the `components/org.wso2.carbon.identity.oauth.endpoint` package. The change ensures that the `commonAuthId` cookie is removed if the authentication flow fails.

### Related issue
 - https://github.com/wso2/product-is/issues/22194