### PR TITLE
Fix post consent not requested mandatory claims

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
@@ -899,6 +899,11 @@ public class OAuth2AuthzEndpoint {
                 List<ClaimMetaData> requestedOidcClaimsList =
                         getRequestedOidcClaimsList(value, oauth2Params, spTenantDomain, false);
                 value.setRequestedClaims(requestedOidcClaimsList);
+                // The instance value contains the configured mandatory claims values. But if the client was not
+                // requested any mandatory claim, then we have to remove it from the values.
+                List<ClaimMetaData> mandatoryOidcClaimsList =
+                        getRequestedOidcClaimsList(value, oauth2Params, spTenantDomain, true);
+                value.setMandatoryClaims(mandatoryOidcClaimsList);
             }
 
             // Call framework and create the consent receipt.


### PR DESCRIPTION
### Proposed changes in this pull request
Issue: https://github.com/wso2/product-is/issues/23228
With [this pull request](https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2685)(https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2685), we introduce a fix to prevent requesting consent, even if the attribute is marked as mandatory in the application section.  

While setting a claim as mandatory without including it as a scope is not an ideal approach, certain scenarios may require this due to legacy behavior. For those scenarios post consent methods is failing, so this fix address that issue by removing those not request attributes before sending to framework sso