### PR TITLE
Add claims from SAML assertion to access token while using SAML2 Bearer Grant

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/saml/SAML2BearerGrantHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/saml/SAML2BearerGrantHandler.java
@@ -18,7 +18,6 @@
 
 package org.wso2.carbon.identity.oauth2.token.handlers.grant.saml;
 
-import java.util.Set;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections4.MapUtils;
@@ -109,6 +108,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/saml/SAML2BearerGrantHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/saml/SAML2BearerGrantHandler.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.oauth2.token.handlers.grant.saml;
 
+import java.util.Set;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections4.MapUtils;
@@ -121,7 +122,7 @@ public class SAML2BearerGrantHandler extends AbstractAuthorizationGrantHandler {
     private static final Log log = LogFactory.getLog(SAML2BearerGrantHandler.class);
     private static final String SAMLSSO_AUTHENTICATOR = "samlsso";
     private static final String SAML2SSO_AUTHENTICATOR_NAME = "SAMLSSOAuthenticator";
-    private final String[] registeredClaimNames = new String[]{"iss", "sub", "aud", "exp", "nbf", "iat", "jti"};
+    private final Set<String> registeredClaimNames = Set.of("iss", "sub", "aud", "exp", "nbf", "iat", "jti");
 
     public static final String SECURITY_SAML_SIGN_KEY_STORE_LOCATION = "Security.SAMLSignKeyStore.Location";
     public static final String SECURITY_SAML_SIGN_KEY_STORE_TYPE = "Security.SAMLSignKeyStore.Type";
@@ -1310,7 +1311,7 @@ public class SAML2BearerGrantHandler extends AbstractAuthorizationGrantHandler {
     }
 
     /**
-     * To get the custom claims map using the custom claims of JWT
+     * To get the custom claims map using the custom claims of JWT.
      *
      * @param customClaims Relevant custom claims
      * @return custom claims.
@@ -1320,14 +1321,8 @@ public class SAML2BearerGrantHandler extends AbstractAuthorizationGrantHandler {
         Map<String, String> customClaimMap = new HashMap<>();
         for (Map.Entry<String, Object> entry : customClaims.entrySet()) {
             String entryKey = entry.getKey();
-            boolean isRegisteredClaim = false;
-            for (String registeredClaimName : registeredClaimNames) {
-                if (registeredClaimName.equals((entryKey))) {
-                    isRegisteredClaim = true;
-                    break;
-                }
-            }
-            if (!isRegisteredClaim) {
+
+            if (!registeredClaimNames.contains(entryKey)) {
                 Object value = entry.getValue();
                 String multiValueSeparator = FrameworkUtils.getMultiAttributeSeparator();
                 if (value instanceof Collection<?>) {
@@ -1344,7 +1339,6 @@ public class SAML2BearerGrantHandler extends AbstractAuthorizationGrantHandler {
                 } else {
                     customClaimMap.put(entry.getKey(), value.toString());
                 }
-
             }
         }
         return customClaimMap;

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/ClaimsUtil.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/ClaimsUtil.java
@@ -71,6 +71,7 @@ public class ClaimsUtil {
     private static final String SP_DIALECT = "http://wso2.org/oidc/claim";
 
     public static boolean isInLocalDialect(Map<String, String> attributes) {
+
         return attributes.keySet().stream()
                 .anyMatch(key -> key.startsWith("http://wso2.org/claims/"));
     }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/ClaimsUtil.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/ClaimsUtil.java
@@ -56,7 +56,6 @@ import org.wso2.carbon.identity.openidconnect.OIDCConstants;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -72,11 +71,8 @@ public class ClaimsUtil {
     private static final String SP_DIALECT = "http://wso2.org/oidc/claim";
 
     public static boolean isInLocalDialect(Map<String, String> attributes) {
-        Iterator<String> iterator = attributes.keySet().iterator();
-        if (iterator.hasNext()) {
-            return iterator.next().startsWith("http://wso2.org/claims/");
-        }
-        return false;
+        return attributes.keySet().stream()
+                .anyMatch(key -> key.startsWith("http://wso2.org/claims/"));
     }
 
     public static Map<String, String> convertFederatedClaimsToLocalDialect(Map<String, String> remoteClaims,


### PR DESCRIPTION
We do not have the implementation to add the claims/attributes from a saml assertion to a JWT Access token when using SAML2 Bearer Grant. With this PR, we are adding the implementation to resolve that.

Issue : 
https://github.com/wso2/product-is/issues/6321
https://github.com/wso2/product-is/issues/12131