### PR TITLE
Fix resolving client app tenant during token revocation

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/OAuth2Service.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/OAuth2Service.java
@@ -680,11 +680,11 @@ public class OAuth2Service extends AbstractAdmin {
                     if (revokeRequestDTO.getConsumerKey().equals(accessTokenDO.getConsumerKey())) {
                         // Resolve the application tenant domain.
                         String tenantDomain;
-                        if (StringUtils.isNotEmpty(PrivilegedCarbonContext.getThreadLocalCarbonContext()
+                        if (StringUtils.isBlank(PrivilegedCarbonContext.getThreadLocalCarbonContext()
                                 .getApplicationResidentOrganizationId())) {
-                            tenantDomain = IdentityTenantUtil.getTenantDomain(accessTokenDO.getTenantID());
-                        } else {
                             tenantDomain = IdentityTenantUtil.getTenantDomain(IdentityTenantUtil.getLoginTenantId());
+                        } else {
+                            tenantDomain = IdentityTenantUtil.getTenantDomain(accessTokenDO.getTenantID());
                         }
                         // Extracting the application details with consumer key and tenant domain.
                         if ((OAuth2Util.getAppInformationByClientId(accessTokenDO.getConsumerKey(), tenantDomain).

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/OAuth2Service.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/OAuth2Service.java
@@ -678,8 +678,15 @@ public class OAuth2Service extends AbstractAdmin {
 
                 } else if (accessTokenDO != null) {
                     if (revokeRequestDTO.getConsumerKey().equals(accessTokenDO.getConsumerKey())) {
+                        // Resolve the application tenant domain.
+                        String tenantDomain;
+                        if (StringUtils.isNotEmpty(PrivilegedCarbonContext.getThreadLocalCarbonContext()
+                                .getApplicationResidentOrganizationId())) {
+                            tenantDomain = IdentityTenantUtil.getTenantDomain(accessTokenDO.getTenantID());
+                        } else {
+                            tenantDomain = IdentityTenantUtil.getTenantDomain(IdentityTenantUtil.getLoginTenantId());
+                        }
                         // Extracting the application details with consumer key and tenant domain.
-                        String tenantDomain = IdentityTenantUtil.getTenantDomain(accessTokenDO.getTenantID());
                         if ((OAuth2Util.getAppInformationByClientId(accessTokenDO.getConsumerKey(), tenantDomain).
                                 isTokenBindingValidationEnabled()) && (!isValidTokenBinding(accessTokenDO.
                                 getTokenBinding(), revokeRequestDTO.getRequest()))) {


### PR DESCRIPTION
### Proposed changes in this pull request
During token revocation currently we get the access token's tenant domain to retrieve the client application. However this doesn't fetch the client application correctly when revoking a sub org federated access token.

This PR fixes that by considering the login tenant domain when the app resident organization id is not set.

### Related Issues
- 

### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description.
- [ ] **Is the PR labeled correctly?**

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled.

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests.
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/).

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components.
- [ ] **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

#### Security

- [ ] **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
- [ ] **Are all UI and API inputs run through forms or serializers?**
- [ ] **Are all external inputs validated and sanitized appropriately?**
- [ ] **Does all branching logic have a default case?**
- [ ] **Does this solution handle outliers and edge cases gracefully?**
- [ ] **Are all external communications secured and restricted to SSL?**

#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes should be documented.
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented.
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki.
