### PR TITLE
Persist impersonation info on context

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
@@ -88,6 +88,7 @@ import org.wso2.carbon.identity.core.model.UserAgent;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.oauth.IdentityOAuthAdminException;
+import org.wso2.carbon.identity.oauth.cache.AppInfoCache;
 import org.wso2.carbon.identity.oauth.cache.AuthorizationGrantCache;
 import org.wso2.carbon.identity.oauth.cache.AuthorizationGrantCacheEntry;
 import org.wso2.carbon.identity.oauth.cache.AuthorizationGrantCacheKey;
@@ -99,6 +100,7 @@ import org.wso2.carbon.identity.oauth.common.OAuth2ErrorCodes;
 import org.wso2.carbon.identity.oauth.common.OAuthConstants;
 import org.wso2.carbon.identity.oauth.common.exception.InvalidOAuthClientException;
 import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
+import org.wso2.carbon.identity.oauth.dao.OAuthAppDAO;
 import org.wso2.carbon.identity.oauth.dao.OAuthAppDO;
 import org.wso2.carbon.identity.oauth.dto.OAuthErrorDTO;
 import org.wso2.carbon.identity.oauth.endpoint.OAuthRequestWrapper;
@@ -135,6 +137,9 @@ import org.wso2.carbon.identity.oauth2.device.constants.Constants;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2AuthorizeReqDTO;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2AuthorizeRespDTO;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2ClientValidationResponseDTO;
+import org.wso2.carbon.identity.oauth2.impersonation.models.ImpersonationContext;
+import org.wso2.carbon.identity.oauth2.impersonation.models.ImpersonationRequestDTO;
+import org.wso2.carbon.identity.oauth2.impersonation.services.ImpersonationMgtService;
 import org.wso2.carbon.identity.oauth2.internal.OAuth2ServiceComponentHolder;
 import org.wso2.carbon.identity.oauth2.model.AccessTokenExtendedAttributes;
 import org.wso2.carbon.identity.oauth2.model.FederatedTokenDO;
@@ -174,6 +179,7 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.StringJoiner;
@@ -206,9 +212,11 @@ import static org.wso2.carbon.identity.application.authentication.endpoint.util.
 import static org.wso2.carbon.identity.application.authentication.endpoint.util.Constants.USER_CLAIMS_CONSENT_ONLY;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.REQUEST_PARAM_SP;
 import static org.wso2.carbon.identity.client.attestation.mgt.utils.Constants.CLIENT_ATTESTATION_CONTEXT;
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.IMPERSONATING_ACTOR;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.LogConstants.InputKeys.RESPONSE_TYPE;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OAuth20Params.CLIENT_ID;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OAuth20Params.REDIRECT_URI;
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OAuth20Params.REQUESTED_SUBJECT;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OAuth20Params.USERINFO;
 import static org.wso2.carbon.identity.oauth.endpoint.state.OAuthAuthorizeState.AUTHENTICATION_RESPONSE;
 import static org.wso2.carbon.identity.oauth.endpoint.state.OAuthAuthorizeState.INITIAL_REQUEST;
@@ -224,6 +232,9 @@ import static org.wso2.carbon.identity.oauth.endpoint.util.factory.OAuthServerCo
 import static org.wso2.carbon.identity.oauth.endpoint.util.factory.RequestObjectServiceFactory.getRequestObjectService;
 import static org.wso2.carbon.identity.oauth.endpoint.util.factory.SSOConsentServiceFactory.getSSOConsentService;
 import static org.wso2.carbon.identity.oauth2.OAuth2Constants.TokenBinderType.CLIENT_REQUEST;
+import static org.wso2.carbon.identity.oauth2.Oauth2ScopeConstants.SYSTEM_SCOPE;
+import static org.wso2.carbon.identity.oauth2.authz.AuthorizationHandlerManager.OAUTH_APP_PROPERTY;
+import static org.wso2.carbon.identity.oauth2.impersonation.utils.Constants.IMPERSONATION_SCOPE_NAME;
 import static org.wso2.carbon.identity.oauth2.util.OAuth2Util.ACCESS_TOKEN_JS_OBJECT;
 import static org.wso2.carbon.identity.oauth2.util.OAuth2Util.DYNAMIC_TOKEN_DATA_FUNCTION;
 import static org.wso2.carbon.identity.openidconnect.model.Constants.AUTH_TIME;
@@ -1209,6 +1220,7 @@ public class OAuth2AuthzEndpoint {
             removeAuthenticationResult(oAuthMessage, sessionDataKeyFromLogin);
 
             if (authnResult.isAuthenticated()) {
+                handleSessionImpersonation(oAuthMessage, tenantDomain, oauth2Params, authnResult);
                 String userIdentifier = null;
                 if (authnResult.getSubject() != null) {
                     try {
@@ -1272,6 +1284,192 @@ public class OAuth2AuthzEndpoint {
             }
             return handleEmptyAuthenticationResult(oAuthMessage, authorizationResponseDTO);
         }
+    }
+
+    private void handleSessionImpersonation(OAuthMessage oAuthMessage, String tenantDomain,
+                                            OAuth2Parameters oauth2Params, AuthenticationResult authnResult)
+            throws OAuthProblemException {
+
+        boolean isUserSessionImpersonationEnabled = OAuthServerConfiguration.getInstance()
+                .isUserSessionImpersonationEnabled();
+        if (!isUserSessionImpersonationEnabled) {
+            return;
+        }
+        boolean isImpersonationInitRequest = StringUtils.contains(oauth2Params.getResponseType(),
+                OAuthConstants.SUBJECT_TOKEN);
+        SessionContext sessionContext = getSessionContextFromCache(oAuthMessage, tenantDomain);
+        if (sessionContext != null) {
+            try {
+                String impersonatingActor = authnResult.getSubject().getAuthenticatedSubjectIdentifier();
+                String impersonatedSubject = sessionContext.getImpersonatedUser();
+                if (isImpersonationInitRequest) {
+                    handleInitImpersonationRequest(impersonatedSubject, oAuthMessage);
+                } else {
+                    handleSSOImpersonationRequest(impersonatingActor, impersonatedSubject, oAuthMessage, oauth2Params,
+                            sessionContext, authnResult);
+                }
+            } catch (IdentityOAuth2Exception | InvalidOAuthClientException e) {
+                throw OAuthProblemException.error(OAuth2ErrorCodes.SERVER_ERROR, "Error while " +
+                        "handling impersonation request.");
+            } catch (UserIdNotFoundException e) {
+                throw OAuthProblemException.error(OAuth2ErrorCodes.INVALID_REQUEST,
+                        "Error while retrieving user.");
+            }
+        }
+    }
+
+    private void handleSSOImpersonationRequest(String impersonatingActor, String impersonatedSubject,
+                                               OAuthMessage oAuthMessage, OAuth2Parameters oauth2Params,
+                                               SessionContext sessionContext, AuthenticationResult authnResult)
+            throws IdentityOAuth2Exception, InvalidOAuthClientException, UserIdNotFoundException {
+
+        /* Change authenticated user as the impersonated user only during SSO. */
+        if (impersonatingActor != null && impersonatedSubject != null) {
+            // Write Impersonation details to the OAuthAuthzReqMessageContext for scope validation.
+            OAuthAuthzReqMessageContext authzReqMsgCtx = getOAuthAuthzReqMessageContext(oAuthMessage,
+                    oauth2Params, sessionContext, authnResult);
+            ImpersonationContext impersonationContext = validateImpersonation(authzReqMsgCtx);
+            if (impersonationContext.isValidated()) {
+                /* Used in two places.
+                    1. When preparing authorization grant cache entry for code & device code.
+                    2. When generating additional claims for implicit & hybrid flows. */
+                String impersonator = authnResult.getSubject().getAuthenticatedSubjectIdentifier();
+                oAuthMessage.setProperty(IMPERSONATING_ACTOR, impersonator);
+                // Set AuthenticationResult authenticated user as impersonatee.
+                AuthenticatedUser impersonatedUser = OAuth2Util.getAuthenticatedUser(impersonatedSubject,
+                        impersonationContext.getImpersonationRequestDTO().getTenantDomain(),
+                        impersonationContext.getImpersonationRequestDTO().getClientId());
+                authnResult.setSubject(impersonatedUser);
+            } else {
+                removeImpersonationScope(impersonationContext);
+            }
+        }
+    }
+
+    private void handleInitImpersonationRequest(String impersonatedSubject, OAuthMessage oAuthMessage)
+            throws OAuthProblemException {
+
+        // Block performing impersonation for an impersonated session.
+        if (StringUtils.isNotBlank(impersonatedSubject)
+                && oAuthMessage.getRequest().getParameterMap() != null) {
+            String requestedSubject = oAuthMessage.getRequest().getParameterMap().get(REQUESTED_SUBJECT)[0];
+            if (requestedSubject != null && !Objects.equals(requestedSubject, impersonatedSubject)) {
+                log.debug("Cannot perform impersonation on more than one user in the same session.");
+                throw OAuthProblemException.error(OAuth2ErrorCodes.INVALID_REQUEST,
+                        "Cannot perform impersonation on more than one user in the same session.");
+            }
+        }
+    }
+
+    private OAuthAuthzReqMessageContext getOAuthAuthzReqMessageContext(OAuthMessage oAuthMessage,
+                                                                       OAuth2Parameters oauth2Params,
+                                                                       SessionContext sessionContext,
+                                                                       AuthenticationResult authenticationResult)
+            throws IdentityOAuth2Exception, InvalidOAuthClientException {
+
+        HttpRequestHeaderHandler httpRequestHeaderHandler = new HttpRequestHeaderHandler(oAuthMessage
+                .getRequest());
+        boolean isImpersonationRequest = oAuthMessage.getProperty(IMPERSONATING_ACTOR) != null;
+        OAuth2AuthorizeReqDTO authzReqDTO =
+                buildAuthRequest(oauth2Params, oAuthMessage.getSessionDataCacheEntry(),
+                        httpRequestHeaderHandler, oAuthMessage.getRequest(), isImpersonationRequest);
+        authzReqDTO.setUser(authenticationResult.getSubject());
+        authzReqDTO.setRequestedSubjectId(sessionContext.getImpersonatedUser());
+        return getOAuthAuthzReqMessageContext(authzReqDTO);
+    }
+
+    private SessionContext getSessionContextFromCache(OAuthMessage oAuthMessage, String tenantDomain) {
+
+        HttpServletRequest request = oAuthMessage.getRequest();
+        String commonAuthIdCookieValue = getCommonAuthCookieString(request);
+        if (StringUtils.isNotBlank(commonAuthIdCookieValue)) {
+            String sessionContextKey = DigestUtils.sha256Hex(commonAuthIdCookieValue);
+            return FrameworkUtils.getSessionContextFromCache(sessionContextKey,
+                    tenantDomain);
+        }
+        return null;
+    }
+
+    private ImpersonationContext validateImpersonation(OAuthAuthzReqMessageContext authzReqMsgCtx)
+            throws IdentityOAuth2Exception {
+
+        // Validate impersonation request.
+        ImpersonationMgtService impersonationMgtService = OAuth2ServiceComponentHolder.getInstance()
+                .getImpersonationMgtService();
+
+        return impersonationMgtService.validateImpersonationRequest(
+                buildImpersonationRequestDTO(authzReqMsgCtx));
+    }
+
+    private OAuthAuthzReqMessageContext getOAuthAuthzReqMessageContext(OAuth2AuthorizeReqDTO authzReqDTO)
+            throws IdentityOAuth2Exception, InvalidOAuthClientException {
+
+        OAuthAuthzReqMessageContext authorizeRequestMessageContext = new OAuthAuthzReqMessageContext(authzReqDTO);
+        // loading the stored application data
+        OAuthAppDO oAuthAppDO = getAppInformation(authzReqDTO);
+        authorizeRequestMessageContext.addProperty(OAUTH_APP_PROPERTY, oAuthAppDO);
+
+        // load the SP tenant domain from the OAuth App info
+        authorizeRequestMessageContext.getAuthorizationReqDTO()
+                .setTenantDomain(OAuth2Util.getTenantDomainOfOauthApp(oAuthAppDO));
+
+        // load requested scopes
+        authorizeRequestMessageContext.setRequestedScopes(authzReqDTO.getScopes());
+
+        return authorizeRequestMessageContext;
+    }
+
+    private OAuthAppDO getAppInformation(OAuth2AuthorizeReqDTO authzReqDTO) throws IdentityOAuth2Exception,
+            InvalidOAuthClientException {
+
+        OAuthAppDO oAuthAppDO = AppInfoCache.getInstance().getValueFromCache(authzReqDTO.getConsumerKey());
+        if (oAuthAppDO != null) {
+            return oAuthAppDO;
+        } else {
+            String tenantDomain = authzReqDTO.getTenantDomain();
+            if (StringUtils.isNotEmpty(tenantDomain)) {
+                oAuthAppDO = new OAuthAppDAO().getAppInformation(
+                        authzReqDTO.getConsumerKey(), IdentityTenantUtil.getTenantId(tenantDomain));
+            } else {
+                oAuthAppDO = new OAuthAppDAO().getAppInformation(authzReqDTO.getConsumerKey());
+            }
+            AppInfoCache.getInstance().addToCache(authzReqDTO.getConsumerKey(), oAuthAppDO);
+            return oAuthAppDO;
+        }
+    }
+
+    private ImpersonationRequestDTO buildImpersonationRequestDTO(OAuthAuthzReqMessageContext authzReqMsgCxt) {
+
+        ImpersonationRequestDTO impersonationRequestDTO = new ImpersonationRequestDTO();
+        impersonationRequestDTO.setoAuthAuthzReqMessageContext(authzReqMsgCxt);
+        impersonationRequestDTO.setSubject(authzReqMsgCxt.getAuthorizationReqDTO().getRequestedSubjectId());
+        impersonationRequestDTO.setImpersonator(authzReqMsgCxt.getAuthorizationReqDTO().getUser());
+        impersonationRequestDTO.setClientId(authzReqMsgCxt.getAuthorizationReqDTO().getConsumerKey());
+        impersonationRequestDTO.setScopes(getScopesBeforeValidation(authzReqMsgCxt));
+        impersonationRequestDTO.setTenantDomain(authzReqMsgCxt.getAuthorizationReqDTO().getTenantDomain());
+        return impersonationRequestDTO;
+    }
+
+    private String[] getScopesBeforeValidation(OAuthAuthzReqMessageContext authzReqMessageContext) {
+
+        String[] initialRequestedScopes = authzReqMessageContext.getAuthorizationReqDTO().getScopes();
+        List<String> updatedRequestedScopes = new ArrayList<>(Arrays.asList(initialRequestedScopes));
+        if (!updatedRequestedScopes.contains(IMPERSONATION_SCOPE_NAME) &&
+                !updatedRequestedScopes.contains(SYSTEM_SCOPE)) {
+            updatedRequestedScopes.add(IMPERSONATION_SCOPE_NAME);
+        }
+        authzReqMessageContext.setRequestedScopes(updatedRequestedScopes.toArray(new String[0]));
+        return updatedRequestedScopes.toArray(new String[0]);
+    }
+
+    private void removeImpersonationScope(ImpersonationContext impersonationContext) {
+
+        OAuthAuthzReqMessageContext authzReqMessageContext = impersonationContext.getImpersonationRequestDTO()
+                .getoAuthAuthzReqMessageContext();
+        String[] initialRequestedScopes = authzReqMessageContext.getAuthorizationReqDTO().getScopes();
+        List<String> updatedRequestedScopes = new ArrayList<>(Arrays.asList(initialRequestedScopes));
+        updatedRequestedScopes.remove(IMPERSONATION_SCOPE_NAME);
+        authzReqMessageContext.setRequestedScopes(updatedRequestedScopes.toArray(new String[0]));
     }
 
     private boolean isAuthnResultFound(AuthenticationResult authnResult) {
@@ -1628,9 +1826,10 @@ public class OAuth2AuthzEndpoint {
         OAuthResponse oauthResponse;
         String responseType = oauth2Params.getResponseType();
         HttpRequestHeaderHandler httpRequestHeaderHandler = new HttpRequestHeaderHandler(oAuthMessage.getRequest());
+        boolean isImpersonationRequest = oAuthMessage.getProperty(IMPERSONATING_ACTOR) != null;
         OAuth2AuthorizeReqDTO authzReqDTO =
                 buildAuthRequest(oauth2Params, oAuthMessage.getSessionDataCacheEntry(), httpRequestHeaderHandler,
-                        oAuthMessage.getRequest());
+                        oAuthMessage.getRequest(), isImpersonationRequest);
         /* We have persisted the oAuthAuthzReqMessageContext before the consent after scope validation. Here we
         retrieve it from the cache and use it again because it contains  information that was set during the scope
         validation process. */
@@ -1639,6 +1838,9 @@ public class OAuth2AuthzEndpoint {
         oAuthAuthzReqMessageContext.setAuthorizationReqDTO(authzReqDTO);
         oAuthAuthzReqMessageContext.addProperty(OAuthConstants.IS_MTLS_REQUEST, oauth2Params.isMtlsRequest());
         oAuthAuthzReqMessageContext.setApprovedAuthorizationDetails(oauth2Params.getAuthorizationDetails());
+        oAuthAuthzReqMessageContext.setImpersonationRequest(isImpersonationRequest);
+        /* Set impersonation details to the authorization request context. To handle implicit and hybrid flows. */
+        setImpersonationDetailsToAuthzRequestContext(oAuthMessage, oAuthAuthzReqMessageContext);
         // authorizing the request
         OAuth2AuthorizeRespDTO authzRespDTO = authorize(oAuthAuthzReqMessageContext);
         if (authzRespDTO != null && authzRespDTO.getCallbackURI() != null) {
@@ -1671,6 +1873,22 @@ public class OAuth2AuthzEndpoint {
                 return appendAuthenticatedIDPs(oAuthMessage.getSessionDataCacheEntry(), oauthResponse.getLocationUri(),
                         authorizationResponseDTO);
             }
+        }
+    }
+
+    private void setImpersonationDetailsToAuthzRequestContext(OAuthMessage oAuthMessage,
+                                                              OAuthAuthzReqMessageContext oAuthAuthzReqMessageContext) {
+
+        boolean isUserSessionImpersonationEnabled = OAuthServerConfiguration.getInstance()
+                .isUserSessionImpersonationEnabled();
+        if (!isUserSessionImpersonationEnabled) {
+            return;
+        }
+        if (oAuthMessage.getProperty(IMPERSONATING_ACTOR) != null) {
+            String impersonator = oAuthMessage.getProperty(IMPERSONATING_ACTOR).toString();
+            oAuthAuthzReqMessageContext.setImpersonationRequest(true);
+            // Mandatory when getting additional claims (may_act & sub).
+            oAuthAuthzReqMessageContext.addProperty(IMPERSONATING_ACTOR, impersonator);
         }
     }
 
@@ -1882,7 +2100,7 @@ public class OAuth2AuthzEndpoint {
                     authorizationResponseDTO);
         }
         if (Constants.RESPONSE_TYPE_DEVICE.equalsIgnoreCase(responseType)) {
-            cacheUserAttributesByDeviceCode(oAuthMessage.getSessionDataCacheEntry());
+            cacheUserAttributesByDeviceCode(oAuthMessage);
         }
         if (isResponseTypeNotIdTokenOrNone(responseType, authzRespDTO)) {
             setAccessToken(authzRespDTO, builder, authorizationResponseDTO);
@@ -2013,6 +2231,20 @@ public class OAuth2AuthzEndpoint {
         }
         addUserAttributesToOAuthMessage(oAuthMessage, authorizationCode, authzRespDTO.getCodeId(),
                 tokenBindingValue, tokenExtendedAttributes);
+        setImpersonationDetailsToAuthGrantCache(oAuthMessage);
+    }
+
+    private void setImpersonationDetailsToAuthGrantCache(OAuthMessage oAuthMessage) {
+
+        boolean isUserSessionImpersonationEnabled = OAuthServerConfiguration.getInstance()
+                .isUserSessionImpersonationEnabled();
+        if (!isUserSessionImpersonationEnabled) {
+            return;
+        }
+        AuthorizationGrantCacheEntry authorizationGrantCacheEntry = oAuthMessage.getAuthorizationGrantCacheEntry();
+        if (oAuthMessage.getProperty(IMPERSONATING_ACTOR) != null) {
+            authorizationGrantCacheEntry.setImpersonator(oAuthMessage.getProperty(IMPERSONATING_ACTOR).toString());
+        }
     }
 
     private AccessTokenExtendedAttributes getExtendedTokenAttributes(OAuthMessage oAuthMessage,
@@ -3001,9 +3233,10 @@ public class OAuth2AuthzEndpoint {
         /* Here we validate all scopes before user consent to prevent invalidate scopes prompt for consent in the
         consent page. */
         HttpRequestHeaderHandler httpRequestHeaderHandler = new HttpRequestHeaderHandler(oAuthMessage.getRequest());
+        boolean isImpersonationRequest = oAuthMessage.getProperty(IMPERSONATING_ACTOR) != null;
         OAuth2AuthorizeReqDTO authzReqDTO =
                 buildAuthRequest(oauth2Params, oAuthMessage.getSessionDataCacheEntry(), httpRequestHeaderHandler,
-                        oAuthMessage.getRequest());
+                        oAuthMessage.getRequest(), isImpersonationRequest);
         try {
             if (LoggerUtils.isDiagnosticLogsEnabled()) {
                 DiagnosticLog.DiagnosticLogBuilder diagnosticLogBuilder = new DiagnosticLog.DiagnosticLogBuilder(
@@ -3833,7 +4066,8 @@ public class OAuth2AuthzEndpoint {
     }
 
     private OAuth2AuthorizeReqDTO buildAuthRequest(OAuth2Parameters oauth2Params, SessionDataCacheEntry
-            sessionDataCacheEntry, HttpRequestHeaderHandler httpRequestHeaderHandler, HttpServletRequest request) {
+            sessionDataCacheEntry, HttpRequestHeaderHandler httpRequestHeaderHandler, HttpServletRequest request,
+                                                   boolean isImpersonationRequest) {
 
         OAuth2AuthorizeReqDTO authzReqDTO = new OAuth2AuthorizeReqDTO();
         authzReqDTO.setCallbackUrl(oauth2Params.getRedirectURI());
@@ -3858,6 +4092,7 @@ public class OAuth2AuthzEndpoint {
         authzReqDTO.setRequestedSubjectId(oauth2Params.getRequestedSubjectId());
         authzReqDTO.setMappedRemoteClaims(sessionDataCacheEntry.getMappedRemoteClaims());
         authzReqDTO.setAuthorizationDetails(oauth2Params.getAuthorizationDetails());
+        authzReqDTO.setImpersonationRequest(isImpersonationRequest);
 
         if (sessionDataCacheEntry.getParamMap() != null && sessionDataCacheEntry.getParamMap().get(OAuthConstants
                 .AMR) != null) {
@@ -4559,9 +4794,10 @@ public class OAuth2AuthzEndpoint {
         return OAuthConstants.Prompt.SELECT_ACCOUNT.equals(oauth2Params.getPrompt());
     }
 
-    private void cacheUserAttributesByDeviceCode(SessionDataCacheEntry sessionDataCacheEntry)
+    private void cacheUserAttributesByDeviceCode(OAuthMessage oAuthMessage)
             throws OAuthSystemException {
 
+        SessionDataCacheEntry sessionDataCacheEntry = oAuthMessage.getSessionDataCacheEntry();
         String userCode = null;
         Optional<String> deviceCodeOptional = Optional.empty();
         String[] userCodeArray = sessionDataCacheEntry.getParamMap().get(Constants.USER_CODE);
@@ -4571,9 +4807,7 @@ public class OAuth2AuthzEndpoint {
         if (StringUtils.isNotBlank(userCode)) {
             deviceCodeOptional = getDeviceCodeByUserCode(userCode);
         }
-        if (deviceCodeOptional.isPresent()) {
-            addUserAttributesToCache(sessionDataCacheEntry, deviceCodeOptional.get());
-        }
+        deviceCodeOptional.ifPresent(s -> addUserAttributesToCache(oAuthMessage, s));
     }
 
     private Optional<String> getDeviceCodeByUserCode(String userCode) throws OAuthSystemException {
@@ -4585,14 +4819,21 @@ public class OAuth2AuthzEndpoint {
         }
     }
 
-    private void addUserAttributesToCache(SessionDataCacheEntry sessionDataCacheEntry, String deviceCode) {
+    private void addUserAttributesToCache(OAuthMessage oAuthMessage, String deviceCode) {
 
+        SessionDataCacheEntry sessionDataCacheEntry = oAuthMessage.getSessionDataCacheEntry();
         DeviceAuthorizationGrantCacheKey cacheKey = new DeviceAuthorizationGrantCacheKey(deviceCode);
         DeviceAuthorizationGrantCacheEntry cacheEntry =
                 new DeviceAuthorizationGrantCacheEntry(sessionDataCacheEntry.getLoggedInUser().getUserAttributes());
         if (sessionDataCacheEntry.getMappedRemoteClaims() != null) {
             cacheEntry.setMappedRemoteClaims(sessionDataCacheEntry
                     .getMappedRemoteClaims());
+        }
+        boolean isUserSessionImpersonationEnabled = OAuthServerConfiguration.getInstance()
+                .isUserSessionImpersonationEnabled();
+        // Add impersonation to the session data cache entry.
+        if (isUserSessionImpersonationEnabled && oAuthMessage.getProperty(IMPERSONATING_ACTOR) != null) {
+            cacheEntry.setImpersonator(oAuthMessage.getProperty(IMPERSONATING_ACTOR).toString());
         }
         DeviceAuthorizationGrantCache.getInstance().addToCache(cacheKey, cacheEntry);
     }

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/message/OAuthMessage.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/message/OAuthMessage.java
@@ -24,6 +24,7 @@ import org.wso2.carbon.identity.oauth.cache.SessionDataCache;
 import org.wso2.carbon.identity.oauth.cache.SessionDataCacheEntry;
 import org.wso2.carbon.identity.oauth.cache.SessionDataCacheKey;
 import org.wso2.carbon.identity.oauth.common.OAuthConstants;
+import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
 import org.wso2.carbon.identity.oauth.endpoint.exception.InvalidRequestParentException;
 import org.wso2.carbon.identity.oauth.endpoint.state.OAuthAuthorizeState;
 import org.wso2.carbon.identity.oauth.endpoint.state.OAuthRequestStateValidator;
@@ -71,6 +72,22 @@ public class OAuthMessage {
             cacheKey = new SessionDataCacheKey(sessionDataKeyFromConsent);
             resultFromConsent = SessionDataCache.getInstance().getValueFromCache(cacheKey);
             SessionDataCache.getInstance().clearCacheEntry(cacheKey);
+        }
+        preparePostConsentOAuthMessage(resultFromConsent);
+    }
+
+    private void preparePostConsentOAuthMessage(SessionDataCacheEntry resultFromConsent) {
+
+        boolean isUserSessionImpersonationEnabled = OAuthServerConfiguration.getInstance()
+                .isUserSessionImpersonationEnabled();
+        if (!isUserSessionImpersonationEnabled) {
+            return;
+        }
+        if (resultFromConsent != null && resultFromConsent.getAuthzReqMsgCtx() != null &&
+                resultFromConsent.getAuthzReqMsgCtx().isImpersonationRequest() &&
+                resultFromConsent.getAuthzReqMsgCtx().getProperty(OAuthConstants.IMPERSONATING_ACTOR) != null) {
+            this.setProperty(OAuthConstants.IMPERSONATING_ACTOR,
+                    resultFromConsent.getAuthzReqMsgCtx().getProperty(OAuthConstants.IMPERSONATING_ACTOR));
         }
     }
 

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
@@ -143,6 +143,7 @@ import static org.wso2.carbon.identity.application.authentication.framework.util
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.CODE;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.CODE_IDTOKEN;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.HTTP_REQ_HEADER_AUTH_METHOD_BASIC;
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.IMPERSONATING_ACTOR;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OauthAppStates.APP_STATE_ACTIVE;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.ResponseModes.JWT;
 import static org.wso2.carbon.identity.oauth.endpoint.util.factory.OAuthAdminServiceFactory.getOAuthAdminService;
@@ -751,6 +752,7 @@ public class EndpointUtil {
                         entry.setRemoveOnConsume(true);
                     }
                     entry.setValidityPeriod(TimeUnit.MINUTES.toNanos(IdentityUtil.getTempDataCleanUpTimeout()));
+                    persistImpersonationInfoToSessionDataCache(entry, oAuthMessage);
                     sessionDataCache.addToCache(new SessionDataCacheKey(sessionDataKeyConsent), entry);
                 } else {
                     if (log.isDebugEnabled()) {
@@ -769,6 +771,25 @@ public class EndpointUtil {
         return consentPageUrl;
     }
 
+    protected static void persistImpersonationInfoToSessionDataCache(SessionDataCacheEntry entry,
+                                                                   OAuthMessage oAuthMessage) {
+
+        boolean isUserSessionImpersonationEnabled = OAuthServerConfiguration.getInstance()
+                .isUserSessionImpersonationEnabled();
+        if (!isUserSessionImpersonationEnabled) {
+            return;
+        }
+        String impersonatingActor = null;
+        if (oAuthMessage != null && oAuthMessage.getProperties() != null &&
+                oAuthMessage.getProperties().get(IMPERSONATING_ACTOR) != null) {
+            impersonatingActor = oAuthMessage.getProperties().get(
+                    IMPERSONATING_ACTOR).toString();
+        }
+        if (impersonatingActor != null) {
+            entry.getAuthzReqMsgCtx().addProperty(IMPERSONATING_ACTOR, impersonatingActor);
+            entry.getAuthzReqMsgCtx().setImpersonationRequest(true);
+        }
+    }
 
     private static ServiceProvider getServiceProvider(OAuth2Parameters params) throws IdentityOAuth2Exception {
 

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpointImpersonationTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpointImpersonationTest.java
@@ -1,0 +1,235 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth.endpoint.authz;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.application.authentication.framework.context.SessionContext;
+import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
+import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticationResult;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
+import org.wso2.carbon.identity.common.testng.WithCarbonHome;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.oauth.cache.AppInfoCache;
+import org.wso2.carbon.identity.oauth.cache.SessionDataCacheEntry;
+import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
+import org.wso2.carbon.identity.oauth.dao.OAuthAppDO;
+import org.wso2.carbon.identity.oauth.endpoint.message.OAuthMessage;
+import org.wso2.carbon.identity.oauth.endpoint.util.TestOAuthEndpointBase;
+import org.wso2.carbon.identity.oauth2.authz.OAuthAuthzReqMessageContext;
+import org.wso2.carbon.identity.oauth2.dto.OAuth2AuthorizeReqDTO;
+import org.wso2.carbon.identity.oauth2.impersonation.models.ImpersonationContext;
+import org.wso2.carbon.identity.oauth2.impersonation.models.ImpersonationRequestDTO;
+import org.wso2.carbon.identity.oauth2.impersonation.services.ImpersonationMgtService;
+import org.wso2.carbon.identity.oauth2.impersonation.services.ImpersonationMgtServiceImpl;
+import org.wso2.carbon.identity.oauth2.internal.OAuth2ServiceComponentHolder;
+import org.wso2.carbon.identity.oauth2.model.OAuth2Parameters;
+import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
+
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.CODE;
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OAuth20Params.REQUESTED_SUBJECT;
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.SUBJECT_TOKEN;
+import static org.wso2.carbon.identity.oauth2.impersonation.utils.Constants.IMPERSONATION_SCOPE_NAME;
+
+@WithCarbonHome
+public class OAuth2AuthzEndpointImpersonationTest extends TestOAuthEndpointBase {
+
+    @DataProvider
+    public Object[][] getHandleSessionImpersonationData() {
+        return new Object[][]{
+                // response type, existingImpersonatedUserId, impersonatedUserIdInReq,
+                // rejectImpersonation, ssoImpersonation, validImpersonation
+                {SUBJECT_TOKEN, "impersonatedUserId", "impersonatedUserId", false, false, true, true},
+                {SUBJECT_TOKEN, null, "impersonatedUserId", false, false, true, true},
+                {SUBJECT_TOKEN, "impersonatedUserId", "otherImpersonatedUserId", true, false, false, true},
+                // Invalid impersonation request
+                {SUBJECT_TOKEN, "impersonatedUserId", null, false, false, false, true},
+                {SUBJECT_TOKEN, null, null, false, false, false, true},
+                // SSO cases.
+                {CODE, "impersonatedUserId", "impersonatedUserId", false, true, true, true},
+                {CODE, "impersonatedUserId", "OtherImpersonatedUserId", false, true, false, true},
+                // Disabled.
+                {CODE, "impersonatedUserId", "impersonatedUserId", false, true, false, false},
+        };
+    }
+
+    @Test(dataProvider = "getHandleSessionImpersonationData")
+    public void testHandleSessionImpersonation(String responseType, String existingImpersonatedUserId,
+                                     String impersonatedUserIdInReq, boolean rejectImpersonation,
+                                     boolean ssoImpersonation, boolean validImpersonation,
+                                               boolean isUserSessionImpersonationEnabled) throws Exception {
+
+        String dummyClientId = "dummyClientId";
+
+        try (MockedStatic<FrameworkUtils> frameworkUtils = mockStatic(FrameworkUtils.class);
+            MockedStatic<IdentityTenantUtil> identityTenantUtil = mockStatic(IdentityTenantUtil.class);
+            MockedStatic<AppInfoCache> appInfoCache = mockStatic(AppInfoCache.class);
+            MockedStatic<OAuthServerConfiguration> oAuthServerConfiguration = mockStatic(
+                    OAuthServerConfiguration.class);
+            MockedStatic<OAuth2ServiceComponentHolder> oAuth2ServiceComponentHolder =
+                     mockStatic(OAuth2ServiceComponentHolder.class, Mockito.CALLS_REAL_METHODS)) {
+
+            OAuthServerConfiguration mockedOAuthServerConfiguration =  mock(OAuthServerConfiguration.class);
+            oAuthServerConfiguration.when(OAuthServerConfiguration::getInstance)
+                    .thenReturn(mockedOAuthServerConfiguration);
+            when(mockedOAuthServerConfiguration.isUserSessionImpersonationEnabled()).thenReturn(
+                    isUserSessionImpersonationEnabled);
+
+            Cookie authCookie = mock(Cookie.class);
+            SessionContext sessionContext = mock(SessionContext.class);
+            OAuthMessage oAuthMessage = mock(OAuthMessage.class);
+            OAuth2Parameters oAuth2Parameters = mock(OAuth2Parameters.class);
+            AuthenticationResult authenticationResult = new AuthenticationResult();
+            HttpServletRequest mockRequest = mock(HttpServletRequest.class);
+            SessionDataCacheEntry mockSessionDataCacheEntry = mock(SessionDataCacheEntry.class);
+            AuthenticatedUser impersonatedUser = mock(AuthenticatedUser.class);
+            AuthenticatedUser impersonator = mock(AuthenticatedUser.class);
+            ImpersonationRequestDTO impersonationRequestDTO = mock(ImpersonationRequestDTO.class);
+            when(impersonationRequestDTO.getClientId()).thenReturn(dummyClientId);
+            when(impersonationRequestDTO.getTenantDomain()).thenReturn("carbon.super");
+
+            // Mark whether the request is a valid token initiation.
+            Map<String, String[]> requestParameterMap = new HashMap<>();
+            requestParameterMap.put(REQUESTED_SUBJECT, new String[]{impersonatedUserIdInReq});
+            requestParameterMap.put(FrameworkConstants.SESSION_DATA_KEY, new String[]{"dummyKey"});
+
+            // Mock request parameter map.
+            when(oAuthMessage.getRequest()).thenReturn(mockRequest);
+            when(mockRequest.getParameterMap()).thenReturn(requestParameterMap);
+
+            // when OAuth2Parameters.getResponseType() return grant type.
+            when(oAuth2Parameters.getResponseType()).thenReturn(responseType);
+            when(oAuth2Parameters.getLoginTenantDomain()).thenReturn("carbon.super");
+            when(oAuth2Parameters.getTenantDomain()).thenReturn("carbon.super");
+            when(oAuth2Parameters.getClientId()).thenReturn(dummyClientId);
+            when(oAuth2Parameters.getScopes()).thenReturn(new HashSet<String>(Collections.singletonList(
+                    IMPERSONATION_SCOPE_NAME)));
+
+            // IdentityTenantUtil.getTenantId
+            identityTenantUtil.when(() -> IdentityTenantUtil.getTenantId(anyString())).thenReturn(1234);
+
+            // Pretend session exist -> SSO case.
+            when(authCookie.getValue()).thenReturn("dummyValue");
+            frameworkUtils.when(() -> FrameworkUtils.getAuthCookie(any())).thenReturn(authCookie);
+            frameworkUtils.when(() -> FrameworkUtils.getSessionContextFromCache(anyString(), anyString()))
+                    .thenReturn(sessionContext);
+
+            // Set impersonating user.
+            when(impersonator.getUserName()).thenReturn("impersonatingActor");
+            when(impersonator.getUserId()).thenReturn("impersonatingActorId");
+            when(impersonator.getTenantDomain()).thenReturn("carbon.super");
+            when(impersonator.getUserStoreDomain()).thenReturn("PRIMARY");
+            when(impersonator.getAuthenticatedSubjectIdentifier()).thenReturn("impersonatingActor");
+            // Set impersonating user.as AuthenticationResult subject.
+            authenticationResult.setSubject(impersonator);
+
+            // Mock Session data Cache Entry.
+            when(mockSessionDataCacheEntry.getLoggedInUser()).thenReturn(impersonator);
+
+            // Mock OAuthMessage.
+            when(oAuthMessage.getSessionDataCacheEntry()).thenReturn(mockSessionDataCacheEntry);
+            when(mockSessionDataCacheEntry.getParamMap()).thenReturn(requestParameterMap);
+
+            // Set impersonatedUser in the sessionContext.
+            when(sessionContext.getImpersonatedUser()).thenReturn(existingImpersonatedUserId);
+
+            // Mock OAuthAppDO.
+            OAuthAppDO oAuthAppDO = mock(OAuthAppDO.class);
+            AppInfoCache mockAppInfoCache = mock(AppInfoCache.class);
+            appInfoCache.when(AppInfoCache::getInstance).thenReturn(mockAppInfoCache);
+            when(mockAppInfoCache.getValueFromCache(anyString())).thenReturn(oAuthAppDO);
+
+            // Mock authorization context.
+            OAuth2AuthorizeReqDTO oAuth2AuthorizeReqDTO = mock(OAuth2AuthorizeReqDTO.class);
+            when(oAuth2AuthorizeReqDTO.getScopes()).thenReturn(new String[0]);
+            OAuthAuthzReqMessageContext authzReqMessageContext = mock(OAuthAuthzReqMessageContext.class);
+            when(authzReqMessageContext.getAuthorizationReqDTO()).thenReturn(oAuth2AuthorizeReqDTO);
+
+            // Mock impersonation validators.
+            ImpersonationContext resultContext = mock(ImpersonationContext.class);
+            when(resultContext.getImpersonationRequestDTO()).thenReturn(impersonationRequestDTO);
+            when(resultContext.isValidated()).thenReturn(validImpersonation);
+            when(impersonationRequestDTO.getoAuthAuthzReqMessageContext()).thenReturn(authzReqMessageContext);
+
+            // Mock ImpersonationMgtService.
+            ImpersonationMgtService impersonationMgtService = mock(ImpersonationMgtServiceImpl.class);
+            OAuth2ServiceComponentHolder.getInstance().setImpersonationMgtService(impersonationMgtService);
+            when(impersonationMgtService.validateImpersonationRequest(any(ImpersonationRequestDTO.class)))
+                    .thenReturn(resultContext);
+
+            try (MockedStatic<OAuth2Util> mockedOAuth2Util = mockStatic(OAuth2Util.class);) {
+                // Invoke impersonation validation.
+                when(impersonatedUser.getUserId()).thenReturn(impersonatedUserIdInReq);
+                mockedOAuth2Util.when(() -> OAuth2Util.getAuthenticatedUser(
+                        impersonatedUserIdInReq, impersonator.getTenantDomain(),
+                        dummyClientId)).thenReturn(impersonatedUser);
+
+                // Invoke handleSessionImpersonation method.
+                Class<?> clazz = OAuth2AuthzEndpoint.class;
+                Object authzEndpointObj = clazz.newInstance();
+                Method handleSessionImpersonation = authzEndpointObj.getClass().
+                        getDeclaredMethod("handleSessionImpersonation", OAuthMessage.class, String.class,
+                                OAuth2Parameters.class, AuthenticationResult.class);
+                handleSessionImpersonation.setAccessible(true);
+
+                if (!isUserSessionImpersonationEnabled) {
+                    handleSessionImpersonation.invoke(authzEndpointObj,
+                            oAuthMessage, "", oAuth2Parameters, authenticationResult);
+                    assertEquals("Impersonation should not be allowed when impersonation is disabled.",
+                            authenticationResult.getSubject().getUserId(), impersonator.getUserId());
+                    return;
+                }
+
+                if (rejectImpersonation) {
+                    assertThrows(Exception.class, () -> {
+                        handleSessionImpersonation.invoke(authzEndpointObj,
+                                oAuthMessage, "carbon.super", oAuth2Parameters, authenticationResult);
+                    });
+                } else {
+                    if (ssoImpersonation) {
+                        handleSessionImpersonation.invoke(authzEndpointObj,
+                                oAuthMessage, "carbon.super", oAuth2Parameters, authenticationResult);
+                        assertEquals(Objects.equals(authenticationResult.getSubject().getUserId(),
+                                impersonatedUser.getUserId()), validImpersonation);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/resources/testng.xml
@@ -26,6 +26,7 @@
             <class name="org.wso2.carbon.identity.oauth.endpoint.util.EndpointUtilTest" />
             <class name="org.wso2.carbon.identity.oauth.endpoint.util.OpenIDConnectUserRPStoreTest" />
             <class name="org.wso2.carbon.identity.oauth.endpoint.authz.OAuth2AuthzEndpointTest" />
+            <class name="org.wso2.carbon.identity.oauth.endpoint.authz.OAuth2AuthzEndpointImpersonationTest" />
             <class name="org.wso2.carbon.identity.oauth.endpoint.introspection.IntrospectionResponseBuilderTest" />
             <class name="org.wso2.carbon.identity.oauth.endpoint.introspection.OAuth2IntrospectionEndpointTest" />
             <class name="org.wso2.carbon.identity.oauth.endpoint.user.OpenIDConnectUserEndpointTest" />
@@ -41,6 +42,7 @@
             <class name="org.wso2.carbon.identity.oauth.endpoint.util.EndpointUtilTest" />
             <class name="org.wso2.carbon.identity.oauth.endpoint.util.OpenIDConnectUserRPStoreTest" />
             <class name="org.wso2.carbon.identity.oauth.endpoint.authz.OAuth2AuthzEndpointTest" />
+            <class name="org.wso2.carbon.identity.oauth.endpoint.authz.OAuth2AuthzEndpointImpersonationTest" />
             <class name="org.wso2.carbon.identity.oauth.endpoint.introspection.OAuth2IntrospectionEndpointTest" />
             <class name="org.wso2.carbon.identity.oauth.endpoint.user.OpenIDConnectUserEndpointTest" />
             <class name="org.wso2.carbon.identity.oauth.endpoint.oidcdiscovery.OIDCDiscoveryEndpointTest" />

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/AuthorizationHandlerManager.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/AuthorizationHandlerManager.java
@@ -663,6 +663,9 @@ public class AuthorizationHandlerManager {
         // load requested scopes
         authorizeRequestMessageContext.setRequestedScopes(authzReqDTO.getScopes());
 
+        // Set impersonation request details.
+        authorizeRequestMessageContext.setImpersonationRequest(authzReqDTO.isImpersonationRequest());
+
         return authorizeRequestMessageContext;
     }
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/impersonation/utils/Constants.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/impersonation/utils/Constants.java
@@ -25,6 +25,7 @@ package org.wso2.carbon.identity.oauth2.impersonation.utils;
 public class Constants {
 
     public static final String IMPERSONATION_SCOPE_NAME = "internal_user_impersonate";
+    public static final String IMPERSONATION_VALIDATION_REQUEST = "IMPERSONATION_VALIDATION_REQUEST";
     public static final String OAUTH_2 = "oauth2";
     public static final String ENABLE_EMAIL_NOTIFICATION = "EnableEmailNotification";
     public static final String IMPERSONATION_RESOURCE_TYPE_NAME = "IMPERSONATION_CONFIGURATION";

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuer.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuer.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.oauth2.token;
 
+import com.nimbusds.jwt.JWTClaimsSet;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
@@ -27,8 +28,10 @@ import org.apache.oltu.oauth2.common.error.OAuthError;
 import org.apache.oltu.oauth2.common.message.types.GrantType;
 import org.owasp.encoder.Encode;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.identity.application.authentication.framework.context.SessionContext;
 import org.wso2.carbon.identity.application.authentication.framework.exception.UserIdNotFoundException;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
 import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
 import org.wso2.carbon.identity.application.common.model.ClaimConfig;
 import org.wso2.carbon.identity.application.common.model.ClaimMapping;
@@ -72,6 +75,7 @@ import org.wso2.carbon.identity.oauth2.impersonation.models.ImpersonationNotific
 import org.wso2.carbon.identity.oauth2.impersonation.services.ImpersonationNotificationMgtService;
 import org.wso2.carbon.identity.oauth2.impersonation.services.ImpersonationNotificationMgtServiceImpl;
 import org.wso2.carbon.identity.oauth2.internal.OAuth2ServiceComponentHolder;
+import org.wso2.carbon.identity.oauth2.model.RequestParameter;
 import org.wso2.carbon.identity.oauth2.rar.util.AuthorizationDetailsUtils;
 import org.wso2.carbon.identity.oauth2.rar.validator.AuthorizationDetailsValidator;
 import org.wso2.carbon.identity.oauth2.rar.validator.DefaultAuthorizationDetailsValidator;
@@ -80,6 +84,7 @@ import org.wso2.carbon.identity.oauth2.token.bindings.TokenBinding;
 import org.wso2.carbon.identity.oauth2.token.handlers.grant.AuthorizationGrantHandler;
 import org.wso2.carbon.identity.oauth2.token.handlers.response.AccessTokenResponseHandler;
 import org.wso2.carbon.identity.oauth2.util.AuthzUtil;
+import org.wso2.carbon.identity.oauth2.util.OAuth2TokenUtil;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 import org.wso2.carbon.identity.oauth2.validators.DefaultOAuth2ScopeValidator;
 import org.wso2.carbon.identity.oauth2.validators.JDBCPermissionBasedInternalScopeValidator;
@@ -103,18 +108,23 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.apache.commons.lang.StringUtils.isNotBlank;
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.ACTOR_TOKEN;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.GrantTypes.REFRESH_TOKEN;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.GrantTypes.TOKEN_EXCHANGE;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.IMPERSONATING_ACTOR;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.LogConstants.InputKeys.IMPERSONATOR;
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.MAY_ACT;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OauthAppStates.APP_STATE_ACTIVE;
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.SUBJECT_TOKEN;
 import static org.wso2.carbon.identity.oauth2.OAuth2Constants.MAX_ALLOWED_LENGTH;
 import static org.wso2.carbon.identity.oauth2.Oauth2ScopeConstants.CONSOLE_SCOPE_PREFIX;
 import static org.wso2.carbon.identity.oauth2.Oauth2ScopeConstants.INTERNAL_SCOPE_PREFIX;
 import static org.wso2.carbon.identity.oauth2.Oauth2ScopeConstants.SYSTEM_SCOPE;
+import static org.wso2.carbon.identity.oauth2.device.constants.Constants.DEVICE_FLOW_GRANT_TYPE;
 import static org.wso2.carbon.identity.oauth2.util.OAuth2Util.EXTENDED_REFRESH_TOKEN_DEFAULT_TIME;
 import static org.wso2.carbon.identity.oauth2.util.OAuth2Util.INTERNAL_LOGIN_SCOPE;
 import static org.wso2.carbon.identity.oauth2.util.OAuth2Util.validateRequestTenantDomain;
@@ -188,6 +198,7 @@ public class AccessTokenIssuer {
         OAuthTokenReqMessageContext tokReqMsgCtx = new OAuthTokenReqMessageContext(tokenReqDTO);
         boolean isRefreshRequest = GrantType.REFRESH_TOKEN.toString().equals(grantType);
         boolean isCodeRequest = GrantType.AUTHORIZATION_CODE.toString().equals(grantType);
+        boolean isDeviceCodeRequest = DEVICE_FLOW_GRANT_TYPE.equals(grantType);
 
         if (isCodeRequest) {
 
@@ -204,6 +215,13 @@ public class AccessTokenIssuer {
                 tokReqMsgCtx.getOauth2AccessTokenReqDTO().setAccessTokenExtendedAttributes(
                         authorizationGrantCacheEntry.getAccessTokenExtensionDO());
             }
+            persistImpersonationInfoToTokenReqCtx(authorizationGrantCacheEntry, tokReqMsgCtx);
+        }
+
+        if (isDeviceCodeRequest) {
+            AuthorizationGrantCacheEntry authorizationGrantCacheEntry =
+                    getAuthzGrantCacheEntryFromDeviceCode(tokenReqDTO);
+            persistImpersonationInfoToTokenReqCtx(authorizationGrantCacheEntry, tokReqMsgCtx);
         }
 
         triggerPreListeners(tokenReqDTO, tokReqMsgCtx, isRefreshRequest);
@@ -383,6 +401,34 @@ public class AccessTokenIssuer {
         synchronized (syncLockString.intern()) {
             return validateGrantAndIssueToken(tokenReqDTO, tokReqMsgCtx, tokenRespDTO, authzGrantHandler,
                     tenantDomainOfApp, oAuthAppDO);
+        }
+    }
+
+    private AuthorizationGrantCacheEntry getAuthzGrantCacheEntryFromDeviceCode(OAuth2AccessTokenReqDTO tokenReqDTO) {
+
+        Optional<String> deviceCodeOptional = getDeviceCode(tokenReqDTO);
+        if (deviceCodeOptional.isPresent()) {
+            String deviceCode = deviceCodeOptional.get();
+            Optional<AuthorizationGrantCacheEntry> authorizationGrantCacheEntryOptional
+                    = getAuthzGrantCacheEntryFromDeviceCode(deviceCode);
+            return authorizationGrantCacheEntryOptional.orElse(null);
+        }
+        return null;
+    }
+
+    private void persistImpersonationInfoToTokenReqCtx(AuthorizationGrantCacheEntry authorizationGrantCacheEntry,
+                                                     OAuthTokenReqMessageContext tokReqMsgCtx) {
+
+        boolean isUserSessionImpersonationEnabled = OAuthServerConfiguration.getInstance()
+                .isUserSessionImpersonationEnabled();
+        if (!isUserSessionImpersonationEnabled) {
+            return;
+        }
+        // Set impersonation details into the token context before triggeringPreListeners.
+        if (authorizationGrantCacheEntry != null && authorizationGrantCacheEntry.getImpersonator() != null) {
+            tokReqMsgCtx.setImpersonationRequest(true);
+            // Mandatory when getting additional claims (may_act & sub).
+            tokReqMsgCtx.addProperty(IMPERSONATING_ACTOR, authorizationGrantCacheEntry.getImpersonator());
         }
     }
 
@@ -664,10 +710,50 @@ public class AccessTokenIssuer {
 
         // Write impersonation details to into the session context.
         if (!tokenRespDTO.isError() && tokReqMsgCtx.isImpersonationRequest() && TOKEN_EXCHANGE.equals(grantType)) {
-            notifyImpersonation(tokReqMsgCtx);
+            persistImpersonationInfoToSessionContext(tokenReqDTO, tenantDomainOfApp,
+                    tokReqMsgCtx.getAuthorizedUser().getTenantDomain(), tokenRespDTO, tokReqMsgCtx);
         }
 
         return tokenRespDTO;
+    }
+
+    private void persistImpersonationInfoToSessionContext(OAuth2AccessTokenReqDTO tokenReqDTO, String tenantDomain,
+                                                          String loginTenantDomain,
+                                                          OAuth2AccessTokenRespDTO tokenRespDTO,
+                                                          OAuthTokenReqMessageContext tokReqMsgCtx)
+            throws IdentityOAuth2Exception {
+
+        boolean isUserSessionImpersonationEnabled = OAuthServerConfiguration.getInstance()
+                .isUserSessionImpersonationEnabled();
+        if (!isUserSessionImpersonationEnabled) {
+            notifyImpersonation(tokReqMsgCtx);
+            return;
+        }
+        RequestParameter[] params = tokenReqDTO.getRequestParameters();
+        Map<String, String> requestParams = Arrays.stream(params).collect(Collectors.toMap(RequestParameter::getKey,
+                requestParam -> requestParam.getValue()[0]));
+        JWTClaimsSet claimsSetSubjectToken = OAuth2TokenUtil.getJWTClaimSet(requestParams.get(SUBJECT_TOKEN));
+        JWTClaimsSet claimsSetActorToken = OAuth2TokenUtil.getJWTClaimSet(requestParams.get(ACTOR_TOKEN));
+
+        if (claimsSetSubjectToken != null && claimsSetActorToken != null) {
+            if (claimsSetSubjectToken.getClaim(MAY_ACT) == null) {
+                throw new IdentityOAuth2Exception("may_act claim is not found in the subject token.");
+            }
+
+            String subClaim = claimsSetSubjectToken.getSubject();
+            String iskClaim = (String) claimsSetActorToken.getClaim(OAuthConstants.OIDCClaims.IDP_SESSION_KEY);
+
+            // Set session context data.
+            if (subClaim != null && iskClaim != null) {
+                SessionContext sessionContext = FrameworkUtils.getSessionContextFromCache(iskClaim, loginTenantDomain);
+                // Send notification only on session impersonation initiation.
+                if (sessionContext.getImpersonatedUser() == null) {
+                    notifyImpersonation(tokReqMsgCtx);
+                }
+                sessionContext.setImpersonatedUser(subClaim);
+                FrameworkUtils.addSessionContextToCache(iskClaim, sessionContext, tenantDomain, loginTenantDomain);
+            }
+        }
     }
 
     private void notifyImpersonation(OAuthTokenReqMessageContext tokReqMsgCtx)
@@ -703,9 +789,24 @@ public class AccessTokenIssuer {
                 authorizationGrantCacheEntry.setMappedRemoteClaims(cacheEntry
                         .getMappedRemoteClaims());
             }
+            persistImpersonationInfoToAuthzGrantCacheEntry(cacheEntry, authorizationGrantCacheEntry);
             return Optional.of(authorizationGrantCacheEntry);
         }
         return Optional.empty();
+    }
+
+    private void persistImpersonationInfoToAuthzGrantCacheEntry(DeviceAuthorizationGrantCacheEntry cacheEntry,
+                                                                AuthorizationGrantCacheEntry
+                                                                        authorizationGrantCacheEntry) {
+
+        boolean isUserSessionImpersonationEnabled = OAuthServerConfiguration.getInstance()
+                .isUserSessionImpersonationEnabled();
+        if (!isUserSessionImpersonationEnabled) {
+            return;
+        }
+        if (cacheEntry.getImpersonator() != null) {
+            authorizationGrantCacheEntry.setImpersonator(cacheEntry.getImpersonator());
+        }
     }
 
     private Optional<AuthorizationGrantCacheEntry> getAuthzGrantCacheEntryFromAuthzCode(OAuth2AccessTokenReqDTO

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AbstractAuthorizationGrantHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AbstractAuthorizationGrantHandler.java
@@ -618,14 +618,15 @@ public abstract class AbstractAuthorizationGrantHandler implements Authorization
             OAuthTokenReqMessageContext tokReqMsgCtx) {
 
         if (tokReqMsgCtx.isImpersonationRequest()) {
-            addExtendedAttribute(IMPERSONATING_ACTOR, tokReqMsgCtx.getProperty(IMPERSONATING_ACTOR).toString(),
+            accessTokenExtendedAttributes =
+                    addExtendedAttribute(IMPERSONATING_ACTOR, tokReqMsgCtx.getProperty(IMPERSONATING_ACTOR).toString(),
                     accessTokenExtendedAttributes);
         }
         // Add any new extended attributes here using @addExtendedAttribute.
         return accessTokenExtendedAttributes;
     }
 
-    private void addExtendedAttribute(String key, String value, AccessTokenExtendedAttributes
+    private AccessTokenExtendedAttributes addExtendedAttribute(String key, String value, AccessTokenExtendedAttributes
             accessTokenExtendedAttributes) {
 
         if (accessTokenExtendedAttributes == null) {
@@ -634,6 +635,7 @@ public abstract class AbstractAuthorizationGrantHandler implements Authorization
         if (key != null && value != null) {
             accessTokenExtendedAttributes.getParameters().put(key, value);
         }
+        return accessTokenExtendedAttributes;
     }
 
     private void updateMessageContextToCreateNewToken(OAuthTokenReqMessageContext tokReqMsgCtx, String consumerKey,


### PR DESCRIPTION
### Proposed changes in this pull request
> This PR will add impersonation details into relevant context and finally persist in the session context.

### Merge this PR after merging all of the below PRs:
- https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2767
- https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2768
- https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2769
- https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2770
- https://github.com/wso2-extensions/identity-oauth2-grant-token-exchange/pull/33
- https://github.com/wso2/carbon-identity-framework/pull/6678
- https://github.com/wso2-extensions/identity-carbon-auth-rest/pull/310
- https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2777
### Related Issues:
- https://github.com/wso2/product-is/issues/23462