### PR TITLE
Fixing the refresh token expiry unit in the request message context

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AbstractAuthorizationGrantHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AbstractAuthorizationGrantHandler.java
@@ -798,7 +798,7 @@ public abstract class AbstractAuthorizationGrantHandler implements Authorization
         long validityPeriodFromMsgContext = tokReqMsgCtx.getRefreshTokenvalidityPeriod();
 
         if (validityPeriodFromMsgContext > 0) {
-            refreshTokenValidityPeriodInMillis = validityPeriodFromMsgContext * SECONDS_TO_MILISECONDS_FACTOR;
+            refreshTokenValidityPeriodInMillis = validityPeriodFromMsgContext;
             if (log.isDebugEnabled()) {
                 log.debug("OAuth application id : " + oAuthAppBean.getOauthConsumerKey() + ", using refresh token " +
                         "validity period configured from OAuthTokenReqMessageContext: " +

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/RefreshGrantHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/RefreshGrantHandler.java
@@ -791,8 +791,7 @@ public class RefreshGrantHandler extends AbstractAuthorizationGrantHandler {
         // Priority given to the validity period mentioned in the OAuthTokenReqMessageContext
         if (validityPeriodFromMsgContext != OAuthConstants.UNASSIGNED_VALIDITY_PERIOD
                 && validityPeriodFromMsgContext > 0) {
-            refreshTokenValidityPeriod = validityPeriodFromMsgContext *
-                    SECONDS_TO_MILISECONDS_FACTOR;
+            refreshTokenValidityPeriod = validityPeriodFromMsgContext;
             if (log.isDebugEnabled()) {
                 log.debug("OAuth application id : " + oAuthAppDO.getOauthConsumerKey() + ", using refresh token " +
                         "validity period configured from OAuthTokenReqMessageContext: " +


### PR DESCRIPTION
Fixing the refresh token expiry unit in the request message context.

This pr should be merged only after following unit tests PR is merged.

- https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2764

Product-is issue

- https://github.com/wso2/product-is/issues/23835