### PR TITLE
[Next]Fix app role claim mismatches in idtoken, jwttoken and userinfo

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/ClaimUtil.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/ClaimUtil.java
@@ -407,8 +407,11 @@ public class ClaimUtil {
             if (isSubOrgImpersonatedUser) {
                 resolveRoleClaimForImpersonatedSubOrgUser(authenticatedUser, serviceProvider, userClaims);
             }
+
+            boolean returnOnlyAppAssociatedRoles = OAuthServerConfiguration.getInstance()
+                    .isReturnOnlyAppAssociatedRolesInUserInfo();
             // Resolving roles claim for sub org apps and shared apps since backward compatibility is not needed.
-            if (isRoleClaimRequested && isSubOrgApp) {
+            if (isRoleClaimRequested && (isSubOrgApp || returnOnlyAppAssociatedRoles)) {
                 String[] appAssociatedRoles = OIDCClaimUtil.getAppAssociatedRolesOfUser(authenticatedUser,
                         serviceProvider.getApplicationResourceId());
                 if (appAssociatedRoles != null && appAssociatedRoles.length > 0) {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
@@ -235,6 +235,8 @@ public class OAuthServerConfiguration {
     private String userInfoJWTSignatureAlgorithm = "SHA256withRSA";
     private boolean userInfoMultiValueSupportEnabled = true;
     private boolean userInfoRemoveInternalPrefixFromRoles = false;
+    private boolean isReturnOnlyAppAssociatedRolesInUserInfo = false;
+    private boolean isReturnOnlyAppAssociatedRolesInJWTToken = false;
 
     private String authContextTTL = "15L";
     // property added to fix IDENTITY-4551 in backward compatible manner
@@ -579,6 +581,10 @@ public class OAuthServerConfiguration {
 
         // Read config for restricted query parameters in oauth requests
         parseRestrictedQueryParameters(oauthElem);
+
+        // Read config for returning only app associated roles in JWT token.
+        parseReturnOnlyApplicationAssociatedRoleClaimInJWTToken(oauthElem);
+
     }
 
     /**
@@ -1651,6 +1657,26 @@ public class OAuthServerConfiguration {
     public boolean isUserInfoResponseRemoveInternalPrefixFromRoles() {
 
         return userInfoRemoveInternalPrefixFromRoles;
+    }
+
+    /**
+     * Return application audience roles only in the userinfo response.
+     *
+     * @return Return application audience roles only in the userinfo response.
+     */
+    public boolean isReturnOnlyAppAssociatedRolesInUserInfo() {
+
+        return isReturnOnlyAppAssociatedRolesInUserInfo;
+    }
+
+    /**
+     * Return application audience roles only in the jwt accesstoken.
+     *
+     * @return Return application audience roles only in the jwt access token.
+     */
+    public boolean isReturnOnlyAppAssociatedRolesInJWTToken() {
+
+        return isReturnOnlyAppAssociatedRolesInJWTToken;
     }
 
     public String getConsumerDialectURI() {
@@ -3594,6 +3620,13 @@ public class OAuthServerConfiguration {
                         Boolean.parseBoolean(userInfoResponseRemoveInternalPrefixFromRoles.getText().trim());
             }
 
+            OMElement returnOnlyAppAssociatedRolesInUserInfoElem = openIDConnectConfigElem.getFirstChildWithName(
+                    getQNameWithIdentityNS(ConfigElements.OPENID_CONNECT_RETURN_APP_ROLES_IN_USERINFO));
+            if (returnOnlyAppAssociatedRolesInUserInfoElem != null) {
+                isReturnOnlyAppAssociatedRolesInUserInfo =
+                        Boolean.parseBoolean(returnOnlyAppAssociatedRolesInUserInfoElem.getText().trim());
+            }
+
             if (openIDConnectConfigElem.getFirstChildWithName(
                     getQNameWithIdentityNS(ConfigElements.OPENID_CONNECT_SIGN_JWT_WITH_SP_KEY)) != null) {
                 isJWTSignedWithSPKey = Boolean.parseBoolean(openIDConnectConfigElem.getFirstChildWithName(
@@ -3964,6 +3997,16 @@ public class OAuthServerConfiguration {
         }
     }
 
+    private void parseReturnOnlyApplicationAssociatedRoleClaimInJWTToken(OMElement oauthConfigElem) {
+
+        OMElement returnOnlyAppAssociatedRolesInJWTTokenElem = oauthConfigElem.getFirstChildWithName(
+                getQNameWithIdentityNS(ConfigElements.RETURN_ONLY_APP_ASSOCIATED_ROLES_IN_JWT_TOKEN));
+        if (returnOnlyAppAssociatedRolesInJWTTokenElem != null) {
+            isReturnOnlyAppAssociatedRolesInJWTToken =
+                    Boolean.parseBoolean(returnOnlyAppAssociatedRolesInJWTTokenElem.getText());
+        }
+    }
+
     /**
      * This method returns the value of the property UseClientIdAsSubClaimForAppTokens for the OAuth configuration
      * in identity.xml.
@@ -4250,6 +4293,9 @@ public class OAuthServerConfiguration {
                 "UserInfoMultiValueSupportEnabled";
         public static final String OPENID_CONNECT_USERINFO_REMOVE_INTERNAL_PREFIX_FROM_ROLES =
                 "UserInfoRemoveInternalPrefixFromRoles";
+        private static final String OPENID_CONNECT_RETURN_APP_ROLES_IN_USERINFO =
+                "ReturnOnlyAppAssociatedRolesInUserInfo";
+
         public static final String OPENID_CONNECT_SIGN_JWT_WITH_SP_KEY = "SignJWTWithSPKey";
         public static final String OPENID_CONNECT_IDTOKEN_CUSTOM_CLAIM_CALLBACK_HANDLER =
                 "IDTokenCustomClaimsCallBackHandler";
@@ -4447,6 +4493,10 @@ public class OAuthServerConfiguration {
         private static final String USE_CLIENT_ID_AS_SUB_CLAIM_FOR_APP_TOKENS = "UseClientIdAsSubClaimForAppTokens";
         private static final String REMOVE_USERNAME_FROM_INTROSPECTION_RESPONSE_FOR_APP_TOKENS =
                 "RemoveUsernameFromIntrospectionResponseForAppTokens";
+
+        private static final String RETURN_ONLY_APP_ASSOCIATED_ROLES_IN_JWT_TOKEN =
+                "ReturnOnlyAppAssociatedRolesInJWTToken";
+
 
         // FAPI Configurations
         private static final String FAPI = "FAPI";

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfigurationTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfigurationTest.java
@@ -512,6 +512,21 @@ public class OAuthServerConfigurationTest {
                 .isValidateAuthenticatedUserForRefreshGrantEnabled());
     }
 
+    @Test
+    public void testParseReturnOnlyApplicationAssociatedRoleClaimInJWT() {
+
+        Assert.assertFalse(OAuthServerConfiguration.getInstance()
+                .isReturnOnlyAppAssociatedRolesInJWTToken());
+    }
+
+    @Test
+    public void testParseReturnOnlyApplicationAssociatedRoleClaimInUserInfo() {
+
+        Assert.assertFalse(OAuthServerConfiguration.getInstance()
+                .isReturnOnlyAppAssociatedRolesInUserInfo());
+    }
+
+
     private String fillURLPlaceholdersForTest(String url) {
 
         return url.replace("${carbon.protocol}", "https")


### PR DESCRIPTION
### Proposed changes in this pull request

1- userinfo returned all the roles of the user in password grant and all the grants when the userattributes are retrieved from userstore. However idtoken returned only the application associated roles of the user. Here idtoken and userinfo had mismatches. https://github.com/wso2/product-is/issues/23075

2- jwt token returned all the roles of the user if there are any attributes requested under application's userattributes sections https://github.com/wso2/product-is/issues/24215

Need to enable this configuration
```
[oauth.oidc.user_info]
return_only_app_associated_roles=true
remove_internal_prefix_from_roles=true 

```

To fix the jwt token issue, add below configuration
```
[oauth.jwt]
return_only_app_associated_roles=true
```

### When should this PR be merged

[Please describe any preconditions that need to be addressed before we
can merge this pull request.]


### Follow up actions

[List any possible follow-up actions here; for instance, testing data
migrations, software that we need to install on staging and production
environments.]

-

## Developer Checklist (Mandatory)

- [ ] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact.



### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description.
- [ ] **Is the PR labeled correctly?**

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled.

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests.
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/).

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components.
- [ ] **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

#### Security

- [ ] **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
- [ ] **Are all UI and API inputs run through forms or serializers?**
- [ ] **Are all external inputs validated and sanitized appropriately?**
- [ ] **Does all branching logic have a default case?**
- [ ] **Does this solution handle outliers and edge cases gracefully?**
- [ ] **Are all external communications secured and restricted to SSL?**

#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes should be documented.
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented.
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki.
