### PR TITLE
Add acr, auth_time new claims to JWT & Opaque access token

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/introspection/IntrospectionResponse.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/introspection/IntrospectionResponse.java
@@ -91,6 +91,11 @@ public final class IntrospectionResponse {
 
     public static final String AUT = "aut";
 
+    // OPTIONAL
+    // Step-up authentication claims
+    public static final String ACR = "acr";
+    public static final String AUTH_TIME = "auth_time";
+
     class Error {
 
         public static final String INVALID_REQUEST = "invalid_request";

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/introspection/IntrospectionResponseBuilder.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/introspection/IntrospectionResponseBuilder.java
@@ -328,4 +328,32 @@ public class IntrospectionResponseBuilder {
         }
         return this;
     }
+
+    /**
+     * Set selected ACR value to the introspection response.
+     *
+     * @param selectedAcr Authorized user type
+     * @return IntrospectionResponseBuilder
+     */
+    public IntrospectionResponseBuilder setSelectedAcr(String selectedAcr) {
+
+        if (StringUtils.isNotBlank(selectedAcr)) {
+            parameters.put(IntrospectionResponse.ACR, selectedAcr);
+        }
+        return this;
+    }
+
+    /**
+     * Set current authentication time to the introspection response.
+     *
+     * @param authTime Authorized user type
+     * @return IntrospectionResponseBuilder
+     */
+    public IntrospectionResponseBuilder setAuthTime(long authTime) {
+
+        if (authTime != 0) {
+            parameters.put(IntrospectionResponse.AUTH_TIME, authTime);
+        }
+        return this;
+    }
 }

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/introspection/OAuth2IntrospectionEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/introspection/OAuth2IntrospectionEndpoint.java
@@ -36,6 +36,7 @@ import org.wso2.carbon.identity.oauth2.dto.OAuth2TokenValidationRequestDTO;
 import org.wso2.carbon.utils.DiagnosticLog;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.FormParam;
@@ -147,8 +148,7 @@ public class OAuth2IntrospectionEndpoint {
                 .setAuthorizedUserType(introspectionResponse.getAut())
                 .setAudience(introspectionResponse.getAud())
                 .setSelectedAcr(introspectionResponse.getAcr())
-                .setAuthTime(introspectionResponse.getAuthTime() / 1000);
-
+                .setAuthTime(TimeUnit.MILLISECONDS.toSeconds(introspectionResponse.getAuthTime()));
 
         boolean isUserSessionImpersonationEnabled = OAuthServerConfiguration.getInstance()
                 .isUserSessionImpersonationEnabled();

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/introspection/OAuth2IntrospectionEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/introspection/OAuth2IntrospectionEndpoint.java
@@ -145,7 +145,9 @@ public class OAuth2IntrospectionEndpoint {
                 .setIssuedAt(introspectionResponse.getIat())
                 .setExpiration(introspectionResponse.getExp())
                 .setAuthorizedUserType(introspectionResponse.getAut())
-                .setAudience(introspectionResponse.getAud());;
+                .setAudience(introspectionResponse.getAud())
+                .setSelectedAcr(introspectionResponse.getAcr())
+                .setAuthTime(introspectionResponse.getAuthTime() / 1000);
 
 
         boolean isUserSessionImpersonationEnabled = OAuthServerConfiguration.getInstance()

--- a/components/org.wso2.carbon.identity.oauth/pom.xml
+++ b/components/org.wso2.carbon.identity.oauth/pom.xml
@@ -292,6 +292,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <scope>test</scope>

--- a/components/org.wso2.carbon.identity.oauth/pom.xml
+++ b/components/org.wso2.carbon.identity.oauth/pom.xml
@@ -292,11 +292,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <scope>test</scope>

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/tokenprocessor/DefaultRefreshTokenGrantProcessor.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/tokenprocessor/DefaultRefreshTokenGrantProcessor.java
@@ -97,6 +97,8 @@ public class DefaultRefreshTokenGrantProcessor implements RefreshTokenGrantProce
         accessTokenDO.setGrantType(tokenReq.getGrantType());
         accessTokenDO.setIssuedTime(timestamp);
         accessTokenDO.setTokenBinding(tokReqMsgCtx.getTokenBinding());
+        accessTokenDO.setAcr(tokReqMsgCtx.getSelectedAcr());
+        accessTokenDO.setAuthTime(tokReqMsgCtx.getAuthTime());
 
         if (OAuth2ServiceComponentHolder.isConsentedTokenColumnEnabled()) {
             String previousGrantType = validationBean.getGrantType();

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/OAuth2Constants.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/OAuth2Constants.java
@@ -55,6 +55,8 @@ public class OAuth2Constants {
     public static final String CONSOLE_CALLBACK_URL_FROM_SERVER_CONFIGS = "Console.CallbackURL";
     public static final String MY_ACCOUNT_CALLBACK_URL_FROM_SERVER_CONFIGS = "MyAccount.CallbackURL";
     public static final String TENANT_DOMAIN_PLACEHOLDER = "{TENANT_DOMAIN}";
+    public static final String ACR = "acr";
+    public static final String AUTH_TIME = "auth_time";
 
     public static final int MAX_ALLOWED_LENGTH = 256;
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dto/OAuth2IntrospectionResponseDTO.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dto/OAuth2IntrospectionResponseDTO.java
@@ -340,18 +340,22 @@ public class OAuth2IntrospectionResponseDTO {
     }
 
     public String getAcr() {
+
         return acr;
     }
 
     public void setAcr(String acr) {
+
         this.acr = acr;
     }
 
     public long getAuthTime() {
+
         return authTime;
     }
 
     public void setAuthTime(long authTime) {
+
         this.authTime = authTime;
     }
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dto/OAuth2IntrospectionResponseDTO.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dto/OAuth2IntrospectionResponseDTO.java
@@ -123,6 +123,16 @@ public class OAuth2IntrospectionResponseDTO {
     private AuthenticatedUser authorizedUser;
 
     /*
+     * OPTIONAL. Selected ACR value of user authentication
+     */
+    private String acr;
+
+    /*
+     * OPTIONAL. Current authentication time
+     */
+    private long authTime;
+
+    /*
      * this is used for extensions.
      */
     private Map<String, Object> properties = new HashMap<String, Object>();
@@ -254,11 +264,6 @@ public class OAuth2IntrospectionResponseDTO {
         return properties;
     }
 
-    public void setProperties(Map<String, Object> properties) {
-
-        this.properties = properties;
-    }
-
     public String getError() {
 
         return error;
@@ -327,5 +332,26 @@ public class OAuth2IntrospectionResponseDTO {
     public void setAuthorizedUser(AuthenticatedUser authorizedUser) {
 
         this.authorizedUser = authorizedUser;
+    }
+
+    public String getAcr() {
+        return acr;
+    }
+
+    public void setAcr(String acr) {
+        this.acr = acr;
+    }
+
+    public long getAuthTime() {
+        return authTime;
+    }
+
+    public void setAuthTime(long authTime) {
+        this.authTime = authTime;
+    }
+
+    public void setProperties(Map<String, Object> properties) {
+
+        this.properties = properties;
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dto/OAuth2IntrospectionResponseDTO.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dto/OAuth2IntrospectionResponseDTO.java
@@ -264,6 +264,11 @@ public class OAuth2IntrospectionResponseDTO {
         return properties;
     }
 
+    public void setProperties(Map<String, Object> properties) {
+
+        this.properties = properties;
+    }
+
     public String getError() {
 
         return error;
@@ -350,8 +355,4 @@ public class OAuth2IntrospectionResponseDTO {
         this.authTime = authTime;
     }
 
-    public void setProperties(Map<String, Object> properties) {
-
-        this.properties = properties;
-    }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/model/AccessTokenDO.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/model/AccessTokenDO.java
@@ -109,8 +109,8 @@ public class AccessTokenDO extends CacheEntry {
     }
 
     public AccessTokenDO(String consumerKey, AuthenticatedUser authzUser, String[] scope,
-            TokenBinding tokenBinding, Timestamp issuedTime, Timestamp refreshTokenIssuedTime,
-            long validityPeriodInMillis, long refreshTokenValidityPeriodInMillis, String tokenType) {
+                         TokenBinding tokenBinding, Timestamp issuedTime, Timestamp refreshTokenIssuedTime,
+                         long validityPeriodInMillis, long refreshTokenValidityPeriodInMillis, String tokenType) {
 
         this.consumerKey = consumerKey;
         this.authzUser = authzUser;
@@ -121,19 +121,6 @@ public class AccessTokenDO extends CacheEntry {
         this.refreshTokenValidityPeriodInMillis = refreshTokenValidityPeriodInMillis;
         this.tokenType = tokenType;
         this.tokenBinding = tokenBinding;
-    }
-
-    public AccessTokenDO(String consumerKey, AuthenticatedUser authzUser, String[] scope,
-                         Timestamp issuedTime, Timestamp refreshTokenIssuedTime, long validityPeriodInMillis,
-                         long refreshTokenValidityPeriodInMillis, String tokenType, String acr, long authTime) {
-        super();
-    }
-
-    public AccessTokenDO(String consumerKey, AuthenticatedUser authzUser, String[] scope,
-                         Timestamp issuedTime, Timestamp refreshTokenIssuedTime, long validityPeriodInMillis,
-                         long refreshTokenValidityPeriodInMillis, String tokenType, Timestamp issuedTime1,
-                         String acr, long authTime) {
-        super();
     }
 
     /**
@@ -151,11 +138,8 @@ public class AccessTokenDO extends CacheEntry {
                 tokenDO.getRefreshTokenIssuedTime(),
                 tokenDO.getValidityPeriodInMillis(),
                 tokenDO.getRefreshTokenValidityPeriodInMillis(),
-                tokenDO.getTokenType(),
-                tokenDO.getAcr(),
-                tokenDO.getAuthTime()
+                tokenDO.getTokenType()
         );
-        newTokenDO.setAuthzUser(tokenDO.getAuthzUser());
         newTokenDO.setTenantID(tokenDO.getTenantID());
         newTokenDO.setTokenState(tokenDO.getTokenState());
         newTokenDO.setRefreshToken(tokenDO.getRefreshToken());
@@ -167,11 +151,6 @@ public class AccessTokenDO extends CacheEntry {
         newTokenDO.setIsConsentedToken(tokenDO.isConsentedToken());
         newTokenDO.setAppResidentTenantId(tokenDO.getAppResidentTenantId());
         newTokenDO.setAccessTokenExtendedAttributes(tokenDO.getAccessTokenExtendedAttributes());
-        newTokenDO.setConsumerKey(tokenDO.getConsumerKey());
-        newTokenDO.setIssuedTime(tokenDO.getIssuedTime());
-        newTokenDO.setRefreshTokenIssuedTime(tokenDO.getRefreshTokenIssuedTime());
-        newTokenDO.setValidityPeriodInMillis(tokenDO.getValidityPeriodInMillis());
-        newTokenDO.setRefreshTokenValidityPeriodInMillis(tokenDO.getRefreshTokenValidityPeriodInMillis());
         newTokenDO.setAcr(tokenDO.getAcr());
         newTokenDO.setAuthTime(tokenDO.getAuthTime());
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/model/AccessTokenDO.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/model/AccessTokenDO.java
@@ -146,7 +146,6 @@ public class AccessTokenDO extends CacheEntry {
         newTokenDO.setTokenBinding(tokenDO.getTokenBinding());
         newTokenDO.setIsConsentedToken(tokenDO.isConsentedToken());
         newTokenDO.setAppResidentTenantId(tokenDO.getAppResidentTenantId());
-        newTokenDO.setAccessTokenExtendedAttributes(tokenDO.getAccessTokenExtendedAttributes());
 
         return newTokenDO;
     }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/model/AccessTokenDO.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/model/AccessTokenDO.java
@@ -79,6 +79,10 @@ public class AccessTokenDO extends CacheEntry {
 
     private int appResidentTenantId = MultitenantConstants.INVALID_TENANT_ID;
 
+    private String acr;
+
+    private long authTime;
+
     public AccessTokenDO(String consumerKey, AuthenticatedUser authzUser, String[] scope, Timestamp issuedTime,
                          Timestamp refreshTokenIssuedTime, long validityPeriodInMillis,
                          long refreshTokenValidityPeriodInMillis, String tokenType) {
@@ -119,6 +123,19 @@ public class AccessTokenDO extends CacheEntry {
         this.tokenBinding = tokenBinding;
     }
 
+    public AccessTokenDO(String consumerKey, AuthenticatedUser authzUser, String[] scope,
+                         Timestamp issuedTime, Timestamp refreshTokenIssuedTime, long validityPeriodInMillis,
+                         long refreshTokenValidityPeriodInMillis, String tokenType, String acr, long authTime) {
+        super();
+    }
+
+    public AccessTokenDO(String consumerKey, AuthenticatedUser authzUser, String[] scope,
+                         Timestamp issuedTime, Timestamp refreshTokenIssuedTime, long validityPeriodInMillis,
+                         long refreshTokenValidityPeriodInMillis, String tokenType, Timestamp issuedTime1,
+                         String acr, long authTime) {
+        super();
+    }
+
     /**
      * Create a copy of the passed token DO object.
      *
@@ -134,8 +151,11 @@ public class AccessTokenDO extends CacheEntry {
                 tokenDO.getRefreshTokenIssuedTime(),
                 tokenDO.getValidityPeriodInMillis(),
                 tokenDO.getRefreshTokenValidityPeriodInMillis(),
-                tokenDO.getTokenType()
+                tokenDO.getTokenType(),
+                tokenDO.getAcr(),
+                tokenDO.getAuthTime()
         );
+        newTokenDO.setAuthzUser(tokenDO.getAuthzUser());
         newTokenDO.setTenantID(tokenDO.getTenantID());
         newTokenDO.setTokenState(tokenDO.getTokenState());
         newTokenDO.setRefreshToken(tokenDO.getRefreshToken());
@@ -146,6 +166,14 @@ public class AccessTokenDO extends CacheEntry {
         newTokenDO.setTokenBinding(tokenDO.getTokenBinding());
         newTokenDO.setIsConsentedToken(tokenDO.isConsentedToken());
         newTokenDO.setAppResidentTenantId(tokenDO.getAppResidentTenantId());
+        newTokenDO.setAccessTokenExtendedAttributes(tokenDO.getAccessTokenExtendedAttributes());
+        newTokenDO.setConsumerKey(tokenDO.getConsumerKey());
+        newTokenDO.setIssuedTime(tokenDO.getIssuedTime());
+        newTokenDO.setRefreshTokenIssuedTime(tokenDO.getRefreshTokenIssuedTime());
+        newTokenDO.setValidityPeriodInMillis(tokenDO.getValidityPeriodInMillis());
+        newTokenDO.setRefreshTokenValidityPeriodInMillis(tokenDO.getRefreshTokenValidityPeriodInMillis());
+        newTokenDO.setAcr(tokenDO.getAcr());
+        newTokenDO.setAuthTime(tokenDO.getAuthTime());
 
         return newTokenDO;
     }
@@ -357,5 +385,21 @@ public class AccessTokenDO extends CacheEntry {
     public void setAppResidentTenantId(int appResidentTenantId) {
 
         this.appResidentTenantId = appResidentTenantId;
+    }
+
+    public String getAcr() {
+        return acr;
+    }
+
+    public void setAcr(String acr) {
+        this.acr = acr;
+    }
+
+    public long getAuthTime() {
+        return authTime;
+    }
+
+    public void setAuthTime(long authTime) {
+        this.authTime = authTime;
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/model/AccessTokenDO.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/model/AccessTokenDO.java
@@ -367,18 +367,22 @@ public class AccessTokenDO extends CacheEntry {
     }
 
     public String getAcr() {
+
         return acr;
     }
 
     public void setAcr(String acr) {
+
         this.acr = acr;
     }
 
     public long getAuthTime() {
+
         return authTime;
     }
 
     public void setAuthTime(long authTime) {
+
         this.authTime = authTime;
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuer.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuer.java
@@ -216,8 +216,12 @@ public class AccessTokenIssuer {
                     tokReqMsgCtx.getOauth2AccessTokenReqDTO().setAccessTokenExtendedAttributes(
                             authorizationGrantCacheEntry.getAccessTokenExtensionDO());
                 }
-                tokReqMsgCtx.setSelectedAcr(authorizationGrantCacheEntry.getSelectedAcrValue());
-                tokReqMsgCtx.setAuthTime(authorizationGrantCacheEntry.getAuthTime());
+                if (authorizationGrantCacheEntry.getAcrValue() != null) {
+                    tokReqMsgCtx.setSelectedAcr(authorizationGrantCacheEntry.getSelectedAcrValue());
+                }
+                if (authorizationGrantCacheEntry.getMaxAge() > 0) {
+                    tokReqMsgCtx.setAuthTime(authorizationGrantCacheEntry.getAuthTime());
+                }
             }
             persistImpersonationInfoToTokenReqCtx(authorizationGrantCacheEntry, tokReqMsgCtx);
         }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuer.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuer.java
@@ -399,16 +399,12 @@ public class AccessTokenIssuer {
 
         String syncLockString = authzGrantHandler.buildSyncLockString(tokReqMsgCtx);
         if (StringUtils.isBlank(syncLockString)) {
-            OAuth2AccessTokenRespDTO respDTO =
-                    validateGrantAndIssueToken(tokenReqDTO, tokReqMsgCtx, tokenRespDTO, authzGrantHandler,
+            return validateGrantAndIssueToken(tokenReqDTO, tokReqMsgCtx, tokenRespDTO, authzGrantHandler,
                     tenantDomainOfApp, oAuthAppDO);
-            return respDTO;
         }
         synchronized (syncLockString.intern()) {
-            OAuth2AccessTokenRespDTO respDTO =
-                    validateGrantAndIssueToken(tokenReqDTO, tokReqMsgCtx, tokenRespDTO, authzGrantHandler,
+            return validateGrantAndIssueToken(tokenReqDTO, tokReqMsgCtx, tokenRespDTO, authzGrantHandler,
                     tenantDomainOfApp, oAuthAppDO);
-            return respDTO;
         }
     }
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuer.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuer.java
@@ -109,6 +109,8 @@ public class JWTTokenIssuer extends OauthTokenIssuerImpl {
     private static final String JWT_TYP_HEADER_VALUE = "jwt";
     private static final String MAY_ACT = "may_act";
     private static final String SUB = "sub";
+    private static final String ACR = "acr";
+    private static final String AUTH_TIME = "auth_time";
 
     public JWTTokenIssuer() throws IdentityOAuth2Exception {
 
@@ -656,6 +658,15 @@ public class JWTTokenIssuer extends OauthTokenIssuerImpl {
         String scope = getScope(authAuthzReqMessageContext, tokenReqMessageContext);
         if (StringUtils.isNotEmpty(scope)) {
             jwtClaimsSetBuilder.claim(SCOPE, scope);
+        }
+
+        if (tokenReqMessageContext != null) {
+            if (tokenReqMessageContext.getSelectedAcr() != null) {
+                jwtClaimsSetBuilder.claim(ACR, tokenReqMessageContext.getSelectedAcr());
+            }
+            if (tokenReqMessageContext.getAuthTime() != 0) {
+                jwtClaimsSetBuilder.claim(AUTH_TIME, tokenReqMessageContext.getAuthTime() / 1000);
+            }
         }
 
         jwtClaimsSetBuilder.claim(OAuthConstants.AUTHORIZED_USER_TYPE,

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuer.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuer.java
@@ -70,6 +70,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCConfigProperties.SUBJECT_TOKEN_EXPIRY_TIME_VALUE;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.RENEW_TOKEN_WITHOUT_REVOKING_EXISTING_ENABLE_CONFIG;
@@ -665,7 +666,7 @@ public class JWTTokenIssuer extends OauthTokenIssuerImpl {
                 jwtClaimsSetBuilder.claim(ACR, tokenReqMessageContext.getSelectedAcr());
             }
             if (tokenReqMessageContext.getAuthTime() != 0) {
-                jwtClaimsSetBuilder.claim(AUTH_TIME, tokenReqMessageContext.getAuthTime() / 1000);
+                jwtClaimsSetBuilder.claim(AUTH_TIME, TimeUnit.MILLISECONDS.toSeconds(tokenReqMessageContext.getAuthTime()));
             }
         }
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuer.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuer.java
@@ -666,7 +666,8 @@ public class JWTTokenIssuer extends OauthTokenIssuerImpl {
                 jwtClaimsSetBuilder.claim(ACR, tokenReqMessageContext.getSelectedAcr());
             }
             if (tokenReqMessageContext.getAuthTime() != 0) {
-                jwtClaimsSetBuilder.claim(AUTH_TIME, TimeUnit.MILLISECONDS.toSeconds(tokenReqMessageContext.getAuthTime()));
+                jwtClaimsSetBuilder.claim(AUTH_TIME,
+                        TimeUnit.MILLISECONDS.toSeconds(tokenReqMessageContext.getAuthTime()));
             }
         }
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/OAuthTokenReqMessageContext.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/OAuthTokenReqMessageContext.java
@@ -68,6 +68,10 @@ public class OAuthTokenReqMessageContext {
 
     private AuthorizationDetails authorizationDetails;
 
+    private String selectedAcr;
+
+    private long authTime;
+
     public OAuthTokenReqMessageContext(OAuth2AccessTokenReqDTO oauth2AccessTokenReqDTO) {
 
         this.oauth2AccessTokenReqDTO = oauth2AccessTokenReqDTO;
@@ -266,5 +270,21 @@ public class OAuthTokenReqMessageContext {
     public void setRefreshTokenValidityPeriodInMillis(long refreshTokenValidityPeriodInMillis) {
 
         this.refreshTokenValidityPeriodInMillis = refreshTokenValidityPeriodInMillis;
+    }
+
+    public long getAuthTime() {
+        return authTime;
+    }
+
+    public void setAuthTime(long authTime) {
+        this.authTime = authTime;
+    }
+
+    public String getSelectedAcr() {
+        return selectedAcr;
+    }
+
+    public void setSelectedAcr(String selectedAcr) {
+        this.selectedAcr = selectedAcr;
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/OAuthTokenReqMessageContext.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/OAuthTokenReqMessageContext.java
@@ -273,18 +273,22 @@ public class OAuthTokenReqMessageContext {
     }
 
     public long getAuthTime() {
+
         return authTime;
     }
 
     public void setAuthTime(long authTime) {
+
         this.authTime = authTime;
     }
 
     public String getSelectedAcr() {
+
         return selectedAcr;
     }
 
     public void setSelectedAcr(String selectedAcr) {
+
         this.selectedAcr = selectedAcr;
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AbstractAuthorizationGrantHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AbstractAuthorizationGrantHandler.java
@@ -604,6 +604,8 @@ public abstract class AbstractAuthorizationGrantHandler implements Authorization
         newTokenBean.setValidityPeriod(tokReqMsgCtx.getValidityPeriod() / SECONDS_TO_MILISECONDS_FACTOR);
         newTokenBean.setTokenBinding(tokReqMsgCtx.getTokenBinding());
         newTokenBean.setAccessTokenExtendedAttributes(tokenReq.getAccessTokenExtendedAttributes());
+        newTokenBean.setAcr(tokReqMsgCtx.getSelectedAcr());
+        newTokenBean.setAuthTime(tokReqMsgCtx.getAuthTime());
         setRefreshTokenDetails(tokReqMsgCtx, existingTokenBean, newTokenBean, oauthTokenIssuer);
 
         return newTokenBean;
@@ -1090,6 +1092,12 @@ public abstract class AbstractAuthorizationGrantHandler implements Authorization
                     log.debug("Retrieved latest access token for client Id: " + tokenReq.getClientId() + " user: " +
                             tokenMsgCtx.getAuthorizedUser() + " and scope: " + scope + " from db");
                 }
+            }
+            if (tokenMsgCtx.getSelectedAcr() != null) {
+                existingToken.setAcr(tokenMsgCtx.getSelectedAcr());
+            }
+            if (tokenMsgCtx.getAuthTime() != 0) {
+                existingToken.setAuthTime(tokenMsgCtx.getAuthTime());
             }
             long expireTime = getAccessTokenExpiryTimeMillis(existingToken);
             if (TOKEN_STATE_ACTIVE.equals(existingToken.getTokenState()) &&

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AbstractAuthorizationGrantHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AbstractAuthorizationGrantHandler.java
@@ -60,6 +60,7 @@ import org.wso2.carbon.identity.oauth2.dto.OAuth2AccessTokenReqDTO;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2AccessTokenRespDTO;
 import org.wso2.carbon.identity.oauth2.internal.OAuth2ServiceComponentHolder;
 import org.wso2.carbon.identity.oauth2.model.AccessTokenDO;
+import org.wso2.carbon.identity.oauth2.model.AccessTokenExtendedAttributes;
 import org.wso2.carbon.identity.oauth2.rar.AuthorizationDetailsService;
 import org.wso2.carbon.identity.oauth2.rar.util.AuthorizationDetailsUtils;
 import org.wso2.carbon.identity.oauth2.token.OAuthTokenReqMessageContext;
@@ -77,11 +78,13 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.IMPERSONATING_ACTOR;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OAUTH_APP;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.RENEW_TOKEN_WITHOUT_REVOKING_EXISTING_ENABLE_CONFIG;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.TokenBindings.NONE;
@@ -603,12 +606,38 @@ public abstract class AbstractAuthorizationGrantHandler implements Authorization
         newTokenBean.setValidityPeriodInMillis(tokReqMsgCtx.getValidityPeriod());
         newTokenBean.setValidityPeriod(tokReqMsgCtx.getValidityPeriod() / SECONDS_TO_MILISECONDS_FACTOR);
         newTokenBean.setTokenBinding(tokReqMsgCtx.getTokenBinding());
-        newTokenBean.setAccessTokenExtendedAttributes(tokenReq.getAccessTokenExtendedAttributes());
+        newTokenBean.setAccessTokenExtendedAttributes(
+                getAccessTokenExtendedAttributes(tokenReq.getAccessTokenExtendedAttributes(), tokReqMsgCtx));
         newTokenBean.setAcr(tokReqMsgCtx.getSelectedAcr());
         newTokenBean.setAuthTime(tokReqMsgCtx.getAuthTime());
         setRefreshTokenDetails(tokReqMsgCtx, existingTokenBean, newTokenBean, oauthTokenIssuer);
 
         return newTokenBean;
+    }
+
+    private AccessTokenExtendedAttributes getAccessTokenExtendedAttributes(
+            AccessTokenExtendedAttributes accessTokenExtendedAttributes,
+            OAuthTokenReqMessageContext tokReqMsgCtx) {
+
+        if (tokReqMsgCtx.isImpersonationRequest()) {
+            accessTokenExtendedAttributes =
+                    addExtendedAttribute(IMPERSONATING_ACTOR, tokReqMsgCtx.getProperty(IMPERSONATING_ACTOR).toString(),
+                            accessTokenExtendedAttributes);
+        }
+        // Add any new extended attributes here using @addExtendedAttribute.
+        return accessTokenExtendedAttributes;
+    }
+
+    private AccessTokenExtendedAttributes addExtendedAttribute(String key, String value, AccessTokenExtendedAttributes
+            accessTokenExtendedAttributes) {
+
+        if (accessTokenExtendedAttributes == null) {
+            accessTokenExtendedAttributes = new AccessTokenExtendedAttributes(new HashMap<>());
+        }
+        if (key != null && value != null) {
+            accessTokenExtendedAttributes.getParameters().put(key, value);
+        }
+        return accessTokenExtendedAttributes;
     }
 
     private void updateMessageContextToCreateNewToken(OAuthTokenReqMessageContext tokReqMsgCtx, String consumerKey,
@@ -633,7 +662,7 @@ public abstract class AbstractAuthorizationGrantHandler implements Authorization
         tokReqMsgCtx.setAccessTokenIssuedTime(timestamp.getTime());
         tokReqMsgCtx.setAudiences(OAuth2Util.getOIDCAudience(consumerKey, oAuthAppBean));
 
-        updateRefreshTokenValidityPeriodInMessageContext(oAuthAppBean, tokReqMsgCtx);
+        updateRefreshTokenValidityPeriodInMessageContext(oAuthAppBean, existingTokenBean, tokReqMsgCtx);
     }
 
     private void setRefreshTokenDetails(OAuthTokenReqMessageContext tokReqMsgCtx, AccessTokenDO existingTokenBean,
@@ -649,12 +678,17 @@ public abstract class AbstractAuthorizationGrantHandler implements Authorization
         if (!isTokenRenewalPerRequestConfigured() &&
                 isRefreshTokenValid(existingTokenBean, tokReqMsgCtx.getValidityPeriod(),
                         tokenReq.getClientId()) && !isExtendedToken) {
-            setRefreshTokenDetailsFromExistingToken(existingTokenBean, newTokenBean);
+            setRefreshTokenDetailsFromExistingToken(existingTokenBean, newTokenBean, tokReqMsgCtx);
         } else {
             // no valid refresh token found in existing Token
             newTokenBean.setRefreshTokenIssuedTime(new Timestamp(tokReqMsgCtx.getAccessTokenIssuedTime()));
             // Set refresh token validity period.
-            newTokenBean.setRefreshTokenValidityPeriodInMillis(tokReqMsgCtx.getRefreshTokenvalidityPeriod());
+            if (tokReqMsgCtx.getRefreshTokenValidityPeriodInMillis() > 0) {
+                newTokenBean.setRefreshTokenValidityPeriodInMillis(
+                        tokReqMsgCtx.getRefreshTokenValidityPeriodInMillis());
+            } else {
+                newTokenBean.setRefreshTokenValidityPeriodInMillis(tokReqMsgCtx.getRefreshTokenvalidityPeriod());
+            }
             newTokenBean.setRefreshToken(getRefreshToken(tokReqMsgCtx, oauthTokenIssuer));
         }
     }
@@ -780,11 +814,22 @@ public abstract class AbstractAuthorizationGrantHandler implements Authorization
     }
 
     private void setRefreshTokenDetailsFromExistingToken(AccessTokenDO existingAccessTokenDO,
-                                                         AccessTokenDO newTokenBean) {
+                                                         AccessTokenDO newTokenBean,
+                                                         OAuthTokenReqMessageContext tokReqMsgCtx) {
+
         newTokenBean.setRefreshToken(existingAccessTokenDO.getRefreshToken());
         newTokenBean.setRefreshTokenIssuedTime(existingAccessTokenDO.getRefreshTokenIssuedTime());
-        newTokenBean.setRefreshTokenValidityPeriodInMillis(existingAccessTokenDO
-                .getRefreshTokenValidityPeriodInMillis());
+
+        /*
+        Giving precedence to OAuthTokenReqMessageContext which is updated during
+        pre-issue access token action execution.
+         */
+        if (tokReqMsgCtx.getRefreshTokenValidityPeriodInMillis() > 0) {
+            newTokenBean.setRefreshTokenValidityPeriodInMillis(tokReqMsgCtx.getRefreshTokenValidityPeriodInMillis());
+        } else {
+            newTokenBean.setRefreshTokenValidityPeriodInMillis(existingAccessTokenDO
+                    .getRefreshTokenValidityPeriodInMillis());
+        }
     }
 
     private void validateGrantTypeParam(OAuth2AccessTokenReqDTO tokenReq) throws IdentityOAuth2Exception {
@@ -794,7 +839,13 @@ public abstract class AbstractAuthorizationGrantHandler implements Authorization
     }
 
     private void updateRefreshTokenValidityPeriodInMessageContext(OAuthAppDO oAuthAppBean,
+                                                                  AccessTokenDO existingTokenBean,
                                                                   OAuthTokenReqMessageContext tokReqMsgCtx) {
+
+        OAuth2AccessTokenReqDTO tokenReq = tokReqMsgCtx.getOauth2AccessTokenReqDTO();
+        boolean isExtendedToken = tokenReq.getAccessTokenExtendedAttributes() != null &&
+                tokenReq.getAccessTokenExtendedAttributes().getRefreshTokenValidityPeriod() >
+                        EXTENDED_REFRESH_TOKEN_DEFAULT_TIME;
 
         long refreshTokenValidityPeriodInMillis;
         long validityPeriodFromMsgContext = tokReqMsgCtx.getRefreshTokenvalidityPeriod();
@@ -806,6 +857,14 @@ public abstract class AbstractAuthorizationGrantHandler implements Authorization
                         "validity period configured from OAuthTokenReqMessageContext: " +
                         refreshTokenValidityPeriodInMillis + " ms");
             }
+        } else if (existingTokenBean != null && !isTokenRenewalPerRequestConfigured() &&
+                isRefreshTokenValid(existingTokenBean, tokReqMsgCtx.getValidityPeriod(), tokenReq.getClientId()) &&
+                !isExtendedToken) {
+            /*
+            Checks if the existing refresh token will be reused. If so, its original expiry time should be
+            retained instead of recalculating it from the application-level configuration.
+             */
+            refreshTokenValidityPeriodInMillis = existingTokenBean.getRefreshTokenValidityPeriodInMillis();
         } else if (oAuthAppBean.getRefreshTokenExpiryTime() != 0) {
             refreshTokenValidityPeriodInMillis =
                     oAuthAppBean.getRefreshTokenExpiryTime() * SECONDS_TO_MILISECONDS_FACTOR;
@@ -819,6 +878,7 @@ public abstract class AbstractAuthorizationGrantHandler implements Authorization
         }
 
         tokReqMsgCtx.setRefreshTokenvalidityPeriod(refreshTokenValidityPeriodInMillis);
+        tokReqMsgCtx.setRefreshTokenValidityPeriodInMillis(refreshTokenValidityPeriodInMillis);
     }
 
     private void addTokenToCache(OAuthCacheKey cacheKey, AccessTokenDO existingAccessTokenDO) {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/RefreshGrantHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/RefreshGrantHandler.java
@@ -204,8 +204,12 @@ public class RefreshGrantHandler extends AbstractAuthorizationGrantHandler {
         AuthorizationGrantCacheEntry authorizationGrantCacheEntry =
                 AuthorizationGrantCache.getInstance().getValueFromCacheByTokenId(cacheKey, tokenId);
         if (authorizationGrantCacheEntry != null) {
-            tokReqMsgCtx.setSelectedAcr(authorizationGrantCacheEntry.getSelectedAcrValue());
-            tokReqMsgCtx.setAuthTime(authorizationGrantCacheEntry.getAuthTime());
+            if (authorizationGrantCacheEntry.getAcrValue() != null) {
+                tokReqMsgCtx.setSelectedAcr(authorizationGrantCacheEntry.getSelectedAcrValue());
+            }
+            if (authorizationGrantCacheEntry.getMaxAge() > 0) {
+                tokReqMsgCtx.setAuthTime(authorizationGrantCacheEntry.getAuthTime());
+            }
         }
     }
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/RefreshGrantHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/RefreshGrantHandler.java
@@ -189,7 +189,6 @@ public class RefreshGrantHandler extends AbstractAuthorizationGrantHandler {
             setTokenDataToMessageContext(tokReqMsgCtx, accessTokenBean);
             addUserAttributesToCache(accessTokenBean, tokReqMsgCtx);
         }
-        
         return buildTokenResponse(tokReqMsgCtx, accessTokenBean);
     }
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -100,7 +100,13 @@ import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.oauth.IdentityOAuthAdminException;
 import org.wso2.carbon.identity.oauth.OAuthUtil;
-import org.wso2.carbon.identity.oauth.cache.*;
+import org.wso2.carbon.identity.oauth.cache.AppInfoCache;
+import org.wso2.carbon.identity.oauth.cache.AuthorizationGrantCache;
+import org.wso2.carbon.identity.oauth.cache.AuthorizationGrantCacheEntry;
+import org.wso2.carbon.identity.oauth.cache.AuthorizationGrantCacheKey;
+import org.wso2.carbon.identity.oauth.cache.CacheEntry;
+import org.wso2.carbon.identity.oauth.cache.OAuthCache;
+import org.wso2.carbon.identity.oauth.cache.OAuthCacheKey;
 import org.wso2.carbon.identity.oauth.common.OAuth2ErrorCodes;
 import org.wso2.carbon.identity.oauth.common.OAuthConstants;
 import org.wso2.carbon.identity.oauth.common.exception.InvalidOAuthClientException;
@@ -2205,8 +2211,12 @@ public class OAuth2Util {
             AuthorizationGrantCacheEntry cacheEntry =
                     AuthorizationGrantCache.getInstance().getValueFromCacheByToken(authorizationGrantCacheKey);
             if (cacheEntry != null) {
-                accessTokenDO.setAcr(cacheEntry.getSelectedAcrValue());
-                accessTokenDO.setAuthTime(cacheEntry.getAuthTime());
+                if (cacheEntry.getAcrValue() != null) {
+                    accessTokenDO.setAcr(cacheEntry.getSelectedAcrValue());
+                }
+                if (cacheEntry.getMaxAge() != 0) {
+                    accessTokenDO.setAuthTime(cacheEntry.getAuthTime());
+                }
             }
         } else {
             if (log.isDebugEnabled()) {
@@ -5878,7 +5888,7 @@ public class OAuth2Util {
         // Set authorized user tenant domain to the tenant domain of the application.
         authenticatedUser.setTenantDomain(appTenantDomain);
     }
-  
+
     public static boolean isPairwiseSubEnabledForAccessTokens() {
 
         return Boolean.parseBoolean(IdentityUtil.getProperty(ENABLE_PPID_FOR_ACCESS_TOKENS));

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -100,10 +100,7 @@ import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.oauth.IdentityOAuthAdminException;
 import org.wso2.carbon.identity.oauth.OAuthUtil;
-import org.wso2.carbon.identity.oauth.cache.AppInfoCache;
-import org.wso2.carbon.identity.oauth.cache.CacheEntry;
-import org.wso2.carbon.identity.oauth.cache.OAuthCache;
-import org.wso2.carbon.identity.oauth.cache.OAuthCacheKey;
+import org.wso2.carbon.identity.oauth.cache.*;
 import org.wso2.carbon.identity.oauth.common.OAuth2ErrorCodes;
 import org.wso2.carbon.identity.oauth.common.OAuthConstants;
 import org.wso2.carbon.identity.oauth.common.exception.InvalidOAuthClientException;
@@ -2185,6 +2182,8 @@ public class OAuth2Util {
 
         // check the cache, if caching is enabled.
         OAuthCacheKey cacheKey = new OAuthCacheKey(accessTokenIdentifier);
+        AuthorizationGrantCacheKey authorizationGrantCacheKey =
+                new AuthorizationGrantCacheKey(accessTokenIdentifier);
         CacheEntry result = OAuthCache.getInstance().getValueFromCache(cacheKey);
         // cache hit, do the type check.
         if (result != null && result instanceof AccessTokenDO) {
@@ -2203,6 +2202,12 @@ public class OAuth2Util {
         if (accessTokenDO == null) {
             accessTokenDO = OAuthTokenPersistenceFactory.getInstance().getAccessTokenDAO()
                     .getAccessToken(accessTokenIdentifier, includeExpired);
+            AuthorizationGrantCacheEntry cacheEntry =
+                    AuthorizationGrantCache.getInstance().getValueFromCacheByToken(authorizationGrantCacheKey);
+            if (cacheEntry != null) {
+                accessTokenDO.setAcr(cacheEntry.getSelectedAcrValue());
+                accessTokenDO.setAuthTime(cacheEntry.getAuthTime());
+            }
         } else {
             if (log.isDebugEnabled()) {
                 log.debug("Retrieved active access token from OAuthCache for token Identifier: " +

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/TokenValidationHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/TokenValidationHandler.java
@@ -444,6 +444,10 @@ public class TokenValidationHandler {
         // Add client id.
         introResp.setClientId(refreshTokenDataDO.getConsumerKey());
         // Adding the AccessTokenDO as a context property for further use.
+        // Set selected acr value
+        introResp.setAcr(refreshTokenDataDO.getAcr());
+        // Set auth_time
+        introResp.setAuthTime(refreshTokenDataDO.getAuthTime());
         messageContext.addProperty("RefreshTokenDO", refreshTokenDataDO);
         // Add authenticated user object since username attribute may not have the domain appended if the
         // subject identifier is built based in the SP config.
@@ -622,6 +626,10 @@ public class TokenValidationHandler {
             }
             // add client id
             introResp.setClientId(accessTokenDO.getConsumerKey());
+            // Set selected acr value
+            introResp.setAcr(accessTokenDO.getAcr());
+            // Set auth_time
+            introResp.setAuthTime(accessTokenDO.getAuthTime());
             // Set token binding info.
             if (accessTokenDO.getTokenBinding() != null) {
                 String bindingType = accessTokenDO.getTokenBinding().getBindingType();

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/TokenValidationHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/TokenValidationHandler.java
@@ -626,9 +626,9 @@ public class TokenValidationHandler {
             }
             // add client id
             introResp.setClientId(accessTokenDO.getConsumerKey());
-            // Set selected acr value
+            // Set selected acr value.
             introResp.setAcr(accessTokenDO.getAcr());
-            // Set auth_time
+            // Set auth_time.
             introResp.setAuthTime(accessTokenDO.getAuthTime());
             // Set token binding info.
             if (accessTokenDO.getTokenBinding() != null) {

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/OAuthUtilTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/OAuthUtilTest.java
@@ -422,7 +422,7 @@ public class OAuthUtilTest {
 
         try (MockedStatic<UserCoreUtil> userCoreUtil = mockStatic(UserCoreUtil.class)) {
 
-            UniqueIDJDBCUserStoreManager userStoreManager = Mockito.spy(
+            UniqueIDJDBCUserStoreManager userStoreManager = spy(
                     new UniqueIDJDBCUserStoreManager(new RealmConfiguration(), 1));
 
             org.wso2.carbon.user.core.common.User mockUser = Mockito.mock(org.wso2.carbon.user.core.common.User.class);
@@ -484,7 +484,7 @@ public class OAuthUtilTest {
         UserStoreManager userStoreManager = mock(UserStoreManager.class);
 
         // Create a real instance of AuthorizationCodeDAO and spy on it
-        AuthorizationCodeDAO authorizationCodeDAO = Mockito.spy(new AuthorizationCodeDAOImpl());
+        AuthorizationCodeDAO authorizationCodeDAO = spy(new AuthorizationCodeDAOImpl());
 
         when(userStoreManager.getTenantId()).thenReturn(-1234);
         when(userStoreManager.getRealmConfiguration()).thenReturn(mock(RealmConfiguration.class));

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/OAuthUtilTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/OAuthUtilTest.java
@@ -540,6 +540,7 @@ public class OAuthUtilTest {
 
     @Test
     public void testGetAccessTokenDOFromDBWithStepUpClaimsFromSessionStore() throws Exception {
+
         // Mocked inputs
         final String testAcr = "test_acr";
         final long testAuthTime = 1686239200L;

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuerTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuerTest.java
@@ -348,6 +348,8 @@ public class JWTTokenIssuerTest {
         tokenReqMessageContext.addProperty(EXPIRY_TIME_JWT, cal.getTime());
         tokenReqMessageContext.addProperty(OAuthConstants.UserType.USER_TYPE, OAuthConstants.UserType.APPLICATION);
         tokenReqMessageContext.setAudiences(Collections.singletonList(DUMMY_CLIENT_ID));
+        tokenReqMessageContext.setSelectedAcr("acr_test");
+        tokenReqMessageContext.setAuthTime(1000);
         authenticatedUserForTokenReq.setFederatedUser(false);
 
         return new Object[][]{
@@ -467,6 +469,8 @@ public class JWTTokenIssuerTest {
                 assertEquals(jwtClaimSet.getClaim(OAuth2Constants.ENTITY_ID), DUMMY_CLIENT_ID);
                 assertEquals(jwtClaimSet.getClaim(OAuth2Constants.IS_CONSENTED), false);
                 assertEquals(jwtClaimSet.getClaim(OAuth2Constants.IS_FEDERATED), false);
+                assertEquals(jwtClaimSet.getClaim(OAuth2Constants.ACR), "acr_test");
+                assertEquals(jwtClaimSet.getClaim(OAuth2Constants.AUTH_TIME), (long) 1);
             }
             if (authzReqMessageContext != null) {
                 assertEquals(jwtClaimSet.getClaim(OAuth2Constants.ENTITY_ID), DUMMY_USER_ID);

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/handlers/claims/AccessTokenStepUpAuthClaimsSetTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/handlers/claims/AccessTokenStepUpAuthClaimsSetTest.java
@@ -1,0 +1,104 @@
+package org.wso2.carbon.identity.oauth2.token.handlers.claims;
+
+import org.mockito.MockedStatic;
+import org.testng.annotations.Test;
+import org.wso2.carbon.CarbonConstants;
+import org.wso2.carbon.identity.action.execution.api.model.ActionType;
+import org.wso2.carbon.identity.action.execution.api.service.ActionExecutorService;
+import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
+import org.wso2.carbon.identity.common.testng.WithCarbonHome;
+import org.wso2.carbon.identity.common.testng.WithH2Database;
+import org.wso2.carbon.identity.common.testng.WithRealmService;
+import org.wso2.carbon.identity.oauth.cache.AuthorizationGrantCache;
+import org.wso2.carbon.identity.oauth.cache.AuthorizationGrantCacheEntry;
+import org.wso2.carbon.identity.oauth.cache.AuthorizationGrantCacheKey;
+import org.wso2.carbon.identity.oauth.internal.OAuthComponentServiceHolder;
+import org.wso2.carbon.identity.oauth2.dto.OAuth2AccessTokenReqDTO;
+import org.wso2.carbon.identity.oauth2.dto.OAuth2AccessTokenRespDTO;
+import org.wso2.carbon.identity.oauth2.model.RefreshTokenValidationDataDO;
+import org.wso2.carbon.identity.oauth2.token.OAuthTokenReqMessageContext;
+import org.wso2.carbon.identity.oauth2.token.handlers.grant.RefreshGrantHandler;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.LinkedHashSet;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.GrantTypes.REFRESH_TOKEN;
+import static org.wso2.carbon.identity.oauth2.token.handlers.grant.RefreshGrantHandler.PREV_ACCESS_TOKEN;
+
+/**
+ * This test class checks whether access token flow gets values of acr and auth_time claims
+ * in the case of AuthorizationGrantCache has successfully stored those values against
+ * the access token id.
+ */
+@WithCarbonHome
+@WithH2Database(jndiName = "jdbc/WSO2IdentityDB",
+        files = {"dbScripts/identity.sql", "dbScripts/insert_application_and_token_for_refresh_token_expiry.sql",
+                "dbScripts/insert_consumer_app.sql", "dbScripts/insert_local_idp.sql"})
+@WithRealmService(injectToSingletons = {OAuthComponentServiceHolder.class})
+
+public class AccessTokenStepUpAuthClaimsSetTest {
+
+    private static final String TOKEN_ID = "test-token-id";
+
+    @Test
+    public void testStepUpClaimsAtRefreshGrant() throws Exception {
+
+        CarbonConstants.ENABLE_LEGACY_AUTHZ_RUNTIME = false;
+        final String testAcr = "test_acr";
+        final long testAuthTime = 1686239200L;
+        final long testMaxAge = 3000L;
+        LinkedHashSet<String> testAcrValue = new LinkedHashSet<>();
+        testAcrValue.add("test_acr_value_1");
+        testAcrValue.add("test_acr_value_2");
+
+        OAuth2AccessTokenReqDTO tokenReq = mock(OAuth2AccessTokenReqDTO.class);
+        when(tokenReq.getClientId()).thenReturn("ca19a540f544777860e44e75f605d927");
+        when(tokenReq.getGrantType()).thenReturn(REFRESH_TOKEN);
+
+        AuthenticatedUser authenticatedUser = mock(AuthenticatedUser.class);
+        when(authenticatedUser.getTenantDomain()).thenReturn("carbon.super");
+        when(authenticatedUser.getUserId()).thenReturn("user-id");
+
+        OAuthTokenReqMessageContext tokReqMsgCtx = spy(new OAuthTokenReqMessageContext(tokenReq));
+        String[] scopeArray = new String[]{"openid", "profile"};
+        tokReqMsgCtx.setScope(scopeArray);
+        tokReqMsgCtx.setAuthorizedUser(authenticatedUser);
+
+        RefreshTokenValidationDataDO validationBean = new RefreshTokenValidationDataDO();
+        validationBean.setAccessTokenValidityInMillis(3600000L);
+        validationBean.setIssuedTime(Timestamp.from(Instant.now()));
+        validationBean.setAuthorizedUser(authenticatedUser);
+        validationBean.setGrantType(REFRESH_TOKEN);
+        validationBean.setTokenId(TOKEN_ID);
+
+        tokReqMsgCtx.addProperty(PREV_ACCESS_TOKEN, validationBean);
+
+        ActionExecutorService actionExecutorService = mock(ActionExecutorService.class);
+        when(actionExecutorService.isExecutionEnabled(ActionType.PRE_ISSUE_ACCESS_TOKEN)).thenReturn(false);
+        OAuthComponentServiceHolder.getInstance().setActionExecutorService(actionExecutorService);
+
+        AuthorizationGrantCacheKey cacheKey = new AuthorizationGrantCacheKey(TOKEN_ID);
+        AuthorizationGrantCacheEntry cacheEntry = spy(new AuthorizationGrantCacheEntry());
+        cacheEntry.setAcrValue(testAcrValue);
+        cacheEntry.setSelectedAcrValue(testAcr);
+        cacheEntry.setMaxAge(testMaxAge);
+        cacheEntry.setAuthTime(testAuthTime);
+        try (MockedStatic<AuthorizationGrantCache> mocked = mockStatic(AuthorizationGrantCache.class)) {
+            AuthorizationGrantCache mockCache = mock(AuthorizationGrantCache.class);
+            mocked.when(AuthorizationGrantCache::getInstance).thenReturn(mockCache);
+            when(mockCache.getValueFromCacheByTokenId(cacheKey, TOKEN_ID)).thenReturn(cacheEntry);
+
+            RefreshGrantHandler refreshGrantHandler = spy(new RefreshGrantHandler());
+            refreshGrantHandler.init();
+            OAuth2AccessTokenRespDTO refreshTokenDTO = refreshGrantHandler.issue(tokReqMsgCtx);
+            assertEquals(tokReqMsgCtx.getSelectedAcr(), testAcr);
+            assertEquals(tokReqMsgCtx.getAuthTime(), testAuthTime);
+        }
+    }
+}

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/handlers/claims/AccessTokenStepUpAuthClaimsSetTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/handlers/claims/AccessTokenStepUpAuthClaimsSetTest.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
 package org.wso2.carbon.identity.oauth2.token.handlers.claims;
 
 import org.mockito.MockedStatic;


### PR DESCRIPTION
### Proposed changes in this pull request

This PR resolves the,
Sub-issue - [Support acr and auth_time claims in access token for step-up authentication #23475  
](https://github.com/wso2/product-is/issues/23475)

![Add acr, auth_time new claims to JWT   Opaque access token](https://github.com/user-attachments/assets/b3a0eaf5-761c-464e-8565-25a595e6dbfd)

Here, when generating the access token in both authorization code and refresh token grants, it already calls to AuthorizationGrantCache (or SessionStore), to retrieve claims.
But in the introspection flow, it had not called to AuthorizationGrantCache (or SessionStore) before I modified.

After this modification, the introspection response will look like this.

{"aut":"APPLICATION_USER","acr":"acr1","nbf":1747377892,"scope":"openid","auth_time":1747377740,"active":true,"token_type":"Bearer","exp":1747381492,"iat":1747377892,"client_id":"WpKDnf1r7FWnyvC02TqowNhQpPEa","username":"harith@carbon.super"}
