### PR TITLE
Extend Authorization Grant Cache Validity to Refresh Token Expiry

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/handlers/TokenResponseTypeHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/handlers/TokenResponseTypeHandler.java
@@ -579,8 +579,9 @@ public class TokenResponseTypeHandler extends AbstractResponseTypeHandler {
                 }
                 authorizationGrantCacheEntry.setSubjectClaim(sub);
             }
-            authorizationGrantCacheEntry
-                    .setValidityPeriod(TimeUnit.MILLISECONDS.toNanos(accessTokenDO.getValidityPeriodInMillis()));
+            // Setting the validity period of the cache entry to be same as the validity period of the refresh token.
+            authorizationGrantCacheEntry.setValidityPeriod(
+                    TimeUnit.MILLISECONDS.toNanos(accessTokenDO.getRefreshTokenValidityPeriodInMillis()));
             AuthorizationGrantCache.getInstance().addToCacheByToken(authorizationGrantCacheKey,
                     authorizationGrantCacheEntry);
         }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/handlers/util/ResponseTypeHandlerUtil.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/handlers/util/ResponseTypeHandlerUtil.java
@@ -495,8 +495,9 @@ public class ResponseTypeHandlerUtil {
                     authorizeReqDTO.getMappedRemoteClaims());
         }
 
+        // Setting the validity period of the cache entry to be same as the validity period of the refresh token.
         authorizationGrantCacheEntry
-                .setValidityPeriod(TimeUnit.MILLISECONDS.toNanos(accessTokenDO.getValidityPeriodInMillis()));
+                .setValidityPeriod(TimeUnit.MILLISECONDS.toNanos(accessTokenDO.getRefreshTokenValidityPeriodInMillis()));
         AuthorizationGrantCache.getInstance().addToCacheByToken(authorizationGrantCacheKey,
                 authorizationGrantCacheEntry);
     }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dto/OAuth2AccessTokenRespDTO.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dto/OAuth2AccessTokenRespDTO.java
@@ -38,6 +38,7 @@ public class OAuth2AccessTokenRespDTO {
     String errorMsg;
     long expiresIn;
     long expiresInMillis;
+    private long refreshTokenExpiresInMillis;
     ResponseHeader[] responseHeaders;
     String authorizedScopes;
     private String idToken;
@@ -128,6 +129,16 @@ public class OAuth2AccessTokenRespDTO {
 
     public void setExpiresInMillis(long expiresInMillis) {
         this.expiresInMillis = expiresInMillis;
+    }
+
+    public void setRefreshTokenExpiresInMillis(long refreshTokenExpiresInMillis) {
+
+        this.refreshTokenExpiresInMillis = refreshTokenExpiresInMillis;
+    }
+
+    public long getRefreshTokenExpiresInMillis() {
+
+        return refreshTokenExpiresInMillis;
     }
 
     /**

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuer.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuer.java
@@ -1403,8 +1403,9 @@ public class AccessTokenIssuer {
                     log.debug("Adding AuthorizationGrantCache entry for the access token");
                 }
             }
+            // Setting the validity period of the cache entry to be same as the validity period of the refresh token.
             authorizationGrantCacheEntry.setValidityPeriod(
-                    TimeUnit.MILLISECONDS.toNanos(tokenRespDTO.getExpiresInMillis()));
+                    TimeUnit.MILLISECONDS.toNanos(tokenRespDTO.getRefreshTokenExpiresInMillis()));
             AuthorizationGrantCache.getInstance().addToCacheByToken(newCacheKey, authorizationGrantCacheEntry);
         } else {
             if (log.isDebugEnabled()) {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AbstractAuthorizationGrantHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AbstractAuthorizationGrantHandler.java
@@ -949,6 +949,14 @@ public abstract class AbstractAuthorizationGrantHandler implements Authorization
             tokenRespDTO.setExpiresIn(Long.MAX_VALUE / SECONDS_TO_MILISECONDS_FACTOR);
             tokenRespDTO.setExpiresInMillis(Long.MAX_VALUE);
         }
+        long refreshTokenExpiresInMillis = existingAccessTokenDO.getRefreshTokenValidityPeriodInMillis();
+        if (refreshTokenExpiresInMillis > 0) {
+            tokenRespDTO.setRefreshTokenExpiresInMillis(refreshTokenExpiresInMillis);
+        } else if (expireTimeMillis > 0) {
+            tokenRespDTO.setRefreshTokenExpiresInMillis(expireTimeMillis);
+        } else {
+            tokenRespDTO.setExpiresInMillis(Long.MAX_VALUE);
+        }
         tokenRespDTO.setAuthorizedScopes(scope);
         tokenRespDTO.setIsConsentedToken(existingAccessTokenDO.isConsentedToken());
         return tokenRespDTO;

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/ClaimsUtil.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/ClaimsUtil.java
@@ -791,7 +791,8 @@ public class ClaimsUtil {
             authorizationGrantCacheEntry.setTokenId(tokenRespDTO.getTokenId());
         }
 
-        long validityPeriod = TimeUnit.MILLISECONDS.toNanos(tokenRespDTO.getExpiresInMillis());
+        // Setting the validity period of the cache entry to be same as the validity period of the refresh token.
+        long validityPeriod = TimeUnit.MILLISECONDS.toNanos(tokenRespDTO.getRefreshTokenExpiresInMillis());
         authorizationGrantCacheEntry.setValidityPeriod(validityPeriod);
         AuthorizationGrantCache.getInstance()
                 .addToCacheByToken(authorizationGrantCacheKey, authorizationGrantCacheEntry);


### PR DESCRIPTION
**Related Issue**
- https://github.com/wso2/product-is/issues/25136

**Background**

- When federated users authenticate with JIT provisioning disabled, their federated claims are stored only in the session store and Authorization Grant cache.
- Once the cache entry expires (based on access token validity) and the session store entry is cleaned up, there is no longer any data to retrieve these claims.
- As a result, refresh token requests issued after the cache expiry will return tokens without federated claims.

**Root Cause**
- Default cache validity is tied to access token expiry.
- Federated claims are lost if the cache is cleaned before the refresh token expiry.
- During a refresh token grant, claims are loaded from the cache; if missing, they are not re-fetched from the federated IdP.

**Solution**
- This fix introduces a configurable option to extend the Authorization Grant cache validity to match the refresh token expiry.
- Default behavior (config disabled): Cache validity = Access token validity.
- With config enabled: Cache validity = Refresh token validity.

**Implementation details:**
- Updated addToCacheByToken() to set cache validity period based on the new config.
- If AccessTokenDO is not available, modified setExpiryInMillis in responseDTO (used only for cache validity, not the response expiresIn value) to reflect the updated expiry period.


**Reproduction Steps (Before Fix)**
- Configure a second WSO2 IS instance as a federated IdP.
- Request some federated claims from that IdP.
- Authenticate and verify the ID token contains the federated claims.
- In the embedded H2 DB, delete the AuthorizationGrantCache entries for the code and token.
- Restart IS.
- Perform a refresh token grant.
- Observe: New tokens do not contain federated claims.

**Verification (After Fix)**
- Enable the config in deployment.toml.
- Repeat the reproduction steps.
- Federated claims remain available in tokens until the refresh token expires.