### PR TITLE
Add method to get public client supported grant types

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImpl.java
@@ -2153,6 +2153,30 @@ public class OAuthAdminServiceImpl {
         return allowedGrants.toArray(new String[allowedGrants.size()]);
     }
 
+    /**
+     * Get the list of grant types that supports public clients.
+     *
+     * @return Array of grant types that supports public clients.
+     */
+    public String[] getPublicClientSupportedGrantTypes() {
+
+        return PublicClientSupportedGrantTypeHolder.PUBLIC_CLIENT_SUPPORTED_GRANTS;
+    }
+
+    private static class PublicClientSupportedGrantTypeHolder {
+
+        static final String[] PUBLIC_CLIENT_SUPPORTED_GRANTS;
+        static {
+            List<String> publicClientSupportedGrantTypes =
+                    OAuthServerConfiguration.getInstance().getPublicClientSupportedGrantTypesList();
+            if (publicClientSupportedGrantTypes == null || publicClientSupportedGrantTypes.isEmpty()) {
+                PUBLIC_CLIENT_SUPPORTED_GRANTS = new String[0];
+            } else {
+                PUBLIC_CLIENT_SUPPORTED_GRANTS = publicClientSupportedGrantTypes.toArray(new String[0]);
+            }
+        }
+    }
+
     boolean isImplicitGrantEnabled() {
 
         Map<String, ResponseTypeHandler> responseTypeHandlers =

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImplTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImplTest.java
@@ -1409,4 +1409,28 @@ public class OAuthAdminServiceImplTest {
                 {scope, oidcDialectClaims}
         };
     }
+
+    @Test
+    public void testGetPublicClientSupportedGrantTypes() {
+
+        try (MockedStatic<OAuthServerConfiguration> oAuthServerConfigurationMockedStatic = mockStatic(
+                OAuthServerConfiguration.class)) {
+
+            OAuthServerConfiguration mockServerConfig = mock(OAuthServerConfiguration.class);
+            oAuthServerConfigurationMockedStatic.when(OAuthServerConfiguration::getInstance)
+                    .thenReturn(mockServerConfig);
+
+            List<String> grantTypes = Arrays.asList("authorization_code", "refresh_token", "password");
+            when(mockServerConfig.getPublicClientSupportedGrantTypesList()).thenReturn(grantTypes);
+
+            OAuthAdminServiceImpl oAuthAdminService = new OAuthAdminServiceImpl();
+            String[] supportedGrantTypes = oAuthAdminService.getPublicClientSupportedGrantTypes();
+
+            Assert.assertNotNull(supportedGrantTypes);
+            Assert.assertEquals(supportedGrantTypes.length, 3);
+            Assert.assertTrue(Arrays.asList(supportedGrantTypes).contains("authorization_code"));
+            Assert.assertTrue(Arrays.asList(supportedGrantTypes).contains("refresh_token"));
+            Assert.assertTrue(Arrays.asList(supportedGrantTypes).contains("password"));
+        }
+    }
 }


### PR DESCRIPTION
### Purpose
Adding a method to get a list of grant types which support public clients.

### Related issue
- https://github.com/wso2/product-is/issues/23972