### PR TITLE
Set requestBinding for refresh token grant.

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/RefreshGrantHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/RefreshGrantHandler.java
@@ -87,6 +87,7 @@ import java.util.stream.Stream;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkErrorConstants.ErrorMessages.ERROR_WHILE_CHECKING_ACCOUNT_LOCK_STATUS;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkErrorConstants.ErrorMessages.ERROR_WHILE_GETTING_USERNAME_ASSOCIATED_WITH_IDP;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.GrantTypes.REFRESH_TOKEN;
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.REQUEST_BINDING_TYPE;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.TokenBindings.NONE;
 import static org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration.JWT_TOKEN_TYPE;
 import static org.wso2.carbon.identity.oauth2.util.OAuth2Util.buildCacheKeyStringForTokenWithUserId;
@@ -652,8 +653,25 @@ public class RefreshGrantHandler extends AbstractAuthorizationGrantHandler {
         createTokens(accessTokenDO, tokReqMsgCtx);
         setRefreshTokenData(accessTokenDO, tokenReq, validationBean, oAuthAppDO, accessTokenDO.getRefreshToken(),
                 timestamp, tokReqMsgCtx);
+        handleRequestBinding(accessTokenDO, tokReqMsgCtx);
         modifyTokensIfUsernameAssertionEnabled(accessTokenDO, tokReqMsgCtx);
         setValidityPeriod(accessTokenDO, tokReqMsgCtx, oAuthAppDO);
+    }
+
+    private void handleRequestBinding(AccessTokenDO accessTokenDO, OAuthTokenReqMessageContext tokReqMsgCtx) {
+
+        if (accessTokenDO.getTokenBinding() != null) {
+            // Another token binding type is already set.
+            return;
+        }
+
+        if (tokReqMsgCtx.getTokenBinding() != null &&
+                REQUEST_BINDING_TYPE.equals(tokReqMsgCtx.getTokenBinding().getBindingType())) {
+            /* Request binding is only set to the context if renew_token_without_revoking_existing config
+             * is enabled and refresh token grant is set as an allowed grant type.
+             */
+            accessTokenDO.setTokenBinding(tokReqMsgCtx.getTokenBinding());
+        }
     }
 
     private void setValidityPeriod(AccessTokenDO accessTokenDO, OAuthTokenReqMessageContext tokReqMsgCtx,


### PR DESCRIPTION
### Purpose

Sets the requestBinding type to the tokens issued from the refresh token grant when the renew_token_without_revoking_existing config is enabled and refresh token grant is set as an allowed grant type

### Related issue
- https://github.com/wso2/product-is/issues/23146