### PR TITLE
Fix: Handle null OAuth2TokenValidationRequestDTO in validate() method

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/OAuth2TokenValidationService.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/OAuth2TokenValidationService.java
@@ -48,6 +48,13 @@ public class OAuth2TokenValidationService extends AbstractAdmin {
      */
     public OAuth2TokenValidationResponseDTO validate(OAuth2TokenValidationRequestDTO validationReqDTO) {
 
+        if (validationReqDTO == null) {
+            OAuth2TokenValidationResponseDTO response = new OAuth2TokenValidationResponseDTO();
+            response.setValid(false);
+            response.setErrorMsg("Invalid token validation request");
+            return response;
+        }
+
         TokenValidationHandler validationHandler = TokenValidationHandler.getInstance();
         //trigger pre listeners
         try {

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/OAuth2TokenValidationServiceTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/OAuth2TokenValidationServiceTest.java
@@ -240,4 +240,12 @@ public class OAuth2TokenValidationServiceTest {
         assertNotNull(tokenValidationService.buildIntrospectionResponse(mockedOAuth2TokenValidationRequestDTO),
                 "Expected to be not null");
     }
+
+    @Test
+    public void testValidateWithNullRequest() {
+        OAuth2TokenValidationResponseDTO response = tokenValidationService.validate(null);
+        assertEquals(response.isValid(), false);
+        assertEquals(response.getErrorMsg(), "Invalid token validation request");
+    }
+
 }


### PR DESCRIPTION
### Proposed changes in this pull request

- Added a null check in `OAuth2TokenValidationService.validate()` to avoid `NullPointerException`.
- Added a corresponding unit test in `OAuth2TokenValidationServiceTest` to verify behavior when `null` is passed.

This prevents unexpected crashes if a null validation request is sent.

### When should this PR be merged

- Can be merged immediately once approved, as it is backward-compatible and isolated to validation logic.

### Follow-up actions

- None required. No breaking changes or migrations involved.

---

## Developer Checklist (Mandatory)

- [x] Added a null check to prevent potential runtime error
- [x] Wrote a test for the added logic
- [x] Ensured all existing tests pass

