### PR TITLE
Improve error messages during request object signature validation for JWT time-based errors

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/RequestObjectValidatorUtil.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/RequestObjectValidatorUtil.java
@@ -61,8 +61,8 @@ public class RequestObjectValidatorUtil {
     private static final String SHA256_WITH_RSA = "SHA256withRSA";
 
     // These constants are based on error messages from the Nimbus JOSE + JWT library.
-    private static final String NIMBUS_ERROR_JWT_BEFORE_USE_TIME = "JWT before use time";
-    private static final String NIMBUS_ERROR_JWT_EXPIRED = "Expired JWT";
+    public static final String NIMBUS_ERROR_JWT_BEFORE_USE_TIME = "JWT before use time";
+    public static final String NIMBUS_ERROR_JWT_EXPIRED = "Expired JWT";
 
     /**
      * Validate the signature of the request object

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/RequestObjectValidatorUtil.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/RequestObjectValidatorUtil.java
@@ -60,6 +60,10 @@ public class RequestObjectValidatorUtil {
             "AllowedSignatureAlgorithms.AllowedSignatureAlgorithm";
     private static final String SHA256_WITH_RSA = "SHA256withRSA";
 
+    // These constants are based on error messages from the Nimbus JOSE + JWT library.
+    private static final String NIMBUS_ERROR_JWT_BEFORE_USE_TIME = "JWT before use time";
+    private static final String NIMBUS_ERROR_JWT_EXPIRED = "Expired JWT";
+
     /**
      * Validate the signature of the request object
      * @param requestObject Request Object
@@ -192,6 +196,14 @@ public class RequestObjectValidatorUtil {
                 return new JWKSBasedJWTValidator().validateSignature(jwtString, jwksUri, alg, MapUtils.EMPTY_MAP);
             } catch (IdentityOAuth2Exception e) {
                 String errorMessage = "Error occurred while validating request object signature using jwks endpoint";
+                String causeMessage = e.getCause() != null ? e.getCause().getMessage() : e.getMessage();
+                if (causeMessage != null) {
+                    if (causeMessage.contains(NIMBUS_ERROR_JWT_BEFORE_USE_TIME)) {
+                        errorMessage += ": request object is not valid yet.";
+                    } else if (causeMessage.contains(NIMBUS_ERROR_JWT_EXPIRED)) {
+                        errorMessage += ": request object is expired.";
+                    }
+                }
                 throw new RequestObjectException(OAuth2ErrorCodes.SERVER_ERROR, errorMessage, e);
             }
         } else {

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/RequestObjectValidatorUtilTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/RequestObjectValidatorUtilTest.java
@@ -28,7 +28,11 @@ import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.RequestObjectException;
 import org.wso2.carbon.identity.oauth2.validators.jwt.JWKSBasedJWTValidator;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 import static org.wso2.carbon.identity.oauth.RequestObjectValidatorUtil.NIMBUS_ERROR_JWT_BEFORE_USE_TIME;

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/RequestObjectValidatorUtilTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/RequestObjectValidatorUtilTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth;
+
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.proc.BadJOSEException;
+import com.nimbusds.jwt.SignedJWT;
+import org.mockito.MockedConstruction;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
+import org.wso2.carbon.identity.oauth2.RequestObjectException;
+import org.wso2.carbon.identity.oauth2.validators.jwt.JWKSBasedJWTValidator;
+
+import static org.mockito.Mockito.*;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+import static org.wso2.carbon.identity.oauth.RequestObjectValidatorUtil.NIMBUS_ERROR_JWT_BEFORE_USE_TIME;
+import static org.wso2.carbon.identity.oauth.RequestObjectValidatorUtil.NIMBUS_ERROR_JWT_EXPIRED;
+
+public class RequestObjectValidatorUtilTest {
+
+    @Test
+    public void testIsSignatureVerifiedNBFError() {
+
+        SignedJWT mockJwt = mock(SignedJWT.class);
+        when(mockJwt.getParsedString()).thenReturn("dummy-jwt");
+
+        JWSHeader mockHeader = mock(JWSHeader.class);
+        when(mockJwt.getHeader()).thenReturn(mockHeader);
+        when(mockHeader.getAlgorithm()).thenReturn(JWSAlgorithm.PS256);
+
+        String jwksUri = "https://example.com/jwks";
+
+        BadJOSEException badJOSEEx = new BadJOSEException(NIMBUS_ERROR_JWT_BEFORE_USE_TIME);
+        IdentityOAuth2Exception ex =
+                new IdentityOAuth2Exception("Signature validation failed for the provided JWT.", badJOSEEx);
+
+        try (MockedConstruction<JWKSBasedJWTValidator> mocked = mockConstruction(JWKSBasedJWTValidator.class,
+                (mock, context) -> {
+                    when(mock.validateSignature(anyString(), anyString(), anyString(), anyMap())).thenThrow(ex);
+                })) {
+
+            RequestObjectValidatorUtil.isSignatureVerified(mockJwt, jwksUri);
+            fail("Expected RequestObjectException was not thrown.");
+        } catch (RequestObjectException e) {
+            assertTrue(e.getMessage().contains("request object is not valid yet"),
+                    "Expected error message to mention 'not valid yet'");
+        }
+    }
+
+    @Test
+    public void testIsSignatureVerified_EXPError() {
+
+        SignedJWT mockJwt = mock(SignedJWT.class);
+        when(mockJwt.getParsedString()).thenReturn("dummy-jwt");
+
+        JWSHeader mockHeader = mock(JWSHeader.class);
+        when(mockJwt.getHeader()).thenReturn(mockHeader);
+        when(mockHeader.getAlgorithm()).thenReturn(JWSAlgorithm.PS256);
+
+        String jwksUri = "https://example.com/jwks";
+
+        BadJOSEException badJOSEEx = new BadJOSEException(NIMBUS_ERROR_JWT_EXPIRED);
+        IdentityOAuth2Exception ex =
+                new IdentityOAuth2Exception("Signature validation failed for the provided JWT.", badJOSEEx);
+
+        try (MockedConstruction<JWKSBasedJWTValidator> mocked = mockConstruction(JWKSBasedJWTValidator.class,
+                (mock, context) -> {
+                    when(mock.validateSignature(anyString(), anyString(), anyString(), anyMap())).thenThrow(ex);
+                })) {
+
+            RequestObjectValidatorUtil.isSignatureVerified(mockJwt, jwksUri);
+            fail("Expected RequestObjectException was not thrown.");
+        } catch (RequestObjectException e) {
+            assertTrue(e.getMessage().contains("request object is expired"),
+                    "Expected error message to mention 'expired'");
+        }
+    }
+}

--- a/components/org.wso2.carbon.identity.oauth/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.identity.oauth/src/test/resources/testng.xml
@@ -27,6 +27,7 @@
         <parameter name="log-levels" value="debug, info" />
         <classes>
             <class name="org.wso2.carbon.identity.oauth.OAuthUtilTest"/>
+            <class name="org.wso2.carbon.identity.oauth.RequestObjectValidatorUtilTest"/>
             <class name="org.wso2.carbon.identity.oauth2.token.handlers.grant.AbstractAuthorizationGrantHandlerTest"/>
             <class name="org.wso2.carbon.identity.oauth2.validators.JDBCScopeValidatorTest"/>
             <class name="org.wso2.carbon.identity.oauth2.validators.OIDCScopeHandlerTest"/>


### PR DESCRIPTION
### Purpose
To improve clarity of error messages returned during request object signature validation failures, especially when failures are due to time-based JWT claims such as `nbf` (Not Before) or `exp` (Expiration Time).

### Goals
* Avoid misleading messages that imply signature validation failure when the actual cause is a timing-related JWT validation error.
* Improve the user experience and debuggability of the authorize flow when using signed request objects.

### Approach
* Caught `IdentityOAuth2Exception` during request object signature validation.
* Checked the cause message for known Nimbus errors.
   * If the cause contains `"JWT before use time"` → appended: `: request object is not valid yet.`
   * If the cause contains `"Expired JWT"` → appended: `: request object is expired.`
* Used constants for Nimbus error strings, with a note that these may change.


## Related Issues

public issue: https://github.com/wso2/product-is/issues/24254