### PR TITLE
Add a util method to extract bearer token from authz header

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -398,6 +398,7 @@ public class OAuth2Util {
     private static final String EXTERNAL_CONSENT_PAGE_URL = "external_consent_page_url";
 
     private static final String BASIC_AUTHORIZATION_PREFIX = "Basic ";
+    private static final String BEARER_AUTHORIZATION_PREFIX = "Bearer ";
 
     private static final List<String> PORTAL_APP_IDS = Arrays.asList(
             ApplicationConstants.MY_ACCOUNT_APPLICATION_CLIENT_ID,
@@ -5610,6 +5611,31 @@ public class OAuth2Util {
         }
 
         return OAuthUtils.decodeClientAuthenticationHeader(authorizationHeader);
+    }
+
+
+    /**
+     * Get the bearer token from the oauth header.
+     *
+     * @param request Http servlet request.
+     * @return Bearer token.
+     * @throws OAuthClientAuthnException If an error occurs.
+     */
+    public static String extractBearerTokenFromAuthzHeader(HttpServletRequest request)
+            throws OAuthClientAuthnException {
+
+        String authorizationHeader = request.getHeader(HTTPConstants.HEADER_AUTHORIZATION);
+        if (StringUtils.isEmpty(authorizationHeader)) {
+            authorizationHeader = request.getHeader(HTTPConstants.HEADER_AUTHORIZATION.toLowerCase());
+        }
+
+        if (StringUtils.isNotEmpty(authorizationHeader)  &&
+                authorizationHeader.toLowerCase().startsWith(BEARER_AUTHORIZATION_PREFIX.toLowerCase())) {
+            return OAuthUtils.getAuthHeaderField(authorizationHeader);
+        } else {
+            String errMsg = "Bearer authorization header is not available in the request.";
+            throw new OAuthClientAuthnException(errMsg, OAuth2ErrorCodes.INVALID_REQUEST);
+        }
     }
 
     /**


### PR DESCRIPTION
### Purpose
This PR adds a utility method to extract the bearer token from the authorization header of the HTTP/S request.

This util method is primarily used in the [OAuthAppTenantResolverValve.java](https://github.com/wso2-extensions/identity-carbon-auth-rest/pull/315/files#diff-54c8fdea858138b946176f413ec96345203ca31adb77433a1104cdcc05875aae) class class to extract the Bearer authorization header from incoming requests.

This is introduced on par with the effort to support backward compatibility with non-tenant-qualified URLs. This util method extends the existing implementation that extracts the [Basic authentication header](https://github.com/wso2-extensions/identity-inbound-auth-oauth/blob/master/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java#L5599), and is now being utilized within the tenant resolution process.

### Related Issue
- https://github.com/wso2/product-is/issues/23710