### PR TITLE
Extract only shared roles from the user's role list when login to a shared app

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/OIDCClaimUtil.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/OIDCClaimUtil.java
@@ -96,7 +96,7 @@ public class OIDCClaimUtil {
     /**
      * Map the local roles of a user to service provider mapped role values.
      *
-     * @param serviceProvider
+     * @param serviceProvider        Service Provider
      * @param locallyMappedUserRoles List of local roles
      * @param claimSeparator         Separator used to combine individual roles in the returned string.
      * @return Service Provider mapped roles combined with claimSeparator
@@ -104,6 +104,7 @@ public class OIDCClaimUtil {
     public static String getServiceProviderMappedUserRoles(ServiceProvider serviceProvider,
                                                            List<String> locallyMappedUserRoles,
                                                            String claimSeparator) throws FrameworkException {
+
         if (isNotEmpty(locallyMappedUserRoles)) {
             locallyMappedUserRoles = new ArrayList<>(locallyMappedUserRoles);
             // Get Local Role to Service Provider Role mappings.


### PR DESCRIPTION
### Proposed changes in this pull request

- $subject
- When login with organization SSO flow, the user's role list will be extracted from the userinfo call. 
- When getting the roles, only shared roles will be picked if the accessing app is a shared app