### PR TITLE
Fix proxy_context_path does not work as expected in authorize request

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
@@ -57,6 +57,7 @@ import org.wso2.carbon.identity.application.common.util.IdentityApplicationManag
 import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.central.log.mgt.utils.LogConstants;
 import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
+import org.wso2.carbon.identity.core.ServiceURL;
 import org.wso2.carbon.identity.core.ServiceURLBuilder;
 import org.wso2.carbon.identity.core.URLBuilderException;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
@@ -180,6 +181,7 @@ public class EndpointUtil {
     private static final String UNKNOWN_ERROR = "unknown_error";
     private static final String ALLOW_ADDITIONAL_PARAMS_FROM_ERROR_URL = "OAuth.AllowAdditionalParamsFromErrorUrl";
     private static final String KEEP_OIDC_SCOPES_IN_CONSENT_URL = "OAuth.KeepOIDCScopesInConsentURL";
+    private static final String USE_ABSOLUTE_PUBLIC_URL_FOR_AUTH_REQUEST = "OAuth.UseAbsolutePublicURLForAuthRequest";
     private static final String IDP_ENTITY_ID = "IdPEntityId";
     private static Class<? extends OAuthAuthzRequest> oAuthAuthzRequestClass;
 
@@ -592,9 +594,13 @@ public class EndpointUtil {
 
         int tenantId = OAuth2Util.getClientTenatId();
 
-        //Build the authentication request context.
-        String commonAuthCallerPath =
-                ServiceURLBuilder.create().addPath(OAUTH2_AUTHORIZE).build().getRelativeInternalURL();
+        // Build the authentication request context.
+        boolean useAbsolutePublicURLForAuthRequest = Boolean.parseBoolean(IdentityUtil.getProperty(
+                USE_ABSOLUTE_PUBLIC_URL_FOR_AUTH_REQUEST));
+        ServiceURL urlBuilder = ServiceURLBuilder.create().addPath(OAUTH2_AUTHORIZE).build();
+        String commonAuthCallerPath = useAbsolutePublicURLForAuthRequest ? urlBuilder.getAbsolutePublicURL() :
+                urlBuilder.getRelativeInternalURL();
+
         authenticationRequest.setCommonAuthCallerPath(commonAuthCallerPath);
         authenticationRequest.setForceAuth(forceAuthenticate);
         authenticationRequest.setPassiveAuth(checkAuthentication);


### PR DESCRIPTION
### Proposed changes in this pull request

- Introduced a new configuration property `OAuth.UseAbsolutePublicURLForAuthRequest` to control whether the `commonAuthCallerPath` is built using the absolute public URL or the relative internal URL.
- Updated `EndpointUtil` to use `ServiceURLBuilder` and select between `getAbsolutePublicURL()` and `getRelativeInternalURL()` based on the config.
- This allows deployments that require the absolute public URL in the authorize request flow to work correctly.
- The configuration is as follows:
```
[oauth]
use_absolute_public_url_for_auth_request = false
```

Fixes: https://github.com/wso2/product-is/issues/22673, https://github.com/wso2/product-is/issues/25357.

### When should this PR be merged

N/A


### Follow up actions

N/A

## Developer Checklist (Mandatory)

- [x] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact.

### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description.
- [ ] **Is the PR labeled correctly?**

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled.

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests.
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/).

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components.
- [ ] **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

#### Security

- [ ] **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
- [ ] **Are all UI and API inputs run through forms or serializers?**
- [ ] **Are all external inputs validated and sanitized appropriately?**
- [ ] **Does all branching logic have a default case?**
- [ ] **Does this solution handle outliers and edge cases gracefully?**
- [ ] **Are all external communications secured and restricted to SSL?**

#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes should be documented.
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented.
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki.
