### PR TITLE
Authz server metadata

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authzservermetadata/AuthzServerMetadataEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authzservermetadata/AuthzServerMetadataEndpoint.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth.endpoint.authzservermetadata;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.base.MultitenantConstants;
+import org.wso2.carbon.base.ServerConfigurationException;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.discovery.OIDCDiscoveryEndPointException;
+import org.wso2.carbon.identity.discovery.OIDCProcessor;
+import org.wso2.carbon.identity.oauth.common.OAuthConstants;
+import org.wso2.carbon.identity.oauth.endpoint.util.factory.OIDCProviderServiceFactory;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+
+/**
+ * Rest implementation of OIDC discovery endpoint.
+ */
+@Path("/{issuer}/.well-known/oauth-authorization-server")
+public class AuthzServerMetadataEndpoint {
+
+    private static final Log log = LogFactory.getLog(AuthzServerMetadataEndpoint.class);
+    private static final String AUTHZ_SERVER_METADATA_ENDPOINT_PATH_COMPONENT_VALUE_TOKEN = "token";
+
+    @GET
+    @Produces("application/json")
+    public Response getOIDProviderConfiguration(
+            @PathParam("issuer") String discoveryEpPathComponent, @Context HttpServletRequest request) {
+
+        String tenantDomain = null;
+        Object tenantObj = IdentityUtil.threadLocalProperties.get().get(OAuthConstants.TENANT_NAME_FROM_CONTEXT);
+        if (tenantObj != null) {
+            tenantDomain = (String) tenantObj;
+        }
+        if (StringUtils.isEmpty(tenantDomain)) {
+            tenantDomain = MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
+        }
+        if (isValidIssuer(discoveryEpPathComponent)) {
+            return this.getResponse(request, tenantDomain);
+        } else {
+            Response.ResponseBuilder errorResponse = Response.status(HttpServletResponse.SC_BAD_REQUEST);
+            if (log.isDebugEnabled()) {
+                log.debug("The discovery path component is " + discoveryEpPathComponent +
+                        " . The expected discovery path component is either '"
+                        + AUTHZ_SERVER_METADATA_ENDPOINT_PATH_COMPONENT_VALUE_TOKEN);
+            }
+            return errorResponse.entity("Invalid path to the discovery document. " +
+                    "Received path : " + discoveryEpPathComponent + " is not resolvable").build();
+        }
+    }
+
+    private boolean isValidIssuer(String issuer) {
+
+        if (AUTHZ_SERVER_METADATA_ENDPOINT_PATH_COMPONENT_VALUE_TOKEN.equals(issuer)) {
+            return true;
+        }
+        if (log.isDebugEnabled()) {
+            log.debug("DiscoveryEndpointPathComponent validation failed. DiscoveryEndpointPathComponent value: " +
+                    issuer + ", not matched to '"
+                    + AUTHZ_SERVER_METADATA_ENDPOINT_PATH_COMPONENT_VALUE_TOKEN);
+        }
+        return false;
+    }
+
+    private Response getResponse(HttpServletRequest request, String tenant) {
+
+        String response;
+        OIDCProcessor processor = OIDCProviderServiceFactory.getOIDCService();
+        try {
+            AuthzServerMetadataJsonResponseBuilder responseBuilder = new AuthzServerMetadataJsonResponseBuilder();
+            response = responseBuilder.getAuthzServerMetadataConfigString(processor.getResponse(request, tenant));
+
+        } catch (OIDCDiscoveryEndPointException e) {
+            Response.ResponseBuilder errorResponse = Response.status(processor.handleError(e));
+            return errorResponse.entity(e.getMessage()).build();
+        } catch (ServerConfigurationException e) {
+            log.error("Server Configuration error occurred.", e);
+            Response.ResponseBuilder errorResponse = Response.status(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+            return errorResponse.entity("Error in reading configuration.").build();
+        }
+        Response.ResponseBuilder responseBuilder = Response.status(HttpServletResponse.SC_OK);
+        return responseBuilder.entity(response).build();
+    }
+}

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authzservermetadata/AuthzServerMetadataEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authzservermetadata/AuthzServerMetadataEndpoint.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.org).
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -49,8 +49,8 @@ public class AuthzServerMetadataEndpoint {
 
     @GET
     @Produces("application/json")
-    public Response getOIDProviderConfiguration(
-            @PathParam("issuer") String discoveryEpPathComponent, @Context HttpServletRequest request) {
+    public Response getAuthzServerMetadata(
+            @PathParam("issuer") String authzServerMetadataEpPathComponent, @Context HttpServletRequest request) {
 
         String tenantDomain = null;
         Object tenantObj = IdentityUtil.threadLocalProperties.get().get(OAuthConstants.TENANT_NAME_FROM_CONTEXT);
@@ -60,17 +60,17 @@ public class AuthzServerMetadataEndpoint {
         if (StringUtils.isEmpty(tenantDomain)) {
             tenantDomain = MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
         }
-        if (isValidIssuer(discoveryEpPathComponent)) {
+        if (isValidIssuer(authzServerMetadataEpPathComponent)) {
             return this.getResponse(request, tenantDomain);
         } else {
             Response.ResponseBuilder errorResponse = Response.status(HttpServletResponse.SC_BAD_REQUEST);
             if (log.isDebugEnabled()) {
-                log.debug("The discovery path component is " + discoveryEpPathComponent +
-                        " . The expected discovery path component is either '"
+                log.debug("The oauth authorization server metadata path component is " + authzServerMetadataEpPathComponent +
+                        " . The expected oauth authorization server metadata path component is either '"
                         + AUTHZ_SERVER_METADATA_ENDPOINT_PATH_COMPONENT_VALUE_TOKEN);
             }
-            return errorResponse.entity("Invalid path to the discovery document. " +
-                    "Received path : " + discoveryEpPathComponent + " is not resolvable").build();
+            return errorResponse.entity("Invalid path to the oauth authorization server metadata document. " +
+                    "Received path : " + authzServerMetadataEpPathComponent + " is not resolvable").build();
         }
     }
 
@@ -80,7 +80,7 @@ public class AuthzServerMetadataEndpoint {
             return true;
         }
         if (log.isDebugEnabled()) {
-            log.debug("DiscoveryEndpointPathComponent validation failed. DiscoveryEndpointPathComponent value: " +
+            log.debug("AuthzServerMetadataEndpointPathComponent validation failed. AuthzServerMetadataEndpointPathComponent value: " +
                     issuer + ", not matched to '"
                     + AUTHZ_SERVER_METADATA_ENDPOINT_PATH_COMPONENT_VALUE_TOKEN);
         }

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authzservermetadata/AuthzServerMetadataEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authzservermetadata/AuthzServerMetadataEndpoint.java
@@ -39,7 +39,7 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 
 /**
- * Rest implementation of OIDC discovery endpoint.
+ * Rest implementation of OAuth 2 Authorization Server Metadata endpoint.
  */
 @Path("/{issuer}/.well-known/oauth-authorization-server")
 public class AuthzServerMetadataEndpoint {

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authzservermetadata/AuthzServerMetadataJsonResponseBuilder.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authzservermetadata/AuthzServerMetadataJsonResponseBuilder.java
@@ -1,0 +1,41 @@
+package org.wso2.carbon.identity.oauth.endpoint.authzservermetadata;
+
+import com.google.gson.Gson;
+import org.wso2.carbon.identity.discovery.OIDProviderConfigResponse;
+
+import java.util.*;
+
+public class AuthzServerMetadataJsonResponseBuilder {
+
+    private static final String[] AUTHZ_SERVER_METADATA_RESPONSE_ATTRIBUTES = {
+            "issuer",
+            "authorization_endpoint",
+            "token_endpoint",
+            "jwks_uri",
+            "scopes_supported",
+            "response_types_supported",
+            "grant_types_supported",
+            "response_modes_supported",
+            "userinfo_endpoint",
+            "registration_endpoint",
+            "token_endpoint_auth_methods_supported",
+            "token_endpoint_auth_signing_alg_values_supported",
+            "revocation_endpoint",
+            "revocation_endpoint_auth_methods_supported",
+            "introspection_endpoint",
+            "introspection_endpoint_auth_methods_supported",
+            "code_challenge_methods_supported"
+
+    };
+
+    public String getAuthzServerMetadataConfigString(OIDProviderConfigResponse oidProviderConfigResponse) {
+
+        Map<String, Object> configs = oidProviderConfigResponse.getConfigMap();
+
+        Set<String> allowedKeys = new HashSet<>(Arrays.asList(AUTHZ_SERVER_METADATA_RESPONSE_ATTRIBUTES));
+        configs.keySet().retainAll(allowedKeys);
+
+        return new Gson().toJson(configs);
+    }
+}
+

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authzservermetadata/AuthzServerMetadataJsonResponseBuilder.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authzservermetadata/AuthzServerMetadataJsonResponseBuilder.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.org).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.wso2.carbon.identity.oauth.endpoint.authzservermetadata;
 
 import com.google.gson.Gson;

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authzservermetadata/AuthzServerMetadataJsonResponseBuilder.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authzservermetadata/AuthzServerMetadataJsonResponseBuilder.java
@@ -43,7 +43,6 @@ public class AuthzServerMetadataJsonResponseBuilder {
             "introspection_endpoint",
             "introspection_endpoint_auth_methods_supported",
             "code_challenge_methods_supported"
-
     };
 
     public String getAuthzServerMetadataConfigString(OIDProviderConfigResponse oidProviderConfigResponse) {

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/webapp/WEB-INF/web.xml
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/webapp/WEB-INF/web.xml
@@ -88,6 +88,7 @@
                 org.wso2.carbon.identity.oauth.endpoint.user.OpenIDConnectUserEndpoint,
                 org.wso2.carbon.identity.oauth.endpoint.jwks.JwksEndpoint,
                 org.wso2.carbon.identity.oauth.endpoint.oidcdiscovery.OIDCDiscoveryEndpoint,
+                org.wso2.carbon.identity.oauth.endpoint.authzservermetadata.AuthzServerMetadataEndpoint,
                 org.wso2.carbon.identity.oauth.endpoint.device.DeviceEndpoint,
                 org.wso2.carbon.identity.oauth.endpoint.device.UserAuthenticationEndpoint,
                 org.wso2.carbon.identity.oauth.endpoint.ciba.OAuth2CibaEndpoint,


### PR DESCRIPTION
### Proposed changes in this pull request

This PR adds support for the OAuth2 Authorization Server Metadata specification[1] by introducing the `.well-known/oauth-authorization-server` endpoint.

[1] https://datatracker.ietf.org/doc/html/rfc8414#section-2
