### PR TITLE
Add `dpop_signing_alg_values_supported` to OIDC Discovery Endpoint

### DIFF
--- a/components/org.wso2.carbon.identity.discovery/src/main/java/org/wso2/carbon/identity/discovery/DiscoveryConstants.java
+++ b/components/org.wso2.carbon.identity.discovery/src/main/java/org/wso2/carbon/identity/discovery/DiscoveryConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2016-2025, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -384,4 +384,10 @@ public class DiscoveryConstants {
      * @see <a href='https://datatracker.ietf.org/doc/html/rfc9396.txt#name-metadata'>rfc9396</a>
      */
     public static final String AUTHORIZATION_DETAILS_TYPES_SUPPORTED = "authorization_details_types_supported";
+
+    /**
+     * DPoP_signing_algorithms_supported
+     * OPTIONAL. JSON array containing a list of the DPoP signing algorithms supported by the AS.
+     */
+    public static final String DPOP_SIGNING_ALGORITHMS_SUPPORTED = "dpop_signing_alg_values_supported";
 }

--- a/components/org.wso2.carbon.identity.discovery/src/main/java/org/wso2/carbon/identity/discovery/DiscoveryUtil.java
+++ b/components/org.wso2.carbon.identity.discovery/src/main/java/org/wso2/carbon/identity/discovery/DiscoveryUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2019-2025, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -19,12 +19,17 @@
 package org.wso2.carbon.identity.discovery;
 
 import org.apache.commons.lang.StringUtils;
+import org.wso2.carbon.identity.core.handler.AbstractIdentityHandler;
+import org.wso2.carbon.identity.core.model.IdentityEventListenerConfig;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 
 /**
  * Utility to handle OIDC Discovery related functionality.
  */
 public class DiscoveryUtil {
+
+    private static final String DPOP_EVENT_LISTENER_NAME = "org.wso2.carbon.identity.oauth2.dpop.listener.O" +
+            "authDPoPInterceptorHandlerProxy";
 
     public static final String OIDC_USE_ENTITY_ID_AS_ISSUER_IN_DISCOVERY = "OAuth" +
             ".UseEntityIdAsIssuerInOidcDiscovery";
@@ -43,4 +48,16 @@ public class DiscoveryUtil {
         return Boolean.parseBoolean(useEntityIdAsIssuerInDiscovery);
     }
 
+    /**
+     * Check whether DPoP is enabled.
+     *
+     * @return True if DPoP is enabled.
+     */
+    public static boolean isDPoPEnabled() {
+
+        IdentityEventListenerConfig identityEventListenerConfig = IdentityUtil.readEventListenerProperty
+                (AbstractIdentityHandler.class.getName(), DPOP_EVENT_LISTENER_NAME);
+        return identityEventListenerConfig == null ||
+                Boolean.parseBoolean(identityEventListenerConfig.getEnable());
+    }
 }

--- a/components/org.wso2.carbon.identity.discovery/src/main/java/org/wso2/carbon/identity/discovery/DiscoveryUtil.java
+++ b/components/org.wso2.carbon.identity.discovery/src/main/java/org/wso2/carbon/identity/discovery/DiscoveryUtil.java
@@ -28,7 +28,7 @@ import org.wso2.carbon.identity.core.util.IdentityUtil;
  */
 public class DiscoveryUtil {
 
-    private static final String DPOP_EVENT_LISTENER_NAME = "org.wso2.carbon.identity.oauth2.dpop.listener.O" +
+    public static final String DPOP_EVENT_LISTENER_NAME = "org.wso2.carbon.identity.oauth2.dpop.listener.O" +
             "authDPoPInterceptorHandlerProxy";
 
     public static final String OIDC_USE_ENTITY_ID_AS_ISSUER_IN_DISCOVERY = "OAuth" +
@@ -57,7 +57,7 @@ public class DiscoveryUtil {
 
         IdentityEventListenerConfig identityEventListenerConfig = IdentityUtil.readEventListenerProperty
                 (AbstractIdentityHandler.class.getName(), DPOP_EVENT_LISTENER_NAME);
-        return identityEventListenerConfig == null ||
-                Boolean.parseBoolean(identityEventListenerConfig.getEnable());
+
+        return identityEventListenerConfig != null && Boolean.parseBoolean(identityEventListenerConfig.getEnable());
     }
 }

--- a/components/org.wso2.carbon.identity.discovery/src/main/java/org/wso2/carbon/identity/discovery/DiscoveryUtil.java
+++ b/components/org.wso2.carbon.identity.discovery/src/main/java/org/wso2/carbon/identity/discovery/DiscoveryUtil.java
@@ -48,6 +48,7 @@ public class DiscoveryUtil {
         return Boolean.parseBoolean(useEntityIdAsIssuerInDiscovery);
     }
 
+    // TODO: Remove this method once DPoP is enabled by default.
     /**
      * Check whether DPoP is enabled.
      *

--- a/components/org.wso2.carbon.identity.discovery/src/main/java/org/wso2/carbon/identity/discovery/OIDProviderConfigResponse.java
+++ b/components/org.wso2.carbon.identity.discovery/src/main/java/org/wso2/carbon/identity/discovery/OIDProviderConfigResponse.java
@@ -616,7 +616,6 @@ public class OIDProviderConfigResponse {
         if (DiscoveryUtil.isDPoPEnabled()) {
             configMap.put(DiscoveryConstants.DPOP_SIGNING_ALGORITHMS_SUPPORTED, this.supportedDPoPSigningAlgorithms);
         }
-        configMap.put(DiscoveryConstants.DPOP_SIGNING_ALGORITHMS_SUPPORTED, this.supportedDPoPSigningAlgorithms);
         if (Boolean.parseBoolean(IdentityUtil.getProperty(MUTUAL_TLS_ALIASES_ENABLED))) {
             Map<String, String> mtlsAliases = new HashMap<String, String>();
             mtlsAliases.put(DiscoveryConstants.TOKEN_ENDPOINT.toLowerCase(), this.mtlsTokenEndpoint);

--- a/components/org.wso2.carbon.identity.discovery/src/main/java/org/wso2/carbon/identity/discovery/OIDProviderConfigResponse.java
+++ b/components/org.wso2.carbon.identity.discovery/src/main/java/org/wso2/carbon/identity/discovery/OIDProviderConfigResponse.java
@@ -543,7 +543,8 @@ public class OIDProviderConfigResponse {
     }
 
     public void setDPoPSupportedSigningAlgorithms(String[] supportedDPoPSigningAlgorithms) {
-        this.supportedDPoPSigningAlgorithms = supportedDPoPSigningAlgorithms; ;
+
+        this.supportedDPoPSigningAlgorithms = supportedDPoPSigningAlgorithms;
     }
 
     public Map<String, Object> getConfigMap() {

--- a/components/org.wso2.carbon.identity.discovery/src/main/java/org/wso2/carbon/identity/discovery/OIDProviderConfigResponse.java
+++ b/components/org.wso2.carbon.identity.discovery/src/main/java/org/wso2/carbon/identity/discovery/OIDProviderConfigResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2016-2025, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -86,6 +86,7 @@ public class OIDProviderConfigResponse {
     private String mtlsTokenEndpoint;
     private String mtlsPushedAuthorizationRequestEndpoint;
     private String[] authorizationDetailsTypesSupported;
+    private String[] supportedDPoPSigningAlgorithms;
 
     private static final String MUTUAL_TLS_ALIASES_ENABLED = "OAuth.MutualTLSAliases.Enabled";
 
@@ -541,6 +542,10 @@ public class OIDProviderConfigResponse {
         this.authorizationDetailsTypesSupported = authorizationDetailsTypesSupported;
     }
 
+    public void setDPoPSupportedSigningAlgorithms(String[] supportedDPoPSigningAlgorithms) {
+        this.supportedDPoPSigningAlgorithms = supportedDPoPSigningAlgorithms; ;
+    }
+
     public Map<String, Object> getConfigMap() {
         Map<String, Object> configMap = new HashMap<String, Object>();
         configMap.put(DiscoveryConstants.ISSUER.toLowerCase(), this.issuer);
@@ -608,6 +613,10 @@ public class OIDProviderConfigResponse {
         configMap.put(DiscoveryConstants.WEBFINGER_ENDPOINT.toLowerCase(), this.webFingerEndpoint);
         configMap.put(DiscoveryConstants.TLS_CLIENT_CERTIFICATE_BOUND_ACCESS_TOKEN.toLowerCase(),
                 this.tlsClientCertificateBoundAccessTokens);
+        if (DiscoveryUtil.isDPoPEnabled()) {
+            configMap.put(DiscoveryConstants.DPOP_SIGNING_ALGORITHMS_SUPPORTED, this.supportedDPoPSigningAlgorithms);
+        }
+        configMap.put(DiscoveryConstants.DPOP_SIGNING_ALGORITHMS_SUPPORTED, this.supportedDPoPSigningAlgorithms);
         if (Boolean.parseBoolean(IdentityUtil.getProperty(MUTUAL_TLS_ALIASES_ENABLED))) {
             Map<String, String> mtlsAliases = new HashMap<String, String>();
             mtlsAliases.put(DiscoveryConstants.TOKEN_ENDPOINT.toLowerCase(), this.mtlsTokenEndpoint);

--- a/components/org.wso2.carbon.identity.discovery/src/main/java/org/wso2/carbon/identity/discovery/builders/ProviderConfigBuilder.java
+++ b/components/org.wso2.carbon.identity.discovery/src/main/java/org/wso2/carbon/identity/discovery/builders/ProviderConfigBuilder.java
@@ -148,9 +148,9 @@ public class ProviderConfigBuilder {
                 .getSupportedTokenEndpointSigningAlgorithms();
         providerConfig.setTokenEndpointAuthSigningAlgValuesSupported(
                 supportedTokenEndpointSigningAlgorithms.toArray(new String[0]));
-        List<String> setDPoPSigningAlgorithms = OAuthServerConfiguration.getInstance()
+        List<String> dPoPSigningAlgorithms = OAuthServerConfiguration.getInstance()
                 .getSupportedDPoPSigningAlgorithms();
-        providerConfig.setDPoPSupportedSigningAlgorithms(setDPoPSigningAlgorithms.toArray(new String[0]));
+        providerConfig.setDPoPSupportedSigningAlgorithms(dPoPSigningAlgorithms.toArray(new String[0]));
         providerConfig.setWebFingerEndpoint(OAuth2Util.OAuthURL.getOidcWebFingerEPUrl());
         providerConfig.setTlsClientCertificateBoundAccessTokens(OAuth2Util.getSupportedTokenBindingTypes()
                 .contains(OAuth2Constants.TokenBinderType.CERTIFICATE_BASED_TOKEN_BINDER));

--- a/components/org.wso2.carbon.identity.discovery/src/main/java/org/wso2/carbon/identity/discovery/builders/ProviderConfigBuilder.java
+++ b/components/org.wso2.carbon.identity.discovery/src/main/java/org/wso2/carbon/identity/discovery/builders/ProviderConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2016-2025, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -148,6 +148,9 @@ public class ProviderConfigBuilder {
                 .getSupportedTokenEndpointSigningAlgorithms();
         providerConfig.setTokenEndpointAuthSigningAlgValuesSupported(
                 supportedTokenEndpointSigningAlgorithms.toArray(new String[0]));
+        List<String> setDPoPSigningAlgorithms = OAuthServerConfiguration.getInstance()
+                .getSupportedDPoPSigningAlgorithms();
+        providerConfig.setDPoPSupportedSigningAlgorithms(setDPoPSigningAlgorithms.toArray(new String[0]));
         providerConfig.setWebFingerEndpoint(OAuth2Util.OAuthURL.getOidcWebFingerEPUrl());
         providerConfig.setTlsClientCertificateBoundAccessTokens(OAuth2Util.getSupportedTokenBindingTypes()
                 .contains(OAuth2Constants.TokenBinderType.CERTIFICATE_BASED_TOKEN_BINDER));

--- a/components/org.wso2.carbon.identity.discovery/src/test/java/org/wso2/carbon/identity/discovery/DiscoveryUtilTest.java
+++ b/components/org.wso2.carbon.identity.discovery/src/test/java/org/wso2/carbon/identity/discovery/DiscoveryUtilTest.java
@@ -66,8 +66,10 @@ public class DiscoveryUtilTest {
         }
     }
 
+    // TODO: Remove the IsDPoPEnabled tests once DPoP is enabled by default.
     @Test
     public void testIsDPoPEnabledWhenConfigIsTrue() {
+
         try (MockedStatic<IdentityUtil> identityUtil = mockStatic(IdentityUtil.class)) {
             IdentityEventListenerConfig config = Mockito.mock(IdentityEventListenerConfig.class);
             when(config.getEnable()).thenReturn("true");
@@ -83,6 +85,7 @@ public class DiscoveryUtilTest {
 
     @Test
     public void testIsDPoPEnabledWhenConfigIsNull() {
+
         try (MockedStatic<IdentityUtil> identityUtil = mockStatic(IdentityUtil.class)) {
             identityUtil.when(() -> IdentityUtil.readEventListenerProperty(
                     eq(AbstractIdentityHandler.class.getName()), eq(DPOP_EVENT_LISTENER_NAME))).thenReturn(null);

--- a/components/org.wso2.carbon.identity.discovery/src/test/java/org/wso2/carbon/identity/discovery/DiscoveryUtilTest.java
+++ b/components/org.wso2.carbon.identity.discovery/src/test/java/org/wso2/carbon/identity/discovery/DiscoveryUtilTest.java
@@ -19,14 +19,21 @@
 package org.wso2.carbon.identity.discovery;
 
 import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+import org.wso2.carbon.identity.core.handler.AbstractIdentityHandler;
+import org.wso2.carbon.identity.core.model.IdentityEventListenerConfig;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+import static org.wso2.carbon.identity.discovery.DiscoveryUtil.DPOP_EVENT_LISTENER_NAME;
 import static org.wso2.carbon.identity.discovery.DiscoveryUtil.OIDC_USE_ENTITY_ID_AS_ISSUER_IN_DISCOVERY;
 
 /**
@@ -56,6 +63,31 @@ public class DiscoveryUtilTest {
             identityUtil.when(() -> IdentityUtil.getProperty(eq(OIDC_USE_ENTITY_ID_AS_ISSUER_IN_DISCOVERY)))
                     .thenReturn(Boolean.FALSE.toString());
             assertEquals(DiscoveryUtil.isUseEntityIdAsIssuerInOidcDiscovery(), false);
+        }
+    }
+
+    @Test
+    public void testIsDPoPEnabledWhenConfigIsTrue() {
+        try (MockedStatic<IdentityUtil> identityUtil = mockStatic(IdentityUtil.class)) {
+            IdentityEventListenerConfig config = Mockito.mock(IdentityEventListenerConfig.class);
+            when(config.getEnable()).thenReturn("true");
+            identityUtil.when(() -> IdentityUtil.readEventListenerProperty(
+                    eq(AbstractIdentityHandler.class.getName()), eq(DPOP_EVENT_LISTENER_NAME))).thenReturn(config);
+
+            assertTrue(
+                    DiscoveryUtil.isDPoPEnabled(),
+                    "DPoP should be enabled when DPoP event listener is enabled ."
+            );
+        }
+    }
+
+    @Test
+    public void testIsDPoPEnabledWhenConfigIsNull() {
+        try (MockedStatic<IdentityUtil> identityUtil = mockStatic(IdentityUtil.class)) {
+            identityUtil.when(() -> IdentityUtil.readEventListenerProperty(
+                    eq(AbstractIdentityHandler.class.getName()), eq(DPOP_EVENT_LISTENER_NAME))).thenReturn(null);
+
+            assertFalse(DiscoveryUtil.isDPoPEnabled(), "DPoP should be disabled when the config is null.");
         }
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfigurationTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfigurationTest.java
@@ -518,5 +518,15 @@ public class OAuthServerConfigurationTest {
                 .replace("${carbon.host}", "localhost")
                 .replace("${carbon.management.port}", "9443");
     }
+
+    @Test
+    public void testGetSupportedDPoPSigningAlgorithms() {
+
+            List<String> supportedDPoPSigningAlgorithms = OAuthServerConfiguration.getInstance()
+                    .getSupportedDPoPSigningAlgorithms();
+            Assert.assertTrue(supportedDPoPSigningAlgorithms.contains("ES256"));
+            Assert.assertTrue(supportedDPoPSigningAlgorithms.contains("RS256"));
+            Assert.assertEquals(supportedDPoPSigningAlgorithms.size(), 2);
+    }
 }
 

--- a/components/org.wso2.carbon.identity.oauth/src/test/resources/repository/conf/identity/identity.xml
+++ b/components/org.wso2.carbon.identity.oauth/src/test/resources/repository/conf/identity/identity.xml
@@ -286,6 +286,10 @@
                 <SupportedTokenEndpointSigningAlgorithm>ES256</SupportedTokenEndpointSigningAlgorithm>
                 <SupportedTokenEndpointSigningAlgorithm>SHA256withRSA</SupportedTokenEndpointSigningAlgorithm>
             </SupportedTokenEndpointSigningAlgorithms>
+            <SupportedDPoPSigningAlgorithms>
+                <SupportedDPoPSigningAlgorithm>ES256</SupportedDPoPSigningAlgorithm>
+                <SupportedDPoPSigningAlgorithm>SHA256withRSA</SupportedDPoPSigningAlgorithm>
+            </SupportedDPoPSigningAlgorithms>
         </OpenIDConnect>
         <DeviceCodeGrant>
             <KeyLength>6</KeyLength>


### PR DESCRIPTION
### Proposed changes in this pull request
As per [RFC 9449](https://datatracker.ietf.org/doc/html/rfc9449), Authorization Servers that support DPoP must include the dpop_signing_alg_values_supported metadata property in the OpenID Provider Configuration (/.well-known/openid-configuration). The presence of this property indicates DPoP support and lists the supported signing algorithms.

Currently, when enabling DPoP support this metadata property is missing from the response. This PR adds the necessary updates to ensure compliance with RFC 9449.

More info can be found [here](https://datatracker.ietf.org/doc/html/rfc9449#name-authorization-server-metada).

###  Screenshots of the Change 

When DPoP is enabled the following will be added to the OIDC Discovery Endpoint response, 
<img width="1001" alt="Screenshot 2025-03-17 at 11 00 08" src="https://github.com/user-attachments/assets/f980b890-114c-4218-90d2-259b4d1fff5d" />


### Related Issue 
- https://github.com/wso2/product-is/issues/23372

### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description.
- [ ] **Is the PR labeled correctly?**

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled.

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests.
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/).

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components.
- [ ] **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

#### Security

- [ ] **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
- [ ] **Are all UI and API inputs run through forms or serializers?**
- [ ] **Are all external inputs validated and sanitized appropriately?**
- [ ] **Does all branching logic have a default case?**
- [ ] **Does this solution handle outliers and edge cases gracefully?**
- [ ] **Are all external communications secured and restricted to SSL?**

#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes should be documented.
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented.
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki.
