### PR TITLE
Fix Null Pointer Exception for Missing client_name in DCR Requests

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/DCRMConstants.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/DCRMConstants.java
@@ -61,7 +61,8 @@ public class DCRMConstants {
         MANDATORY_SOFTWARE_STATEMENT("Mandatory software statement is missing"),
         FAILED_TO_READ_SSA("Error occurred while reading the software statement"),
         ADDITIONAL_ATTRIBUTE_ERROR("Error occurred while handling additional attributes"),
-        FAILED_TO_RESOLVE_TENANT_DOMAIN("Error while resolving tenant domain from the organization id: %s");
+        FAILED_TO_RESOLVE_TENANT_DOMAIN("Error while resolving tenant domain from the organization id: %s"),
+        MISSING_CLIENT_NAME("The client name is missing or empty.");
 
         private final String message;
         private final String errorCode;

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/service/DCRMService.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/service/DCRMService.java
@@ -536,6 +536,12 @@ public class DCRMService {
         String spName = registrationRequest.getClientName();
         String templateName = registrationRequest.getSpTemplateName();
         boolean isManagementApp = registrationRequest.isManagementApp();
+
+        if (StringUtils.isBlank(spName)) {
+            throw DCRMUtils.generateClientException(DCRMConstants.ErrorMessages.BAD_REQUEST_INVALID_INPUT,
+                    DCRMConstants.ErrorMessages.MISSING_CLIENT_NAME.getMessage());
+        }
+
         // Regex validation of the application name.
         if (!DCRMUtils.isRegexValidated(spName)) {
             throw DCRMUtils.generateClientException(DCRMConstants.ErrorMessages.BAD_REQUEST_INVALID_SP_NAME,


### PR DESCRIPTION
### Purpose

Prevent runtime failures when a Dynamic Client Registration (DCR) request is submitted without a `client_name` by handling the missing value gracefully.

### Goals

* Avoid `NullPointerException` caused by `null` or empty `client_name`.
* Provide a clear, descriptive error message to the client.
* Ensure consistent validation for required fields in DCR.

### Approach

* Introduced a null/empty check for `client_name` in the `createOAuthApplication` method of `RegistrationHandler.java`.
* Added a new error enum `MISSING_CLIENT_NAME` to `DCRMConstants.ErrorMessages` with the message: `"The 'client_name' field is missing or empty."`.
* Replaced the raw validation logic with a structured error response using `DCRMUtils.generateClientException(...)`.

## Related Issues
public issue: https://github.com/wso2/product-is/issues/23990