### PR TITLE
Remove idp column and consent column check

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/tokenprocessor/DefaultRefreshTokenGrantProcessor.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/tokenprocessor/DefaultRefreshTokenGrantProcessor.java
@@ -98,25 +98,23 @@ public class DefaultRefreshTokenGrantProcessor implements RefreshTokenGrantProce
         accessTokenDO.setIssuedTime(timestamp);
         accessTokenDO.setTokenBinding(tokReqMsgCtx.getTokenBinding());
 
-        if (OAuth2ServiceComponentHolder.isConsentedTokenColumnEnabled()) {
-            String previousGrantType = validationBean.getGrantType();
-            // Check if the previous grant type is consent refresh token type or not.
-            if (!OAuthConstants.GrantTypes.REFRESH_TOKEN.equals(previousGrantType)) {
-                // If the previous grant type is not a refresh token, then check if it's a consent token or not.
-                if (OIDCClaimUtil.isConsentBasedClaimFilteringApplicable(previousGrantType)) {
-                    accessTokenDO.setIsConsentedToken(true);
-                }
-            } else {
-                /* When previousGrantType == refresh_token, we need to check whether the original grant type
-                 is consented or not. */
-                AccessTokenDO accessTokenDOFromTokenIdentifier = OAuth2Util.getAccessTokenDOFromTokenIdentifier(
-                        validationBean.getAccessToken(), false);
-                accessTokenDO.setIsConsentedToken(accessTokenDOFromTokenIdentifier.isConsentedToken());
+        String previousGrantType = validationBean.getGrantType();
+        // Check if the previous grant type is consent refresh token type or not.
+        if (!OAuthConstants.GrantTypes.REFRESH_TOKEN.equals(previousGrantType)) {
+            // If the previous grant type is not a refresh token, then check if it's a consent token or not.
+            if (OIDCClaimUtil.isConsentBasedClaimFilteringApplicable(previousGrantType)) {
+                accessTokenDO.setIsConsentedToken(true);
             }
+        } else {
+            /* When previousGrantType == refresh_token, we need to check whether the original grant type
+             is consented or not. */
+            AccessTokenDO accessTokenDOFromTokenIdentifier = OAuth2Util.getAccessTokenDOFromTokenIdentifier(
+                    validationBean.getAccessToken(), false);
+            accessTokenDO.setIsConsentedToken(accessTokenDOFromTokenIdentifier.isConsentedToken());
+        }
 
-            if (accessTokenDO.isConsentedToken()) {
-                tokReqMsgCtx.setConsentedToken(true);
-            }
+        if (accessTokenDO.isConsentedToken()) {
+            tokReqMsgCtx.setConsentedToken(true);
         }
         return accessTokenDO;
     }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/handlers/util/ResponseTypeHandlerUtil.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/handlers/util/ResponseTypeHandlerUtil.java
@@ -665,16 +665,14 @@ public class ResponseTypeHandlerUtil {
         newTokenBean.setGrantType(grantType);
         /* If the existing token is available, the consented token flag will be extracted from that. Otherwise,
         from the current grant. */
-        if (OAuth2ServiceComponentHolder.isConsentedTokenColumnEnabled()) {
-            if (existingTokenBean != null) {
-                newTokenBean.setIsConsentedToken(existingTokenBean.isConsentedToken());
-            } else {
-                if (OIDCClaimUtil.isConsentBasedClaimFilteringApplicable(grantType)) {
-                    newTokenBean.setIsConsentedToken(true);
-                }
+        if (existingTokenBean != null) {
+            newTokenBean.setIsConsentedToken(existingTokenBean.isConsentedToken());
+        } else {
+            if (OIDCClaimUtil.isConsentBasedClaimFilteringApplicable(grantType)) {
+                newTokenBean.setIsConsentedToken(true);
             }
-            oauthAuthzMsgCtx.setConsentedToken(newTokenBean.isConsentedToken());
         }
+        oauthAuthzMsgCtx.setConsentedToken(newTokenBean.isConsentedToken());
         newTokenBean.setAccessToken(getNewAccessToken(oauthAuthzMsgCtx, oauthIssuerImpl));
         setRefreshTokenDetails(oauthAuthzMsgCtx, oAuthAppBean, existingTokenBean, newTokenBean, oauthIssuerImpl,
                 timestamp);

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dao/AuthorizationCodeDAOImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dao/AuthorizationCodeDAOImpl.java
@@ -96,12 +96,7 @@ public class AuthorizationCodeDAOImpl extends AbstractOAuthDAO implements Author
         String userDomain = OAuth2Util.getUserStoreDomain(authzCodeDO.getAuthorizedUser());
         String authenticatedIDP = OAuth2Util.getAuthenticatedIDP(authzCodeDO.getAuthorizedUser());
         try {
-            String sql;
-            if (OAuth2ServiceComponentHolder.isIDPIdColumnEnabled()) {
-                sql = SQLQueries.STORE_AUTHORIZATION_CODE_WITH_PKCE_IDP_NAME;
-            } else {
-                sql = SQLQueries.STORE_AUTHORIZATION_CODE_WITH_PKCE;
-            }
+            String sql = SQLQueries.STORE_AUTHORIZATION_CODE_WITH_PKCE_IDP_NAME;
             prepStmt = connection.prepareStatement(sql);
 
             prepStmt.setString(1, authzCodeDO.getAuthzCodeId());
@@ -122,14 +117,10 @@ public class AuthorizationCodeDAOImpl extends AbstractOAuthDAO implements Author
             prepStmt.setString(13, getHashingPersistenceProcessor().getProcessedAuthzCode(authzCode));
             prepStmt.setString(14, getPersistenceProcessor().getProcessedClientId(consumerKey));
             int appTenantId = IdentityTenantUtil.getTenantId(appTenantDomain);
-            if (OAuth2ServiceComponentHolder.isIDPIdColumnEnabled()) {
-                prepStmt.setString(15, authenticatedIDP);
-                // Set tenant ID of the IDP by considering it is same as appTenantID.
-                prepStmt.setInt(16, appTenantId);
-                prepStmt.setInt(17, appTenantId);
-            } else {
-                prepStmt.setInt(15, appTenantId);
-            }
+            prepStmt.setString(15, authenticatedIDP);
+            // Set tenant ID of the IDP by considering it is same as appTenantID.
+            prepStmt.setInt(16, appTenantId);
+            prepStmt.setInt(17, appTenantId);
 
             prepStmt.execute();
 
@@ -235,12 +226,7 @@ public class AuthorizationCodeDAOImpl extends AbstractOAuthDAO implements Author
             long validityPeriod = 0;
             int tenantId;
 
-            String sql;
-            if (OAuth2ServiceComponentHolder.isIDPIdColumnEnabled()) {
-                sql = SQLQueries.VALIDATE_AUTHZ_CODE_WITH_PKCE_IDP_NAME;
-            } else {
-                sql = SQLQueries.VALIDATE_AUTHZ_CODE_WITH_PKCE;
-            }
+            String sql = SQLQueries.VALIDATE_AUTHZ_CODE_WITH_PKCE_IDP_NAME;
             prepStmt = connection.prepareStatement(sql);
             prepStmt.setString(1, getPersistenceProcessor().getProcessedClientId(consumerKey));
             prepStmt.setInt(2, IdentityTenantUtil.getLoginTenantId());
@@ -266,10 +252,7 @@ public class AuthorizationCodeDAOImpl extends AbstractOAuthDAO implements Author
                 subjectIdentifier = resultSet.getString(12);
                 pkceCodeChallenge = resultSet.getString(13);
                 pkceCodeChallengeMethod = resultSet.getString(14);
-                String authenticatedIDP = null;
-                if (OAuth2ServiceComponentHolder.isIDPIdColumnEnabled()) {
-                    authenticatedIDP = resultSet.getString(15);
-                }
+                String authenticatedIDP = resultSet.getString(15);
                 user = OAuth2Util.createAuthenticatedUser(authorizedUser, userstoreDomain, tenantDomain,
                         authenticatedIDP);
                 ServiceProvider serviceProvider;
@@ -690,12 +673,7 @@ public class AuthorizationCodeDAOImpl extends AbstractOAuthDAO implements Author
 
         List<AuthzCodeDO> latestAuthzCodes = new ArrayList<>();
         try {
-            String sqlQuery;
-            if (OAuth2ServiceComponentHolder.isIDPIdColumnEnabled()) {
-                sqlQuery = SQLQueries.LIST_LATEST_AUTHZ_CODES_IN_TENANT_IDP_NAME;
-            } else {
-                sqlQuery = SQLQueries.LIST_LATEST_AUTHZ_CODES_IN_TENANT;
-            }
+            String sqlQuery = SQLQueries.LIST_LATEST_AUTHZ_CODES_IN_TENANT_IDP_NAME;
             ps = connection.prepareStatement(sqlQuery);
             ps.setInt(1, tenantId);
             rs = ps.executeQuery();
@@ -713,10 +691,7 @@ public class AuthorizationCodeDAOImpl extends AbstractOAuthDAO implements Author
                             ServiceURLBuilder.create().build().getAbsolutePublicUrlWithoutPath());
                 }
                 String userStoreDomain = rs.getString(9);
-                String authenticatedIDP = null;
-                if (OAuth2ServiceComponentHolder.isIDPIdColumnEnabled()) {
-                    authenticatedIDP = rs.getString(10);
-                }
+                String authenticatedIDP = rs.getString(10);
 
                 AuthenticatedUser user = OAuth2Util.createAuthenticatedUser(authzUser, userStoreDomain, OAuth2Util
                         .getTenantDomain(tenantId), authenticatedIDP);
@@ -759,12 +734,7 @@ public class AuthorizationCodeDAOImpl extends AbstractOAuthDAO implements Author
 
         List<AuthzCodeDO> latestAuthzCodes = new ArrayList<>();
         try {
-            String sqlQuery;
-            if (OAuth2ServiceComponentHolder.isIDPIdColumnEnabled()) {
-                sqlQuery = SQLQueries.LIST_LATEST_AUTHZ_CODES_IN_USER_DOMAIN_IDP_NAME;
-            } else {
-                sqlQuery = SQLQueries.LIST_LATEST_AUTHZ_CODES_IN_USER_DOMAIN;
-            }
+            String sqlQuery = SQLQueries.LIST_LATEST_AUTHZ_CODES_IN_USER_DOMAIN_IDP_NAME;
             ps = connection.prepareStatement(sqlQuery);
             ps.setInt(1, tenantId);
             ps.setString(2, userStoreDomain);
@@ -782,10 +752,7 @@ public class AuthorizationCodeDAOImpl extends AbstractOAuthDAO implements Author
                     callbackUrl = StringUtils.replace(callbackUrl, BASE_URL_PLACEHOLDER,
                             ServiceURLBuilder.create().build().getAbsolutePublicUrlWithoutPath());
                 }
-                String authenticatedIDP = null;
-                if (OAuth2ServiceComponentHolder.isIDPIdColumnEnabled()) {
-                    authenticatedIDP = rs.getString(9);
-                }
+                String authenticatedIDP = rs.getString(9);
 
                 AuthenticatedUser user = OAuth2Util.createAuthenticatedUser(authzUser, userStoreDomain, OAuth2Util
                         .getTenantDomain(tenantId), authenticatedIDP);

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dao/OldTokensCleanDAO.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dao/OldTokensCleanDAO.java
@@ -49,12 +49,7 @@ public class OldTokensCleanDAO {
         try {
             connection.setAutoCommit(false);
             if (OAuthServerConfiguration.getInstance().useRetainOldAccessTokens()) {
-                String sql;
-                if (OAuth2ServiceComponentHolder.isIDPIdColumnEnabled()) {
-                    sql = SQLQueries.RETRIEVE_AND_STORE_IN_AUDIT_WITH_IDP_NAME;
-                } else {
-                    sql = SQLQueries.RETRIEVE_AND_STORE_IN_AUDIT;
-                }
+                String sql = SQLQueries.RETRIEVE_AND_STORE_IN_AUDIT_WITH_IDP_NAME;
                 PreparedStatement prepStmt = connection.prepareStatement(sql);
                 prepStmt.setTimestamp(1, new Timestamp(System.currentTimeMillis()));
                 prepStmt.setString(2, tokenId);
@@ -71,12 +66,7 @@ public class OldTokensCleanDAO {
     public void cleanupTokenByTokenValue(String token, Connection connection) throws SQLException {
         OldAccessTokenDO oldAccessTokenObject = new OldAccessTokenDO();
 
-        String sql;
-        if (OAuth2ServiceComponentHolder.isIDPIdColumnEnabled()) {
-            sql = SQLQueries.RETRIEVE_OLD_TOKEN_BY_TOKEN_HASH_WITH_IDP_NAME;
-        } else {
-            sql = SQLQueries.RETRIEVE_OLD_TOKEN_BY_TOKEN_HASH;
-        }
+        String sql = SQLQueries.RETRIEVE_OLD_TOKEN_BY_TOKEN_HASH_WITH_IDP_NAME;
 
         PreparedStatement prepStmt = connection.prepareStatement(sql);
         prepStmt.setString(1, token);
@@ -115,10 +105,7 @@ public class OldTokensCleanDAO {
             }
 
             oldAccessTokenObject.setAuthorizedOrganizationId(resultSet.getString(22));
-
-            if (OAuth2ServiceComponentHolder.isIDPIdColumnEnabled()) {
-                oldAccessTokenObject.setIdpId(resultSet.getInt(23));
-            }
+            oldAccessTokenObject.setIdpId(resultSet.getInt(23));
         }
         if (OAuthServerConfiguration.getInstance().useRetainOldAccessTokens()) {
             saveTokenInAuditTable(oldAccessTokenObject, connection);
@@ -128,12 +115,7 @@ public class OldTokensCleanDAO {
 
     private void saveTokenInAuditTable(OldAccessTokenDO oldAccessTokenDAO, Connection connection) throws SQLException {
 
-        String sql;
-        if (OAuth2ServiceComponentHolder.isIDPIdColumnEnabled()) {
-            sql = SQLQueries.STORE_OLD_TOKEN_IN_AUDIT_WITH_IDP_NAME;
-        } else {
-            sql = SQLQueries.STORE_OLD_TOKEN_IN_AUDIT;
-        }
+        String sql = SQLQueries.STORE_OLD_TOKEN_IN_AUDIT_WITH_IDP_NAME;
 
         PreparedStatement insertintoaudittable = connection.prepareStatement(sql);
         insertintoaudittable.setString(1, oldAccessTokenDAO.getTokenId());
@@ -164,9 +146,7 @@ public class OldTokensCleanDAO {
         }
         insertintoaudittable.setString(22, Boolean.toString(oldAccessTokenDAO.isConsentedToken()));
         insertintoaudittable.setString(23, oldAccessTokenDAO.getAuthorizedOrganizationId());
-        if (OAuth2ServiceComponentHolder.isIDPIdColumnEnabled()) {
-            insertintoaudittable.setInt(24, oldAccessTokenDAO.getIdpId());
-        }
+        insertintoaudittable.setInt(24, oldAccessTokenDAO.getIdpId());
         insertintoaudittable.execute();
         if (log.isDebugEnabled()) {
             log.debug(

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dao/TokenManagementDAOImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dao/TokenManagementDAOImpl.java
@@ -106,52 +106,35 @@ public class TokenManagementDAOImpl extends AbstractOAuthDAO implements TokenMan
             String driverName = connection.getMetaData().getDriverName();
             boolean isMysqlOrMarinaDBOrH2 =
                     driverName.contains("MySQL") || driverName.contains("MariaDB") || driverName.contains("H2");
-            if (OAuth2ServiceComponentHolder.isIDPIdColumnEnabled()) {
-                if (isAccessTokenExtendedTableExist()) {
-                    if (isMysqlOrMarinaDBOrH2) {
-                        sql = SQLQueries.RETRIEVE_ACCESS_TOKEN_VALIDATION_DATA_WITH_EXTENDED_ATTRIBUTES_MYSQL;
-                    } else if (connection.getMetaData().getDatabaseProductName().contains("DB2")) {
-                        sql = SQLQueries.RETRIEVE_ACCESS_TOKEN_VALIDATION_DATA_WITH_EXTENDED_ATTRIBUTES_DB2SQL;
-                    } else if (driverName.contains("MS SQL")
-                            || driverName.contains("Microsoft")) {
-                        sql = SQLQueries.RETRIEVE_ACCESS_TOKEN_VALIDATION_DATA_WITH_EXTENDED_ATTRIBUTES_MSSQL;
-                    } else if (driverName.contains("PostgreSQL")) {
-                        sql = SQLQueries.RETRIEVE_ACCESS_TOKEN_VALIDATION_DATA_WITH_EXTENDED_ATTRIBUTES_POSTGRESQL;
-                    } else if (driverName.contains("INFORMIX")) {
-                        sql = SQLQueries.RETRIEVE_ACCESS_TOKEN_VALIDATION_DATA_WITH_EXTENDED_ATTRIBUTES_INFORMIX;
-                    } else {
-                        sql = SQLQueries.RETRIEVE_ACCESS_TOKEN_VALIDATION_DATA_WITH_EXTENDED_ATTRIBUTES_ORACLE;
-                    }
+            if (isAccessTokenExtendedTableExist()) {
+                if (isMysqlOrMarinaDBOrH2) {
+                    sql = SQLQueries.RETRIEVE_ACCESS_TOKEN_VALIDATION_DATA_WITH_EXTENDED_ATTRIBUTES_MYSQL;
+                } else if (connection.getMetaData().getDatabaseProductName().contains("DB2")) {
+                    sql = SQLQueries.RETRIEVE_ACCESS_TOKEN_VALIDATION_DATA_WITH_EXTENDED_ATTRIBUTES_DB2SQL;
+                } else if (driverName.contains("MS SQL")
+                        || driverName.contains("Microsoft")) {
+                    sql = SQLQueries.RETRIEVE_ACCESS_TOKEN_VALIDATION_DATA_WITH_EXTENDED_ATTRIBUTES_MSSQL;
+                } else if (driverName.contains("PostgreSQL")) {
+                    sql = SQLQueries.RETRIEVE_ACCESS_TOKEN_VALIDATION_DATA_WITH_EXTENDED_ATTRIBUTES_POSTGRESQL;
+                } else if (driverName.contains("INFORMIX")) {
+                    sql = SQLQueries.RETRIEVE_ACCESS_TOKEN_VALIDATION_DATA_WITH_EXTENDED_ATTRIBUTES_INFORMIX;
                 } else {
-                    if (isMysqlOrMarinaDBOrH2) {
-                        sql = SQLQueries.RETRIEVE_ACCESS_TOKEN_VALIDATION_DATA_IDP_NAME_MYSQL;
-                    } else if (connection.getMetaData().getDatabaseProductName().contains("DB2")) {
-                        sql = SQLQueries.RETRIEVE_ACCESS_TOKEN_VALIDATION_DATA_IDP_NAME_DB2SQL;
-                    } else if (driverName.contains("MS SQL")
-                            || driverName.contains("Microsoft")) {
-                        sql = SQLQueries.RETRIEVE_ACCESS_TOKEN_VALIDATION_DATA_IDP_NAME_MSSQL;
-                    } else if (driverName.contains("PostgreSQL")) {
-                        sql = SQLQueries.RETRIEVE_ACCESS_TOKEN_VALIDATION_DATA_IDP_NAME_POSTGRESQL;
-                    } else if (driverName.contains("INFORMIX")) {
-                        sql = SQLQueries.RETRIEVE_ACCESS_TOKEN_VALIDATION_DATA_IDP_NAME_INFORMIX;
-                    } else {
-                        sql = SQLQueries.RETRIEVE_ACCESS_TOKEN_VALIDATION_DATA_IDP_NAME_ORACLE;
-                    }
+                    sql = SQLQueries.RETRIEVE_ACCESS_TOKEN_VALIDATION_DATA_WITH_EXTENDED_ATTRIBUTES_ORACLE;
                 }
             } else {
                 if (isMysqlOrMarinaDBOrH2) {
-                    sql = SQLQueries.RETRIEVE_ACCESS_TOKEN_VALIDATION_DATA_MYSQL;
+                    sql = SQLQueries.RETRIEVE_ACCESS_TOKEN_VALIDATION_DATA_IDP_NAME_MYSQL;
                 } else if (connection.getMetaData().getDatabaseProductName().contains("DB2")) {
-                    sql = SQLQueries.RETRIEVE_ACCESS_TOKEN_VALIDATION_DATA_DB2SQL;
+                    sql = SQLQueries.RETRIEVE_ACCESS_TOKEN_VALIDATION_DATA_IDP_NAME_DB2SQL;
                 } else if (driverName.contains("MS SQL")
                         || driverName.contains("Microsoft")) {
-                    sql = SQLQueries.RETRIEVE_ACCESS_TOKEN_VALIDATION_DATA_MSSQL;
+                    sql = SQLQueries.RETRIEVE_ACCESS_TOKEN_VALIDATION_DATA_IDP_NAME_MSSQL;
                 } else if (driverName.contains("PostgreSQL")) {
-                    sql = SQLQueries.RETRIEVE_ACCESS_TOKEN_VALIDATION_DATA_POSTGRESQL;
+                    sql = SQLQueries.RETRIEVE_ACCESS_TOKEN_VALIDATION_DATA_IDP_NAME_POSTGRESQL;
                 } else if (driverName.contains("INFORMIX")) {
-                    sql = SQLQueries.RETRIEVE_ACCESS_TOKEN_VALIDATION_DATA_INFORMIX;
+                    sql = SQLQueries.RETRIEVE_ACCESS_TOKEN_VALIDATION_DATA_IDP_NAME_INFORMIX;
                 } else {
-                    sql = SQLQueries.RETRIEVE_ACCESS_TOKEN_VALIDATION_DATA_ORACLE;
+                    sql = SQLQueries.RETRIEVE_ACCESS_TOKEN_VALIDATION_DATA_IDP_NAME_ORACLE;
                 }
             }
 
@@ -219,10 +202,7 @@ public class TokenManagementDAOImpl extends AbstractOAuthDAO implements TokenMan
                             resultSet.getTimestamp(13, Calendar.getInstance(TimeZone.getTimeZone(UTC))));
                     validationDataDO.setAccessTokenValidityInMillis(resultSet.getLong(14));
                     String authorizedOrganization = resultSet.getString(15);
-                    String authenticatedIDP = null;
-                    if (OAuth2ServiceComponentHolder.isIDPIdColumnEnabled()) {
-                        authenticatedIDP = resultSet.getString(16);
-                    }
+                    String authenticatedIDP = resultSet.getString(16);
                     AuthenticatedUser user = OAuth2Util.createAuthenticatedUser(userName, userDomain, tenantDomain,
                             authenticatedIDP);
                     user.setAuthenticatedSubjectIdentifier(subjectIdentifier);
@@ -289,12 +269,7 @@ public class TokenManagementDAOImpl extends AbstractOAuthDAO implements TokenMan
         PreparedStatement prepStmt = null;
         ResultSet resultSet = null;
 
-        String sql;
-        if (OAuth2ServiceComponentHolder.isIDPIdColumnEnabled()) {
-            sql = SQLQueries.RETRIEVE_REFRESH_TOKEN_WITH_IDP_NAME;
-        } else {
-            sql = SQLQueries.RETRIEVE_REFRESH_TOKEN;
-        }
+        String sql = SQLQueries.RETRIEVE_REFRESH_TOKEN_WITH_IDP_NAME;
 
         try {
             sql = OAuth2Util.getTokenPartitionedSqlByToken(sql, refreshToken);
@@ -323,10 +298,7 @@ public class TokenManagementDAOImpl extends AbstractOAuthDAO implements TokenMan
                     String tokenId = resultSet.getString(12);
                     String grantType = resultSet.getString(13);
                     String subjectIdentifier = resultSet.getString(14);
-                    String authenticatedIDP = null;
-                    if (OAuth2ServiceComponentHolder.isIDPIdColumnEnabled()) {
-                        authenticatedIDP = resultSet.getString(15);
-                    }
+                    String authenticatedIDP = resultSet.getString(15);
 
                     AuthenticatedUser user = OAuth2Util.createAuthenticatedUser(authorizedUser, userDomain,
                             tenantDomain, authenticatedIDP);

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuth2ServiceComponent.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuth2ServiceComponent.java
@@ -159,8 +159,6 @@ import javax.xml.stream.XMLStreamReader;
 import static org.wso2.carbon.identity.oauth2.Oauth2ScopeConstants.PERMISSIONS_BINDING_TYPE;
 import static org.wso2.carbon.identity.oauth2.device.constants.Constants.DEVICE_FLOW_GRANT_TYPE;
 import static org.wso2.carbon.identity.oauth2.util.OAuth2Util.checkAudienceEnabled;
-import static org.wso2.carbon.identity.oauth2.util.OAuth2Util.checkConsentedTokenColumnAvailable;
-import static org.wso2.carbon.identity.oauth2.util.OAuth2Util.checkIDPIdColumnAvailable;
 import static org.wso2.carbon.identity.oauth2.util.OAuth2Util.getJWTRenewWithoutRevokeAllowedGrantTypes;
 import static org.wso2.carbon.identity.oauth2.util.OAuth2Util.isAccessTokenExtendedTableExist;
 
@@ -449,19 +447,7 @@ public class OAuth2ServiceComponent {
             }
             OAuth2ServiceComponentHolder.setAudienceEnabled(false);
         }
-        if (checkIDPIdColumnAvailable()) {
-            if (log.isDebugEnabled()) {
-                log.debug("IDP_ID column is available in all relevant tables. " +
-                        "Setting isIDPIdColumnEnabled to true.");
-            }
-            OAuth2ServiceComponentHolder.setIDPIdColumnEnabled(true);
-        } else {
-            if (log.isDebugEnabled()) {
-                log.debug("IDP_ID column is not available in all relevant tables. " +
-                        "Setting isIDPIdColumnEnabled to false.");
-            }
-            OAuth2ServiceComponentHolder.setIDPIdColumnEnabled(false);
-        }
+        OAuth2ServiceComponentHolder.setIDPIdColumnEnabled(true);
 
         if (isAccessTokenExtendedTableExist()) {
             log.debug("IDN_OAUTH2_ACCESS_TOKEN_EXTENDED table is available Setting " +
@@ -469,17 +455,9 @@ public class OAuth2ServiceComponent {
             OAuth2ServiceComponentHolder.setTokenExtendedTableExist(true);
         }
 
-        boolean isConsentedTokenColumnAvailable = checkConsentedTokenColumnAvailable();
-        OAuth2ServiceComponentHolder.setConsentedTokenColumnEnabled(isConsentedTokenColumnAvailable);
-        if (log.isDebugEnabled()) {
-            if (isConsentedTokenColumnAvailable) {
-                log.debug("CONSENTED_TOKEN column is available in IDN_OAUTH2_ACCESS_TOKEN table. Hence setting " +
-                        "consentedColumnAvailable to true.");
-            } else {
-                log.debug("CONSENTED_TOKEN column is not available in IDN_OAUTH2_ACCESS_TOKEN table. Hence " +
-                        "setting consentedColumnAvailable to false.");
-            }
-        }
+        OAuth2ServiceComponentHolder.setConsentedTokenColumnEnabled(true);
+        log.debug("CONSENTED_TOKEN column is available in IDN_OAUTH2_ACCESS_TOKEN table. Hence setting " +
+                "consentedColumnAvailable to true.");
         if (OAuthServerConfiguration.getInstance().isGlobalRbacScopeIssuerEnabled()) {
             bundleContext.registerService(ScopeValidator.class, new RoleBasedScopeIssuer(), null);
         }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuth2ServiceComponentHolder.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuth2ServiceComponentHolder.java
@@ -90,10 +90,10 @@ public class OAuth2ServiceComponentHolder {
     private static AuthenticationMethodNameTranslator authenticationMethodNameTranslator;
     private static List<OAuthClientAuthenticator> authenticationHandlers = new ArrayList<>();
     private static List<ClaimProvider> claimProviders = new ArrayList<>();
-    private static boolean idpIdColumnEnabled = false;
+    private static boolean idpIdColumnEnabled = true;
     private static Map<String, ResponseModeProvider> responseModeProviders;
     private static ResponseModeProvider defaultResponseModeProvider;
-    private static boolean consentedTokenColumnEnabled = false;
+    private static boolean consentedTokenColumnEnabled = true;
     private static IdentityEventService identityEventService;
     private static boolean tokenExtendedTableExist = false;
     private List<TokenBinder> tokenBinders = new ArrayList<>();
@@ -191,6 +191,12 @@ public class OAuth2ServiceComponentHolder {
         OAuth2ServiceComponentHolder.audienceEnabled = audienceEnabled;
     }
 
+    /**
+     * Check whether the idp_id table column is enabled.
+     * @return isIDPIdColumnEnabled.
+     * @deprecated This method is deprecated since the idp_id column is always enabled.
+     */
+    @Deprecated
     public static boolean isIDPIdColumnEnabled() {
 
         return idpIdColumnEnabled;
@@ -201,6 +207,12 @@ public class OAuth2ServiceComponentHolder {
         OAuth2ServiceComponentHolder.idpIdColumnEnabled = idpIdColumnEnabled;
     }
 
+    /**
+     * Check whether the consented_token table column is enabled.
+     * @return isConsentedTokenColumnEnabled.
+     * @deprecated This method is deprecated since the consented token column is always enabled.
+     */
+    @Deprecated
     public static boolean isConsentedTokenColumnEnabled() {
 
         return consentedTokenColumnEnabled;

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuer.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuer.java
@@ -1135,16 +1135,14 @@ public class JWTTokenIssuer extends OauthTokenIssuerImpl {
                 throw new IdentityOAuth2Exception("User id not found for user: "
                         + authenticatedUser.getLoggableMaskedUserId(), e);
             }
-            if (OAuth2ServiceComponentHolder.isConsentedTokenColumnEnabled()) {
-                boolean isConsented;
-                if (tokenReqMessageContext != null) {
-                    isConsented = tokenReqMessageContext.isConsentedToken();
-                } else {
-                    isConsented = authAuthzReqMessageContext.isConsentedToken();
-                }
-                // when no persistence of tokens, there is no existing token to check the consented value for.
-                jwtClaimsSetBuilder.claim(OAuth2Constants.IS_CONSENTED, isConsented);
+            boolean isConsented;
+            if (tokenReqMessageContext != null) {
+                isConsented = tokenReqMessageContext.isConsentedToken();
+            } else {
+                isConsented = authAuthzReqMessageContext.isConsentedToken();
             }
+            // when no persistence of tokens, there is no existing token to check the consented value for.
+            jwtClaimsSetBuilder.claim(OAuth2Constants.IS_CONSENTED, isConsented);
             jwtClaimsSetBuilder.claim(OAuth2Constants.IS_FEDERATED, authenticatedUser.isFederatedUser());
         }
     }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AbstractAuthorizationGrantHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AbstractAuthorizationGrantHandler.java
@@ -644,16 +644,15 @@ public abstract class AbstractAuthorizationGrantHandler implements Authorization
 
         /* If the existing token is available, the consented token flag will be extracted from that. Otherwise,
         from the current grant. */
-        if (OAuth2ServiceComponentHolder.isConsentedTokenColumnEnabled()) {
-            if (existingTokenBean != null) {
-                tokReqMsgCtx.setConsentedToken(existingTokenBean.isConsentedToken());
-            } else {
-                if (OIDCClaimUtil.isConsentBasedClaimFilteringApplicable(
-                        tokReqMsgCtx.getOauth2AccessTokenReqDTO().getGrantType())) {
-                    tokReqMsgCtx.setConsentedToken(true);
-                }
+        if (existingTokenBean != null) {
+            tokReqMsgCtx.setConsentedToken(existingTokenBean.isConsentedToken());
+        } else {
+            if (OIDCClaimUtil.isConsentBasedClaimFilteringApplicable(
+                    tokReqMsgCtx.getOauth2AccessTokenReqDTO().getGrantType())) {
+                tokReqMsgCtx.setConsentedToken(true);
             }
         }
+
         OAuthAppDO oAuthAppBean = getoAuthApp(consumerKey);
         long validityPeriodInMillis = getConfiguredExpiryTimeForApplication(tokReqMsgCtx, consumerKey, oAuthAppBean);
         tokReqMsgCtx.setValidityPeriod(validityPeriodInMillis);

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/AbstractUserInfoResponseBuilder.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/AbstractUserInfoResponseBuilder.java
@@ -274,17 +274,13 @@ public abstract class AbstractUserInfoResponseBuilder implements UserInfoRespons
             AccessTokenDO accessTokenDO = OAuth2ServiceComponentHolder.getInstance().getTokenProvider()
                     .getVerifiedAccessToken(accessToken, false);
             grantType = getGrantType(accessTokenDO);
-            if (OAuth2ServiceComponentHolder.isConsentedTokenColumnEnabled()) {
-                // Get the Access Token details from the database/cache to check if the token is consented or not.
-                boolean isConsentedToken = accessTokenDO.isConsentedToken();
-                return OIDCClaimUtil.filterUserClaimsBasedOnConsent(userClaims, user, clientId, tenantDomain, grantType,
-                        getServiceProvider(tenantDomain, clientId), isConsentedToken);
-            }
+            // Get the Access Token details from the database/cache to check if the token is consented or not.
+            boolean isConsentedToken = accessTokenDO.isConsentedToken();
+            return OIDCClaimUtil.filterUserClaimsBasedOnConsent(userClaims, user, clientId, tenantDomain, grantType,
+                    getServiceProvider(tenantDomain, clientId), isConsentedToken);
         } catch (IdentityOAuth2Exception e) {
             throw new UserInfoEndpointException("An error occurred while fetching the access token details.", e);
         }
-        return OIDCClaimUtil.filterUserClaimsBasedOnConsent(userClaims, user, clientId, tenantDomain, grantType,
-                getServiceProvider(tenantDomain, clientId));
     }
 
 


### PR DESCRIPTION
Public Issue: https://github.com/wso2/product-is/issues/24929

This pull request simplifies the handling of consented tokens and IDP ID columns in the OAuth2 token processing and DAO layers. The main change is the removal of feature flag checks for the "consented token" and "IDP ID" columns, making the code always assume these features are enabled. This results in less conditional logic and a more streamlined codebase, but it also means the system now expects these columns to always be present in the database schema.

Key changes include:

**DAO Layer Simplification:**

* Removed all conditional checks for `isConsentedTokenColumnEnabled` and `isIDPIdColumnEnabled` in `AccessTokenDAOImpl`, and now always use SQL queries and prepared statement parameters that assume both the consented token and IDP ID columns exist. [[1]](diffhunk://#diff-6709864b96560546358e0932e0c74fdcdf5dad1ca233d92ac87896c1ea06cf44L183-R183) [[2]](diffhunk://#diff-6709864b96560546358e0932e0c74fdcdf5dad1ca233d92ac87896c1ea06cf44L274-L298) [[3]](diffhunk://#diff-6709864b96560546358e0932e0c74fdcdf5dad1ca233d92ac87896c1ea06cf44L538-L543) [[4]](diffhunk://#diff-6709864b96560546358e0932e0c74fdcdf5dad1ca233d92ac87896c1ea06cf44L630-L631) [[5]](diffhunk://#diff-6709864b96560546358e0932e0c74fdcdf5dad1ca233d92ac87896c1ea06cf44L657-L716) [[6]](diffhunk://#diff-6709864b96560546358e0932e0c74fdcdf5dad1ca233d92ac87896c1ea06cf44L750) [[7]](diffhunk://#diff-6709864b96560546358e0932e0c74fdcdf5dad1ca233d92ac87896c1ea06cf44L771-L791) [[8]](diffhunk://#diff-6709864b96560546358e0932e0c74fdcdf5dad1ca233d92ac87896c1ea06cf44L814-L833) [[9]](diffhunk://#diff-6709864b96560546358e0932e0c74fdcdf5dad1ca233d92ac87896c1ea06cf44L864-L869) [[10]](diffhunk://#diff-6709864b96560546358e0932e0c74fdcdf5dad1ca233d92ac87896c1ea06cf44L955-L965) [[11]](diffhunk://#diff-6709864b96560546358e0932e0c74fdcdf5dad1ca233d92ac87896c1ea06cf44L988-L992)

**Token Creation and Processing:**

* Removed checks for `isConsentedTokenColumnEnabled` in token creation logic in both `DefaultRefreshTokenGrantProcessor` and `ResponseTypeHandlerUtil`, so consented token logic is always executed. [[1]](diffhunk://#diff-3e23e220c42796106519c06b93c60071e40300cb58f9f313afff40e864e36753L101) [[2]](diffhunk://#diff-3e23e220c42796106519c06b93c60071e40300cb58f9f313afff40e864e36753L120) [[3]](diffhunk://#diff-7e08c276b3496b6945375daaf475f0c02116931f38d77af2ff706a606b21d21eL668) [[4]](diffhunk://#diff-7e08c276b3496b6945375daaf475f0c02116931f38d77af2ff706a606b21d21eL677)
