### PR TITLE
Get attributes from the context

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/JWTAccessTokenOIDCClaimsHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/JWTAccessTokenOIDCClaimsHandler.java
@@ -317,11 +317,21 @@ public class JWTAccessTokenOIDCClaimsHandler implements CustomClaimsCallbackHand
         if (isEmpty(userAttributes)) {
             if (isLocalUser(authzReqMessageContext)) {
                 if (log.isDebugEnabled()) {
-                    log.debug("User attributes not found in cache. Trying to retrieve attribute for " +
-                            "local user: " + authzReqMessageContext.getAuthorizationReqDTO().getUser());
+                    log.debug("User attributes not found in cache. Trying to retrieve attribute from auth " +
+                            "context for local user: " + authzReqMessageContext.getAuthorizationReqDTO().getUser());
                 }
+                userAttributes = authzReqMessageContext.getAuthorizationReqDTO().getUser()
+                        .getUserAttributes();
 
-                userClaimsInOIDCDialect = retrieveClaimsForLocalUser(authzReqMessageContext);
+                if (isEmpty(userAttributes)) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("User attributes not found in cache. Trying to retrieve attribute for " +
+                                "local user: " + authzReqMessageContext.getAuthorizationReqDTO().getUser());
+                    }
+                    userClaimsInOIDCDialect = retrieveClaimsForLocalUser(authzReqMessageContext);
+                } else {
+                    userClaimsInOIDCDialect = getOIDCClaimMapFromUserAttributes(userAttributes);
+                }
             } else {
                 if (log.isDebugEnabled()) {
                     log.debug("User attributes not found in cache. Trying to retrieve attribute for federated " +


### PR DESCRIPTION
### Proposed changes in this pull request

​To ensure that JWT tokens accurately reflect any changes made through adaptive scripts or lookup handlers, user attributes should first be fetched from the context before querying the user store.