### PR TITLE
Token issuer cache improvement

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/cache/AuthorizationGrantCache.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/cache/AuthorizationGrantCache.java
@@ -104,6 +104,9 @@ public class AuthorizationGrantCache extends
                 log.debug("Getting cache entry from session store using tokenId: " + tokenId);
             }
             cacheEntry = getFromSessionStore(tokenId);
+            if (cacheEntry != null) {
+                super.addToCache(key, cacheEntry);
+            }
         }
         return cacheEntry;
     }
@@ -126,6 +129,9 @@ public class AuthorizationGrantCache extends
                 }
             }
             cacheEntry = getFromSessionStore(replaceFromTokenId(key.getUserAttributesId()));
+            if (cacheEntry != null) {
+                super.addToCache(key, cacheEntry);
+            }
         }
         return cacheEntry;
     }
@@ -182,6 +188,9 @@ public class AuthorizationGrantCache extends
                 }
             }
             cacheEntry = getFromSessionStore(replaceFromCodeId(key.getUserAttributesId()));
+            if (cacheEntry != null) {
+                super.addToCache(key, cacheEntry);
+            }
         }
         return cacheEntry;
     }

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/cache/AuthorizationGrantCacheTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/cache/AuthorizationGrantCacheTest.java
@@ -30,7 +30,10 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.wso2.carbon.identity.application.authentication.framework.store.SessionDataStore;
 import org.wso2.carbon.identity.base.IdentityConstants;
+import org.wso2.carbon.identity.common.testng.WithCarbonHome;
+import org.wso2.carbon.identity.common.testng.WithRealmService;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.oauth.internal.OAuthComponentServiceHolder;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.dao.AccessTokenDAO;
 import org.wso2.carbon.identity.oauth2.dao.AuthorizationCodeDAO;
@@ -51,15 +54,14 @@ import static org.mockito.Mockito.when;
 /**
  * Unit tests for AuthorizationGrantCacheTest class.
  */
+@WithCarbonHome
+@WithRealmService(injectToSingletons = {OAuthComponentServiceHolder.class})
 public class AuthorizationGrantCacheTest {
 
     @Mock
     private AccessTokenDAO accessTokenDAO;
 
     private AuthorizationGrantCache cache;
-
-    @Mock
-    private OAuthTokenPersistenceFactory mockedOAuthTokenPersistenceFactory;
 
     @Mock
     private AuthorizationCodeDAO authorizationCodeDAO;
@@ -102,6 +104,7 @@ public class AuthorizationGrantCacheTest {
              MockedStatic<SessionDataStore> mockedSessionDataStore = mockStatic(SessionDataStore.class);
              MockedStatic<IdentityUtil> mockedIdentityUtil = mockStatic(IdentityUtil.class)) {
 
+            OAuthTokenPersistenceFactory mockedOAuthTokenPersistenceFactory = mock(OAuthTokenPersistenceFactory.class);
             when(mockLog.isDebugEnabled()).thenReturn(true);
             mockedFactory.when(OAuthTokenPersistenceFactory::getInstance).thenReturn(
                     mockedOAuthTokenPersistenceFactory);
@@ -192,6 +195,7 @@ public class AuthorizationGrantCacheTest {
              MockedStatic<SessionDataStore> mockedSessionDataStore = mockStatic(SessionDataStore.class);
              MockedStatic<IdentityUtil> mockedIdentityUtil = mockStatic(IdentityUtil.class)) {
 
+            OAuthTokenPersistenceFactory mockedOAuthTokenPersistenceFactory = mock(OAuthTokenPersistenceFactory.class);
             mockedSessionDataStore.when(SessionDataStore::getInstance).thenReturn(sessionDataStore);
             when(sessionDataStore.getSessionData(codeId, "AuthorizationGrantCache")).thenReturn(expectedEntry);
 

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/cache/AuthorizationGrantCacheTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/cache/AuthorizationGrantCacheTest.java
@@ -149,7 +149,9 @@ public class AuthorizationGrantCacheTest {
             AuthorizationGrantCacheEntry result = cache.getValueFromCacheByToken(key);
 
             // Verify the token ID returned from the DAO is as expected.
-            assertEquals(tokenId, result.getTokenId());
+            if (!isFailedTokenRetrieval && !isInvalidJWTToken) {
+                assertEquals(tokenId, result.getTokenId());
+            }
 
             // Verify that the JWT token was parsed and the correct claim was retrieved if it was a JWT.
             if (isJwtToken && !isInvalidJWTToken) {
@@ -175,8 +177,8 @@ public class AuthorizationGrantCacheTest {
         return new Object[][]{
                 {"jwt.Access.Token", "jwtId", "jwtTokenId", true, false, false, false},
                 {"nonJWTAccessToken", null, "nonJWTTokenId", false, false, false, false},
-                {"invalid.JWT.Token", null, "invalid.JWT.Token", true, true, false, true},
-                {"invalid.JWT.Token", null, "invalid.JWT.Token", true, true, false, false},
+                {"invalid.JWT.Token", null, "invalid.JWT.Token", true, true, true, true},
+                {"invalid.JWT.Token", null, "invalid.JWT.Token", true, true, true, false},
                 {"fail.Store.TokenId", "jwtId", "jwtId", true, false, true, false}
         };
     }

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/cache/AuthorizationGrantCacheTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/cache/AuthorizationGrantCacheTest.java
@@ -96,7 +96,7 @@ public class AuthorizationGrantCacheTest {
     @Test(dataProvider = "replaceFromTokenIdDataProvider")
     public void testReplaceFromTokenId(String accessToken, String jwtId, String tokenId, boolean isJwtToken,
                                        boolean isInvalidJWTToken, boolean isFailedTokenRetrieval,
-                                       boolean isTokenLoggable) throws Exception {
+                                       boolean isTokenLoggable, boolean isTestCaching) throws Exception {
 
         try (MockedStatic<OAuthTokenPersistenceFactory> mockedFactory =
         mockStatic(OAuthTokenPersistenceFactory.class);
@@ -154,10 +154,12 @@ public class AuthorizationGrantCacheTest {
             }
 
             // Verify that the JWT token was parsed and the correct claim was retrieved if it was a JWT.
-            if (isJwtToken && !isInvalidJWTToken) {
-                verify(accessTokenDAO).getTokenIdByAccessToken(jwtId);
-            } else {
-                verify(accessTokenDAO).getTokenIdByAccessToken(accessToken);
+            if (!isTestCaching) {
+                if (isJwtToken && !isInvalidJWTToken) {
+                    verify(accessTokenDAO).getTokenIdByAccessToken(jwtId);
+                } else {
+                    verify(accessTokenDAO).getTokenIdByAccessToken(accessToken);
+                }
             }
 
             if (isInvalidJWTToken) {
@@ -175,11 +177,12 @@ public class AuthorizationGrantCacheTest {
     public Object[][] getReplaceFromTokenIdData() {
 
         return new Object[][]{
-                {"jwt.Access.Token", "jwtId", "jwtTokenId", true, false, false, false},
-                {"nonJWTAccessToken", null, "nonJWTTokenId", false, false, false, false},
-                {"invalid.JWT.Token", null, "invalid.JWT.Token", true, true, true, true},
-                {"invalid.JWT.Token", null, "invalid.JWT.Token", true, true, true, false},
-                {"fail.Store.TokenId", "jwtId", "jwtId", true, false, true, false}
+                {"jwt.Access.Token", "jwtId", "jwtTokenId", true, false, false, false, false},
+                {"nonJWTAccessToken", null, "nonJWTTokenId", false, false, false, false, false},
+                {"nonJWTAccessToken", null, "nonJWTTokenId", false, false, false, false, true},
+                {"invalid.JWT.Token", null, "invalid.JWT.Token", true, true, true, true, false},
+                {"invalid.JWT.Token", null, "invalid.JWT.Token", true, true, true, false, false},
+                {"fail.Store.TokenId", "jwtId", "jwtId", true, false, true, false, false}
         };
     }
 


### PR DESCRIPTION
$subject

This fix will,
- Stop adding the same token to the cache, which leading to cache invalidation due to cache renewal.
- Adds the entries to the cache, retrieved from the DB during a cache miss.

Test fix:
- For invalid JWTs, the token retrieval should fail -> hence changed the test data to cater this

Resolves https://github.com/wso2/product-is/issues/23149