### PR TITLE
Fix picking correct domain qualified name of shared user for user claim retrieval on organization switch

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/OIDCClaimUtil.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/OIDCClaimUtil.java
@@ -500,7 +500,7 @@ public class OIDCClaimUtil {
 
             try {
                 FrameworkUtils.startTenantFlow(userAccessingTenantDomain);
-                userClaims = getUserClaimsInLocalDialect(fullQualifiedUsername, realm, claimURIList);
+                userClaims = getUserClaimsInLocalDialect(fullQualifiedSharedUsername, realm, claimURIList);
             } finally {
                 FrameworkUtils.endTenantFlow();
             }


### PR DESCRIPTION
### Proposed changes in this pull request
Fix https://github.com/wso2/product-is/issues/23031


https://github.com/user-attachments/assets/6033127d-01f1-4e4d-8e49-78c27876c5f3

