### PR TITLE
Handle token null scenario when retrieving the token hash from the issuer

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/DefaultOIDCClaimsCallbackHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/DefaultOIDCClaimsCallbackHandler.java
@@ -323,7 +323,7 @@ public class DefaultOIDCClaimsCallbackHandler implements CustomClaimsCallbackHan
             OauthTokenIssuer tokenIssuer = getTokenIssuer(requestMsgCtx);
             String accessToken = getAccessToken(requestMsgCtx);
             String accessTokenHash = accessToken;
-            if (tokenIssuer != null) {
+            if (tokenIssuer != null && accessToken != null) {
                 // For the JWT tokens the hash is the JTI.
                 accessTokenHash = tokenIssuer.getAccessTokenHash(accessToken);
             }


### PR DESCRIPTION
Related to the fix in https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2732