### PR TITLE
Enforce literal charactors in callback uri validation with a configuration

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/validators/AbstractResponseTypeRequestValidator.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/validators/AbstractResponseTypeRequestValidator.java
@@ -350,6 +350,54 @@ public abstract class AbstractResponseTypeRequestValidator implements ResponseTy
             registeredCallbackUrl =
                     registeredCallbackUrl.replaceFirst(OAuthConstants.LOOPBACK_IP_PORT_REGEX, StringUtils.EMPTY);
         }
-        return (regexp != null && callbackURI.matches(regexp)) || registeredCallbackUrl.equals(callbackURI);
+
+        if (regexp == null) {
+            return registeredCallbackUrl.equals(callbackURI);
+        }
+
+        /*
+        Escape (.), (+), (?) only when followed by a letter/digit (so .com, .org, etc. get escaped),
+        but don't touch .* or .+ or .{n} .
+         */
+        String escapedSpecialCharRegexp = regexp
+                .replaceAll("(?<!\\\\)\\.(?=[A-Za-z0-9])", "\\\\.")
+                .replaceAll("(?<!\\\\)\\+(?=[A-Za-z0-9])", "\\\\+")
+                .replaceAll("(?<!\\\\)\\?(?=[A-Za-z0-9])", "\\\\?");
+        boolean matchWithEnforcedLiteralCharacters = callbackURI.matches(escapedSpecialCharRegexp);
+        if (isLiteralCharactersEnforcedInCallback()) {
+            return matchWithEnforcedLiteralCharacters;
+        }
+
+        boolean matchWithoutEnforcingLiteralCharacters = callbackURI.matches(regexp);
+        if (LoggerUtils.isDiagnosticLogsEnabled() && matchWithoutEnforcingLiteralCharacters &&
+                !matchWithEnforcedLiteralCharacters) {
+            String[] callbackURIs = regexp.split("\\|");
+            if (regexp.startsWith("(") && regexp.endsWith(")")) {
+                callbackURIs = regexp.substring(1, regexp.length() - 1).split("\\|");
+            }
+            LoggerUtils.triggerDiagnosticLogEvent(new DiagnosticLog.DiagnosticLogBuilder(OAUTH_INBOUND_SERVICE,
+                    VALIDATE_INPUT_PARAMS)
+                    .inputParam(LogConstants.InputKeys.CLIENT_ID, oauthApp.getOauthConsumerKey())
+                    .inputParam(OAuthConstants.LogConstants.InputKeys.REDIRECT_URI, callbackURI)
+                    .configParam(LogConstants.InputKeys.APPLICATION_NAME, oauthApp.getApplicationName())
+                    .configParam(OAuthConstants.LogConstants.ConfigKeys.CALLBACK_URI, callbackURIs)
+                    .resultMessage("Provided callback URI does not match when the characters (., +, ?) " +
+                            "are treated as literals in configured callback URI(s) of the application.")
+                    .logDetailLevel(DiagnosticLog.LogDetailLevel.APPLICATION)
+                    .resultStatus(DiagnosticLog.ResultStatus.FAILED));
+        }
+
+        return matchWithoutEnforcingLiteralCharacters;
+    }
+
+    private boolean isLiteralCharactersEnforcedInCallback() {
+
+        String enforceLiteralCharactersInCallbackValue = IdentityUtil.getProperty(
+                "OAuth.Callback.EnforceLiteralCharacters");
+        if (StringUtils.isBlank(enforceLiteralCharactersInCallbackValue)) {
+            return true;
+        }
+
+        return Boolean.parseBoolean(enforceLiteralCharactersInCallbackValue);
     }
 }


### PR DESCRIPTION
### Proposed changes in this pull request

This pull request updates the callback URI validation logic in the OAuth2 authorization request validator. The main change is an improvement to how regular expressions are handled to ensure more accurate matching of callback URIs.

Callback URI validation improvements:

- The code now escapes`.`, `?`, `+` in the regular expression only when they are followed by a letter or digit (e.g., .com, .org), which prevents unintended matches and avoids interfering with wildcard patterns like .* or .+ or .{n}. when the particular configuration is enabled
- The validation logic now checks for the presence of a regular expression: if none is provided, it falls back to a direct string comparison between the registered and provided callback URIs.
- Also adding a diagnostic log to identify the failing callback validations when the literal charactors are enforced, before enforcing the new behavior with the configuration

### Changes derived from
- http://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2883

### Depends on
- https://github.com/wso2/carbon-identity-framework/pull/7351