### PR TITLE
Improve redirect uri validation

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/validators/AbstractResponseTypeRequestValidator.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/validators/AbstractResponseTypeRequestValidator.java
@@ -36,8 +36,6 @@ import org.wso2.carbon.identity.oauth2.dto.OAuth2ClientValidationResponseDTO;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 import org.wso2.carbon.utils.DiagnosticLog;
 
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;


### PR DESCRIPTION
### Proposed changes in this pull request
This pull request updates the callback URI validation logic in the OAuth2 authorization request validator. The main change is an improvement to how regular expressions are handled to ensure more accurate matching of callback URIs.

Callback URI validation improvements:

* The code now escapes dots in the regular expression only when they are followed by a letter or digit (e.g., `.com`, `.org`), which prevents unintended matches and avoids interfering with wildcard patterns like `.*` or `.+` or `.{n}`.
* The validation logic now checks for the presence of a regular expression: if none is provided, it falls back to a direct string comparison between the registered and provided callback URIs.