### PR TITLE
Support DPoP tokens in /oauth2/userinfo endpoint

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/user/impl/UserInforRequestDefaultValidator.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/user/impl/UserInforRequestDefaultValidator.java
@@ -101,7 +101,7 @@ public class UserInforRequestDefaultValidator implements UserInfoRequestValidato
 
         if (authzHeaderInfo.length < 2) {
             throw new UserInfoEndpointException(
-                    OAuthError.ResourceResponse.INVALID_REQUEST, "No valid Authorization header provided"
+                    OAuthError.ResourceResponse.INVALID_REQUEST, "Bearer token missing"
             );
         }
 
@@ -121,7 +121,7 @@ public class UserInforRequestDefaultValidator implements UserInfoRequestValidato
             return authzHeaderInfo[1];
         } else {
             throw new UserInfoEndpointException(
-                    OAuthError.ResourceResponse.INVALID_REQUEST, "No valid Authorization header provided"
+                    OAuthError.ResourceResponse.INVALID_REQUEST, "Bearer token missing"
             );
         }
     }

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/user/impl/UserInfoISAccessTokenValidatorTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/user/impl/UserInfoISAccessTokenValidatorTest.java
@@ -151,7 +151,7 @@ public class UserInfoISAccessTokenValidatorTest {
                         "DPoP header is required with DPoP tokens"},
                 // Unsupported token scheme
                 {"Basic " + token, contentTypeHeaderValue, null,
-                        "No valid Authorization header provided"},
+                        "Bearer token missing"},
         };
     }
 


### PR DESCRIPTION
## Purpose

Fixes [wso2/product-is#24273](https://github.com/wso2/product-is/issues/24273)

## Background

The UserInfo endpoint in WSO2 Identity Server was originally implemented to support only Bearer tokens for authorization. However, with the introduction of DPoP-bound access token support, the logic needed to be enhanced to accept DPoP tokens in addition to Bearer tokens.

The reported issue indicated that when a DPoP-bound access token was used to access the UserInfo endpoint, it failed with the error "Bearer token missing", even though the token was technically present and valid under the DPoP scheme. This behavior was limiting in scenarios where DPoP tokens were legitimately used.

## Changes Introduced in This PR

- Enhance the UserInfo endpoint to validate access tokens against both Bearer and DPoP schemes.
- Update the token validation logic to extract and accept either a Bearer token or a DPoP-bound token from the Authorization header.
- Introduced additional conditions to handle:
   _Missing Authorization header
   Invalid or unsupported authorization schemes_

## Testing

- Unit tests updated to cover both Bearer and DPoP token parsing.
- Verified behavior for the following cases:
   _Missing Authorization header
   Authorization header with unsupported scheme (e.g., Basic)
   Valid Bearer token
   Valid DPoP-bound access token_