### PR TITLE
Generic Error Response on Token Endpoint

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/client/authentication/OAuthClientAuthnService.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/client/authentication/OAuthClientAuthnService.java
@@ -185,11 +185,11 @@ public class OAuthClientAuthnService {
                     executeAuthenticator(oAuthClientAuthenticator, oAuthClientAuthnContext, request, bodyContentMap);
                 });
             } catch (InvalidOAuthClientException e) {
-                String errorMessage = "A valid OAuth client could not be found for client_id: " + clientId;
                 if (log.isDebugEnabled()) {
-                    log.debug(errorMessage, e);
+                    log.debug("A valid OAuth client could not be found for client_id: " + clientId, e);
                 }
-                setErrorToContext(OAuth2ErrorCodes.INVALID_CLIENT, errorMessage, oAuthClientAuthnContext);
+                setErrorToContext(OAuth2ErrorCodes.INVALID_CLIENT, "Client credentials are invalid.",
+                        oAuthClientAuthnContext);
             } catch (IdentityOAuth2Exception e) {
                 throw new OAuthClientAuthnException("Error while obtaining the service provider for client_id: " +
                         clientId, OAuth2ErrorCodes.SERVER_ERROR);


### PR DESCRIPTION
### Purpose

This PR unifies the error_description of the the OAuth2 authentication requests with the following grant types. 
- Refresh token grant
- Client credentials grant
- Password grant
- Token exchange grant
- SAML 2.0 bearer grant
- Organization switch grant

When the Client ID/Client Secret is incorrect, now the related endpoints will return the following error.
```
{
    "error_description": "Client credentials are invalid.",
    "error": "invalid_client"
}
```

### Related Issue
- https://github.com/wso2/product-is/issues/22336