### PR TITLE
Revamp the Console to Function in a Multi-Tenant Environment at All Times

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
@@ -23,6 +23,7 @@ import org.apache.cxf.interceptor.InInterceptors;
 import org.apache.oltu.oauth2.common.exception.OAuthProblemException;
 import org.apache.oltu.oauth2.common.exception.OAuthSystemException;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
+import org.wso2.carbon.identity.application.mgt.ApplicationConstants;
 import org.wso2.carbon.identity.base.IdentityException;
 import org.wso2.carbon.identity.client.attestation.filter.ClientAttestationProxy;
 import org.wso2.carbon.identity.client.attestation.mgt.model.ClientAttestationContext;
@@ -167,10 +168,12 @@ public class OAuth2AuthzEndpoint {
      */
     private boolean isSystemApplication(String tenantDomain, String clientID) {
 
-        boolean isConsoleRequest = StringUtils.equalsIgnoreCase(clientID, "CONSOLE") ||
-                StringUtils.equalsIgnoreCase(clientID, "CONSOLE_" + tenantDomain);
-        boolean isMyAccountRequest = StringUtils.equalsIgnoreCase(clientID, "MY_ACCOUNT") ||
-                StringUtils.equalsIgnoreCase(clientID, "MY_ACCOUNT_" + tenantDomain);
+        boolean isConsoleRequest = StringUtils.equalsIgnoreCase(clientID,
+                ApplicationConstants.CONSOLE_APPLICATION_CLIENT_ID) || StringUtils.equalsIgnoreCase(clientID,
+                ApplicationConstants.CONSOLE_APPLICATION_CLIENT_ID + "_" + tenantDomain);
+        boolean isMyAccountRequest = StringUtils.equalsIgnoreCase(clientID,
+                ApplicationConstants.MY_ACCOUNT_APPLICATION_CLIENT_ID) || StringUtils.equalsIgnoreCase(clientID,
+                ApplicationConstants.MY_ACCOUNT_APPLICATION_CLIENT_ID + "_" + tenantDomain);
 
         return isConsoleRequest || isMyAccountRequest;
     }

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
@@ -119,7 +119,7 @@ public class OAuth2AuthzEndpoint {
                     tenantDomain = EndpointUtil.getSPTenantDomainFromClientId(oAuthMessage.getClientId());
                     // Checks if the current application is a system app and sets the value to thread local
                     IdentityUtil.threadLocalProperties.get().put(IdentityCoreConstants.IS_SYSTEM_APPLICATION,
-                            IdentityTenantUtil.isSystemApplication(tenantDomain, oAuthMessage.getClientId()));
+                            isSystemApplication(tenantDomain, oAuthMessage.getClientId()));
                 } else if (oAuthMessage.getSessionDataCacheEntry() != null) {
                     OAuth2Parameters oauth2Params = AuthzUtil.getOauth2Params(oAuthMessage);
                     tenantDomain = oauth2Params.getTenantDomain();
@@ -156,6 +156,23 @@ public class OAuth2AuthzEndpoint {
                 FrameworkUtils.endTenantFlow();
             }
         }
+    }
+
+    /**
+     * Checks whether the current application is a system app.
+     *
+     * @param tenantDomain Tenant Domain.
+     * @param clientID Client ID.
+     * @return true if the application is a system app.
+     */
+    private boolean isSystemApplication(String tenantDomain, String clientID) {
+
+        boolean isConsoleRequest = StringUtils.equalsIgnoreCase(clientID, "CONSOLE") ||
+                StringUtils.equalsIgnoreCase(clientID, "CONSOLE_" + tenantDomain);
+        boolean isMyAccountRequest = StringUtils.equalsIgnoreCase(clientID, "MY_ACCOUNT") ||
+                StringUtils.equalsIgnoreCase(clientID, "MY_ACCOUNT_" + tenantDomain);
+
+        return isConsoleRequest || isMyAccountRequest;
     }
 
     @POST

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
@@ -26,7 +26,9 @@ import org.wso2.carbon.identity.application.authentication.framework.util.Framew
 import org.wso2.carbon.identity.base.IdentityException;
 import org.wso2.carbon.identity.client.attestation.filter.ClientAttestationProxy;
 import org.wso2.carbon.identity.client.attestation.mgt.model.ClientAttestationContext;
+import org.wso2.carbon.identity.core.util.IdentityCoreConstants;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.oauth.client.authn.filter.OAuthClientAuthenticatorProxy;
 import org.wso2.carbon.identity.oauth.common.OAuth2ErrorCodes;
 import org.wso2.carbon.identity.oauth.endpoint.OAuthRequestWrapper;
@@ -115,6 +117,9 @@ public class OAuth2AuthzEndpoint {
                 String tenantDomain = null;
                 if (StringUtils.isNotEmpty(oAuthMessage.getClientId())) {
                     tenantDomain = EndpointUtil.getSPTenantDomainFromClientId(oAuthMessage.getClientId());
+                    // Checks if the current application is a system app and sets the value to thread local
+                    IdentityUtil.threadLocalProperties.get().put(IdentityCoreConstants.IS_SYSTEM_APPLICATION,
+                            IdentityTenantUtil.isSystemApplication(tenantDomain, oAuthMessage.getClientId()));
                 } else if (oAuthMessage.getSessionDataCacheEntry() != null) {
                     OAuth2Parameters oauth2Params = AuthzUtil.getOauth2Params(oAuthMessage);
                     tenantDomain = oauth2Params.getTenantDomain();

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
@@ -120,7 +120,7 @@ public class OAuth2AuthzEndpoint {
                     tenantDomain = EndpointUtil.getSPTenantDomainFromClientId(oAuthMessage.getClientId());
                     // Checks if the current application is a system app and sets the value to thread local
                     IdentityUtil.threadLocalProperties.get().put(IdentityCoreConstants.IS_SYSTEM_APPLICATION,
-                            isSystemApplication(tenantDomain, oAuthMessage.getClientId()));
+                            IdentityTenantUtil.isSystemApplication(tenantDomain, oAuthMessage.getClientId()));
                 } else if (oAuthMessage.getSessionDataCacheEntry() != null) {
                     OAuth2Parameters oauth2Params = AuthzUtil.getOauth2Params(oAuthMessage);
                     tenantDomain = oauth2Params.getTenantDomain();
@@ -157,25 +157,6 @@ public class OAuth2AuthzEndpoint {
                 FrameworkUtils.endTenantFlow();
             }
         }
-    }
-
-    /**
-     * Checks whether the current application is a system app.
-     *
-     * @param tenantDomain Tenant Domain.
-     * @param clientID Client ID.
-     * @return true if the application is a system app.
-     */
-    private boolean isSystemApplication(String tenantDomain, String clientID) {
-
-        boolean isConsoleRequest = StringUtils.equalsIgnoreCase(clientID,
-                ApplicationConstants.CONSOLE_APPLICATION_CLIENT_ID) || StringUtils.equalsIgnoreCase(clientID,
-                ApplicationConstants.CONSOLE_APPLICATION_CLIENT_ID + "_" + tenantDomain);
-        boolean isMyAccountRequest = StringUtils.equalsIgnoreCase(clientID,
-                ApplicationConstants.MY_ACCOUNT_APPLICATION_CLIENT_ID) || StringUtils.equalsIgnoreCase(clientID,
-                ApplicationConstants.MY_ACCOUNT_APPLICATION_CLIENT_ID + "_" + tenantDomain);
-
-        return isConsoleRequest || isMyAccountRequest;
     }
 
     @POST

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
@@ -23,7 +23,6 @@ import org.apache.cxf.interceptor.InInterceptors;
 import org.apache.oltu.oauth2.common.exception.OAuthProblemException;
 import org.apache.oltu.oauth2.common.exception.OAuthSystemException;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
-import org.wso2.carbon.identity.application.mgt.ApplicationConstants;
 import org.wso2.carbon.identity.base.IdentityException;
 import org.wso2.carbon.identity.client.attestation.filter.ClientAttestationProxy;
 import org.wso2.carbon.identity.client.attestation.mgt.model.ClientAttestationContext;

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/OAuth2Constants.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/OAuth2Constants.java
@@ -52,8 +52,6 @@ public class OAuth2Constants {
     public static final String OAUTH_TOKEN_PERSISTENCE_ENABLE = "OAuth.TokenPersistence.Enable";
     public static final String OAUTH_CODE_PERSISTENCE_ENABLE = "OAuth.EnableAuthCodePersistence";
     public static final String OAUTH_ENABLE_REVOKE_TOKEN_HEADERS = "OAuth.EnableRevokeTokenHeadersInResponse";
-    public static final String CONSOLE_CLIENT_ID = "CONSOLE";
-    public static final String MY_ACCOUNT_CLIENT_ID = "MY_ACCOUNT";
     public static final String CONSOLE_CALLBACK_URL_FROM_SERVER_CONFIGS = "Console.CallbackURL";
     public static final String MY_ACCOUNT_CALLBACK_URL_FROM_SERVER_CONFIGS = "MyAccount.CallbackURL";
     public static final String TENANT_DOMAIN_PLACEHOLDER = "{TENANT_DOMAIN}";

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/OAuth2Constants.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/OAuth2Constants.java
@@ -52,6 +52,8 @@ public class OAuth2Constants {
     public static final String OAUTH_TOKEN_PERSISTENCE_ENABLE = "OAuth.TokenPersistence.Enable";
     public static final String OAUTH_CODE_PERSISTENCE_ENABLE = "OAuth.EnableAuthCodePersistence";
     public static final String OAUTH_ENABLE_REVOKE_TOKEN_HEADERS = "OAuth.EnableRevokeTokenHeadersInResponse";
+    public static final String CONSOLE_CLIENT_ID = "CONSOLE";
+    public static final String MY_ACCOUNT_CLIENT_ID = "MY_ACCOUNT";
     public static final String CONSOLE_CALLBACK_URL_FROM_SERVER_CONFIGS = "Console.CallbackURL";
     public static final String MY_ACCOUNT_CALLBACK_URL_FROM_SERVER_CONFIGS = "MyAccount.CallbackURL";
     public static final String TENANT_DOMAIN_PLACEHOLDER = "{TENANT_DOMAIN}";

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -4558,8 +4558,7 @@ public class OAuth2Util {
 
     public static String getIdTokenIssuer(String tenantDomain, boolean isMtlsRequest) throws IdentityOAuth2Exception {
 
-        if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled() && StringUtils.isEmpty(PrivilegedCarbonContext.
-                getThreadLocalCarbonContext().getApplicationResidentOrganizationId())) {
+        if (useTenantQualifiedURLs()) {
             try {
                 return isMtlsRequest ? OAuthURL.getOAuth2MTLSTokenEPUrl() :
                         ServiceURLBuilder.create().addPath(OAUTH2_TOKEN_EP_URL).build().getAbsolutePublicURL();
@@ -4576,7 +4575,7 @@ public class OAuth2Util {
     public static String getIdTokenIssuer(String tenantDomain, String clientId, boolean isMtlsRequest)
             throws IdentityOAuth2Exception {
 
-        if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled() || IdentityTenantUtil.isConsoleAppRequest()) {
+        if (useTenantQualifiedURLs()) {
             try {
                 return isMtlsRequest ? OAuthURL.getOAuth2MTLSTokenEPUrl() :
                         ServiceURLBuilder.create().addPath(OAUTH2_TOKEN_EP_URL).setSkipDomainBranding(
@@ -4589,6 +4588,18 @@ public class OAuth2Util {
         } else {
             return getIssuerLocation(tenantDomain);
         }
+    }
+
+    /**
+     * Used to check if tenant qualified URLs should be used to access resources.
+     *
+     * Console and My account applications in each tenant should operate in a tenanted environment at all times.
+     * @return if tenant qualified URLs should be used or not.
+     */
+    private static boolean useTenantQualifiedURLs() {
+
+        return IdentityTenantUtil.isTenantQualifiedUrlsEnabled() || IdentityTenantUtil.isConsoleAppRequest()
+                || IdentityTenantUtil.isMyAccountAppRequest();
     }
 
     /**

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -1515,12 +1515,35 @@ public class OAuth2Util {
                     IdentityUtil.getProperty(OAuthConstants.MTLS_HOSTNAME));
         }
 
+        /**
+         * This method is used to get token endpoint URL when mTLS is enabled.
+         *
+         * @return token endpoint URL when mTLS is enabled.
+         */
         public static String getOAuth2MTLSTokenEPUrl() {
 
             return buildUrlWithHostname(OAUTH2_TOKEN_EP_URL,
                     OAuthServerConfiguration.getInstance()::getOAuth2TokenEPUrl,
                     OAuthServerConfiguration.getInstance()::getOauth2TokenEPUrlV2,
                     IdentityUtil.getProperty(OAuthConstants.MTLS_HOSTNAME));
+        }
+
+        /**
+         * This method is used to get token endpoint URL when mTLS is enabled.
+         * Tenant qualified token endpoint URL will be returned if ‘tenant_context.enable_tenant_qualified_urls’
+         * mode is set in deployment.toml, or if the request originates from a system application.
+         *
+         * @param clientID client ID.
+         * @param tenantDomain tenant domain.
+         * @return token endpoint URL when mTLS is enabled.
+         */
+        public static String getOAuth2MTLSTokenEPUrl(String clientID, String tenantDomain) {
+
+            return buildUrlWithHostname(OAUTH2_TOKEN_EP_URL,
+                    OAuthServerConfiguration.getInstance()::getOAuth2TokenEPUrl,
+                    OAuthServerConfiguration.getInstance()::getOauth2TokenEPUrlV2,
+                    IdentityUtil.getProperty(OAuthConstants.MTLS_HOSTNAME),
+                    clientID, tenantDomain);
         }
 
         /**
@@ -1764,6 +1787,36 @@ public class OAuth2Util {
     }
 
     /**
+     * Builds a URL with a given context in both the tenant-qualified url supported mode and the legacy mode.
+     * Gives precedence to the file configurations in the legacy mode except for system applications.
+     * Returns the absolute URL build from the default context in the tenant-qualified url supported mode.
+     * When the legacy mode is enabled, system applications will still function in tenanted environment to ensure
+     * tenant level separation for non-SaaS console and my account.
+     *
+     * @param defaultContext              Default URL context.
+     * @param getValueFromFileBasedConfig File-based Configuration.
+     * @param hostname                    hostname of the service
+     * @return Absolute URL.
+     */
+    private static String buildUrlWithHostname(String defaultContext, Supplier<String> getValueFromFileBasedConfig,
+                                               Supplier<String> getValueFromFileBasedConfigV2, String hostname,
+                                               String clientID, String tenantDomain) {
+
+        String oauth2EndpointURLInFile = null;
+        String oauth2EndpointURLV2InFile = null;
+        if (getValueFromFileBasedConfig != null) {
+            oauth2EndpointURLInFile = getValueFromFileBasedConfig.get();
+        }
+        if (getValueFromFileBasedConfigV2 != null) {
+            oauth2EndpointURLV2InFile = getValueFromFileBasedConfigV2.get();
+        }
+        return hostname != null ?
+                buildServiceUrlWithHostname(defaultContext, oauth2EndpointURLInFile, oauth2EndpointURLV2InFile,
+                        hostname, clientID, tenantDomain) :
+                buildServiceUrl(defaultContext, oauth2EndpointURLInFile, oauth2EndpointURLV2InFile);
+    }
+
+    /**
      * Returns the public service url given the default context and the url picked from the configuration based on
      * the 'tenant_context.enable_tenant_qualified_urls' mode set in deployment.toml.
      *
@@ -1847,6 +1900,46 @@ public class OAuth2Util {
                                                      String oauth2EndpointURLInFileV2, String hostname) {
 
         if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled()) {
+            if (StringUtils.isNotBlank(oauth2EndpointURLInFileV2)) {
+                return oauth2EndpointURLInFileV2;
+            }
+            try {
+                String organizationId = PrivilegedCarbonContext.getThreadLocalCarbonContext().getOrganizationId();
+                return ServiceURLBuilder.create().addPath(defaultContext).setOrganization(organizationId)
+                        .build(hostname).getAbsolutePublicURL();
+            } catch (URLBuilderException e) {
+                throw new OAuthRuntimeException("Error while building url for context: " + defaultContext, e);
+            }
+        } else if (StringUtils.isNotBlank(oauth2EndpointURLInFile)) {
+            // Use the value configured in the file.
+            return oauth2EndpointURLInFile;
+        }
+        // Use the default context.
+        try {
+            return ServiceURLBuilder.create().addPath(defaultContext).build(hostname).getAbsolutePublicURL();
+        } catch (URLBuilderException e) {
+            throw new OAuthRuntimeException("Error while building url for context: " + defaultContext, e);
+        }
+    }
+
+    /**
+     * Builds the public service URL using the default context path.
+     * Tenant qualified service URL will be returned if ‘tenant_context.enable_tenant_qualified_urls’ mode is set
+     * in deployment.toml, or if the request originates from a system application.
+     *
+     * @param defaultContext          default url context path.
+     * @param oauth2EndpointURLInFile url picked from the file configuration.
+     * @param oauth2EndpointURLInFileV2 v2 url picked from the file configuration.
+     * @param hostname                hostname of the service.
+     * @param clientID clientID of the application.
+     * @param tenantDomain tenant domain.
+     * @return absolute public url of the service.
+     */
+    public static String buildServiceUrlWithHostname(String defaultContext, String oauth2EndpointURLInFile,
+                                                     String oauth2EndpointURLInFileV2, String hostname,
+                                                     String clientID, String tenantDomain) {
+
+        if (useTenantQualifiedURLs(clientID, tenantDomain)) {
             if (StringUtils.isNotBlank(oauth2EndpointURLInFileV2)) {
                 return oauth2EndpointURLInFileV2;
             }
@@ -4558,7 +4651,7 @@ public class OAuth2Util {
 
     public static String getIdTokenIssuer(String tenantDomain, boolean isMtlsRequest) throws IdentityOAuth2Exception {
 
-        if (useTenantQualifiedURLs()) {
+        if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled()) {
             try {
                 return isMtlsRequest ? OAuthURL.getOAuth2MTLSTokenEPUrl() :
                         ServiceURLBuilder.create().addPath(OAUTH2_TOKEN_EP_URL).build().getAbsolutePublicURL();
@@ -4575,9 +4668,9 @@ public class OAuth2Util {
     public static String getIdTokenIssuer(String tenantDomain, String clientId, boolean isMtlsRequest)
             throws IdentityOAuth2Exception {
 
-        if (useTenantQualifiedURLs()) {
+        if (useTenantQualifiedURLs(clientId, tenantDomain)) {
             try {
-                return isMtlsRequest ? OAuthURL.getOAuth2MTLSTokenEPUrl() :
+                return isMtlsRequest ? OAuthURL.getOAuth2MTLSTokenEPUrl(clientId, tenantDomain) :
                         ServiceURLBuilder.create().addPath(OAUTH2_TOKEN_EP_URL).setSkipDomainBranding(
                                 PORTAL_APP_IDS.contains(clientId)).build().getAbsolutePublicURL();
             } catch (URLBuilderException e) {
@@ -4591,16 +4684,26 @@ public class OAuth2Util {
     }
 
     /**
-     * Used to check if tenant qualified URLs should be used to access resources.
-     *
+     * Use to check if tenant qualified URLs should be used to access resources.
      * Console and My Account applications in each tenant should continue to function in a multi-tenant environment
      * even if tenant-qualified URLs are disabled.
-     * @return if tenant qualified URLs should be used or not.
+     *
+     * @param clientID client ID.
+     * @param tenantDomain tenant domain.
+     * @return true if tenant qualified URLs should be used.
      */
-    private static boolean useTenantQualifiedURLs() {
+    private static boolean useTenantQualifiedURLs(String clientID, String tenantDomain) {
 
-        return IdentityTenantUtil.isTenantQualifiedUrlsEnabled() || IdentityTenantUtil.isConsoleAppRequest()
-                || IdentityTenantUtil.isMyAccountAppRequest();
+        if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled()) {
+            return true;
+        }
+
+        boolean isConsoleRequest = StringUtils.equalsIgnoreCase(clientID, OAuth2Constants.CONSOLE_CLIENT_ID) ||
+                StringUtils.equalsIgnoreCase(clientID, OAuth2Constants.CONSOLE_CLIENT_ID + "_" + tenantDomain);
+        boolean isMyAccountRequest = StringUtils.equalsIgnoreCase(clientID, OAuth2Constants.MY_ACCOUNT_CLIENT_ID) ||
+                StringUtils.equalsIgnoreCase(clientID, OAuth2Constants.MY_ACCOUNT_CLIENT_ID + "_" + tenantDomain);
+
+        return isConsoleRequest || isMyAccountRequest;
     }
 
     /**

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -4576,7 +4576,7 @@ public class OAuth2Util {
     public static String getIdTokenIssuer(String tenantDomain, String clientId, boolean isMtlsRequest)
             throws IdentityOAuth2Exception {
 
-        if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled()) {
+        if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled() || IdentityTenantUtil.isConsoleAppRequest()) {
             try {
                 return isMtlsRequest ? OAuthURL.getOAuth2MTLSTokenEPUrl() :
                         ServiceURLBuilder.create().addPath(OAUTH2_TOKEN_EP_URL).setSkipDomainBranding(

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -4593,7 +4593,8 @@ public class OAuth2Util {
     /**
      * Used to check if tenant qualified URLs should be used to access resources.
      *
-     * Console and My account applications in each tenant should operate in a tenanted environment at all times.
+     * Console and My Account applications in each tenant should continue to function in a multi-tenant environment
+     * even if tenant-qualified URLs are disabled.
      * @return if tenant qualified URLs should be used or not.
      */
     private static boolean useTenantQualifiedURLs() {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -1797,7 +1797,7 @@ public class OAuth2Util {
     public static String buildServiceUrl(String defaultContext, String oauth2EndpointURLInFile,
                                          String oauth2EndpointURLV2InFile) {
 
-        if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled()) {
+        if (IdentityTenantUtil.shouldUseTenantQualifiedURLs()) {
             if (StringUtils.isNotBlank(oauth2EndpointURLV2InFile)) {
                 return oauth2EndpointURLV2InFile;
             }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -4563,7 +4563,8 @@ public class OAuth2Util {
 
     public static String getIdTokenIssuer(String tenantDomain, boolean isMtlsRequest) throws IdentityOAuth2Exception {
 
-        if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled()) {
+        if (IdentityTenantUtil.shouldUseTenantQualifiedURLs() && StringUtils.isEmpty(PrivilegedCarbonContext.
+                getThreadLocalCarbonContext().getApplicationResidentOrganizationId())) {
             try {
                 return isMtlsRequest ? OAuthURL.getOAuth2MTLSTokenEPUrl() :
                         ServiceURLBuilder.create().addPath(OAUTH2_TOKEN_EP_URL).build().getAbsolutePublicURL();

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -4596,29 +4596,6 @@ public class OAuth2Util {
     }
 
     /**
-     * Use to check if tenant qualified URLs should be used to access resources.
-     * Console and My Account applications in each tenant should continue to function in a multi-tenant environment
-     * even if tenant-qualified URLs are disabled.
-     *
-     * @param clientID client ID.
-     * @param tenantDomain tenant domain.
-     * @return true if tenant qualified URLs should be used.
-     */
-    private static boolean useTenantQualifiedURLs(String clientID, String tenantDomain) {
-
-        if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled()) {
-            return true;
-        }
-
-        boolean isConsoleRequest = StringUtils.equalsIgnoreCase(clientID, OAuth2Constants.CONSOLE_CLIENT_ID) ||
-                StringUtils.equalsIgnoreCase(clientID, OAuth2Constants.CONSOLE_CLIENT_ID + "_" + tenantDomain);
-        boolean isMyAccountRequest = StringUtils.equalsIgnoreCase(clientID, OAuth2Constants.MY_ACCOUNT_CLIENT_ID) ||
-                StringUtils.equalsIgnoreCase(clientID, OAuth2Constants.MY_ACCOUNT_CLIENT_ID + "_" + tenantDomain);
-
-        return isConsoleRequest || isMyAccountRequest;
-    }
-
-    /**
      * Used to get the issuer url for a given tenant.
      *
      * @param tenantDomain Tenant domain.

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/DefaultIDTokenBuilder.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/DefaultIDTokenBuilder.java
@@ -33,6 +33,9 @@ import org.wso2.carbon.base.MultitenantConstants;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.application.authentication.framework.AuthenticationMethodNameTranslator;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
+import org.wso2.carbon.identity.core.util.IdentityCoreConstants;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.oauth.cache.AuthorizationGrantCache;
 import org.wso2.carbon.identity.oauth.cache.AuthorizationGrantCacheEntry;
 import org.wso2.carbon.identity.oauth.cache.AuthorizationGrantCacheKey;
@@ -112,6 +115,10 @@ public class DefaultIDTokenBuilder implements org.wso2.carbon.identity.openidcon
                                OAuth2AccessTokenRespDTO tokenRespDTO) throws IdentityOAuth2Exception {
         String clientId = tokenReqMsgCtxt.getOauth2AccessTokenReqDTO().getClientId();
         String spTenantDomain = getSpTenantDomain(tokenReqMsgCtxt);
+        if (StringUtils.isNotEmpty(spTenantDomain) && StringUtils.isNotEmpty(clientId)) {
+            IdentityUtil.threadLocalProperties.get().put(IdentityCoreConstants.IS_SYSTEM_APPLICATION,
+                    IdentityTenantUtil.isSystemApplication(spTenantDomain, clientId));
+        }
         String requestURL = tokenReqMsgCtxt.getOauth2AccessTokenReqDTO().getHttpServletRequestWrapper()
                 .getRequestURL().toString();
         String idTokenIssuer = OAuth2Util.getIdTokenIssuer(spTenantDomain, clientId,

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/DefaultIDTokenBuilder.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/DefaultIDTokenBuilder.java
@@ -118,7 +118,7 @@ public class DefaultIDTokenBuilder implements org.wso2.carbon.identity.openidcon
         // Checks if the current application is a system app and sets the value to thread local
         if (StringUtils.isNotEmpty(spTenantDomain) && StringUtils.isNotEmpty(clientId)) {
             IdentityUtil.threadLocalProperties.get().put(IdentityCoreConstants.IS_SYSTEM_APPLICATION,
-                    IdentityTenantUtil.isSystemApplication(spTenantDomain, clientId));
+                    isSystemApplication(spTenantDomain, clientId));
         }
         String requestURL = tokenReqMsgCtxt.getOauth2AccessTokenReqDTO().getHttpServletRequestWrapper()
                 .getRequestURL().toString();
@@ -345,6 +345,23 @@ public class DefaultIDTokenBuilder implements org.wso2.carbon.identity.openidcon
 
         return getIDToken(clientId, spTenantDomain, jwtClaimsSet, oAuthAppDO,
                 getSigningTenantDomain(authzReqMessageContext), idTokenSignatureAlgorithm);
+    }
+
+    /**
+     * Checks whether the current application is a system app.
+     *
+     * @param tenantDomain Tenant Domain.
+     * @param clientID Client ID.
+     * @return true if the application is a system app.
+     */
+    private boolean isSystemApplication(String tenantDomain, String clientID) {
+
+        boolean isConsoleRequest = StringUtils.equalsIgnoreCase(clientID, "CONSOLE") ||
+                StringUtils.equalsIgnoreCase(clientID, "CONSOLE_" + tenantDomain);
+        boolean isMyAccountRequest = StringUtils.equalsIgnoreCase(clientID, "MY_ACCOUNT") ||
+                StringUtils.equalsIgnoreCase(clientID, "MY_ACCOUNT_" + tenantDomain);
+
+        return isConsoleRequest || isMyAccountRequest;
     }
 
     private String getIDToken(String clientId, String spTenantDomain, JWTClaimsSet jwtClaimsSet, OAuthAppDO oAuthAppDO,

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/DefaultIDTokenBuilder.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/DefaultIDTokenBuilder.java
@@ -115,6 +115,7 @@ public class DefaultIDTokenBuilder implements org.wso2.carbon.identity.openidcon
                                OAuth2AccessTokenRespDTO tokenRespDTO) throws IdentityOAuth2Exception {
         String clientId = tokenReqMsgCtxt.getOauth2AccessTokenReqDTO().getClientId();
         String spTenantDomain = getSpTenantDomain(tokenReqMsgCtxt);
+        // Checks if the current application is a system app and sets the value to thread local
         if (StringUtils.isNotEmpty(spTenantDomain) && StringUtils.isNotEmpty(clientId)) {
             IdentityUtil.threadLocalProperties.get().put(IdentityCoreConstants.IS_SYSTEM_APPLICATION,
                     IdentityTenantUtil.isSystemApplication(spTenantDomain, clientId));

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/DefaultIDTokenBuilder.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/DefaultIDTokenBuilder.java
@@ -33,8 +33,8 @@ import org.wso2.carbon.base.MultitenantConstants;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.application.authentication.framework.AuthenticationMethodNameTranslator;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
+import org.wso2.carbon.identity.application.mgt.ApplicationConstants;
 import org.wso2.carbon.identity.core.util.IdentityCoreConstants;
-import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.oauth.cache.AuthorizationGrantCache;
 import org.wso2.carbon.identity.oauth.cache.AuthorizationGrantCacheEntry;
@@ -356,10 +356,12 @@ public class DefaultIDTokenBuilder implements org.wso2.carbon.identity.openidcon
      */
     private boolean isSystemApplication(String tenantDomain, String clientID) {
 
-        boolean isConsoleRequest = StringUtils.equalsIgnoreCase(clientID, "CONSOLE") ||
-                StringUtils.equalsIgnoreCase(clientID, "CONSOLE_" + tenantDomain);
-        boolean isMyAccountRequest = StringUtils.equalsIgnoreCase(clientID, "MY_ACCOUNT") ||
-                StringUtils.equalsIgnoreCase(clientID, "MY_ACCOUNT_" + tenantDomain);
+        boolean isConsoleRequest = StringUtils.equalsIgnoreCase(clientID,
+                ApplicationConstants.CONSOLE_APPLICATION_CLIENT_ID) || StringUtils.equalsIgnoreCase(clientID,
+                ApplicationConstants.CONSOLE_APPLICATION_CLIENT_ID + "_" + tenantDomain);
+        boolean isMyAccountRequest = StringUtils.equalsIgnoreCase(clientID,
+                ApplicationConstants.MY_ACCOUNT_APPLICATION_CLIENT_ID) || StringUtils.equalsIgnoreCase(clientID,
+                ApplicationConstants.MY_ACCOUNT_APPLICATION_CLIENT_ID + "_" + tenantDomain);
 
         return isConsoleRequest || isMyAccountRequest;
     }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/DefaultIDTokenBuilder.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/DefaultIDTokenBuilder.java
@@ -35,6 +35,7 @@ import org.wso2.carbon.identity.application.authentication.framework.Authenticat
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
 import org.wso2.carbon.identity.application.mgt.ApplicationConstants;
 import org.wso2.carbon.identity.core.util.IdentityCoreConstants;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.oauth.cache.AuthorizationGrantCache;
 import org.wso2.carbon.identity.oauth.cache.AuthorizationGrantCacheEntry;
@@ -118,7 +119,7 @@ public class DefaultIDTokenBuilder implements org.wso2.carbon.identity.openidcon
         // Checks if the current application is a system app and sets the value to thread local
         if (StringUtils.isNotEmpty(spTenantDomain) && StringUtils.isNotEmpty(clientId)) {
             IdentityUtil.threadLocalProperties.get().put(IdentityCoreConstants.IS_SYSTEM_APPLICATION,
-                    isSystemApplication(spTenantDomain, clientId));
+                    IdentityTenantUtil.isSystemApplication(spTenantDomain, clientId));
         }
         String requestURL = tokenReqMsgCtxt.getOauth2AccessTokenReqDTO().getHttpServletRequestWrapper()
                 .getRequestURL().toString();
@@ -345,25 +346,6 @@ public class DefaultIDTokenBuilder implements org.wso2.carbon.identity.openidcon
 
         return getIDToken(clientId, spTenantDomain, jwtClaimsSet, oAuthAppDO,
                 getSigningTenantDomain(authzReqMessageContext), idTokenSignatureAlgorithm);
-    }
-
-    /**
-     * Checks whether the current application is a system app.
-     *
-     * @param tenantDomain Tenant Domain.
-     * @param clientID Client ID.
-     * @return true if the application is a system app.
-     */
-    private boolean isSystemApplication(String tenantDomain, String clientID) {
-
-        boolean isConsoleRequest = StringUtils.equalsIgnoreCase(clientID,
-                ApplicationConstants.CONSOLE_APPLICATION_CLIENT_ID) || StringUtils.equalsIgnoreCase(clientID,
-                ApplicationConstants.CONSOLE_APPLICATION_CLIENT_ID + "_" + tenantDomain);
-        boolean isMyAccountRequest = StringUtils.equalsIgnoreCase(clientID,
-                ApplicationConstants.MY_ACCOUNT_APPLICATION_CLIENT_ID) || StringUtils.equalsIgnoreCase(clientID,
-                ApplicationConstants.MY_ACCOUNT_APPLICATION_CLIENT_ID + "_" + tenantDomain);
-
-        return isConsoleRequest || isMyAccountRequest;
     }
 
     private String getIDToken(String clientId, String spTenantDomain, JWTClaimsSet jwtClaimsSet, OAuthAppDO oAuthAppDO,

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/DefaultIDTokenBuilder.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/DefaultIDTokenBuilder.java
@@ -33,7 +33,6 @@ import org.wso2.carbon.base.MultitenantConstants;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.application.authentication.framework.AuthenticationMethodNameTranslator;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
-import org.wso2.carbon.identity.application.mgt.ApplicationConstants;
 import org.wso2.carbon.identity.core.util.IdentityCoreConstants;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/util/OAuth2UtilTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/util/OAuth2UtilTest.java
@@ -1296,6 +1296,8 @@ public class OAuth2UtilTest {
                      mockStatic(IdentityApplicationManagementUtil.class)) {
             identityTenantUtil.when(IdentityTenantUtil::isTenantQualifiedUrlsEnabled)
                     .thenReturn(enableTenantURLSupport);
+            identityTenantUtil.when(IdentityTenantUtil::shouldUseTenantQualifiedURLs)
+                    .thenReturn(enableTenantURLSupport);
             identityTenantUtil.when(IdentityTenantUtil::getTenantDomainFromContext).thenReturn(tenantDomain);
             PrivilegedCarbonContext mockPrivilegedCarbonContext = mock(PrivilegedCarbonContext.class);
             privilegedCarbonContext.when(
@@ -1432,6 +1434,7 @@ public class OAuth2UtilTest {
 
         when(oauthServerConfigurationMock.getOAuth2JWKSPageUrl()).thenReturn(configUrl);
         identityTenantUtil.when(IdentityTenantUtil::isTenantQualifiedUrlsEnabled).thenReturn(enableTenantURLSupport);
+        identityTenantUtil.when(IdentityTenantUtil::shouldUseTenantQualifiedURLs).thenReturn(enableTenantURLSupport);
         identityTenantUtil.when(IdentityTenantUtil::getTenantDomainFromContext).thenReturn(tenantDomain);
         lenient().when(PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain())
                 .thenReturn("carbon.super");
@@ -1468,6 +1471,7 @@ public class OAuth2UtilTest {
 
         when(oauthServerConfigurationMock.getOAuth2DCREPUrl()).thenReturn(configUrl);
         identityTenantUtil.when(IdentityTenantUtil::isTenantQualifiedUrlsEnabled).thenReturn(enableTenantURLSupport);
+        identityTenantUtil.when(IdentityTenantUtil::shouldUseTenantQualifiedURLs).thenReturn(enableTenantURLSupport);
         identityTenantUtil.when(IdentityTenantUtil::getTenantDomainFromContext).thenReturn(tenantDomain);
         lenient().when(PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain())
                 .thenReturn("carbon.super");
@@ -1533,6 +1537,7 @@ public class OAuth2UtilTest {
 
         when(oauthServerConfigurationMock.getOidcWebFingerEPUrl()).thenReturn(configUrl);
         identityTenantUtil.when(IdentityTenantUtil::isTenantQualifiedUrlsEnabled).thenReturn(enableTenantURLSupport);
+        identityTenantUtil.when(IdentityTenantUtil::shouldUseTenantQualifiedURLs).thenReturn(enableTenantURLSupport);
         identityTenantUtil.when(IdentityTenantUtil::getTenantDomainFromContext).thenReturn(tenantDomain);
         lenient().when(PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain())
                 .thenReturn("carbon.super");
@@ -1588,6 +1593,7 @@ public class OAuth2UtilTest {
 
         when(oauthServerConfigurationMock.getOauth2UserInfoEPUrl()).thenReturn(configUrl);
         identityTenantUtil.when(IdentityTenantUtil::isTenantQualifiedUrlsEnabled).thenReturn(enableTenantURLSupport);
+        identityTenantUtil.when(IdentityTenantUtil::shouldUseTenantQualifiedURLs).thenReturn(enableTenantURLSupport);
         identityTenantUtil.when(IdentityTenantUtil::getTenantDomainFromContext).thenReturn(tenantDomain);
         lenient().when(PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain())
                 .thenReturn("carbon.super");
@@ -1634,6 +1640,7 @@ public class OAuth2UtilTest {
 
         when(oauthServerConfigurationMock.getOauth2RevocationEPUrl()).thenReturn(configUrl);
         identityTenantUtil.when(IdentityTenantUtil::isTenantQualifiedUrlsEnabled).thenReturn(enableTenantURLSupport);
+        identityTenantUtil.when(IdentityTenantUtil::shouldUseTenantQualifiedURLs).thenReturn(enableTenantURLSupport);
         identityTenantUtil.when(IdentityTenantUtil::getTenantDomainFromContext).thenReturn(tenantDomain);
         lenient().when(PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain())
                 .thenReturn("carbon.super");
@@ -1681,6 +1688,7 @@ public class OAuth2UtilTest {
 
         when(oauthServerConfigurationMock.getOauth2IntrospectionEPUrl()).thenReturn(configUrl);
         identityTenantUtil.when(IdentityTenantUtil::isTenantQualifiedUrlsEnabled).thenReturn(enableTenantURLSupport);
+        identityTenantUtil.when(IdentityTenantUtil::shouldUseTenantQualifiedURLs).thenReturn(enableTenantURLSupport);
         identityTenantUtil.when(IdentityTenantUtil::getTenantDomainFromContext).thenReturn(tenantDomain);
         lenient().when(PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain())
                 .thenReturn("carbon.super");

--- a/components/org.wso2.carbon.identity.oidc.session/src/test/java/org/wso2/carbon/identity/oidc/session/backchannellogout/DefaultLogoutTokenBuilderTest.java
+++ b/components/org.wso2.carbon.identity.oidc.session/src/test/java/org/wso2/carbon/identity/oidc/session/backchannellogout/DefaultLogoutTokenBuilderTest.java
@@ -173,6 +173,8 @@ public class DefaultLogoutTokenBuilderTest {
 
             identityTenantUtilMockedStatic.when(IdentityTenantUtil::isTenantQualifiedUrlsEnabled)
                     .thenReturn(true);
+            identityTenantUtilMockedStatic.when(IdentityTenantUtil::shouldUseTenantQualifiedURLs)
+                    .thenReturn(true);
             organizationManagementUtilMockedStatic.when(() -> OrganizationManagementUtil
                             .isOrganization(appDO.getUser().getTenantDomain())).thenReturn(isOrganization);
             oAuthServerConfigurationMockedStatic.when(OAuthServerConfiguration::getInstance)

--- a/pom.xml
+++ b/pom.xml
@@ -967,7 +967,7 @@
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!-- Carbon Identity Framework version -->
-        <carbon.identity.framework.version>7.8.113</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.8.140</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.25.234, 8.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
         <identity.oauth.xacml.version.range>[2.0.0, 3.0.0)</identity.oauth.xacml.version.range>

--- a/pom.xml
+++ b/pom.xml
@@ -967,7 +967,7 @@
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!-- Carbon Identity Framework version -->
-        <carbon.identity.framework.version>7.8.113</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.8.141</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.25.234, 8.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
         <identity.oauth.xacml.version.range>[2.0.0, 3.0.0)</identity.oauth.xacml.version.range>

--- a/pom.xml
+++ b/pom.xml
@@ -967,7 +967,7 @@
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!-- Carbon Identity Framework version -->
-        <carbon.identity.framework.version>7.8.140</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.8.113</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.25.234, 8.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
         <identity.oauth.xacml.version.range>[2.0.0, 3.0.0)</identity.oauth.xacml.version.range>


### PR DESCRIPTION
### Purpose
This PR addresses the requirement to consistently handle Console applications as tenant-qualified across all tenants, irrespective of the `enableTenantQualifiedURLs` configuration. This aligns with the initiative [1] to support non-tenant-qualified URLs post-7.0.0 ensuring the backward compatibility of the product.

With this change, the Console will continue operating within a tenant-aware context, even if non-tenant-qualified URLs are enabled. This ensures consistent tenant-level isolation.

The following is the toml configuration to enable tenant-qualified URLs.
```
[tenant_context]
enable_tenant_qualified_urls = false
```
### Related PRs (Merge First)
- https://github.com/wso2/carbon-identity-framework/pull/6696
- https://github.com/wso2/carbon-identity-framework/pull/6723

NOTE: The PR builder is failing due to the above dependency.

### Related Issue
- [1] https://github.com/wso2/product-is/issues/23710