### PR TITLE
Enhance cross-sub org access token introspection

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
@@ -182,6 +182,7 @@ public class OAuthServerConfiguration {
     private boolean accessTokenPartitioningEnabled = false;
     private boolean redirectToRequestedRedirectUriEnabled = true;
     private boolean allowCrossTenantIntrospection = true;
+    private boolean allowCrossSubOrgIntrospection = true;
     private boolean useClientIdAsSubClaimForAppTokens = true;
     private boolean removeUsernameFromIntrospectionResponseForAppTokens = true;
     private boolean useLegacyScopesAsAliasForNewScopes = false;
@@ -551,6 +552,9 @@ public class OAuthServerConfiguration {
 
         // Read config for cross tenant allow.
         parseAllowCrossTenantIntrospection(oauthElem);
+
+        // Read config for cross sub org allow.
+        parseAllowCrossSubOrgIntrospection(oauthElem);
 
         // Read config for using client id as sub claim for application tokens.
         parseUseClientIdAsSubClaimForAppTokens(oauthElem);
@@ -3911,12 +3915,36 @@ public class OAuthServerConfiguration {
     }
 
     /**
+     * Parses the AllowCrossTenantTokenIntrospection configuration that used to allow or block token introspection
+     * from other tenants.
+     *
+     * @param oauthConfigElem oauthConfigElem.
+     */
+    private void parseAllowCrossSubOrgIntrospection(OMElement oauthConfigElem) {
+
+        OMElement allowCrossSubOrgIntrospectionElem = oauthConfigElem.getFirstChildWithName(getQNameWithIdentityNS(
+                ConfigElements.ALLOW_CROSS_SUB_ORG_TOKEN_INTROSPECTION));
+        if (allowCrossSubOrgIntrospectionElem != null) {
+            allowCrossSubOrgIntrospection = Boolean.parseBoolean(allowCrossSubOrgIntrospectionElem.getText());
+        }
+    }
+
+    /**
      * This method returns the value of the property AllowCrossTenantTokenIntrospection for the OAuth configuration
      * in identity.xml.
      */
     public boolean isCrossTenantTokenIntrospectionAllowed() {
 
         return allowCrossTenantIntrospection;
+    }
+
+    /**
+     * This method returns the value of the property AllowCrossSubOrgTokenIntrospection for the OAuth configuration
+     * in identity.xml.
+     */
+    public boolean isCrossSubOrgTokenIntrospectionAllowed() {
+
+        return allowCrossSubOrgIntrospection;
     }
 
     /**
@@ -4412,6 +4440,7 @@ public class OAuthServerConfiguration {
 
         // Allow Cross Tenant Introspection Config.
         private static final String ALLOW_CROSS_TENANT_TOKEN_INTROSPECTION = "AllowCrossTenantTokenIntrospection";
+        private static final String ALLOW_CROSS_SUB_ORG_TOKEN_INTROSPECTION = "AllowCrossSubOrgTokenIntrospection";
 
         private static final String USE_CLIENT_ID_AS_SUB_CLAIM_FOR_APP_TOKENS = "UseClientIdAsSubClaimForAppTokens";
         private static final String REMOVE_USERNAME_FROM_INTROSPECTION_RESPONSE_FOR_APP_TOKENS =

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/TokenValidationHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/TokenValidationHandler.java
@@ -37,6 +37,7 @@ import org.wso2.carbon.identity.oauth.common.OAuthConstants;
 import org.wso2.carbon.identity.oauth.common.exception.InvalidOAuthClientException;
 import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
 import org.wso2.carbon.identity.oauth.dao.OAuthAppDO;
+import org.wso2.carbon.identity.oauth.internal.OAuthComponentServiceHolder;
 import org.wso2.carbon.identity.oauth.tokenprocessor.TokenProvider;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2ClientException;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
@@ -50,6 +51,7 @@ import org.wso2.carbon.identity.oauth2.internal.OAuth2ServiceComponentHolder;
 import org.wso2.carbon.identity.oauth2.model.AccessTokenDO;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
+import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementServerException;
 import org.wso2.carbon.identity.organization.management.service.util.OrganizationManagementUtil;
 import org.wso2.carbon.utils.DiagnosticLog;
 
@@ -535,19 +537,30 @@ public class TokenValidationHandler {
                  then getting the tenant domain from the token.
                 */
                 String appTenantDomain = IdentityTenantUtil.getTenantDomain(accessTokenDO.getTenantID());
+                boolean isFragmentApp = false;
                 if (OrganizationManagementUtil.isOrganization(appTenantDomain)) {
                     ServiceProviderProperty[] serviceProviderProperties = OAuth2Util.getServiceProvider(
                             accessTokenDO.getConsumerKey(), appTenantDomain).getSpProperties();
-                    if (!isFragmentApp(serviceProviderProperties)) {
-                        tenantDomain = appTenantDomain;
-                    }
+                    isFragmentApp = isFragmentApp(serviceProviderProperties);
                 }
+
+                // If not a fragment app, set tenantDomain to the application's tenant domain
+                if (!isFragmentApp) {
+                    tenantDomain = appTenantDomain;
+                }
+
                 boolean isCrossTenantTokenIntrospectionAllowed
                         = OAuthServerConfiguration.getInstance().isCrossTenantTokenIntrospectionAllowed();
+                boolean isCrossSubOrgTokenIntrospectionAllowed
+                        = OAuthServerConfiguration.getInstance().isCrossSubOrgTokenIntrospectionAllowed();
                 if (!isCrossTenantTokenIntrospectionAllowed && accessTokenDO != null &&
-                        !tenantDomain.equalsIgnoreCase(accessTokenDO.getAuthzUser().getTenantDomain()) &&
-                        StringUtils.isEmpty(accessTokenDO.getAuthzUser().getAccessingOrganization())) {
-                    throw new IllegalArgumentException("Invalid Access Token. ACTIVE access token is not found.");
+                        !tenantDomain.equalsIgnoreCase(accessTokenDO.getAuthzUser().getTenantDomain())
+                        || !isFragmentApp) {
+                    if (StringUtils.isEmpty(accessTokenDO.getAuthzUser().getAccessingOrganization())) {
+                        throw new IllegalArgumentException("Invalid Access Token. ACTIVE access token is not found.");
+                    } else if (!isCrossSubOrgTokenIntrospectionAllowed) {
+                        validateTokenIntrospectionForSubOrgs(accessTokenDO.getAuthzUser().getAccessingOrganization());
+                    }
                 }
                 List<String> allowedScopes = OAuthServerConfiguration.getInstance().getAllowedScopes();
                 String[] requestedScopes = accessTokenDO.getScope();
@@ -964,6 +977,18 @@ public class TokenValidationHandler {
         } catch (InvalidOAuthClientException e) {
             log.warn("Unable to set the audience in the introspection response. Failed to retrieve the " +
                     "application for client id: " + accessTokenDO.getConsumerKey() + " in tenant: " + tenantDomain);
+        }
+    }
+
+    private void validateTokenIntrospectionForSubOrgs(String accessingOrganization)
+            throws OrganizationManagementServerException {
+
+        String introspectingTenant = IdentityTenantUtil.getTenant(
+                PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantId()).getAssociatedOrganizationUUID();
+        if (introspectingTenant != null && !introspectingTenant.equalsIgnoreCase(
+                OAuthComponentServiceHolder.getInstance().getOrganizationManager()
+                        .getPrimaryOrganizationId(accessingOrganization))) {
+            throw new IllegalArgumentException("Invalid Access Token. ACTIVE access token is not found.");
         }
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/validators/TokenValidationHandlerTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/validators/TokenValidationHandlerTest.java
@@ -74,6 +74,7 @@ import org.wso2.carbon.identity.organization.management.service.util.Organizatio
 import org.wso2.carbon.identity.organization.management.service.util.OrganizationManagementUtil;
 import org.wso2.carbon.idp.mgt.IdentityProviderManager;
 import org.wso2.carbon.user.api.RealmConfiguration;
+import org.wso2.carbon.user.api.Tenant;
 import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.carbon.user.core.tenant.TenantManager;
 
@@ -278,6 +279,7 @@ public class TokenValidationHandlerTest {
                 lenient().doReturn(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME).when(tenantManager)
                         .getDomain(Mockito.anyInt());
                 OAuthComponentServiceHolder.getInstance().setRealmService(realmService);
+                OAuthComponentServiceHolder.getInstance().setOrganizationManager(organizationManager);
                 IdentityTenantUtil.setRealmService(realmService);
                 lenient().when(realmService.getBootstrapRealmConfiguration()).thenReturn(realmConfiguration);
                 identityUtil.when(IdentityUtil::getPrimaryDomainName).thenReturn("PRIMARY");
@@ -299,7 +301,16 @@ public class TokenValidationHandlerTest {
                 tokenBinding.setBindingValue("R4Hj_0nNdIzVvPdCdsWlxNKm6a74cszp4Za4M1iE8P9");
                 accessTokenDO.setTokenBinding(tokenBinding);
 
+                String testUUID = "testUUID";
+                Tenant tenant = new Tenant();
+                tenant.setId(MultitenantConstants.SUPER_TENANT_ID);
+                tenant.setAssociatedOrganizationUUID(testUUID);
+                tenantManager.addTenant(tenant);
+                when(tenantManager.getTenant(anyInt())).thenReturn(tenant);
+                when(organizationManager.getPrimaryOrganizationId(any())).thenReturn(testUUID);
+
                 PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain("carbon.super");
+                PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantId(MultitenantConstants.SUPER_TENANT_ID);
                 TokenProvider tokenProvider = Mockito.mock(TokenProvider.class);
                 when(oAuth2ServiceComponentHolderInstance.getTokenProvider()).thenReturn(tokenProvider);
                 when(tokenProvider.getVerifiedAccessToken(Mockito.anyString(), Mockito.anyBoolean())).thenReturn(


### PR DESCRIPTION
### Purpose
The purpose of this fix is to ensure consistent and correct behavior when introspecting opaque access tokens in a multi-tenant environment. Specifically, it addresses a scenario where application credentials from one tenant could introspect tokens issued by a sub-organization of another tenant, which was not aligned with the intended tenant isolation rules. With this fix, token introspection for sub-organization-issued tokens will follow the same cross-tenant validation rules applied to tokens issued directly by a parent tenant. A configuration option is also introduced to allow reverting to the previous behavior if required.

### Implementation
The fix refines the token introspection logic by adding an explicit check for sub-organization tokens during the validation process. It ensures that when the access token belongs to a sub-organization, introspection is only allowed if cross-sub-organization token introspection is enabled in the configuration. This involves determining whether the application is a fragment application, identifying the correct tenant domain from the token’s metadata, and enforcing the same authorization checks applied to cross-tenant requests. Additionally, a new configuration, is introduced. This setting defaults to false to enforce the new validation logic but can be set to true to fall back to the previous behavior, allowing cross-sub-organization token introspection without restriction.

```
[oauth.introspect]  
allow_cross_sub_org = false  
```

### Related Issue
- https://github.com/wso2/product-is/issues/25005

### Related PRs
- https://github.com/wso2/carbon-identity-framework/pull/7092