### PR TITLE
Adding back-channel logout url for OIDC apps shared with organizations

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/pom.xml
+++ b/components/org.wso2.carbon.identity.oauth/pom.xml
@@ -245,6 +245,10 @@
             <artifactId>org.wso2.carbon.identity.organization.management.role.management.service</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.organization.management</groupId>
+            <artifactId>org.wso2.carbon.identity.organization.management.application</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.wso2.carbon.identity.framework</groupId>
             <artifactId>org.wso2.carbon.identity.consent.server.configs.mgt</artifactId>
         </dependency>
@@ -448,6 +452,7 @@
                             org.wso2.carbon.identity.organization.management.role.management.service.models; version="${carbon.identity.organization.management.version.range}",
                             org.wso2.carbon.identity.organization.management.organization.user.sharing.util;version="${carbon.identity.organization.management.version.range}",
                             org.wso2.carbon.identity.organization.management.organization.user.sharing.models;version="${carbon.identity.organization.management.version.range}",
+                            org.wso2.carbon.identity.organization.management.application.constant;version="${carbon.identity.organization.management.version.range}",
                             org.wso2.carbon.identity.handler.event.account.lock.service.*;version="${account.lock.service.imp.pkg.version.range}",
 
                             org.wso2.carbon.base; version="${carbon.base.imp.pkg.version.range}",

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dao/OAuthAppDO.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dao/OAuthAppDO.java
@@ -45,8 +45,9 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlTransient;
 
 
+import static org.wso2.carbon.identity.application.mgt.ApplicationConstants.DEFAULT_BACKCHANNEL_LOGOUT_URL;
+import static org.wso2.carbon.identity.application.mgt.ApplicationConstants.IS_FRAGMENT_APP;
 import static org.wso2.carbon.identity.configuration.mgt.core.constant.ConfigurationConstants.TENANT_CONTEXT_PATH_COMPONENT;
-import static org.wso2.carbon.identity.organization.management.application.constant.OrgApplicationMgtConstants.IS_FRAGMENT_APP;
 
 /**
  * OAuth application data object.
@@ -57,7 +58,6 @@ import static org.wso2.carbon.identity.organization.management.application.const
 public class OAuthAppDO extends InboundConfigurationProtocol implements Serializable {
 
     private static final long serialVersionUID = -6453843721358989519L;
-    private static final String DEFAULT_BACKCHANNEL_LOGOUT_URL = "/identity/oidc/slo";
 
     @XmlTransient
     private int id;

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dao/OAuthAppDO.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dao/OAuthAppDO.java
@@ -19,10 +19,23 @@ package org.wso2.carbon.identity.oauth.dao;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import org.apache.commons.lang.StringUtils;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
+import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
 import org.wso2.carbon.identity.application.common.model.InboundConfigurationProtocol;
+import org.wso2.carbon.identity.application.common.model.ServiceProvider;
+import org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants;
+import org.wso2.carbon.identity.core.ServiceURLBuilder;
+import org.wso2.carbon.identity.core.URLBuilderException;
+import org.wso2.carbon.identity.oauth.internal.OAuthComponentServiceHolder;
+import org.wso2.carbon.identity.oauth2.internal.OAuth2ServiceComponentHolder;
+import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
+import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
+import org.wso2.carbon.identity.organization.management.service.util.OrganizationManagementUtil;
+import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
 import java.io.Serializable;
+import java.util.Arrays;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -30,6 +43,10 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlTransient;
+
+
+import static org.wso2.carbon.identity.configuration.mgt.core.constant.ConfigurationConstants.TENANT_CONTEXT_PATH_COMPONENT;
+import static org.wso2.carbon.identity.organization.management.application.constant.OrgApplicationMgtConstants.IS_FRAGMENT_APP;
 
 /**
  * OAuth application data object.
@@ -40,6 +57,7 @@ import javax.xml.bind.annotation.XmlTransient;
 public class OAuthAppDO extends InboundConfigurationProtocol implements Serializable {
 
     private static final long serialVersionUID = -6453843721358989519L;
+    private static final String DEFAULT_BACKCHANNEL_LOGOUT_URL = "/identity/oidc/slo";
 
     @XmlTransient
     private int id;
@@ -299,6 +317,9 @@ public class OAuthAppDO extends InboundConfigurationProtocol implements Serializ
 
     public String getBackChannelLogoutUrl() {
 
+        if (StringUtils.isBlank(backChannelLogoutUrl)) {
+            this.backChannelLogoutUrl = resolveBackChannelLogoutURLForSharedApps();
+        }
         return backChannelLogoutUrl;
     }
 
@@ -533,5 +554,66 @@ public class OAuthAppDO extends InboundConfigurationProtocol implements Serializ
     public void setAccessTokenClaims(String[] accessTokenClaims) {
 
         this.accessTokenClaims = accessTokenClaims;
+    }
+
+    /**
+     * Resolves the back-channel logout URL for the shared oAuth apps in organizations.
+     *
+     * @return Back-channel logout URL.
+     */
+    private String resolveBackChannelLogoutURLForSharedApps() {
+
+        String tenantDomain = getTenantDomain();
+        try {
+            if (OrganizationManagementUtil.isOrganization(tenantDomain)) {
+                ServiceProvider orgApplication = getOrgApplication(oauthConsumerKey, tenantDomain);
+                boolean isFragmentApp = Arrays.stream(orgApplication.getSpProperties())
+                        .anyMatch(property -> IS_FRAGMENT_APP.equals(property.getName()) &&
+                                Boolean.parseBoolean(property.getValue()));
+
+                if (isFragmentApp) {
+                    String rootOrganizationId = getOrganizationManager().getPrimaryOrganizationId(tenantDomain);
+                    return resolveBackChannelLogoutURL(rootOrganizationId);
+                }
+            }
+        } catch (OrganizationManagementException | URLBuilderException | IdentityApplicationManagementException e) {
+            return null;
+        }
+        return null;
+    }
+
+    private String resolveBackChannelLogoutURL(String organizationId)
+            throws URLBuilderException, OrganizationManagementException {
+
+        String tenantDomain = getOrganizationManager().resolveTenantDomain(organizationId);
+        if (MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equals(tenantDomain)) {
+            return ServiceURLBuilder.create()
+                    .addPath(DEFAULT_BACKCHANNEL_LOGOUT_URL)
+                    .setTenant(tenantDomain).build().getAbsolutePublicURL();
+        }
+        String context = String.format(TENANT_CONTEXT_PATH_COMPONENT, tenantDomain)
+                + DEFAULT_BACKCHANNEL_LOGOUT_URL;
+        return ServiceURLBuilder.create().addPath(context).build().getAbsolutePublicURL();
+    }
+
+    private OrganizationManager getOrganizationManager() {
+
+        return OAuthComponentServiceHolder.getInstance().getOrganizationManager();
+    }
+
+    private String getTenantDomain() {
+
+        String tenantDomain = MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
+        if (getAppOwner() != null) {
+            tenantDomain = getAppOwner().getTenantDomain();
+        }
+        return tenantDomain;
+    }
+
+    public static ServiceProvider getOrgApplication(String clientId, String tenantDomain)
+            throws IdentityApplicationManagementException {
+
+        return OAuth2ServiceComponentHolder.getApplicationMgtService().getServiceProviderByClientId(
+                clientId, IdentityApplicationConstants.OAuth2.NAME, tenantDomain);
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImplTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImplTest.java
@@ -105,6 +105,7 @@ import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 import static org.testng.Assert.assertThrows;
 import static org.wso2.carbon.base.MultitenantConstants.SUPER_TENANT_ID;
+import static org.wso2.carbon.identity.application.mgt.ApplicationConstants.DEFAULT_BACKCHANNEL_LOGOUT_URL;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.ENABLE_CLAIMS_SEPARATION_FOR_ACCESS_TOKEN;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDC_DIALECT;
 import static org.wso2.carbon.utils.multitenancy.MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
@@ -234,6 +235,7 @@ public class OAuthAdminServiceImplTest {
             AuthenticatedUser authenticatedUser = new AuthenticatedUser();
             oAuthAppDO.setApplicationName("testapp1");
             oAuthAppDO.setUser(authenticatedUser);
+            oAuthAppDO.setBackChannelLogoutUrl(DEFAULT_BACKCHANNEL_LOGOUT_URL);
             authenticatedUser.setUserName(userName);
 
             try (MockedConstruction<OAuthAppDAO> mockedConstruction = Mockito.mockConstruction(OAuthAppDAO.class,
@@ -289,6 +291,7 @@ public class OAuthAdminServiceImplTest {
             oAuthConsumerAppDTO.setOauthConsumerSecret(consumerSecret);
             oAuthConsumerAppDTO.setOAuthVersion(oauthVersion);
             oAuthConsumerAppDTO.setRenewRefreshTokenEnabled("true");
+            oAuthConsumerAppDTO.setBackChannelLogoutUrl(DEFAULT_BACKCHANNEL_LOGOUT_URL);
 
             try (MockedConstruction<OAuthAppDAO> mockedConstruction = Mockito.mockConstruction(OAuthAppDAO.class,
                     (mock, context) -> {
@@ -722,6 +725,7 @@ public class OAuthAdminServiceImplTest {
             OAuthAppDO oAuthAppDO = new OAuthAppDO();
             oAuthAppDO.setOauthConsumerKey(CONSUMER_KEY);
             oAuthAppDO.setOauthConsumerSecret(UPDATED_CONSUMER_SECRET);
+            oAuthAppDO.setBackChannelLogoutUrl(DEFAULT_BACKCHANNEL_LOGOUT_URL);
 
             AuthenticatedUser authenticatedUser = new AuthenticatedUser();
             authenticatedUser.setUserName("test_user");

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/authcontext/JWTTokenGeneratorTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/authcontext/JWTTokenGeneratorTest.java
@@ -65,6 +65,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
+import static org.wso2.carbon.identity.application.mgt.ApplicationConstants.DEFAULT_BACKCHANNEL_LOGOUT_URL;
 import static org.wso2.carbon.identity.oauth2.test.utils.CommonTestUtils.setFinalStatic;
 
 @WithCarbonHome
@@ -247,6 +248,7 @@ public class JWTTokenGeneratorTest {
         oAuthAppDO.setUser(user);
         oAuthAppDO.setApplicationName("testApp" + new Random(4));
         oAuthAppDO.setOauthVersion("2.0");
+        oAuthAppDO.setBackChannelLogoutUrl(DEFAULT_BACKCHANNEL_LOGOUT_URL);
 
         OAuthAppDAO authAppDAO = new OAuthAppDAO();
         authAppDAO.addOAuthConsumer("testUser", -1234, "PRIMARY");

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/authz/handlers/CodeResponseTypeHandlerTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/authz/handlers/CodeResponseTypeHandlerTest.java
@@ -47,6 +47,7 @@ import org.wso2.carbon.identity.oauth2.util.AuthzUtil;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.wso2.carbon.identity.application.mgt.ApplicationConstants.DEFAULT_BACKCHANNEL_LOGOUT_URL;
 
 /**
  * Test class covering CodeResponseTypeHandler
@@ -163,6 +164,7 @@ public class CodeResponseTypeHandlerTest {
         appDO.setUserAccessTokenExpiryTime(3600);
         appDO.setRefreshTokenExpiryTime(84100);
         appDO.setIdTokenExpiryTime(3600);
+        appDO.setBackChannelLogoutUrl(DEFAULT_BACKCHANNEL_LOGOUT_URL);
         return appDO;
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/authz/handlers/TokenResponseTypeHandlerTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/authz/handlers/TokenResponseTypeHandlerTest.java
@@ -48,6 +48,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.wso2.carbon.identity.application.mgt.ApplicationConstants.DEFAULT_BACKCHANNEL_LOGOUT_URL;
 
 /**
  * Unit test covering TokenResponseTypeHandler class
@@ -108,6 +109,7 @@ public class TokenResponseTypeHandlerTest {
         oAuthAppDO.setOauthConsumerKey(clientId);
         oAuthAppDO.setUser(authenticatedUser);
         oAuthAppDO.setOauthVersion(OAuthConstants.OAuthVersions.VERSION_2);
+        oAuthAppDO.setBackChannelLogoutUrl(DEFAULT_BACKCHANNEL_LOGOUT_URL);
 
         AccessTokenDO accessTokenDO = new AccessTokenDO();
         accessTokenDO.setAccessToken("abcdefghijklmn");

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AbstractAuthorizationGrantHandlerTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AbstractAuthorizationGrantHandlerTest.java
@@ -91,6 +91,7 @@ import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
+import static org.wso2.carbon.identity.application.mgt.ApplicationConstants.DEFAULT_BACKCHANNEL_LOGOUT_URL;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.TokenStates.TOKEN_STATE_ACTIVE;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.TokenStates.TOKEN_STATE_REVOKED;
 
@@ -147,6 +148,7 @@ public class AbstractAuthorizationGrantHandlerTest {
         oAuthAppDO.setUser(authenticatedUser);
         oAuthAppDO.setCallbackUrl("http://i.have.nowhere.to.go");
         oAuthAppDO.setOauthVersion(OAuthConstants.OAuthVersions.VERSION_2);
+        oAuthAppDO.setBackChannelLogoutUrl(DEFAULT_BACKCHANNEL_LOGOUT_URL);
 
         oAuthAppDAO.addOAuthApplication(oAuthAppDO);
 

--- a/pom.xml
+++ b/pom.xml
@@ -252,6 +252,11 @@
                 <version>${carbon.identity.organization.management.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.wso2.carbon.identity.organization.management</groupId>
+                <artifactId>org.wso2.carbon.identity.organization.management.application</artifactId>
+                <version>${carbon.identity.organization.management.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.wso2.carbon.identity.framework</groupId>
                 <artifactId>org.wso2.carbon.identity.consent.server.configs.mgt</artifactId>
                 <version>${carbon.identity.framework.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -972,7 +972,7 @@
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!-- Carbon Identity Framework version -->
-        <carbon.identity.framework.version>7.7.140</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.7.221</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.25.234, 8.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
         <identity.oauth.xacml.version.range>[2.0.0, 3.0.0)</identity.oauth.xacml.version.range>


### PR DESCRIPTION
### Summary
This pull request adds back-channel logout URL for OIDC applications shared with sub-organizations to send a backchannel logout request to SSO application in the root org.

### Related issue
https://github.com/wso2/product-is/issues/22338
