### PR TITLE
Move email sending module from token-exchange to oauth

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/impersonation/models/ImpersonationNotificationRequestDTO.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/impersonation/models/ImpersonationNotificationRequestDTO.java
@@ -1,0 +1,73 @@
+/*
+ *  Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+
+package org.wso2.carbon.identity.oauth2.impersonation.models;
+
+import org.wso2.carbon.identity.oauth2.token.OAuthTokenReqMessageContext;
+
+/**
+ * Data Transfer Object (DTO) for handling impersonation notification requests.
+ */
+public class ImpersonationNotificationRequestDTO {
+
+    private String subject;
+    private String impersonator;
+    private String tenantDomain;
+    private OAuthTokenReqMessageContext tokenReqMessageContext;
+
+    public String getSubject() {
+
+        return subject;
+    }
+
+    public void setSubject(String subject) {
+
+        this.subject = subject;
+    }
+
+    public String getTenantDomain() {
+
+        return tenantDomain;
+    }
+
+    public void setTenantDomain(String tenantDomain) {
+
+        this.tenantDomain = tenantDomain;
+    }
+
+    public String getImpersonator() {
+
+        return impersonator;
+    }
+
+    public void setImpersonator(String impersonator) {
+
+        this.impersonator = impersonator;
+    }
+
+    public OAuthTokenReqMessageContext getTokenReqMessageContext() {
+
+        return tokenReqMessageContext;
+    }
+
+    public void setTokenReqMessageContext(OAuthTokenReqMessageContext tokenReqMessageContext) {
+
+        this.tokenReqMessageContext = tokenReqMessageContext;
+    }
+}

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/impersonation/notifiers/ImpersonationEmailNotifier.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/impersonation/notifiers/ImpersonationEmailNotifier.java
@@ -1,0 +1,124 @@
+/*
+ *  Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+
+package org.wso2.carbon.identity.oauth2.impersonation.notifiers;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
+import org.wso2.carbon.identity.event.IdentityEventConstants;
+import org.wso2.carbon.identity.event.event.Event;
+import org.wso2.carbon.identity.oauth2.impersonation.exceptions.ImpersonationConfigMgtException;
+import org.wso2.carbon.identity.oauth2.impersonation.models.ImpersonationConfig;
+import org.wso2.carbon.identity.oauth2.impersonation.services.ImpersonationConfigMgtService;
+import org.wso2.carbon.identity.oauth2.impersonation.services.ImpersonationConfigMgtServiceImpl;
+import org.wso2.carbon.identity.oauth2.internal.OAuth2ServiceComponentHolder;
+import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.Locale;
+
+/**
+ * The ImpersonationEmailNotifier class is responsible for sending email notifications related to impersonation events.
+ * It retrieves authenticated user details and triggers notification events when impersonation occurs,
+ * ensuring that notifications are sent based on the configuration settings for each tenant domain.
+ */
+public class ImpersonationEmailNotifier {
+
+    private static final Log LOG = LogFactory.getLog(ImpersonationEmailNotifier.class);
+    private static final String UTC = "UTC";
+    private static final String DATE_FORMAT = "MMMM dd, yyyy 'at' hh:mm a z";
+    private static final String USER_NAME = "user-name";
+    private static final String LOGIN_TIME = "login-time";
+    private static final String IMPERSONATION_USER_NAME = "impersonator-user-name";
+    private static final String TEMPLATE_TYPE_IMPERSONATION = "ImpersonationEmailNotification";
+    private static final String TEMPLATE_TYPE = "TEMPLATE_TYPE";
+
+    /**
+     * Triggers a notification event when an impersonation occurs. This method checks if email notifications are
+     * enabled for the tenant domain and, if so, sends an email notification with the impersonation details.
+     *
+     * @param subjectId The ID of the user being impersonated.
+     * @param impersonatorId The ID of the impersonator.
+     * @param tenantDomain The domain of the tenant where the impersonation occurred.
+     * @param clientId The client id.
+     */
+    public void triggerNotification(String subjectId, String impersonatorId, String tenantDomain, String clientId) {
+
+        try {
+            boolean sendEmail = isSendEmail(tenantDomain);
+
+            if (sendEmail) {
+                String eventName = IdentityEventConstants.Event.TRIGGER_NOTIFICATION;
+
+                ZonedDateTime nowUtc = ZonedDateTime.now(ZoneId.of(UTC));
+
+                DateTimeFormatter formatter = DateTimeFormatter.ofPattern(DATE_FORMAT,
+                        Locale.ENGLISH);
+
+                String formattedDateTime = nowUtc.format(formatter);
+
+                AuthenticatedUser subject = OAuth2Util.getAuthenticatedUser(subjectId, tenantDomain, clientId);
+                AuthenticatedUser impersonator = OAuth2Util.getAuthenticatedUserFromSubjectIdentifier(impersonatorId,
+                        tenantDomain, clientId);
+
+                HashMap<String, Object> properties = new HashMap<>();
+                properties.put(USER_NAME, subject.getUserName());
+                properties.put(LOGIN_TIME, formattedDateTime);
+                properties.put(IMPERSONATION_USER_NAME, impersonator.getUserName());
+                properties.put(IdentityEventConstants.EventProperty.TENANT_DOMAIN, subject.getTenantDomain());
+                properties.put(IdentityEventConstants.EventProperty.USER_STORE_DOMAIN, subject.getUserStoreDomain());
+                properties.put(TEMPLATE_TYPE, TEMPLATE_TYPE_IMPERSONATION);
+
+                Event identityMgtEvent = new Event(eventName, properties);
+                OAuth2ServiceComponentHolder.getIdentityEventService()
+                        .handleEvent(identityMgtEvent);
+            }
+        } catch (Exception e) {
+            String errorMsg = "Error occurred while calling triggerNotification, detail : " + e.getMessage();
+            /*
+            We are not throwing any exception from here, because this event notification should not break the main
+            flow.
+             */
+            LOG.warn(errorMsg);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug(errorMsg, e);
+            }
+        }
+    }
+
+    /**
+     * Determines if email notifications are enabled for the specified tenant domain. Retrieves the impersonation
+     * configuration and checks if email notifications are enabled.
+     *
+     * @param tenantDomain The domain of the tenant to check for email notification settings.
+     * @return True if email notifications are enabled, false otherwise.
+     * @throws ImpersonationConfigMgtException If there is an error retrieving the impersonation configuration.
+     */
+    private static boolean isSendEmail(String tenantDomain) throws ImpersonationConfigMgtException {
+
+        ImpersonationConfigMgtService impersonationConfigMgtService = new ImpersonationConfigMgtServiceImpl();
+        ImpersonationConfig impersonationConfig = impersonationConfigMgtService
+                .getImpersonationConfig(tenantDomain);
+        return impersonationConfig.isEnableEmailNotification();
+    }
+}

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/impersonation/notifiers/ImpersonationEmailNotifier.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/impersonation/notifiers/ImpersonationEmailNotifier.java
@@ -57,10 +57,10 @@ public class ImpersonationEmailNotifier {
      * Triggers a notification event when an impersonation occurs. This method checks if email notifications are
      * enabled for the tenant domain and, if so, sends an email notification with the impersonation details.
      *
-     * @param subjectId The ID of the user being impersonated.
+     * @param subjectId      The ID of the user being impersonated.
      * @param impersonatorId The ID of the impersonator.
-     * @param tenantDomain The domain of the tenant where the impersonation occurred.
-     * @param clientId The client id.
+     * @param tenantDomain   The domain of the tenant where the impersonation occurred.
+     * @param clientId       The client id.
      */
     public void triggerNotification(String subjectId, String impersonatorId, String tenantDomain, String clientId) {
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/impersonation/services/ImpersonationNotificationMgtService.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/impersonation/services/ImpersonationNotificationMgtService.java
@@ -1,0 +1,40 @@
+/*
+ *  Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+
+package org.wso2.carbon.identity.oauth2.impersonation.services;
+
+import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
+import org.wso2.carbon.identity.oauth2.impersonation.models.ImpersonationNotificationRequestDTO;
+
+/**
+ * Service interface for managing impersonation notifications. This interface defines the contract for notifying
+ * about impersonation events, including the necessary details required to process and send notifications.
+ */
+public interface ImpersonationNotificationMgtService {
+
+    /**
+     * Notifies about an impersonation event using the details provided in the ImpersonationNotificationRequestDTO.
+     * This method handles the process of sending notifications when an impersonation occurs.
+     *
+     * @param impersonationNotificationRequestDTO The DTO containing details of the impersonation event.
+     * @throws IdentityOAuth2Exception If there is an error while processing the notification request.
+     */
+    public void notifyImpersonation(ImpersonationNotificationRequestDTO impersonationNotificationRequestDTO)
+            throws IdentityOAuth2Exception;
+}

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/impersonation/services/ImpersonationNotificationMgtServiceImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/impersonation/services/ImpersonationNotificationMgtServiceImpl.java
@@ -1,0 +1,45 @@
+/*
+ *  Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+
+package org.wso2.carbon.identity.oauth2.impersonation.services;
+
+import org.wso2.carbon.identity.oauth2.impersonation.models.ImpersonationNotificationRequestDTO;
+import org.wso2.carbon.identity.oauth2.impersonation.notifiers.ImpersonationEmailNotifier;
+
+/**
+ * Implementation of the ImpersonationNotificationMgtService interface.
+ */
+public class ImpersonationNotificationMgtServiceImpl implements ImpersonationNotificationMgtService {
+
+    /**
+     * Notifies about an impersonation event using the details provided in the ImpersonationNotificationRequestDTO.
+     *
+     * @param impersonationNotificationRequestDTO The DTO containing details of the impersonation event.
+     */
+    @Override
+    public void notifyImpersonation(ImpersonationNotificationRequestDTO impersonationNotificationRequestDTO) {
+
+        ImpersonationEmailNotifier impersonationEmailNotifier = new ImpersonationEmailNotifier();
+        impersonationEmailNotifier.triggerNotification(impersonationNotificationRequestDTO.getSubject(),
+                impersonationNotificationRequestDTO.getImpersonator(),
+                impersonationNotificationRequestDTO.getTenantDomain(),
+                impersonationNotificationRequestDTO.getTokenReqMessageContext()
+                        .getOauth2AccessTokenReqDTO().getClientId());
+    }
+}

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuth2ServiceComponent.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuth2ServiceComponent.java
@@ -81,6 +81,8 @@ import org.wso2.carbon.identity.oauth2.device.response.DeviceFlowResponseTypeReq
 import org.wso2.carbon.identity.oauth2.impersonation.services.ImpersonationConfigMgtService;
 import org.wso2.carbon.identity.oauth2.impersonation.services.ImpersonationConfigMgtServiceImpl;
 import org.wso2.carbon.identity.oauth2.impersonation.services.ImpersonationMgtServiceImpl;
+import org.wso2.carbon.identity.oauth2.impersonation.services.ImpersonationNotificationMgtService;
+import org.wso2.carbon.identity.oauth2.impersonation.services.ImpersonationNotificationMgtServiceImpl;
 import org.wso2.carbon.identity.oauth2.impersonation.validators.ImpersonationValidator;
 import org.wso2.carbon.identity.oauth2.impersonation.validators.ImpersonatorPermissionValidator;
 import org.wso2.carbon.identity.oauth2.impersonation.validators.SubjectScopeValidator;
@@ -412,6 +414,8 @@ public class OAuth2ServiceComponent {
             bundleContext.registerService(ImpersonationValidator.class, new ImpersonatorPermissionValidator(), null);
             bundleContext.registerService(ImpersonationConfigMgtService.class, new ImpersonationConfigMgtServiceImpl(),
                     null);
+            bundleContext.registerService(ImpersonationNotificationMgtService.class,
+                    new ImpersonationNotificationMgtServiceImpl(), null);
 
             bundleContext.registerService(AccessTokenResponseHandler.class, new AccessTokenResponseRARHandler(), null);
             bundleContext.registerService(JWTAccessTokenClaimProvider.class,

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -76,6 +76,7 @@ import org.wso2.carbon.identity.application.common.model.ClaimMapping;
 import org.wso2.carbon.identity.application.common.model.FederatedAuthenticatorConfig;
 import org.wso2.carbon.identity.application.common.model.IdentityProvider;
 import org.wso2.carbon.identity.application.common.model.ServiceProvider;
+import org.wso2.carbon.identity.application.common.model.User;
 import org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants;
 import org.wso2.carbon.identity.application.common.util.IdentityApplicationManagementUtil;
 import org.wso2.carbon.identity.application.mgt.ApplicationConstants;
@@ -96,6 +97,7 @@ import org.wso2.carbon.identity.core.util.IdentityDatabaseUtil;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.oauth.IdentityOAuthAdminException;
+import org.wso2.carbon.identity.oauth.OAuthUtil;
 import org.wso2.carbon.identity.oauth.cache.AppInfoCache;
 import org.wso2.carbon.identity.oauth.cache.CacheEntry;
 import org.wso2.carbon.identity.oauth.cache.OAuthCache;
@@ -205,6 +207,7 @@ import java.util.stream.Collectors;
 import javax.servlet.http.HttpServletRequest;
 import javax.xml.namespace.QName;
 
+import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.USER_ID_CLAIM;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OAUTH_BUILD_ISSUER_WITH_HOSTNAME;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OAuth10AEndpoints.OAUTH_AUTHZ_EP_URL;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OAuth10AEndpoints.OAUTH_REQUEST_TOKEN_EP_URL;
@@ -224,6 +227,7 @@ import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OAuth20Endpoi
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OAuth20Endpoints.OIDC_CONSENT_EP_URL;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OAuth20Endpoints.OIDC_WEB_FINGER_EP_URL;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.RENEW_TOKEN_WITHOUT_REVOKING_EXISTING_ALLOWED_GRANT_TYPES_CONFIG;
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.Scope.OAUTH2;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.SignatureAlgorithms.KID_HASHING_ALGORITHM;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.SignatureAlgorithms.PREVIOUS_KID_HASHING_ALGORITHM;
 import static org.wso2.carbon.identity.oauth2.Oauth2ScopeConstants.PERMISSIONS_BINDING_TYPE;
@@ -3836,6 +3840,211 @@ public class OAuth2Util {
             authenticatedUser.setFederatedUser(isFederatedUser(authenticatedUser));
         }
         return authenticatedUser;
+    }
+
+    /**
+     * Get Authenticated user object.
+     *
+     * @param userId          User id of the user.
+     * @param tenantDomain    Tenant domain of the user.
+     * @param clientId        Client id of the application.
+     * @return An Authenticated user object.
+     * @throws IdentityOAuth2Exception Throws if an error occurred while getting the authenticated user.
+     */
+    public static AuthenticatedUser getAuthenticatedUser(String userId, String tenantDomain, String clientId)
+            throws IdentityOAuth2Exception {
+
+        try {
+            RealmService realmService = OAuthComponentServiceHolder.getInstance().getRealmService();
+            int tenantId = realmService.getTenantManager().getTenantId(tenantDomain);
+
+            User user = OAuthUtil.getUserFromTenant(userId, tenantId);
+            if (user == null) {
+                throw new IdentityOAuth2ClientException(OAuth2ErrorCodes.INVALID_REQUEST,
+                        "Invalid User Id provided for the request. Unable to find the user for given " +
+                                "user id : " + userId + " tenant id : " + tenantId);
+            }
+            return getAuthenticatedUser(userId, user.getUserName(), tenantDomain,
+                    user.getUserStoreDomain(), clientId, null);
+        } catch (UserStoreException | IdentityOAuth2Exception e) {
+            throw new IdentityOAuth2Exception(OAuth2ErrorCodes.INVALID_REQUEST,
+                    "Use mapped local subject is mandatory but a local user couldn't be found");
+        }
+    }
+
+    /**
+     * Get Authenticated user using user id and tenant domain.
+     *
+     * @param userId          User id of the user.
+     * @param userName        Username of the user.
+     * @param tenantDomain    Tenant domain of the user.
+     * @param userStoreDomain User store domain of the user.
+     * @param clientId        Client id of the application.
+     * @return An Authenticated user object.
+     * @throws IdentityOAuth2Exception Throws if an error occurred while getting the authenticated user.
+     */
+    public static AuthenticatedUser getAuthenticatedUser(String userId, String userName,
+                                                          String tenantDomain, String userStoreDomain, String clientId,
+                                                          String subjectIdentifier)
+            throws IdentityOAuth2Exception {
+
+        AuthenticatedUser authenticatedImpersonatingUser = new AuthenticatedUser();
+        authenticatedImpersonatingUser.setUserId(userId);
+        authenticatedImpersonatingUser.setAuthenticatedSubjectIdentifier(subjectIdentifier != null ? subjectIdentifier :
+                getAuthenticatedSubjectIdentifier(userId, userName, tenantDomain, userStoreDomain,
+                clientId, false));
+        authenticatedImpersonatingUser.setUserName(userName);
+        authenticatedImpersonatingUser.setUserStoreDomain(userStoreDomain);
+        authenticatedImpersonatingUser.setTenantDomain(tenantDomain);
+        return authenticatedImpersonatingUser;
+    }
+
+    /**
+     * Returns the user subject identifier
+     *
+     * @param userName        User name.
+     * @param tenantDomain    Tenant domain.
+     * @param userStoreDomain User store domain.
+     * @param clientId        Client id.
+     * @param isFederatedUser True if the user is a federated user.
+     * @return Authenticated user subject identifier.
+     * @throws IdentityOAuth2Exception Throws if an error occurred while getting the authenticated user.
+     */
+    public static String getAuthenticatedSubjectIdentifier(String userId, String userName, String tenantDomain,
+                                                           String userStoreDomain, String clientId,
+                                                           boolean isFederatedUser)
+            throws IdentityOAuth2Exception {
+
+        String authenticatedSubjectIdentifier = userId;
+        try {
+            ServiceProvider serviceProvider = OAuth2ServiceComponentHolder.getApplicationMgtService()
+                    .getServiceProviderByClientId(clientId, OAUTH2, tenantDomain);
+            if (!isFederatedUser) {
+                String subjectClaimUri = serviceProvider.getLocalAndOutBoundAuthenticationConfig()
+                        .getSubjectClaimUri();
+                if (subjectClaimUri != null) {
+                    String subjectClaimValue = getClaimValue(userName,
+                            OAuth2ServiceComponentHolder.getInstance().getRealmService().getTenantUserRealm(
+                                            IdentityTenantUtil.getTenantId(tenantDomain))
+                                    .getUserStoreManager(), subjectClaimUri);
+
+                    if (subjectClaimValue != null) {
+                        authenticatedSubjectIdentifier = subjectClaimValue;
+                    }
+                }
+
+                boolean useUserStoreDomainInLocalSubjectIdentifier
+                        = serviceProvider.getLocalAndOutBoundAuthenticationConfig()
+                        .isUseUserstoreDomainInLocalSubjectIdentifier();
+                boolean useTenantDomainInLocalSubjectIdentifier
+                        = serviceProvider.getLocalAndOutBoundAuthenticationConfig()
+                        .isUseTenantDomainInLocalSubjectIdentifier();
+                if (useUserStoreDomainInLocalSubjectIdentifier && StringUtils.isNotEmpty(userStoreDomain)) {
+                    authenticatedSubjectIdentifier = IdentityUtil.addDomainToName(authenticatedSubjectIdentifier,
+                            userStoreDomain);
+                }
+                if (useTenantDomainInLocalSubjectIdentifier && StringUtils.isNotEmpty(tenantDomain) &&
+                        StringUtils.countMatches(authenticatedSubjectIdentifier,
+                                UserCoreConstants.TENANT_DOMAIN_COMBINER) < 2) {
+                    authenticatedSubjectIdentifier = UserCoreUtil.addTenantDomainToEntry(authenticatedSubjectIdentifier,
+                            tenantDomain);
+                }
+            }
+        } catch (IdentityApplicationManagementException | UserStoreException e) {
+            throw new IdentityOAuth2Exception("Error while obtaining subject identifier for user: " + userName, e);
+        }
+        return authenticatedSubjectIdentifier;
+    }
+
+    public static String getSubjectClaimFromSubjectIdentifier(String subjectIdentifier, String clientId,
+                                                           String tenantDomain, boolean isFederatedUser)
+            throws IdentityOAuth2Exception {
+
+        String subjectClaimValue = subjectIdentifier;
+        try {
+            ServiceProvider serviceProvider = OAuth2ServiceComponentHolder.getApplicationMgtService()
+                    .getServiceProviderByClientId(clientId, OAUTH2, tenantDomain);
+            if (!isFederatedUser) {
+                boolean useUserStoreDomainInLocalSubjectIdentifier
+                        = serviceProvider.getLocalAndOutBoundAuthenticationConfig()
+                        .isUseUserstoreDomainInLocalSubjectIdentifier();
+                boolean useTenantDomainInLocalSubjectIdentifier
+                        = serviceProvider.getLocalAndOutBoundAuthenticationConfig()
+                        .isUseTenantDomainInLocalSubjectIdentifier();
+                if (useTenantDomainInLocalSubjectIdentifier) {
+                    subjectClaimValue = subjectClaimValue.split(UserCoreConstants.TENANT_DOMAIN_COMBINER)[0];
+                }
+                if (useUserStoreDomainInLocalSubjectIdentifier) {
+                    subjectClaimValue = UserCoreUtil.removeDomainFromName(subjectClaimValue);
+                }
+            }
+        } catch (IdentityApplicationManagementException e) {
+            throw new IdentityOAuth2Exception("Error while obtaining subject claim from subject value: "
+                    + subjectIdentifier, e);
+        }
+        return subjectClaimValue;
+    }
+
+    private static String getClaimValue(String username, org.wso2.carbon.user.api.UserStoreManager userStoreManager,
+                                        String claimURI) throws IdentityOAuth2Exception {
+
+        try {
+            Map<String, String> claimValues = userStoreManager.getUserClaimValues(username, new String[]{claimURI},
+                    UserCoreConstants.DEFAULT_PROFILE);
+            return claimValues.get(claimURI);
+        } catch (UserStoreException e) {
+            throw new IdentityOAuth2Exception("Error occurred while retrieving claim: " + claimURI, e);
+        }
+    }
+
+    /**
+     * Get authenticated user from subject identifier.
+     *
+     * @param claimValue    Subject identifier value.
+     * @param tenantDomain  Tenant domain.
+     * @param clientId      Client id of the application.
+     * @return Authenticated user object.
+     * @throws IdentityOAuth2Exception Throws if an error occurred while getting the authenticated user.
+     */
+    public static AuthenticatedUser getAuthenticatedUserFromSubjectIdentifier(String claimValue, String tenantDomain,
+                                                                              String clientId)
+            throws IdentityOAuth2Exception {
+
+        try {
+            ServiceProvider serviceProvider = OAuth2ServiceComponentHolder.getApplicationMgtService()
+                    .getServiceProviderByClientId(clientId, OAUTH2, tenantDomain);
+            String subjectClaimUri = serviceProvider.getLocalAndOutBoundAuthenticationConfig()
+                    .getSubjectClaimUri();
+            String subjectClaimValue = getSubjectClaimFromSubjectIdentifier(claimValue, clientId, tenantDomain, false);
+            org.wso2.carbon.user.core.common.User user = getUserFromSubjectIdentifier(subjectClaimValue,
+                    subjectClaimUri != null ? subjectClaimUri : USER_ID_CLAIM, tenantDomain);
+
+            return getAuthenticatedUser(user.getUserID(), user.getUsername(), tenantDomain, user.getUserStoreDomain(),
+                    clientId, claimValue);
+        } catch (IdentityApplicationManagementException e) {
+            throw new IdentityOAuth2Exception("Error occurred while retrieving application for client id: " + clientId);
+        }
+    }
+
+    private static org.wso2.carbon.user.core.common.User getUserFromSubjectIdentifier(String claimValue,
+                                                                                      String claimUri,
+                                                                                      String tenantDomain)
+            throws IdentityOAuth2Exception {
+
+        try {
+            org.wso2.carbon.user.api.UserStoreManager userStoreManager = OAuth2ServiceComponentHolder.getInstance()
+                    .getRealmService().getTenantUserRealm(IdentityTenantUtil.getTenantId(tenantDomain))
+                    .getUserStoreManager();
+            List<org.wso2.carbon.user.core.common.User> userList = ((AbstractUserStoreManager) userStoreManager)
+                    .getUserListWithID(claimUri, claimValue, UserCoreConstants.DEFAULT_PROFILE);
+            if (userList != null && !userList.isEmpty()) {
+                return userList.get(0);
+            } else {
+                throw new IdentityOAuth2Exception("Error occurred while retrieving claim: " + claimValue);
+            }
+        } catch (UserStoreException e) {
+            throw new IdentityOAuth2Exception("Error occurred while retrieving claim: " + claimValue, e);
+        }
     }
 
     /**

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -3956,6 +3956,16 @@ public class OAuth2Util {
         return authenticatedSubjectIdentifier;
     }
 
+    /**
+     * Get subject claim from subject identifier.
+     *
+     * @param subjectIdentifier Subject identifier value.
+     * @param clientId          Client id of the application.
+     * @param tenantDomain      Tenant domain.
+     * @param isFederatedUser   True if the user is a federated user.
+     * @return Subject claim value.
+     * @throws IdentityOAuth2Exception Throws if an error occurred while getting the subject claim.
+     */
     public static String getSubjectClaimFromSubjectIdentifier(String subjectIdentifier, String clientId,
                                                            String tenantDomain, boolean isFederatedUser)
             throws IdentityOAuth2Exception {


### PR DESCRIPTION
### Proposed changes in this pull request
> The email sending module that was in token exchange module has been moved to oauth component, as now we have requirements of sending impersonation related emails to requests started with other grant types too.

### Related PRs:
- https://github.com/wso2-extensions/identity-oauth2-grant-token-exchange/pull/33

### Related Issues:
- https://github.com/wso2/product-is/issues/23462