### PR TITLE
fix issue in sending server error when redirect url in invalid

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.dcr/src/main/java/org/wso2/carbon/identity/oauth2/dcr/endpoint/util/DCRMUtils.java
+++ b/components/org.wso2.carbon.identity.api.server.dcr/src/main/java/org/wso2/carbon/identity/oauth2/dcr/endpoint/util/DCRMUtils.java
@@ -171,7 +171,8 @@ public class DCRMUtils {
             } else if (errorCode.startsWith(FORBIDDEN_STATUS)) {
                 status = Response.Status.FORBIDDEN;
             } else if (errorCode.startsWith(DCRMConstants.ErrorCodes.INVALID_CLIENT_METADATA) ||
-                    errorCode.startsWith(DCRMConstants.ErrorCodes.INVALID_SOFTWARE_STATEMENT)) {
+                    errorCode.startsWith(DCRMConstants.ErrorCodes.INVALID_SOFTWARE_STATEMENT) ||
+                    errorCode.startsWith(DCRMConstants.ErrorCodes.INVALID_REDIRECT_URI)) {
                 status = Response.Status.BAD_REQUEST;
                 isStatusOnly = false;
             }
@@ -293,7 +294,8 @@ public class DCRMUtils {
             return new DCRMEndpointException(status);
         } else {
             String error = DCRMConstants.ErrorCodes.INVALID_CLIENT_METADATA;
-            if (DCRMConstants.ErrorMessages.BAD_REQUEST_INVALID_REDIRECT_URI.toString().equals(code)) {
+            if (DCRMConstants.ErrorMessages.BAD_REQUEST_INVALID_REDIRECT_URI.toString().equals(code) ||
+                    DCRMConstants.ErrorCodes.INVALID_REDIRECT_URI.equals(code)) {
                 error = DCRMConstants.ErrorCodes.INVALID_REDIRECT_URI;
             }
             if (code.equals(DCRMConstants.ErrorCodes.INVALID_SOFTWARE_STATEMENT)) {


### PR DESCRIPTION
This PR fixes below issues in DCR endpoint.

1. Issue in sending server error when redirect URL in invalid
In the currnet implementation if we set `invalid_redirect_uri` from the AdditionalAttributeFIlter (extension for DCR validations) it responds as internal server error. It was because `invalid_redirect_uri` was not handled from [1]. Hence added a fix to support `invalid_redirect_uri` as ell.


[1] https://github.com/wso2-support/identity-inbound-auth-oauth/blob/support-7.0.259.x-full/components/org.wso2.carbon.identity.api.server.dcr/src/main/java/org/wso2/carbon/identity/oauth2/dcr/endpoint/util/DCRMUtils.java#L173