### PR TITLE
Support to use multivalued parameters in the API based authentication request

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/api/auth/model/SelectedAuthenticator.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/api/auth/model/SelectedAuthenticator.java
@@ -27,13 +27,13 @@ import java.util.Map;
 public class SelectedAuthenticator {
 
     private String authenticatorId;
-    private Map<String, String> params = new HashMap<String, String>();
+    private Map<String, Object> params = new HashMap<String, Object>();
 
     public SelectedAuthenticator() {
 
     }
 
-    public SelectedAuthenticator(String authenticatorId, Map<String, String> params) {
+    public SelectedAuthenticator(String authenticatorId, Map<String, Object> params) {
 
         this.authenticatorId = authenticatorId;
         this.params = params;
@@ -49,12 +49,12 @@ public class SelectedAuthenticator {
         this.authenticatorId = authenticatorId;
     }
 
-    public Map<String, String> getParams() {
+    public Map<String, Object> getParams() {
 
         return params;
     }
 
-    public void setParams(Map<String, String> params) {
+    public void setParams(Map<String, Object> params) {
 
         this.params = params;
     }


### PR DESCRIPTION
- Currently, the SelectedAutenticator object implementation is limited to accept only string values for parameters.
- However an input parameter can be multi valued
- We can represent this param as a String Array in the API based authentication request payload
Eg:
```
"selectedAuthenticator": {
        "authenticatorId": "U2Vzc2lvbkV4ZWN1dG9yOkxPQ0FM",
        "params": {
            "param1": "value1",
            "param2": "value2",
            "param3": "value3",
            "param4": ["value4, "value5"]
        }
    }
```
- This PR adds the support for processing

### Related issue
- https://github.com/wso2-enterprise/wso2-iam-internal/issues/3135