### PR TITLE
Add authenticated user validation logic for the refresh grant flow.

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/pom.xml
+++ b/components/org.wso2.carbon.identity.oauth/pom.xml
@@ -112,6 +112,24 @@
             <artifactId>org.wso2.carbon.identity.event</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.event.handler.accountlock</groupId>
+            <artifactId>org.wso2.carbon.identity.handler.event.account.lock</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.opensaml</groupId>
+                    <artifactId>opensaml1</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.opensaml</groupId>
+                    <artifactId>opensaml</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.wso2.carbon.identity.framework</groupId>
+                    <artifactId>org.wso2.carbon.identity.mgt</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
             <groupId>org.wso2.carbon.identity.framework</groupId>
             <artifactId>org.wso2.carbon.identity.core</artifactId>
             <exclusions>
@@ -397,6 +415,7 @@
                             org.wso2.carbon.identity.oauth.common.token.bindings.*;version="${identity.inbound.auth.oauth.imp.pkg.version.range}",
                             org.wso2.carbon.identity.oauth.common.*;version="${identity.inbound.auth.oauth.imp.pkg.version.range}",
                             org.wso2.carbon.identity.saml.common.util.*; version="${saml.common.util.version.range}",
+                            org.wso2.carbon.identity.handler.event.account.lock.service.*;version="${account.lock.service.imp.pkg.version.range}",
                             org.wso2.carbon.identity.organization.management.service; version="${carbon.identity.organization.management.core.version.range}",
                             org.wso2.carbon.identity.organization.management.service.exception; version="${carbon.identity.organization.management.core.version.range}",
                             org.wso2.carbon.identity.organization.management.role.management.service; version="${carbon.identity.organization.management.version.range}",

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
@@ -150,6 +150,7 @@ public class OAuthServerConfiguration {
     private boolean isTokenRenewalPerRequestEnabled = false;
     private boolean isRefreshTokenRenewalEnabled = true;
     private boolean isExtendRenewedTokenExpiryTimeEnabled = true;
+    private boolean isValidateAuthenticatedUserForRefreshGrantEnabled = false;
     private boolean assertionsUserNameEnabled = false;
     private boolean accessTokenPartitioningEnabled = false;
     private boolean redirectToRequestedRedirectUriEnabled = true;
@@ -372,6 +373,9 @@ public class OAuthServerConfiguration {
 
         // read refresh token renewal config
         parseRefreshTokenRenewalConfiguration(oauthElem);
+
+        // Read the authenticated user validation config for refresh grant.
+        parseRefreshTokenGrantValidationConfiguration(oauthElem);
 
         // read token persistence processor config
         parseTokenPersistenceProcessorConfig(oauthElem);
@@ -821,6 +825,16 @@ public class OAuthServerConfiguration {
 
     public boolean isExtendRenewedTokenExpiryTimeEnabled() {
         return isExtendRenewedTokenExpiryTimeEnabled;
+    }
+
+    /**
+     * Check if the authenticated user validation is enabled for refresh token grant flow.
+     *
+     * @return Returns true if the config is enabled.
+     */
+    public boolean isValidateAuthenticatedUserForRefreshGrantEnabled() {
+
+        return isValidateAuthenticatedUserForRefreshGrantEnabled;
     }
 
     public Map<String, OauthTokenIssuer> getOauthTokenIssuerMap() {
@@ -2020,6 +2034,20 @@ public class OAuthServerConfiguration {
         }
         if (log.isDebugEnabled()) {
             log.debug("ExtendRenewedRefreshTokenExpiryTime was set to : " + isExtendRenewedTokenExpiryTimeEnabled);
+        }
+    }
+
+    private void parseRefreshTokenGrantValidationConfiguration(OMElement oauthConfigElem) {
+
+        OMElement validateAuthenticatedUserForRefreshGrantElem = oauthConfigElem.getFirstChildWithName(
+                getQNameWithIdentityNS(ConfigElements.VALIDATE_AUTHENTICATED_USER_FOR_REFRESH_GRANT));
+        if (validateAuthenticatedUserForRefreshGrantElem != null) {
+            isValidateAuthenticatedUserForRefreshGrantEnabled =
+                    Boolean.parseBoolean(validateAuthenticatedUserForRefreshGrantElem.getText());
+        }
+        if (log.isDebugEnabled()) {
+            log.debug("ValidateAuthenticatedUserForRefreshGrant was set to : " +
+                    isValidateAuthenticatedUserForRefreshGrantEnabled);
         }
     }
 
@@ -3426,6 +3454,9 @@ public class OAuthServerConfiguration {
         private static final String ENABLE_CACHE = "EnableOAuthCache";
         // Enable/Disable refresh token renewal on each refresh_token grant request
         private static final String RENEW_REFRESH_TOKEN_FOR_REFRESH_GRANT = "RenewRefreshTokenForRefreshGrant";
+        // Enable/Disable Authenticated user validation on refresh_token grant request.
+        private static final String VALIDATE_AUTHENTICATED_USER_FOR_REFRESH_GRANT =
+                "ValidateAuthenticatedUserForRefreshGrant";
         // Enable/Disable extend the lifetime of the new refresh token
         private static final String EXTEND_RENEWED_REFRESH_TOKEN_EXPIRY_TIME = "ExtendRenewedRefreshTokenExpiryTime";
         // TokenPersistenceProcessor

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuth2ServiceComponent.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuth2ServiceComponent.java
@@ -38,6 +38,7 @@ import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.application.mgt.listener.ApplicationMgtListener;
 import org.wso2.carbon.identity.core.util.IdentityCoreInitializedEvent;
 import org.wso2.carbon.identity.event.handler.AbstractEventHandler;
+import org.wso2.carbon.identity.handler.event.account.lock.service.AccountLockService;
 import org.wso2.carbon.identity.oauth.common.OAuthConstants;
 import org.wso2.carbon.identity.oauth.common.token.bindings.TokenBinderInfo;
 import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
@@ -559,6 +560,25 @@ public class OAuth2ServiceComponent {
     protected void unsetIdpManager(IdpManager idpManager) {
 
         OAuth2ServiceComponentHolder.getInstance().setIdpManager(null);
+    }
+
+    @Reference(
+            name = "org.wso2.carbon.identity.handler.event.account.lock.service.AccountLockService",
+            service = AccountLockService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetAccountLockService"
+    )
+    protected void setAccountLockService(AccountLockService accountLockService) {
+
+        log.debug("AccountLockService set in OAuth2ServiceComponent bundle.");
+        OAuth2ServiceComponentHolder.setAccountLockService(accountLockService);
+    }
+
+    protected void unsetAccountLockService(AccountLockService accountLockService) {
+
+        log.debug("AccountLockService unset in OAuth2ServiceComponent bundle.");
+        OAuth2ServiceComponentHolder.setAccountLockService(null);
     }
 
     @Reference(

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuth2ServiceComponentHolder.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuth2ServiceComponentHolder.java
@@ -23,6 +23,7 @@ import org.wso2.carbon.identity.application.authentication.framework.Authenticat
 import org.wso2.carbon.identity.application.authentication.framework.UserSessionManagementService;
 import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.core.handler.HandlerComparator;
+import org.wso2.carbon.identity.handler.event.account.lock.service.AccountLockService;
 import org.wso2.carbon.identity.oauth.OAuthAdminServiceImpl;
 import org.wso2.carbon.identity.oauth.dto.ScopeDTO;
 import org.wso2.carbon.identity.oauth.tokenprocessor.DefaultOAuth2RevocationProcessor;
@@ -79,6 +80,7 @@ public class OAuth2ServiceComponentHolder {
     private List<Scope> oauthScopeBinding = new ArrayList<>();
     private ScopeClaimMappingDAO scopeClaimMappingDAO;
     private static List<String> jwtRenewWithoutRevokeAllowedGrantTypes = new ArrayList<>();
+    private static AccountLockService accountLockService;
     private AccessTokenDAO accessTokenDAOService;
     private TokenManagementDAO tokenManagementDAOService;
     private RefreshTokenGrantProcessor refreshTokenGrantProcessor;
@@ -165,6 +167,26 @@ public class OAuth2ServiceComponentHolder {
 
         OAuth2ServiceComponentHolder.jwtRenewWithoutRevokeAllowedGrantTypes =
                 jwtRenewWithoutRevokeAllowedGrantTypes;
+    }
+
+    /**
+     * Set the account lock service to the OAuth2ServiceComponentHolder.
+     *
+     * @param accountLockService Account lock service instance.
+     */
+    public static void setAccountLockService(AccountLockService accountLockService) {
+
+        OAuth2ServiceComponentHolder.accountLockService = accountLockService;
+    }
+
+    /**
+     * Retrieve the account lock service.
+     *
+     * @return Account lock service instance.
+     */
+    public static AccountLockService getAccountLockService() {
+
+        return OAuth2ServiceComponentHolder.accountLockService;
     }
 
     public static boolean isConsentedTokenColumnEnabled() {

--- a/components/org.wso2.carbon.identity.oidc.session/pom.xml
+++ b/components/org.wso2.carbon.identity.oidc.session/pom.xml
@@ -79,6 +79,12 @@
         <dependency>
             <groupId>org.wso2.carbon.identity.framework</groupId>
             <artifactId>org.wso2.carbon.identity.application.authentication.framework</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.wso2.carbon.identity.event.handler.accountlock</groupId>
+                    <artifactId>org.wso2.carbon.identity.handler.event.account.lock</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.wso2.carbon.identity.inbound.auth.oauth2</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -254,6 +254,13 @@
                 <version>${saml.common.util.version}</version>
             </dependency>
 
+            <!--Event handler dependencies-->
+            <dependency>
+                <groupId>org.wso2.carbon.identity.event.handler.accountlock</groupId>
+                <artifactId>org.wso2.carbon.identity.handler.event.account.lock</artifactId>
+                <version>${account.lock.service.version}</version>
+            </dependency>
+
             <!-- Orbit dependencies -->
             <dependency>
                 <groupId>com.google.gdata.wso2</groupId>
@@ -873,6 +880,10 @@
         <!--SAML Common Util Version-->
         <saml.common.util.version>1.3.0</saml.common.util.version>
         <saml.common.util.version.range>[1.0.0,2.0.0)</saml.common.util.version.range>
+
+        <!-- Account lock service versions -->
+        <account.lock.service.version>1.4.0.16</account.lock.service.version>
+        <account.lock.service.imp.pkg.version.range>[1.4.0.16, 2.0.0)</account.lock.service.imp.pkg.version.range>
 
         <!-- Commons -->
         <commons-lang.wso2.version>2.6.0.wso2v1</commons-lang.wso2.version>


### PR DESCRIPTION
Introduce validation logic to check if the user account is locked from the userstore. If locked, an error with an account lock message will be thrown. As this may cause a performance impact on the refresh grant flow, a configuration option has been added to enable this validation, which is disabled by default.

```
[oauth.token_renewal]
validate_authenticated_user_for_refresh_grant = true
```