### PR TITLE
Fix consent page for mandatory attributes

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
@@ -916,7 +916,7 @@ public class OAuth2AuthzEndpoint {
                 value.setRequestedClaims(removeConsentRequestedNullUserAttributes(value.getRequestedClaims(),
                         loggedInUser.getUserAttributes(), spTenantDomain));
                 List<ClaimMetaData> requestedOidcClaimsList =
-                        getRequestedOidcClaimsList(value, oauth2Params, spTenantDomain);
+                        getRequestedOidcClaimsList(value, oauth2Params, spTenantDomain, false);
                 value.setRequestedClaims(requestedOidcClaimsList);
             }
 
@@ -3333,15 +3333,17 @@ public class OAuth2AuthzEndpoint {
                         removeConsentRequestedNullUserAttributes(claimsForApproval.getRequestedClaims(),
                                 user.getUserAttributes(), spTenantDomain));
                 List<ClaimMetaData> requestedOidcClaimsList =
-                        getRequestedOidcClaimsList(claimsForApproval, oauth2Params, spTenantDomain);
+                        getRequestedOidcClaimsList(claimsForApproval, oauth2Params, spTenantDomain, false);
                 if (CollectionUtils.isNotEmpty(requestedOidcClaimsList)) {
                     requestClaimsQueryParam = REQUESTED_CLAIMS + "=" +
                             buildConsentClaimString(requestedOidcClaimsList);
                 }
 
-                if (CollectionUtils.isNotEmpty(claimsForApproval.getMandatoryClaims())) {
+                List<ClaimMetaData> mandatoryOidcClaims =
+                        getRequestedOidcClaimsList(claimsForApproval, oauth2Params, spTenantDomain, true);
+                if (CollectionUtils.isNotEmpty(mandatoryOidcClaims)) {
                     mandatoryClaimsQueryParam = MANDATORY_CLAIMS + "=" +
-                            buildConsentClaimString(claimsForApproval.getMandatoryClaims());
+                            buildConsentClaimString(mandatoryOidcClaims);
                 }
                 additionalQueryParam = buildQueryParamString(requestClaimsQueryParam, mandatoryClaimsQueryParam);
             }
@@ -3424,17 +3426,19 @@ public class OAuth2AuthzEndpoint {
     }
 
     /**
-     * Filter requested claims based on OIDC claims and return the claims which includes in OIDC.
+     * Filter requested or mandatory claims based on OIDC claims and return the claims included in OIDC.
      *
      * @param claimsForApproval         Consent required claims.
      * @param oauth2Params              OAuth parameters.
      * @param spTenantDomain            Tenant domain.
-     * @return                          Requested OIDC claim list.
+     * @param isMandatory               If true, filter mandatory claims; otherwise, filter requested claims.
+     * @return                          Filtered OIDC claim list.
      * @throws RequestObjectException   If an error occurred while getting essential claims for the session data key.
      * @throws ClaimMetadataException   If an error occurred while getting claim mappings.
      */
     private List<ClaimMetaData> getRequestedOidcClaimsList(ConsentClaimsData claimsForApproval,
-                                                           OAuth2Parameters oauth2Params, String spTenantDomain)
+                                                           OAuth2Parameters oauth2Params, String spTenantDomain,
+                                                           boolean isMandatory)
             throws RequestObjectException, ClaimMetadataException {
 
         List<ClaimMetaData> requestedOidcClaimsList = new ArrayList<>();
@@ -3447,14 +3451,13 @@ public class OAuth2AuthzEndpoint {
 
         List<String> essentialRequestedClaims = new ArrayList<>();
 
-        if (oauth2Params.isRequestObjectFlow()) {
+        if (!isMandatory && oauth2Params.isRequestObjectFlow()) {
             // Get the requested claims came through request object.
             List<RequestedClaim> requestedClaimsOfIdToken = EndpointUtil.getRequestObjectService()
                     .getRequestedClaimsForSessionDataKey(oauth2Params.getSessionDataKey(), false);
 
             List<RequestedClaim> requestedClaimsOfUserInfo = EndpointUtil.getRequestObjectService()
                     .getRequestedClaimsForSessionDataKey(oauth2Params.getSessionDataKey(), true);
-
 
             // Get the list of id token's essential claims.
             for (RequestedClaim requestedClaim : requestedClaimsOfIdToken) {
@@ -3473,7 +3476,7 @@ public class OAuth2AuthzEndpoint {
 
         // Add user info's essential claims requested using claims parameter. Claims for id_token are skipped
         // since claims parameter does not support id_token yet.
-        if (oauth2Params.getEssentialClaims() != null) {
+        if (!isMandatory && oauth2Params.getEssentialClaims() != null) {
             essentialRequestedClaims.addAll(OAuth2Util.getEssentialClaims(oauth2Params.getEssentialClaims(),
                     USERINFO));
         }
@@ -3506,10 +3509,13 @@ public class OAuth2AuthzEndpoint {
             }
         }
 
-        /* Check whether the local claim of oidc claims contains the requested claims or essential claims of
-         request object contains the requested claims, If it contains add it as requested claim.
-         */
-        for (ClaimMetaData claimMetaData : claimsForApproval.getRequestedClaims()) {
+        // Determine the source claims list based on whether it is mandatory or requested.
+        List<ClaimMetaData> approvalPendingClaims = isMandatory
+                ? claimsForApproval.getMandatoryClaims()
+                : claimsForApproval.getRequestedClaims();
+
+        // Filter claims based on OIDC mappings.
+        for (ClaimMetaData claimMetaData : approvalPendingClaims) {
             if (localClaimsOfOidcClaims.contains(claimMetaData.getClaimUri()) ||
                     localClaimsOfEssentialClaims.contains(claimMetaData.getClaimUri())) {
                 requestedOidcClaimsList.add(claimMetaData);


### PR DESCRIPTION
### Proposed changes in this pull request
Issue: https://github.com/wso2/product-is/issues/21888

We have two claim categories: Required and Mandatory. These claims can be configured in the User Attributes section. Before filtering the claims for pre-consent, the claims are returned by the framework. The requested scopes are then filtered, and the consent page is displayed.

Over time, we implemented several fixes that inadvertently disrupted this flow.

In [PR #1698](https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/1698), we introduced a change to pass the requested scopes first to the framework. The framework would then filter the claims and return both Required and Mandatory claims. However, this approach had a flaw where essential claims were missed.

To address this, in [PR #2405](https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2405), we reverted the behavior to stop passing scopes to the framework, restoring the previous logic while filtering essential claims. Unfortunately, this introduced another issue.

As mentioned in [Issue #21888](https://github.com/wso2/product-is/issues/21888), even if the requested scopes do not include mandatory attributes, these attributes still appear on the consent page. This happens because filtering was removed. Although this is an edge case (e.g., why would an attribute be configured as mandatory but not requested by the client?), it still needs to be addressed to ensure consent is only provided for requested attributes.

This PR resolves the issue, ensuring that the consent page reflects only the requested scopes and associated attributes, maintaining expected behavior.

I tested all three issues to avoid any regressions.

1. https://github.com/wso2/product-is/issues/11331
Consent should be given only requested attributes.


https://github.com/user-attachments/assets/b3ebc536-6485-47ac-9f15-279c9adb2d73

2. https://github.com/wso2/product-is/issues/19817
Essential claims request and response should work as expected with proper consent screen


https://github.com/user-attachments/assets/d6883297-f4b2-405a-afde-ef96f55fc52e

3. https://github.com/wso2/product-is/issues/21888


https://github.com/user-attachments/assets/edb39a00-d002-42f3-88fb-3a03d06920e6



