### PR TITLE
Improve data validation for app native auth response

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/api/auth/ApiAuthnHandler.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/api/auth/ApiAuthnHandler.java
@@ -185,8 +185,7 @@ public class ApiAuthnHandler {
 
     private boolean isAdditionalAuthenticatorDataAvailable(AuthenticatorData authenticatorData) {
 
-        // We can assume if required params are empty that other additional data is also empty.
-        return !authenticatorData.getRequiredParams().isEmpty();
+        return !authenticatorData.getRequiredParams().isEmpty() || (authenticatorData.getAdditionalData() != null);
     }
 
     private Map<String, String> getAdditionalData(AdditionalData additionalData) {


### PR DESCRIPTION
Previous there were no authenticators that sent additional data without any required params. But with the introduction of push based authentication since the actual authentication happens in a decoupled manner the auth request for push auth doesn't have any required params. However the push authenticator needs to transmit additional data.