### PR TITLE
Fixes for token revocation & introspection flows

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dao/AccessTokenDAOImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dao/AccessTokenDAOImpl.java
@@ -1159,7 +1159,7 @@ public class AccessTokenDAOImpl extends AbstractOAuthDAO implements AccessTokenD
                     dataDO.setIsConsentedToken(isConsentedToken);
                     dataDO.setAppResidentTenantId(appResideTenantId);
                     dataDO.setAccessTokenExtendedAttributes(new AccessTokenExtendedAttributes(
-                            getAccessTokenExtendedAttributeParameters(accessTokenIdentifier)));
+                            getAccessTokenExtendedAttributeParameters(tokenId)));
 
                     if (StringUtils.isNotBlank(tokenBindingReference) && !NONE.equals(tokenBindingReference)) {
                         setTokenBindingToAccessTokenDO(dataDO, connection, tokenId);

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/bindings/handlers/TokenBindingExpiryEventHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/bindings/handlers/TokenBindingExpiryEventHandler.java
@@ -329,7 +329,7 @@ public class TokenBindingExpiryEventHandler extends AbstractEventHandler {
                     }
 
                     boolean isImpersonatingActorInitiatedRevocation = validateImpersonatingActorInitiatedRevocation(
-                            accessTokenDO, userId);
+                            accessTokenDO, user.getAuthenticatedSubjectIdentifier());
                     if (isFederatedRoleBasedAuthzEnabled
                             && StringUtils.equalsIgnoreCase(
                                     user.getFederatedIdPName(), authenticatedUser.getFederatedIdPName())
@@ -354,7 +354,8 @@ public class TokenBindingExpiryEventHandler extends AbstractEventHandler {
         }
     }
 
-    private boolean validateImpersonatingActorInitiatedRevocation(AccessTokenDO accessTokenDO, String userId) {
+    private boolean validateImpersonatingActorInitiatedRevocation(
+            AccessTokenDO accessTokenDO, String authenticatedSubjectIdentifier) {
 
         boolean isUserSessionImpersonationEnabled = OAuthServerConfiguration.getInstance()
                 .isUserSessionImpersonationEnabled();
@@ -366,7 +367,7 @@ public class TokenBindingExpiryEventHandler extends AbstractEventHandler {
                 accessTokenDO.getAccessTokenExtendedAttributes().getParameters().containsKey(IMPERSONATING_ACTOR);
         if (isImpersonationRequest) {
             return Objects.equals(accessTokenDO.getAccessTokenExtendedAttributes()
-                    .getParameters().get(IMPERSONATING_ACTOR), userId);
+                    .getParameters().get(IMPERSONATING_ACTOR), authenticatedSubjectIdentifier);
         }
         return false;
     }


### PR DESCRIPTION
### Proposed changes in this pull request

1. When revoking tokens when checking whether the impersonator initiated of not, use subject identifier to compare the users.
2. When getting access token attributes from the table, use tokenId as the key, not accessToken itself.


Related Issues:
- https://github.com/wso2/product-is/issues/23462