### PR TITLE
Bump http client orbit version to 4.5.13.wso2v1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1049,7 +1049,7 @@
         <tomcat.version>9.0.96</tomcat.version>
         <tomcat.wso2.imp.pkg.version.range>[9.0.0, 9.5.0)</tomcat.wso2.imp.pkg.version.range>
 
-        <httpcore.version>4.4.14.wso2v1</httpcore.version>
+        <httpcore.version>4.4.16.wso2v1</httpcore.version>
         <httpcore.version.osgi.import.range>[4.3.0, 5.0.0)</httpcore.version.osgi.import.range>
         <httpcomponents-httpclient.wso2.version>4.5.13.wso2v1</httpcomponents-httpclient.wso2.version>
         <org.apache.cxf.version>3.5.9</org.apache.cxf.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1049,7 +1049,7 @@
         <tomcat.version>9.0.96</tomcat.version>
         <tomcat.wso2.imp.pkg.version.range>[9.0.0, 9.5.0)</tomcat.wso2.imp.pkg.version.range>
 
-        <httpcore.version>4.3.3.wso2v1</httpcore.version>
+        <httpcore.version>4.4.14.wso2v1</httpcore.version>
         <httpcore.version.osgi.import.range>[4.3.0, 5.0.0)</httpcore.version.osgi.import.range>
         <httpcomponents-httpclient.wso2.version>4.5.13.wso2v1</httpcomponents-httpclient.wso2.version>
         <org.apache.cxf.version>3.5.9</org.apache.cxf.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1051,7 +1051,7 @@
 
         <httpcore.version>4.3.3.wso2v1</httpcore.version>
         <httpcore.version.osgi.import.range>[4.3.0, 5.0.0)</httpcore.version.osgi.import.range>
-        <httpcomponents-httpclient.wso2.version>4.3.6.wso2v2</httpcomponents-httpclient.wso2.version>
+        <httpcomponents-httpclient.wso2.version>4.5.13.wso2v1</httpcomponents-httpclient.wso2.version>
         <org.apache.cxf.version>3.5.9</org.apache.cxf.version>
         <encoder.wso2.version>1.2.0.wso2v1</encoder.wso2.version>
         <json-simple.version>1.1.wso2v1</json-simple.version>


### PR DESCRIPTION
### Proposed changes in this pull request
$subject
- http core version is also bumped to 4.414 because 4.3.3 is not compatible with http client 4.5.13
- Referenced PR : https://github.com/wso2/carbon-analytics-common/pull/762