### PR TITLE
Framework version bump with some unit test refactoring for testng

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.extension/src/test/java/org/wso2/carbon/identity/oauth/extension/engine/impl/OpenJdkJSEngineImplTest.java
+++ b/components/org.wso2.carbon.identity.oauth.extension/src/test/java/org/wso2/carbon/identity/oauth/extension/engine/impl/OpenJdkJSEngineImplTest.java
@@ -28,9 +28,9 @@ import java.util.Map;
 
 import javax.script.ScriptException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 
 public class OpenJdkJSEngineImplTest {
 

--- a/components/org.wso2.carbon.identity.oauth.par/src/test/java/org/wso2/carbon/identity/oauth/par/core/OAuthParRequestWrapperTest.java
+++ b/components/org.wso2.carbon.identity.oauth.par/src/test/java/org/wso2/carbon/identity/oauth/par/core/OAuthParRequestWrapperTest.java
@@ -29,12 +29,12 @@ import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.HttpMethod;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
 
 /**
  * Test class for OAuthParRequestWrapper.

--- a/components/org.wso2.carbon.identity.oauth.rar/src/test/java/org/wso2/carbon/identity/oauth/rar/AuthorizationDetailsSchemaValidatorTest.java
+++ b/components/org.wso2.carbon.identity.oauth.rar/src/test/java/org/wso2/carbon/identity/oauth/rar/AuthorizationDetailsSchemaValidatorTest.java
@@ -34,8 +34,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 import static org.wso2.carbon.identity.oauth.rar.util.TestConstants.TEST_SCHEMA;
 import static org.wso2.carbon.identity.oauth.rar.util.TestConstants.TEST_TYPE;
 

--- a/components/org.wso2.carbon.identity.oauth.rar/src/test/java/org/wso2/carbon/identity/oauth/rar/dao/AuthorizationDetailsDAOImplTest.java
+++ b/components/org.wso2.carbon.identity.oauth.rar/src/test/java/org/wso2/carbon/identity/oauth/rar/dao/AuthorizationDetailsDAOImplTest.java
@@ -40,11 +40,11 @@ import java.util.Collections;
 import java.util.Set;
 import java.util.UUID;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
 import static org.wso2.carbon.identity.oauth.rar.util.TestConstants.TEST_AUTHORIZATION_CODE;
 import static org.wso2.carbon.identity.oauth.rar.util.TestConstants.TEST_CODE_ID;
 import static org.wso2.carbon.identity.oauth.rar.util.TestConstants.TEST_CONSENT_ID;

--- a/components/org.wso2.carbon.identity.oauth.rar/src/test/java/org/wso2/carbon/identity/oauth/rar/util/AuthorizationDetailsCommonUtilsTest.java
+++ b/components/org.wso2.carbon.identity.oauth.rar/src/test/java/org/wso2/carbon/identity/oauth/rar/util/AuthorizationDetailsCommonUtilsTest.java
@@ -27,11 +27,11 @@ import java.lang.reflect.Method;
 import java.util.Map;
 import java.util.Set;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 import static org.wso2.carbon.identity.oauth.rar.util.AuthorizationDetailsConstants.EMPTY_JSON_ARRAY;
 import static org.wso2.carbon.identity.oauth.rar.util.AuthorizationDetailsConstants.EMPTY_JSON_OBJECT;
 import static org.wso2.carbon.identity.oauth.rar.util.TestConstants.TEST_NAME;

--- a/pom.xml
+++ b/pom.xml
@@ -967,7 +967,7 @@
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!-- Carbon Identity Framework version -->
-        <carbon.identity.framework.version>7.8.141</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.8.194</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.25.234, 8.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
         <identity.oauth.xacml.version.range>[2.0.0, 3.0.0)</identity.oauth.xacml.version.range>


### PR DESCRIPTION
This pr includes,

1. The framework version bump from 7.8.141 to 7.8.194
2. Some sub-modules were using JUnit instead of TestNG through an indirect compile-time dependency brought in by SecureVault. With the SecureVault version upgrade, this transitive JUnit dependency was removed, resulting in compilation errors during the framework version bump. Since the current direction is to adopt TestNG over JUnit, the affected test cases were refactored accordingly.