### PR TITLE
Introduce show_auth_Failure_reason configuration specific to password grant

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
@@ -314,6 +314,7 @@ public class OAuthServerConfiguration {
     // By default, this is true because OIDC claims are not required for client credential grant type
     // and CC grant doesn't involve a user.
     private boolean skipOIDCClaimsForClientCredentialGrant = true;
+    private boolean showAuthFailureReasonForPasswordGrant = false;
 
     private String tokenValueGeneratorClassName;
     //property to define hashing algorithm when enabling hashing of tokens and authorization codes.
@@ -488,6 +489,8 @@ public class OAuthServerConfiguration {
 
         parseSkipOIDCClaimsForClientCredentialGrantConfig(oauthElem);
 
+        parseShowAuthFailureReasonForPasswordGrant(oauthElem);
+
         // parse OAuth 2.0 token generator
         parseOAuthTokenGeneratorConfig(oauthElem);
 
@@ -645,6 +648,17 @@ public class OAuthServerConfiguration {
         if (skipOIDCClaimsForClientCredentialGrantElement != null) {
             skipOIDCClaimsForClientCredentialGrant = Boolean.parseBoolean(
                     skipOIDCClaimsForClientCredentialGrantElement.getText().trim());
+        }
+    }
+
+    private void parseShowAuthFailureReasonForPasswordGrant(OMElement oauthElem) {
+
+        OMElement showAuthFailureReasonForPasswordGrantElement = oauthElem
+                .getFirstChildWithName(getQNameWithIdentityNS(ConfigElements
+                        .SHOW_AUTH_FAILURE_REASON_FOR_PASSWORD_GRANT));
+        if (showAuthFailureReasonForPasswordGrantElement != null) {
+            showAuthFailureReasonForPasswordGrant = Boolean.parseBoolean(
+                    showAuthFailureReasonForPasswordGrantElement.getText().trim());
         }
     }
 
@@ -897,6 +911,12 @@ public class OAuthServerConfiguration {
 
         return skipOIDCClaimsForClientCredentialGrant;
     }
+
+    public boolean isShowAuthFailureReasonForPasswordGrant() {
+
+        return showAuthFailureReasonForPasswordGrant;
+    }
+
     /**
      * instantiate the OAuth token generator. to override the default implementation, one can specify the custom class
      * in the identity.xml.
@@ -4402,6 +4422,8 @@ public class OAuthServerConfiguration {
 
         private static final String SKIP_OIDC_CLAIMS_FOR_CLIENT_CREDENTIAL_GRANT =
                 "SkipOIDCClaimsForClientCredentialGrant";
+        private static final String SHOW_AUTH_FAILURE_REASON_FOR_PASSWORD_GRANT =
+                "ShowAuthFailureReasonForPasswordGrant";
         private static final String SUPPORTED_TOKEN_ENDPOINT_SIGNING_ALGS = "SupportedTokenEndpointSigningAlgorithms";
         private static final String SUPPORTED_TOKEN_ENDPOINT_SIGNING_ALG = "SupportedTokenEndpointSigningAlgorithm";
         private static final String USE_LEGACY_SCOPES_AS_ALIAS_FOR_NEW_SCOPES = "UseLegacyScopesAsAliasForNewScopes";

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/PasswordGrantHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/PasswordGrantHandler.java
@@ -93,7 +93,6 @@ import javax.servlet.http.HttpServletResponse;
 
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.ALLOW_SESSION_CREATION;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.BASIC_AUTHENTICATOR_CLASS;
-import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.SHOW_AUTHFAILURE_RESON_CONFIG;
 
 /**
  * Handles the Password Grant Type of the OAuth 2.0 specification. Resource owner sends his
@@ -355,8 +354,8 @@ public class PasswordGrantHandler extends AbstractAuthorizationGrantHandler {
 
         boolean isPublishPasswordGrantLoginEnabled = Boolean.parseBoolean(
                 IdentityUtil.getProperty(PUBLISH_PASSWORD_GRANT_LOGIN));
-        boolean isShowAuthFailureReason = Boolean.parseBoolean(
-                getBasicAuthenticatorConfigs().getParameterMap().get(SHOW_AUTHFAILURE_RESON_CONFIG));
+        boolean isShowAuthFailureReason =
+                OAuthServerConfiguration.getInstance().isShowAuthFailureReasonForPasswordGrant();
         String genericErrorUserName = tokenReq.getResourceOwnerUsername();
         try {
             // Get the user store preference order supplier.

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/PasswordGrantHandlerTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/PasswordGrantHandlerTest.java
@@ -262,25 +262,11 @@ public class PasswordGrantHandlerTest {
              MockedStatic<MultitenantUtils> multitenantUtils = mockStatic(MultitenantUtils.class);
              MockedStatic<IdentityUtil> identityUtil = mockStatic(IdentityUtil.class);
              MockedStatic<FrameworkUtils> frameworkUtils = mockStatic(FrameworkUtils.class);
-             MockedStatic<IdentityTenantUtil> identityTenantUtil = mockStatic(IdentityTenantUtil.class);
-             MockedStatic<FileBasedConfigurationBuilder> fileBasedConfigBuilder = mockStatic(
-                     FileBasedConfigurationBuilder.class)) {
-
-            fileBasedConfigBuilder.when(FileBasedConfigurationBuilder::getInstance)
-                    .thenReturn(fileBasedConfigurationBuilder);
-            AuthenticatorConfig basicAuthenticatorConfig = new AuthenticatorConfig();
-            Map<String, String> parameterMap = new HashMap<>();
-            if (isShowAuthFailureReason) {
-                parameterMap.put(SHOW_AUTHFAILURE_RESON_CONFIG, "true");
-            } else {
-                parameterMap.put(SHOW_AUTHFAILURE_RESON_CONFIG, "false");
-            }
-            basicAuthenticatorConfig.setParameterMap(parameterMap);
-            when(fileBasedConfigurationBuilder.getAuthenticatorBean(anyString())).thenReturn(
-                    basicAuthenticatorConfig);
+             MockedStatic<IdentityTenantUtil> identityTenantUtil = mockStatic(IdentityTenantUtil.class)) {
 
             oAuthServerConfiguration.when(OAuthServerConfiguration::getInstance).thenReturn(serverConfiguration);
             when(serverConfiguration.getIdentityOauthTokenIssuer()).thenReturn(oauthIssuer);
+            when(serverConfiguration.isShowAuthFailureReasonForPasswordGrant()).thenReturn(isShowAuthFailureReason);
             multitenantUtils.when(() -> MultitenantUtils.getTenantDomain(anyString())).thenReturn(tenantDomain);
 
             when(tokReqMsgCtx.getOauth2AccessTokenReqDTO()).thenReturn(oAuth2AccessTokenReqDTO);


### PR DESCRIPTION
### Purpose

With this PR, the below configuration will be used to show auth failure reason in Password Grant instead of the configuration for basic authentication.

```
[oauth.grant_type.password]
show_auth_failure_reason = false
```

This change ensures password grant has its own configuration to change the behavior of showing the auth failure reason


### Related PRs
- https://github.com/wso2/carbon-identity-framework/pull/6648
- https://github.com/wso2/carbon-identity-framework/pull/6635

### Related issues
- https://github.com/wso2/product-is/issues/23476
