### PR TITLE
Pass domain to account lock service

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/impersonation/validators/UserAccountStatusValidator.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/impersonation/validators/UserAccountStatusValidator.java
@@ -68,7 +68,7 @@ public class UserAccountStatusValidator implements ImpersonationValidator {
         String subjectUserName = subjectUser.getUserName();
         String domainName = subjectUser.getUserStoreDomain();
 
-        if (isUserAccountLocked(subjectUserName, tenantDomain)
+        if (isUserAccountLocked(subjectUserName, tenantDomain, domainName)
                 || isUserAccountDisabled(subjectUserName, tenantDomain, domainName)) {
             String errorMessage = String.format("Cannot impersonate an inactive user account: %s.", subjectUserName);
             impersonationContext.setValidated(false);
@@ -81,12 +81,13 @@ public class UserAccountStatusValidator implements ImpersonationValidator {
         return impersonationContext;
     }
 
-    private boolean isUserAccountLocked(String username, String tenantDomain)
+    private boolean isUserAccountLocked(String username, String tenantDomain, String domainName)
             throws IdentityOAuth2Exception {
 
         if (username != null && tenantDomain != null) {
             try {
-                return OAuth2ServiceComponentHolder.getAccountLockService().isAccountLocked(username, tenantDomain);
+                return OAuth2ServiceComponentHolder.getAccountLockService().isAccountLocked(
+                        username, tenantDomain, domainName);
             } catch (AccountLockServiceException e) {
                 throw new IdentityOAuth2Exception(ERROR_WHILE_CHECKING_ACCOUNT_LOCK_STATUS.getCode(),
                         String.format(ERROR_WHILE_CHECKING_ACCOUNT_LOCK_STATUS.getMessage(), username), e);

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/impersonation/UserAccountStatusValidatorTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/impersonation/UserAccountStatusValidatorTest.java
@@ -135,7 +135,8 @@ public class UserAccountStatusValidatorTest {
             OAuth2ServiceComponentHolder.setAccountDisableService(mockAccountDisableService);
             // Mock service output.
             lenient().when(mockAccountLockService.isAccountLocked(impersonatedUser.getUserName(),
-                    impersonationRequestDTO.getTenantDomain())).thenReturn(accountLocked);
+                    impersonationRequestDTO.getTenantDomain(), impersonatedUser.getUserStoreDomain()))
+                    .thenReturn(accountLocked);
             lenient().when(mockAccountDisableService.isAccountDisabled(impersonatedUser.getUserName(),
                     impersonationRequestDTO.getTenantDomain(), impersonatedUser.getUserStoreDomain()))
                     .thenReturn(accountDisabled);


### PR DESCRIPTION
### Proposed changes in this pull request
> Use is account lock function with domain aware username instead of domain aware username.

### Related Issues:
- https://github.com/wso2/product-is/issues/23462