### PR TITLE
Remove trailing semicolon from store PAR SQL query

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.par/src/main/java/org/wso2/carbon/identity/oauth/par/common/SQLQueries.java
+++ b/components/org.wso2.carbon.identity.oauth.par/src/main/java/org/wso2/carbon/identity/oauth/par/common/SQLQueries.java
@@ -33,7 +33,7 @@ public class SQLQueries {
     public static class ParSQLQueries {
 
         public static final String STORE_PAR_REQUEST = "INSERT INTO IDN_OAUTH_PAR " +
-                "(REQ_URI_REF, CLIENT_ID, SCHEDULED_EXPIRY, PARAMETERS) VALUES (?, ?, ?, ?);";
+                "(REQ_URI_REF, CLIENT_ID, SCHEDULED_EXPIRY, PARAMETERS) VALUES (?, ?, ?, ?)";
 
         public static final String RETRIEVE_PAR_REQUEST = "SELECT CLIENT_ID, SCHEDULED_EXPIRY, PARAMETERS " +
                 "FROM IDN_OAUTH_PAR WHERE REQ_URI_REF = ?";


### PR DESCRIPTION
### Purpose
Removed a trailing semicolon from the SQL query used to insert details related to PAR authorization requests.

### Related issue
- https://github.com/wso2/product-is/issues/24210

