### PR TITLE
Fix resource handling in the back channel logout thread pool

### DIFF
--- a/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/OIDCSessionConstants.java
+++ b/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/OIDCSessionConstants.java
@@ -71,11 +71,13 @@ public class OIDCSessionConstants {
     public static class OIDCLogoutRequestConstants {
 
         public static final String POOL_SIZE = "OAuth.OpenIDConnect.LogoutRequestSender.PoolSize";
+        public static final String WORK_QUEUE_SIZE = "OAuth.OpenIDConnect.LogoutRequestSender.WorkQueueSize";
         public static final String KEEP_ALIVE_TIME = "OAuth.OpenIDConnect.LogoutRequestSender.KeepAliveTime";
         public static final String HTTP_CONNECT_TIMEOUT = "OAuth.OpenIDConnect.LogoutRequestSender.HttpConnectTimeout";
         public static final String HTTP_SOCKET_TIMEOUT = "OAuth.OpenIDConnect.LogoutRequestSender.HttpSocketTimeout";
 
-        public static final String DEFAULT_POOL_SIZE = "2";
+        public static final String DEFAULT_POOL_SIZE = "20";
+        public static final String DEFAULT_WORK_QUEUE_SIZE = "1000";
         public static final String DEFAULT_KEEP_ALIVE_TIME = "60000";
         public static final String DEFAULT_HTTP_CONNECT_TIMEOUT = "10000";
         public static final String DEFAULT_HTTP_SOCKET_TIMEOUT = "20000";

--- a/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/OIDCSessionConstants.java
+++ b/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/OIDCSessionConstants.java
@@ -65,6 +65,22 @@ public class OIDCSessionConstants {
         public static final String OIDC_LOGOUT_ENDPOINT = "/oidc/logout";
     }
 
+    /**
+     * Contains the constants related to OIDC logout request sender.
+     */
+    public static class OIDCLogoutRequestConstants {
+
+        public static final String POOL_SIZE = "OAuth.OpenIDConnect.LogoutRequestSender.PoolSize";
+        public static final String KEEP_ALIVE_TIME = "OAuth.OpenIDConnect.LogoutRequestSender.KeepAliveTime";
+        public static final String HTTP_CONNECT_TIMEOUT = "OAuth.OpenIDConnect.LogoutRequestSender.HttpConnectTimeout";
+        public static final String HTTP_SOCKET_TIMEOUT = "OAuth.OpenIDConnect.LogoutRequestSender.HttpSocketTimeout";
+
+        public static final String DEFAULT_POOL_SIZE = "2";
+        public static final String DEFAULT_KEEP_ALIVE_TIME = "60000";
+        public static final String DEFAULT_HTTP_CONNECT_TIMEOUT = "10000";
+        public static final String DEFAULT_HTTP_SOCKET_TIMEOUT = "20000";
+    }
+
     private OIDCSessionConstants() {
 
     }

--- a/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/backchannellogout/LogoutRequestSender.java
+++ b/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/backchannellogout/LogoutRequestSender.java
@@ -18,6 +18,7 @@
 package org.wso2.carbon.identity.oidc.session.backchannellogout;
 
 import org.apache.commons.collections.MapUtils;
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.http.HttpResponse;
@@ -59,12 +60,12 @@ import javax.servlet.http.HttpServletRequest;
 public class LogoutRequestSender {
 
     private static final Log LOG = LogFactory.getLog(LogoutRequestSender.class);
+    private static LogoutRequestSender instance = null;
+
     private static ExecutorService threadPool = null;
     private boolean hostNameVerificationEnabled = true;
     private static int httpConnectTimeout = 0;
     private static int httpSocketTimeout = 0;
-
-    private static LogoutRequestSender instance = new LogoutRequestSender();
     private static final String LOGOUT_TOKEN = "logout_token";
 
     private LogoutRequestSender() {
@@ -81,19 +82,19 @@ public class LogoutRequestSender {
         String hostNameVerificationEnabledProperty = IdentityUtil.getProperty(
                 IdentityConstants.ServerConfig.SLO_HOST_NAME_VERIFICATION_ENABLED);
 
-        if (poolSize == null) {
+        if (StringUtils.isBlank(poolSize)) {
             poolSize = OIDCSessionConstants.OIDCLogoutRequestConstants.DEFAULT_POOL_SIZE;
         }
-        if (workQueueSize == null) {
+        if (StringUtils.isBlank(workQueueSize)) {
             workQueueSize = OIDCSessionConstants.OIDCLogoutRequestConstants.DEFAULT_WORK_QUEUE_SIZE;
         }
-        if (keepAliveTime == null) {
+        if (StringUtils.isBlank(keepAliveTime)) {
             keepAliveTime = OIDCSessionConstants.OIDCLogoutRequestConstants.DEFAULT_KEEP_ALIVE_TIME;
         }
-        if (httpConnectTimeoutProperty == null) {
+        if (StringUtils.isBlank(httpConnectTimeoutProperty)) {
             httpConnectTimeoutProperty = OIDCSessionConstants.OIDCLogoutRequestConstants.DEFAULT_HTTP_CONNECT_TIMEOUT;
         }
-        if (httpSocketTimeoutProperty == null) {
+        if (StringUtils.isBlank(httpSocketTimeoutProperty)) {
             httpSocketTimeoutProperty = OIDCSessionConstants.OIDCLogoutRequestConstants.DEFAULT_HTTP_SOCKET_TIMEOUT;
         }
 
@@ -141,6 +142,14 @@ public class LogoutRequestSender {
      * @return LogoutRequestSender instance
      */
     public static LogoutRequestSender getInstance() {
+
+        if (instance == null) {
+            synchronized (LogoutRequestSender.class) {
+                if (instance == null) {
+                    instance = new LogoutRequestSender();
+                }
+            }
+        }
 
         return instance;
     }

--- a/components/org.wso2.carbon.identity.oidc.session/src/test/java/org/wso2/carbon/identity/oidc/session/backchannellogout/LogoutRequestSenderTest.java
+++ b/components/org.wso2.carbon.identity.oidc.session/src/test/java/org/wso2/carbon/identity/oidc/session/backchannellogout/LogoutRequestSenderTest.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oidc.session.backchannellogout;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import org.apache.commons.lang.StringUtils;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
+import org.mockito.MockitoAnnotations;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.base.IdentityConstants;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.oidc.session.OIDCSessionConstants;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.reflect.Field;
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+public class LogoutRequestSenderTest {
+
+    private AutoCloseable closeable;
+    private LogoutRequestSender logoutRequestSender;
+
+    /*
+     * The logout request is executed in a spawned child thread and it makes it harder to
+     * test the request. To overcome this, we are using a mock server to receive the request
+     * and add the logout tokens for each method to a list.
+     */
+    private HttpServer mockServer;
+    private static final int MOCK_SERVER_PORT = 8081;
+    private static final List<String> mockServerTokenList = new ArrayList<>();
+
+    @BeforeClass
+    public void setUp() throws IOException {
+
+        closeable = MockitoAnnotations.openMocks(this);
+        startMockServer();
+    }
+
+    @AfterClass
+    public void tearDown() throws Exception {
+
+        closeable.close();
+        if (mockServer != null) {
+            mockServer.stop(0);
+        }
+    }
+
+    private void startMockServer() throws IOException {
+
+        mockServer = HttpServer.create(new InetSocketAddress(MOCK_SERVER_PORT), 0);
+        mockServer.createContext("/logout1", new MockHandler(200, "Success"));
+        mockServer.createContext("/logout2", new MockHandler(200, "Success"));
+        // Use the default executor.
+        mockServer.setExecutor(null);
+        mockServer.start();
+    }
+
+    private void initLogoutRequestSender(String poolSize, String workQueueSize, String keepAliveTime,
+                                         String connectTimeout, String socketTimeout) {
+
+        try (MockedStatic<IdentityUtil> identityUtil = mockStatic(IdentityUtil.class)) {
+            identityUtil.when(() -> IdentityUtil.getProperty(
+                    OIDCSessionConstants.OIDCLogoutRequestConstants.POOL_SIZE)).thenReturn(poolSize);
+            identityUtil.when(() -> IdentityUtil.getProperty(
+                    OIDCSessionConstants.OIDCLogoutRequestConstants.WORK_QUEUE_SIZE)).thenReturn(workQueueSize);
+            identityUtil.when(() -> IdentityUtil.getProperty(
+                    OIDCSessionConstants.OIDCLogoutRequestConstants.KEEP_ALIVE_TIME)).thenReturn(keepAliveTime);
+            identityUtil.when(() -> IdentityUtil.getProperty(
+                    OIDCSessionConstants.OIDCLogoutRequestConstants.HTTP_CONNECT_TIMEOUT)).thenReturn(connectTimeout);
+            identityUtil.when(() -> IdentityUtil.getProperty(
+                    OIDCSessionConstants.OIDCLogoutRequestConstants.HTTP_SOCKET_TIMEOUT)).thenReturn(socketTimeout);
+            identityUtil.when(() -> IdentityUtil.getProperty(
+                    IdentityConstants.ServerConfig.SLO_HOST_NAME_VERIFICATION_ENABLED)).thenReturn("true");
+
+            logoutRequestSender = LogoutRequestSender.getInstance();
+        }
+    }
+
+    /**
+     * Mock handler to handle HTTP requests and extract the logout token from the request body.
+     */
+    private static class MockHandler implements HttpHandler {
+
+        private final int responseCode;
+        private final String responseBody;
+
+        public MockHandler(int responseCode, String responseBody) {
+
+            this.responseCode = responseCode;
+            this.responseBody = responseBody;
+        }
+
+        @Override
+        public void handle(HttpExchange exchange) throws IOException {
+
+            // Read the request body and extract the logout token.
+            String requestBody = new String(exchange.getRequestBody().readAllBytes());
+            if (StringUtils.isNotEmpty(requestBody) && requestBody.contains("logout_token")) {
+                String logoutToken = requestBody.split("logout_token=")[1].split("&")[0];
+                mockServerTokenList.add(logoutToken);
+            }
+
+            // Send the response.
+            exchange.sendResponseHeaders(responseCode, responseBody.length());
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(responseBody.getBytes());
+            }
+        }
+    }
+
+    @BeforeMethod
+    public void beforeMethod() throws NoSuchFieldException, IllegalAccessException {
+
+        // Reset the LogoutRequestSender instance before each test.
+        Field instance = LogoutRequestSender.class.getDeclaredField("instance");
+        instance.setAccessible(true);
+        instance.set(null, null);
+
+        // Reset the mock server token list.
+        mockServerTokenList.clear();
+    }
+
+    @DataProvider
+    public Object[][] logoutRequestSenderDataProvider() {
+
+        return new Object[][]{
+                {null, null, null, null, null},
+                {"10", "100", "60000", "10000", "20000"},
+                {null, "-1", null, null, null},
+                {"-1", null, null, null, null},
+                {"", "", "", "", ""},
+        };
+    }
+
+    @Test(dataProvider = "logoutRequestSenderDataProvider")
+    public void testSendLogoutRequests(String poolSize, String workQueueSize, String keepAliveTime,
+                                       String connectTimeout, String socketTimeout) throws Exception {
+
+        initLogoutRequestSender(poolSize, workQueueSize, keepAliveTime, connectTimeout, socketTimeout);
+
+        try (MockedConstruction<DefaultLogoutTokenBuilder> tokenBuilderMockCons = mockConstruction(
+                DefaultLogoutTokenBuilder.class, (mock, context) -> {
+                    Map<String, String> logoutTokenList = new HashMap<>();
+                    logoutTokenList.put("logoutToken1", "http://localhost:" + MOCK_SERVER_PORT + "/logout1");
+                    logoutTokenList.put("logoutToken2", "http://localhost:" + MOCK_SERVER_PORT + "/logout2");
+                    when(mock.buildLogoutToken(any(), any())).thenReturn(logoutTokenList);
+            });
+        ) {
+            // Call the method under test.
+            logoutRequestSender.sendLogoutRequests("testCookie", "testTenant");
+
+            // Stop accepting new tasks and wait for the thread pool to finish processing.
+            Field threadPoolField = LogoutRequestSender.class.getDeclaredField("threadPool");
+            threadPoolField.setAccessible(true);
+            ExecutorService threadPool = (ExecutorService) threadPoolField.get(logoutRequestSender);
+
+            threadPool.shutdown();
+            if (!threadPool.awaitTermination(10, TimeUnit.SECONDS)) {
+                throw new RuntimeException("Timeout waiting for thread pool to finish.");
+            }
+
+            // Verify that the logout token was sent to the mock server.
+            Assert.assertEquals(mockServerTokenList.size(), 2);
+            Assert.assertTrue(mockServerTokenList.contains("logoutToken1"));
+            Assert.assertTrue(mockServerTokenList.contains("logoutToken2"));
+        }
+    }
+}

--- a/components/org.wso2.carbon.identity.oidc.session/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.identity.oidc.session/src/test/resources/testng.xml
@@ -29,6 +29,7 @@
         <class name="org.wso2.carbon.identity.oidc.session.cache.OIDCSessionParticipantCacheTest"/>
         <class name="org.wso2.carbon.identity.oidc.session.cache.OIDCSessionDataCacheTest"/>
         <class name="org.wso2.carbon.identity.oidc.session.config.OIDCSessionManagementConfigurationTest" />
+        <class name="org.wso2.carbon.identity.oidc.session.backchannellogout.LogoutRequestSenderTest"/>
     </classes>
 </test>
     <test name="OIDCSessionMgt-Tests-with-info-logs" preserve-order="true" parallel="false">
@@ -43,6 +44,7 @@
             <class name="org.wso2.carbon.identity.oidc.session.cache.OIDCSessionDataCacheTest"/>
             <class name="org.wso2.carbon.identity.oidc.session.config.OIDCSessionManagementConfigurationTest" />
             <class name="org.wso2.carbon.identity.oidc.session.backchannellogout.DefaultLogoutTokenBuilderTest"/>
+            <class name="org.wso2.carbon.identity.oidc.session.backchannellogout.LogoutRequestSenderTest"/>
         </classes>
     </test>
 </suite>


### PR DESCRIPTION
### Proposed changes in this pull request

Currently the back channel logout requests are submitted to a thread pool and executed asynchronously. This is a fixed-size thread pool of 2 and does not have a configured maximum task count or timeout. If two back-channel logout requests submitted to the pool hang for a long time or indefinitely (conceptually), subsequent tasks will not be processed until the two active requests are completed (conceptually could wait indefinitely). 

Additionally, the HTTP client used to send the logout requests is not properly closed after consuming the request leading to potential resource exhaustion.

This PR fixes this issue by defining a custom thread pool with required properties. Also the support has been provided to configure these properties via the deployment.toml. Additionally the http connection is closed properly with defining http connection timeouts.

### When should this PR be merged

Merge after merging: 

### Related Issue
- https://github.com/wso2/product-is/issues/23777

### Related PRs
- https://github.com/wso2/carbon-identity-framework/pull/6676

### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description.
- [ ] **Is the PR labeled correctly?**

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled.

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests.
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/).

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components.
- [ ] **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

#### Security

- [ ] **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
- [ ] **Are all UI and API inputs run through forms or serializers?**
- [ ] **Are all external inputs validated and sanitized appropriately?**
- [ ] **Does all branching logic have a default case?**
- [ ] **Does this solution handle outliers and edge cases gracefully?**
- [ ] **Are all external communications secured and restricted to SSL?**

#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes should be documented.
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented.
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki.
