### PR TITLE
Fix missing isk claim on id tokens retrieved with refresh grant

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/listener/OAuthTokenSessionMappingEventHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/listener/OAuthTokenSessionMappingEventHandler.java
@@ -42,6 +42,7 @@ import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 import java.util.Map;
 
 import static org.apache.commons.lang.StringUtils.isNotBlank;
+import static org.wso2.carbon.identity.oauth2.token.handlers.grant.RefreshGrantHandler.SESSION_IDENTIFIER;
 
 /**
  * This class extends AbstractOAuthEventInterceptor and listen to oauth related events. In this class, we persist
@@ -143,9 +144,13 @@ public class OAuthTokenSessionMappingEventHandler extends AbstractOAuthEventInte
             }
             return;
         }
-        persistTokenToSessionMapping(getSessionContextIdentifierByToken(tokenRespDTO.getAccessToken()),
-                tokenRespDTO.getTokenId(), OAuth2Util.getTenantId(tokenReqDTO.getTenantDomain()),
-                tokenReqDTO.getClientId());
+        String sessionContextId = (String) tokReqMsgCtx.getProperty(SESSION_IDENTIFIER);
+        if (StringUtils.isBlank(sessionContextId)) {
+            // Try to get the session context id from the authorization grant cache.
+            sessionContextId = getSessionContextIdentifierByToken(tokenRespDTO.getAccessToken());
+        }
+        persistTokenToSessionMapping(sessionContextId, tokenRespDTO.getTokenId(),
+                OAuth2Util.getTenantId(tokenReqDTO.getTenantDomain()), tokenReqDTO.getClientId());
     }
 
     /**


### PR DESCRIPTION
After getting an access token, when another token is requested using refresh grant, for consecutive token requests, isk claim will get missing in the id token. Because, since we only tried to read the session context Id from cache before persisting a tokenId sessionContextId mapping in the IDN_OAUTH2_TOKEN_BINDING table.

Related issues:
- https://github.com/wso2/product-is/issues/23928

Related previous PR:
- https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2617