### PR TITLE
Fix the client ids missing in filtering.

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthUtil.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthUtil.java
@@ -1116,7 +1116,7 @@ public final class OAuthUtil {
                             .getTokenManagementDAO().getAllTimeAuthorizedClientIds(authenticatedOrgUser));
                 }
 
-                Set<String> filteredClientIds = new HashSet<>();
+                Set<String> filteredClientIds = clientIds;
                 if (role != null && RoleConstants.ORGANIZATION.equals(role.getAudience())) {
                     filteredClientIds = filterClientIdsWithOrganizationAudience(new ArrayList<>(clientIds),
                             authenticatedUser.getTenantDomain());


### PR DESCRIPTION
### Purpose
- $subject

### Description
- From this https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2710/files PR, we have used filtered client ids set to filter out the client ids.
- But when there is no role change this will set client ids to empty since we intialized it as a empty set.

### Related issues
- https://github.com/wso2/product-is/issues/23047