### PR TITLE
Improve impersonation validators

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/impersonation/validators/ImpersonatorPermissionValidator.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/impersonation/validators/ImpersonatorPermissionValidator.java
@@ -74,13 +74,13 @@ public class ImpersonatorPermissionValidator implements ImpersonationValidator {
         if (authorizedScopes.contains(IMPERSONATION_SCOPE_NAME)) {
             impersonationContext.setValidated(true);
         } else {
+            String errorMessage = String.format("Authenticated user : %s doesn't have impersonation permission for " +
+                            "client :%s in the tenant %s.",
+                    authzReqMessageContext.getAuthorizationReqDTO().getUser().getLoggableMaskedUserId(),
+                    clientId, tenantDomain);
             impersonationContext.setValidated(false);
-            impersonationContext.setValidationFailureErrorMessage("Authenticated user : " + authzReqMessageContext
-                    .getAuthorizationReqDTO().getUser().getLoggableMaskedUserId() + " doesn't have impersonation " +
-                    "permission for client : " + clientId +  " in the tenant : " + tenantDomain);
-            LOG.error("Authenticated user : " + authzReqMessageContext
-                    .getAuthorizationReqDTO().getUser().getLoggableMaskedUserId() + "doesn't have impersonation " +
-                    "permission for client : " + clientId +  " in the tenant : " + tenantDomain);
+            impersonationContext.setValidationFailureErrorMessage(errorMessage);
+            LOG.debug(errorMessage);
         }
         return impersonationContext;
     }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/impersonation/validators/SubjectScopeValidator.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/impersonation/validators/SubjectScopeValidator.java
@@ -22,21 +22,14 @@ package org.wso2.carbon.identity.oauth2.impersonation.validators;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
-import org.wso2.carbon.identity.application.common.model.User;
-import org.wso2.carbon.identity.oauth.common.OAuth2ErrorCodes;
-import org.wso2.carbon.identity.oauth.internal.OAuthComponentServiceHolder;
-import org.wso2.carbon.identity.oauth2.IdentityOAuth2ClientException;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.authz.OAuthAuthzReqMessageContext;
 import org.wso2.carbon.identity.oauth2.impersonation.models.ImpersonationContext;
 import org.wso2.carbon.identity.oauth2.impersonation.models.ImpersonationRequestDTO;
+import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 import org.wso2.carbon.identity.oauth2.validators.DefaultOAuth2ScopeValidator;
-import org.wso2.carbon.user.api.UserStoreException;
-import org.wso2.carbon.user.core.service.RealmService;
 
 import java.util.List;
-
-import static org.wso2.carbon.identity.oauth.OAuthUtil.getUserFromTenant;
 
 /**
  * The {@code SubjectScopeValidator} class implements the {@link ImpersonationValidator} interface
@@ -74,14 +67,14 @@ public class SubjectScopeValidator implements ImpersonationValidator {
         ImpersonationRequestDTO impersonationRequestDTO = impersonationContext.getImpersonationRequestDTO();
         OAuthAuthzReqMessageContext authzReqMessageContext = impersonationRequestDTO.getoAuthAuthzReqMessageContext();
 
-        String tenantDomain = authzReqMessageContext.getAuthorizationReqDTO().getTenantDomain();
-        String subjectUserId = authzReqMessageContext.getAuthorizationReqDTO().getRequestedSubjectId();
+        String subjectUserId = impersonationRequestDTO.getSubject();
+        AuthenticatedUser impersonator = impersonationRequestDTO.getImpersonator();
 
         authzReqMessageContext.getAuthorizationReqDTO().setScopes(authzReqMessageContext.getRequestedScopes());
 
         // Switching end-user as authenticated user to validate scopes.
-        AuthenticatedUser impersonator = impersonationRequestDTO.getImpersonator();
-        AuthenticatedUser subjectUser = getAuthenticatedSubjectUser(subjectUserId, tenantDomain);
+        AuthenticatedUser subjectUser = OAuth2Util.getAuthenticatedUser(subjectUserId, impersonator.getTenantDomain(),
+                impersonationRequestDTO.getClientId());
         authzReqMessageContext.getAuthorizationReqDTO().setUser(subjectUser);
         List<String> authorizedScopes = scopeValidator.validateScope(authzReqMessageContext);
         authzReqMessageContext.setApprovedScope(authorizedScopes.toArray(new String[0]));
@@ -90,31 +83,5 @@ public class SubjectScopeValidator implements ImpersonationValidator {
 
         impersonationContext.setValidated(true);
         return impersonationContext;
-    }
-
-    private AuthenticatedUser getAuthenticatedSubjectUser(String subjectUserId, String tenantDomain)
-            throws IdentityOAuth2Exception {
-
-        try {
-            RealmService realmService = OAuthComponentServiceHolder.getInstance().getRealmService();
-
-            int tenantId = realmService.getTenantManager().getTenantId(tenantDomain);
-            User user = getUserFromTenant(subjectUserId, tenantId);
-            if (user == null) {
-                throw new IdentityOAuth2ClientException(OAuth2ErrorCodes.INVALID_REQUEST,
-                        "Invalid User Id provided for Impersonation request. Unable to find the user for given " +
-                                "user id : " + subjectUserId + " tenant Domain : " + tenantDomain);
-            }
-            AuthenticatedUser authenticatedUser = new AuthenticatedUser();
-            authenticatedUser.setUserId(subjectUserId);
-            authenticatedUser.setAuthenticatedSubjectIdentifier(subjectUserId);
-            authenticatedUser.setUserName(user.getUserName());
-            authenticatedUser.setUserStoreDomain(user.getUserStoreDomain());
-            authenticatedUser.setTenantDomain(tenantDomain);
-            return authenticatedUser;
-        } catch (UserStoreException | IdentityOAuth2Exception e) {
-            throw new IdentityOAuth2Exception(OAuth2ErrorCodes.INVALID_REQUEST,
-                    "Use mapped local subject is mandatory but a local user couldn't be found");
-        }
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/impersonation/validators/UserAccountStatusValidator.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/impersonation/validators/UserAccountStatusValidator.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth2.impersonation.validators;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.application.authentication.framework.exception.FrameworkException;
+import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
+import org.wso2.carbon.identity.application.common.model.Property;
+import org.wso2.carbon.identity.handler.event.account.lock.exception.AccountDisableServiceException;
+import org.wso2.carbon.identity.handler.event.account.lock.exception.AccountLockServiceException;
+import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
+import org.wso2.carbon.identity.oauth2.impersonation.models.ImpersonationContext;
+import org.wso2.carbon.identity.oauth2.internal.OAuth2ServiceComponentHolder;
+import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
+
+import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.ResidentIdpPropertyName.ACCOUNT_DISABLE_HANDLER_ENABLE_PROPERTY;
+import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkErrorConstants.ErrorMessages.ERROR_WHILE_CHECKING_ACCOUNT_DISABLE_STATUS;
+import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkErrorConstants.ErrorMessages.ERROR_WHILE_CHECKING_ACCOUNT_LOCK_STATUS;
+
+/**
+ * The {@code UserAccountStatusValidator} class is responsible for validating the status of a user account
+ * during the impersonation process. It implements the {@code ImpersonationValidator} interface.
+ * <p>
+ */
+public class UserAccountStatusValidator implements ImpersonationValidator {
+
+    private static final String NAME = "UserAccountStatusValidator";
+    private static final Log LOG = LogFactory.getLog(UserAccountStatusValidator.class);
+
+    @Override
+    public int getPriority() {
+
+        return 200;
+    }
+
+    @Override
+    public String getImpersonationValidatorName() {
+
+        return NAME;
+    }
+
+    @Override
+    public ImpersonationContext validateImpersonation(ImpersonationContext impersonationContext)
+            throws IdentityOAuth2Exception {
+
+        String subjectUserId = impersonationContext.getImpersonationRequestDTO().getSubject();
+        String tenantDomain = impersonationContext.getImpersonationRequestDTO().getTenantDomain();
+        AuthenticatedUser subjectUser = OAuth2Util.getAuthenticatedUser(
+                subjectUserId, tenantDomain, impersonationContext.getImpersonationRequestDTO().getClientId());
+        String subjectUserName = subjectUser.getUserName();
+        String domainName = subjectUser.getUserStoreDomain();
+
+        if (isUserAccountLocked(subjectUserName, tenantDomain)
+                || isUserAccountDisabled(subjectUserName, tenantDomain, domainName)) {
+            String errorMessage = String.format("Cannot impersonate an inactive user account: %s.", subjectUserName);
+            impersonationContext.setValidated(false);
+            impersonationContext.setValidationFailureErrorMessage(errorMessage);
+            LOG.debug(errorMessage);
+        } else {
+            impersonationContext.setValidated(true);
+            LOG.debug("User account is not locked or disabled. Impersonation is allowed.");
+        }
+        return impersonationContext;
+    }
+
+    private boolean isUserAccountLocked(String username, String tenantDomain)
+            throws IdentityOAuth2Exception {
+
+        if (username != null && tenantDomain != null) {
+            try {
+                return OAuth2ServiceComponentHolder.getAccountLockService().isAccountLocked(username, tenantDomain);
+            } catch (AccountLockServiceException e) {
+                throw new IdentityOAuth2Exception(ERROR_WHILE_CHECKING_ACCOUNT_LOCK_STATUS.getCode(),
+                        String.format(ERROR_WHILE_CHECKING_ACCOUNT_LOCK_STATUS.getMessage(), username), e);
+            }
+        }
+        return true;
+    }
+
+    private boolean isUserAccountDisabled(String username, String tenantDomain, String userDomain)
+            throws IdentityOAuth2Exception {
+
+        if (username != null && tenantDomain != null && userDomain != null) {
+            try {
+                if (!isAccountDisablingEnabled(tenantDomain)) {
+                    return false;
+                }
+                return OAuth2ServiceComponentHolder.getAccountDisableService().isAccountDisabled(
+                        username, tenantDomain, userDomain);
+            } catch (IllegalArgumentException | AccountDisableServiceException | FrameworkException e) {
+                throw new IdentityOAuth2Exception(ERROR_WHILE_CHECKING_ACCOUNT_DISABLE_STATUS.getCode(),
+                        String.format(ERROR_WHILE_CHECKING_ACCOUNT_DISABLE_STATUS.getMessage(), username), e);
+            }
+        }
+        return true;
+    }
+
+    private boolean isAccountDisablingEnabled(String tenantDomain) throws FrameworkException {
+
+        Property accountDisableConfigProperty = FrameworkUtils.getResidentIdpConfiguration(
+                ACCOUNT_DISABLE_HANDLER_ENABLE_PROPERTY, tenantDomain);
+
+        return accountDisableConfigProperty != null && Boolean.parseBoolean(accountDisableConfigProperty.getValue());
+    }
+}

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuth2ServiceComponent.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuth2ServiceComponent.java
@@ -50,6 +50,7 @@ import org.wso2.carbon.identity.core.util.IdentityCoreInitializedEvent;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.event.handler.AbstractEventHandler;
 import org.wso2.carbon.identity.event.services.IdentityEventService;
+import org.wso2.carbon.identity.handler.event.account.lock.service.AccountDisableService;
 import org.wso2.carbon.identity.handler.event.account.lock.service.AccountLockService;
 import org.wso2.carbon.identity.oauth.common.OAuthConstants;
 import org.wso2.carbon.identity.oauth.common.token.bindings.TokenBinderInfo;
@@ -86,6 +87,7 @@ import org.wso2.carbon.identity.oauth2.impersonation.services.ImpersonationNotif
 import org.wso2.carbon.identity.oauth2.impersonation.validators.ImpersonationValidator;
 import org.wso2.carbon.identity.oauth2.impersonation.validators.ImpersonatorPermissionValidator;
 import org.wso2.carbon.identity.oauth2.impersonation.validators.SubjectScopeValidator;
+import org.wso2.carbon.identity.oauth2.impersonation.validators.UserAccountStatusValidator;
 import org.wso2.carbon.identity.oauth2.keyidprovider.DefaultKeyIDProviderImpl;
 import org.wso2.carbon.identity.oauth2.keyidprovider.KeyIDProvider;
 import org.wso2.carbon.identity.oauth2.listener.TenantCreationEventListener;
@@ -412,6 +414,7 @@ public class OAuth2ServiceComponent {
             OAuth2ServiceComponentHolder.getInstance().setImpersonationMgtService(new ImpersonationMgtServiceImpl());
             bundleContext.registerService(ImpersonationValidator.class, new SubjectScopeValidator(), null);
             bundleContext.registerService(ImpersonationValidator.class, new ImpersonatorPermissionValidator(), null);
+            bundleContext.registerService(ImpersonationValidator.class, new UserAccountStatusValidator(), null);
             bundleContext.registerService(ImpersonationConfigMgtService.class, new ImpersonationConfigMgtServiceImpl(),
                     null);
             bundleContext.registerService(ImpersonationNotificationMgtService.class,
@@ -1649,6 +1652,25 @@ public class OAuth2ServiceComponent {
 
         OAuth2ServiceComponentHolder.setAccountLockService(null);
         log.debug("AccountLockService unset in OAuth2ServiceComponent bundle.");
+    }
+
+    @Reference(
+            name = "org.wso2.carbon.identity.handler.event.account.lock.service.AccountDisableService",
+            service = AccountDisableService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetAccountDisableService"
+    )
+    protected void setAccountDisableService(AccountDisableService accountDisableService) {
+
+        OAuth2ServiceComponentHolder.setAccountDisableService(accountDisableService);
+        log.debug("AccountDisableService set in OAuth2ServiceComponent bundle.");
+    }
+
+    protected void unsetAccountDisableService(AccountDisableService accountDisableService) {
+
+        OAuth2ServiceComponentHolder.setAccountDisableService(null);
+        log.debug("AccountDisableService unset in OAuth2ServiceComponent bundle.");
     }
 
     /**

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuth2ServiceComponentHolder.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuth2ServiceComponentHolder.java
@@ -31,6 +31,7 @@ import org.wso2.carbon.identity.consent.server.configs.mgt.services.ConsentServe
 import org.wso2.carbon.identity.core.SAMLSSOServiceProviderManager;
 import org.wso2.carbon.identity.core.handler.HandlerComparator;
 import org.wso2.carbon.identity.event.services.IdentityEventService;
+import org.wso2.carbon.identity.handler.event.account.lock.service.AccountDisableService;
 import org.wso2.carbon.identity.handler.event.account.lock.service.AccountLockService;
 import org.wso2.carbon.identity.oauth.OAuthAdminServiceImpl;
 import org.wso2.carbon.identity.oauth.dto.ScopeDTO;
@@ -130,6 +131,7 @@ public class OAuth2ServiceComponentHolder {
     private List<ImpersonationValidator> impersonationValidators = new ArrayList<>();
     private ConfigurationManager configurationManager;
     private static AccountLockService accountLockService;
+    private static AccountDisableService accountDisableService;
     private ClaimMetadataManagementService claimMetadataManagementService;
 
     private AuthorizationDetailsService authorizationDetailsService;
@@ -921,6 +923,26 @@ public class OAuth2ServiceComponentHolder {
     public static AccountLockService getAccountLockService() {
 
         return OAuth2ServiceComponentHolder.accountLockService;
+    }
+
+    /**
+     * Set the account disable service to the OAuth2ServiceComponentHolder.
+     *
+     * @param accountDisableService Account disable service instance.
+     */
+    public static void setAccountDisableService(AccountDisableService accountDisableService) {
+
+        OAuth2ServiceComponentHolder.accountDisableService = accountDisableService;
+    }
+
+    /**
+     * Retrieve the account disable service.
+     *
+     * @return Account disable service instance.
+     */
+    public static AccountDisableService getAccountDisableService() {
+
+        return OAuth2ServiceComponentHolder.accountDisableService;
     }
 
     /**

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/impersonation/ImpersonatorPermissionValidatorTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/impersonation/ImpersonatorPermissionValidatorTest.java
@@ -106,6 +106,7 @@ public class ImpersonatorPermissionValidatorTest {
 
         ImpersonationContext impersonationContext = new ImpersonationContext();
         impersonationContext.setImpersonationRequestDTO(impersonationRequestDTO);
+        impersonationContext.setValidationFailureErrorMessage("Validation error message");
         ImpersonatorPermissionValidator impersonatorPermissionValidator = new ImpersonatorPermissionValidator();
         Field field = ImpersonatorPermissionValidator.class.getDeclaredField("scopeValidator");
         field.setAccessible(true);

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/impersonation/SubjectScopeValidatorTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/impersonation/SubjectScopeValidatorTest.java
@@ -29,7 +29,7 @@ import org.wso2.carbon.identity.application.authentication.framework.model.Authe
 import org.wso2.carbon.identity.application.common.model.User;
 import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.base.IdentityException;
-import org.wso2.carbon.identity.oauth.OAuthUtil;
+import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
 import org.wso2.carbon.identity.oauth.internal.OAuthComponentServiceHolder;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.authz.OAuthAuthzReqMessageContext;
@@ -38,6 +38,7 @@ import org.wso2.carbon.identity.oauth2.impersonation.models.ImpersonationContext
 import org.wso2.carbon.identity.oauth2.impersonation.models.ImpersonationRequestDTO;
 import org.wso2.carbon.identity.oauth2.impersonation.validators.SubjectScopeValidator;
 import org.wso2.carbon.identity.oauth2.internal.OAuth2ServiceComponentHolder;
+import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 import org.wso2.carbon.identity.oauth2.validators.DefaultOAuth2ScopeValidator;
 import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.carbon.user.core.tenant.TenantManager;
@@ -72,43 +73,64 @@ public class SubjectScopeValidatorTest {
     @Mock
     private OAuthComponentServiceHolder mockOAuthComponentServiceHolder;
     @Mock
+    private OAuthServerConfiguration mockOAuthServerConfiguration;
+    @Mock
     private RealmService mockRealmService;
     @Mock
     private TenantManager mockTenantManager;
     private ImpersonationRequestDTO impersonationRequestDTO;
     private static final String[] SCOPES_WITHOUT_OPENID = new String[]{"scope1", "scope2"};
     private MockedStatic<OAuthComponentServiceHolder> oAuthComponentServiceHolder;
-    private MockedStatic<OAuthUtil> oAuthUtil;
+    private MockedStatic<OAuth2Util> mockedOAuth2Util;
     private MockedStatic<OAuth2ServiceComponentHolder> oAuth2ServiceComponentHolder;
+    private MockedStatic<OAuthServerConfiguration> oAuthServerConfiguration;
 
     @BeforeMethod
     public void setUp() throws Exception {
 
+        oAuthServerConfiguration = mockStatic(OAuthServerConfiguration.class);
+        oAuthServerConfiguration.when(OAuthServerConfiguration::getInstance).thenReturn(mockOAuthServerConfiguration);
         oAuthComponentServiceHolder = mockStatic(OAuthComponentServiceHolder.class);
         oAuthComponentServiceHolder.when(OAuthComponentServiceHolder::getInstance)
                 .thenReturn(mockOAuthComponentServiceHolder);
-        when(mockOAuthComponentServiceHolder.getRealmService()).thenReturn(mockRealmService);
-        when(mockRealmService.getTenantManager()).thenReturn(mockTenantManager);
-        when(mockTenantManager.getTenantId("carbon.super")).thenReturn(-1234);
-        oAuthUtil = mockStatic(OAuthUtil.class);
+        lenient().when(mockOAuthComponentServiceHolder.getRealmService()).thenReturn(mockRealmService);
+        lenient().when(mockRealmService.getTenantManager()).thenReturn(mockTenantManager);
+        lenient().when(mockTenantManager.getTenantId("carbon.super")).thenReturn(-1234);
+        mockedOAuth2Util = mockStatic(OAuth2Util.class);
         oAuth2ServiceComponentHolder = mockStatic(OAuth2ServiceComponentHolder.class);
         oAuth2ServiceComponentHolder.when(
                 OAuth2ServiceComponentHolder::getApplicationMgtService).thenReturn(applicationManagementService);
         lenient().when(applicationManagementService.getApplicationResourceIDByInboundKey("dummyConsumerKey",
                 OAUTH_2, "carbon.super")).thenReturn("dummyAppId");
         lenient().when(impersonator.getLoggableMaskedUserId()).thenReturn("123456789");
-        when(oAuth2AuthorizeReqDTO.getRequestedSubjectId()).thenReturn("dummySubjectId");
+        lenient().when(oAuth2AuthorizeReqDTO.getRequestedSubjectId()).thenReturn("dummySubjectId");
         lenient().when(oAuth2AuthorizeReqDTO.getUser()).thenReturn(impersonator);
         lenient().when(oAuth2AuthorizeReqDTO.getConsumerKey()).thenReturn("dummyConsumerKey");
         lenient().when(oAuth2AuthorizeReqDTO.getScopes()).thenReturn(SCOPES_WITHOUT_OPENID);
-        when(oAuth2AuthorizeReqDTO.getTenantDomain()).thenReturn("carbon.super");
-        when(oAuthAuthzReqMessageContext.getAuthorizationReqDTO()).thenReturn(oAuth2AuthorizeReqDTO);
-        when(oAuthAuthzReqMessageContext.getRequestedScopes()).thenReturn(SCOPES_WITHOUT_OPENID);
+        lenient().when(oAuth2AuthorizeReqDTO.getTenantDomain()).thenReturn("carbon.super");
+        lenient().when(oAuthAuthzReqMessageContext.getAuthorizationReqDTO()).thenReturn(oAuth2AuthorizeReqDTO);
+        lenient().when(oAuthAuthzReqMessageContext.getRequestedScopes()).thenReturn(SCOPES_WITHOUT_OPENID);
         impersonationRequestDTO = new ImpersonationRequestDTO();
         impersonationRequestDTO.setoAuthAuthzReqMessageContext(oAuthAuthzReqMessageContext);
+        impersonationRequestDTO.setImpersonator(impersonator);
+        impersonationRequestDTO.setSubject("dummySubjectId");
+        lenient().when(impersonator.getTenantDomain()).thenReturn("carbon.super");
+        lenient().when(impersonator.getUserStoreDomain()).thenReturn("PRIMARY");
 
-        oAuthUtil.when(() -> OAuthUtil.getUserFromTenant("dummySubjectId", -1234))
-                .thenReturn(getDummyUser());
+        mockedOAuth2Util.when(() -> OAuth2Util.getAuthenticatedUser(
+                "dummySubjectId", impersonator.getTenantDomain(), "dummyConsumerKey"))
+                .thenReturn(getDummyAuthenticatedUserUser());
+    }
+
+    private AuthenticatedUser getDummyAuthenticatedUserUser() {
+
+        AuthenticatedUser authenticatedImpersonatingUser = new AuthenticatedUser();
+        authenticatedImpersonatingUser.setUserId("dummyUserId");
+        authenticatedImpersonatingUser.setAuthenticatedSubjectIdentifier("dummySubjectId");
+        authenticatedImpersonatingUser.setUserName("dummyUserName");
+        authenticatedImpersonatingUser.setUserStoreDomain("dummyUserStore");
+        authenticatedImpersonatingUser.setTenantDomain("carbon.super");
+        return authenticatedImpersonatingUser;
     }
 
     private User getDummyUser() {
@@ -122,9 +144,10 @@ public class SubjectScopeValidatorTest {
 
     @AfterMethod
     public void tearDown() {
-        oAuthUtil.close();
         oAuth2ServiceComponentHolder.close();
         oAuthComponentServiceHolder.close();;
+        oAuthServerConfiguration.close();
+        mockedOAuth2Util.close();
     }
 
     @Test

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/impersonation/UserAccountStatusValidatorTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/impersonation/UserAccountStatusValidatorTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth2.impersonation;
+
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
+import org.wso2.carbon.identity.application.common.model.Property;
+import org.wso2.carbon.identity.base.IdentityException;
+import org.wso2.carbon.identity.handler.event.account.lock.service.AccountDisableService;
+import org.wso2.carbon.identity.handler.event.account.lock.service.AccountLockService;
+import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
+import org.wso2.carbon.identity.oauth2.authz.OAuthAuthzReqMessageContext;
+import org.wso2.carbon.identity.oauth2.dto.OAuth2AuthorizeReqDTO;
+import org.wso2.carbon.identity.oauth2.impersonation.models.ImpersonationContext;
+import org.wso2.carbon.identity.oauth2.impersonation.models.ImpersonationRequestDTO;
+import org.wso2.carbon.identity.oauth2.impersonation.validators.UserAccountStatusValidator;
+import org.wso2.carbon.identity.oauth2.internal.OAuth2ServiceComponentHolder;
+import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
+
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.testng.Assert.assertEquals;
+import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.ResidentIdpPropertyName.ACCOUNT_DISABLE_HANDLER_ENABLE_PROPERTY;
+
+/**
+ * Unit test class for {@link UserAccountStatusValidator}.
+ */
+@Listeners(MockitoTestNGListener.class)
+public class UserAccountStatusValidatorTest {
+
+    @Mock
+    private AuthenticatedUser impersonator;
+    @Mock
+    private AuthenticatedUser impersonatedUser;
+    @Mock
+    private OAuth2AuthorizeReqDTO oAuth2AuthorizeReqDTO;
+    @Mock
+    private OAuthAuthzReqMessageContext oAuthAuthzReqMessageContext;
+    private ImpersonationRequestDTO impersonationRequestDTO;
+    private static final String[] SCOPES_WITHOUT_OPENID = new String[]{"scope1", "scope2"};
+    @Mock
+    private AccountLockService mockAccountLockService;
+    @Mock
+    private AccountDisableService mockAccountDisableService;
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+
+        lenient().when(impersonator.getLoggableMaskedUserId()).thenReturn("123456789");
+
+        lenient().when(impersonatedUser.getUserId()).thenReturn("dummySubjectId");
+        lenient().when(impersonatedUser.getUserName()).thenReturn("dummySubjectUserName");
+        lenient().when(impersonatedUser.getUserStoreDomain()).thenReturn("PRIMARY");
+
+        lenient().when(oAuth2AuthorizeReqDTO.getRequestedSubjectId()).thenReturn("dummySubjectId");
+        lenient().when(oAuth2AuthorizeReqDTO.getUser()).thenReturn(impersonator);
+        lenient().when(oAuth2AuthorizeReqDTO.getConsumerKey()).thenReturn("dummyConsumerKey");
+        lenient().when(oAuth2AuthorizeReqDTO.getScopes()).thenReturn(SCOPES_WITHOUT_OPENID);
+        lenient().when(oAuth2AuthorizeReqDTO.getTenantDomain()).thenReturn("carbon.super");
+        lenient().when(oAuthAuthzReqMessageContext.getAuthorizationReqDTO()).thenReturn(oAuth2AuthorizeReqDTO);
+
+        impersonationRequestDTO = new ImpersonationRequestDTO();
+        impersonationRequestDTO.setoAuthAuthzReqMessageContext(oAuthAuthzReqMessageContext);
+        impersonationRequestDTO.setSubject("dummySubjectId");
+        impersonationRequestDTO.setImpersonator(impersonator);
+        impersonationRequestDTO.setClientId("dummyConsumerKey");
+        impersonationRequestDTO.setScopes(SCOPES_WITHOUT_OPENID);
+        impersonationRequestDTO.setTenantDomain("carbon.super");
+    }
+
+    @DataProvider(name = "getImpersonationRequestData")
+    public Object[][] getImpersonationRequestData() {
+
+        return new Object[][]{
+                // accountLocked, accountDisabled, isDisableFeatureEnabled, expected
+                // Account is locked → always false
+                {true, false, false, false},
+                {true, true, false, false},
+                {true, false, true, false},
+                {true, true, true, false},
+                // Account is not locked, feature disabled → result depends only on lock
+                {false, false, false, true},  // feature off, not locked, not disabled → allow
+                {false, true, false, true},   // feature off, not locked, disabled → still allow
+                // Account is not locked, feature enabled, disabled → false
+                {false, true, true, false},
+                // Account is not locked, feature enabled, not disabled → allow
+                {false, false, true, true}
+        };
+    }
+
+    @Test(dataProvider = "getImpersonationRequestData")
+    public void testValidateImpersonation(boolean accountLocked, boolean accountDisabled,
+                                          boolean isDisableFeatureEnabled, boolean expected)
+            throws IdentityException {
+
+        try (MockedStatic<OAuthServerConfiguration> oAuthServerConfiguration = mockStatic(
+                        OAuthServerConfiguration.class);
+             MockedStatic<OAuth2ServiceComponentHolder> oAuth2ServiceComponentHolder =
+                     mockStatic(OAuth2ServiceComponentHolder.class, Mockito.CALLS_REAL_METHODS);
+             MockedStatic<FrameworkUtils> frameworkUtils = mockStatic(FrameworkUtils.class);) {
+
+            // Prepare OAuthServerConfiguration.
+            OAuthServerConfiguration mockOAuthServerConfiguration = mock(OAuthServerConfiguration.class);
+            oAuthServerConfiguration.when(OAuthServerConfiguration::getInstance)
+                    .thenReturn(mockOAuthServerConfiguration);
+            lenient().when(mockOAuthServerConfiguration.getTimeStampSkewInSeconds()).thenReturn(3600L);
+
+            // Prepare Account lock & disable services.
+            OAuth2ServiceComponentHolder.setAccountLockService(mockAccountLockService);
+            OAuth2ServiceComponentHolder.setAccountDisableService(mockAccountDisableService);
+            // Mock service output.
+            lenient().when(mockAccountLockService.isAccountLocked(impersonatedUser.getUserName(),
+                    impersonationRequestDTO.getTenantDomain())).thenReturn(accountLocked);
+            lenient().when(mockAccountDisableService.isAccountDisabled(impersonatedUser.getUserName(),
+                    impersonationRequestDTO.getTenantDomain(), impersonatedUser.getUserStoreDomain()))
+                    .thenReturn(accountDisabled);
+            Property accountDisableConfigProperty = new Property();
+            accountDisableConfigProperty.setValue(String.valueOf(isDisableFeatureEnabled));
+            frameworkUtils.when(() -> FrameworkUtils.getResidentIdpConfiguration(
+                    ACCOUNT_DISABLE_HANDLER_ENABLE_PROPERTY, impersonationRequestDTO.getTenantDomain()))
+                    .thenReturn(accountDisableConfigProperty);
+
+            try (MockedStatic<OAuth2Util> mockedOAuth2Util = mockStatic(OAuth2Util.class);) {
+                // Invoke impersonation validation.
+                mockedOAuth2Util.when(() -> OAuth2Util.getAuthenticatedUser(
+                        "dummySubjectId", "carbon.super",
+                        "dummyConsumerKey")).thenReturn(impersonatedUser);
+                ImpersonationContext impersonationContext = new ImpersonationContext();
+                impersonationContext.setImpersonationRequestDTO(impersonationRequestDTO);
+                UserAccountStatusValidator userAccountStatusValidator = new UserAccountStatusValidator();
+                impersonationContext = userAccountStatusValidator.validateImpersonation(impersonationContext);
+                // Validate results.
+                assertEquals(impersonationContext.isValidated(), expected, "Impersonation validation failed.");
+            }
+        }
+    }
+}

--- a/components/org.wso2.carbon.identity.oauth/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.identity.oauth/src/test/resources/testng.xml
@@ -43,6 +43,7 @@
             <class name="org.wso2.carbon.identity.oauth2.token.SubjectTokenIssuerTest"/>
             <class name="org.wso2.carbon.identity.oauth2.impersonation.ImpersonatorPermissionValidatorTest"/>
             <class name="org.wso2.carbon.identity.oauth2.impersonation.SubjectScopeValidatorTest"/>
+            <class name="org.wso2.carbon.identity.oauth2.impersonation.UserAccountStatusValidatorTest"/>
             <class name="org.wso2.carbon.identity.oauth2.impersonation.ImpersonationConfigMgtTest"/>
             <class name="org.wso2.carbon.identity.openidconnect.RememberMeStoreTest"/>
             <class name="org.wso2.carbon.identity.openidconnect.RequestObjectValidatorImplTest"/>
@@ -196,6 +197,7 @@
             <class name="org.wso2.carbon.identity.oauth2.token.SubjectTokenIssuerTest"/>
             <class name="org.wso2.carbon.identity.oauth2.impersonation.ImpersonatorPermissionValidatorTest"/>
             <class name="org.wso2.carbon.identity.oauth2.impersonation.SubjectScopeValidatorTest"/>
+            <class name="org.wso2.carbon.identity.oauth2.impersonation.UserAccountStatusValidatorTest"/>
             <class name="org.wso2.carbon.identity.oauth2.impersonation.ImpersonationConfigMgtTest"/>
             <class name="org.wso2.carbon.identity.oauth2.token.OauthTokenIssuerImplTest"/>
             <class name="org.wso2.carbon.identity.oauth2.util.OAuth2UtilTest"/>


### PR DESCRIPTION
### Proposed changes in this pull request
> Added improvements to the existing impersonation validators. Onboarded new impersonation validator called UserAccountStatusValidator to check whether the user account is locked or disabled before issuing tokens.

### Related Issues:
- https://github.com/wso2/product-is/issues/23462