### PR TITLE
Generic Error Response on Token Endpoint

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
@@ -1283,8 +1283,7 @@ public class EndpointUtil {
                         "A valid OAuth application could not be found for the given client_id.",
                         "validate-oauth-client", null);
             }
-            throw new InvalidApplicationClientException("A valid OAuth client could not be found for client_id: " +
-                    Encode.forHtml(consumerKey));
+            throw new InvalidApplicationClientException("Client credentials are invalid.");
         }
 
         if (isNotActiveState(appState)) {


### PR DESCRIPTION
Changes the error handling in the OAuth application validation logic. The error message returned when an invalid client ID is provided has been updated to be more generic, no longer including the specific client ID in the exception message.

* Updated the error message in `validateOauthApplication` (in `EndpointUtil.java`) to a generic message ("Client credentials are invalid.") instead of including the `client_id` value in the exception.

Fixes https://github.com/wso2/api-manager/issues/4061