### PR TITLE
Extend the support to handle multiple active tokens.

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
+++ b/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
@@ -37,7 +37,10 @@ public final class OAuthConstants {
     public static final String HTTP_REQ_HEADER_AUTH_METHOD_BASIC = "Basic";
     public static final List<String> ALLOWED_CONTENT_TYPES = Arrays.asList("application/x-www-form-urlencoded",
                                                                            "application/json");
-
+    public static final String RENEW_TOKEN_WITHOUT_REVOKING_EXISTING_ALLOWED_GRANT_TYPES_CONFIG_FOR_OPAQUE =
+            "OAuth.Opaque.RenewTokenWithoutRevokingExisting.AllowedGrantTypes.AllowedGrantType";
+    public static final String RENEW_TOKEN_WITHOUT_REVOKING_EXISTING_ENABLE_CONFIG_FOR_OPAQUE =
+            "OAuth.Opaque.RenewTokenWithoutRevokingExisting.Enable";
     // OAuth2 response headers
     public static final String HTTP_RESP_HEADER_CACHE_CONTROL = "Cache-Control";
     public static final String HTTP_RESP_HEADER_PRAGMA = "Pragma";

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dao/AccessTokenDAO.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dao/AccessTokenDAO.java
@@ -60,6 +60,26 @@ public interface AccessTokenDAO {
     }
 
     /**
+     * Get latest access token.
+     *
+     * @param consumerKey consumer key.
+     * @param authzUser authorized user.
+     * @param userStoreDomain user store domain.
+     * @param scope scope.
+     * @param tokenBindingReference token binding reference.
+     * @param includeExpiredTokens include expired tokens.
+     * @param includeTokenBindingRef include token binding reference.
+     * @return latest access token.
+     * @throws IdentityOAuth2Exception in case of failure.
+     */
+    default AccessTokenDO getLatestAccessToken(String consumerKey, AuthenticatedUser authzUser, String userStoreDomain,
+            String scope, String tokenBindingReference, boolean includeExpiredTokens,
+            boolean includeTokenBindingRef) throws IdentityOAuth2Exception {
+
+        return null;
+    }
+
+    /**
      * Get tokenId by binding reference.
      * @param bindingRef BindingRef.
      * @return TokenId.

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dao/AccessTokenDAOImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dao/AccessTokenDAOImpl.java
@@ -466,6 +466,15 @@ public class AccessTokenDAOImpl extends AbstractOAuthDAO implements AccessTokenD
         }
     }
 
+    private String getActiveAccessTokenWithoutBindingRefQuerySQL(Connection connection) throws SQLException {
+
+        String sql = getLatestAccessTokenQuerySQL(connection);
+        if (sql.contains("AND TOKEN_BINDING_REF = ?")) {
+            sql = sql.replace("AND TOKEN_BINDING_REF = ?", "");
+        }
+        return sql;
+    }
+
     @Override
     public AccessTokenDO getLatestAccessToken(String consumerKey, AuthenticatedUser authzUser, String userStoreDomain,
                                               String scope, boolean includeExpiredTokens)
@@ -478,6 +487,15 @@ public class AccessTokenDAOImpl extends AbstractOAuthDAO implements AccessTokenD
     public AccessTokenDO getLatestAccessToken(String consumerKey, AuthenticatedUser authzUser, String userStoreDomain,
                                               String scope, String tokenBindingReference, boolean includeExpiredTokens)
             throws IdentityOAuth2Exception {
+
+        return getLatestAccessToken(consumerKey, authzUser, userStoreDomain, scope, tokenBindingReference,
+                includeExpiredTokens, true);
+    }
+
+    @Override
+    public AccessTokenDO getLatestAccessToken(String consumerKey, AuthenticatedUser authzUser, String userStoreDomain,
+            String scope, String tokenBindingReference, boolean includeExpiredTokens,
+            boolean includeTokenBindingRef) throws IdentityOAuth2Exception {
 
         if (log.isDebugEnabled()) {
             log.debug("Retrieving latest access token for client: " + consumerKey + " user: "
@@ -500,7 +518,12 @@ public class AccessTokenDAOImpl extends AbstractOAuthDAO implements AccessTokenD
         ResultSet resultSet = null;
         try {
 
-            String sql = getLatestAccessTokenQuerySQL(connection);
+            String sql;
+            if (includeTokenBindingRef) {
+                sql = getLatestAccessTokenQuerySQL(connection);
+            } else {
+                sql = getActiveAccessTokenWithoutBindingRefQuerySQL(connection);
+            }
 
             if (!includeExpiredTokens) {
                 sql = sql.replace("TOKEN_SCOPE_HASH=?", "TOKEN_SCOPE_HASH=? AND TOKEN_STATE='ACTIVE'");
@@ -533,8 +556,16 @@ public class AccessTokenDAOImpl extends AbstractOAuthDAO implements AccessTokenD
                 prepStmt.setString(6, hashedScope);
             }
 
-            prepStmt.setString(7, tokenBindingReference);
-            prepStmt.setString(8, authorizedOrganization);
+            if (includeTokenBindingRef) {
+                prepStmt.setString(7, tokenBindingReference);
+                if (OAuth2ServiceComponentHolder.isIDPIdColumnEnabled()) {
+                    prepStmt.setString(8, authenticatedIDP);
+                }
+            } else {
+                if (OAuth2ServiceComponentHolder.isIDPIdColumnEnabled()) {
+                    prepStmt.setString(7, authenticatedIDP);
+                }
+            }
 
             if (OAuth2ServiceComponentHolder.isIDPIdColumnEnabled()) {
                 prepStmt.setString(9, authenticatedIDP);
@@ -598,7 +629,8 @@ public class AccessTokenDAOImpl extends AbstractOAuthDAO implements AccessTokenD
                     if (StringUtils.isNotEmpty(isConsentedToken)) {
                         accessTokenDO.setIsConsentedToken(Boolean.parseBoolean(isConsentedToken));
                     }
-                    if (StringUtils.isNotBlank(tokenBindingReference) && !NONE.equals(tokenBindingReference)) {
+                    if (includeTokenBindingRef && StringUtils.isNotBlank(tokenBindingReference) &&
+                            !NONE.equals(tokenBindingReference)) {
                         setTokenBindingToAccessTokenDO(accessTokenDO, connection, tokenId);
                     }
                     if (log.isDebugEnabled() && IdentityUtil

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dao/AccessTokenDAOImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dao/AccessTokenDAOImpl.java
@@ -558,21 +558,22 @@ public class AccessTokenDAOImpl extends AbstractOAuthDAO implements AccessTokenD
 
             if (includeTokenBindingRef) {
                 prepStmt.setString(7, tokenBindingReference);
+                prepStmt.setString(8, authorizedOrganization);
+                if (OAuth2ServiceComponentHolder.isIDPIdColumnEnabled()) {
+                    prepStmt.setString(9, authenticatedIDP);
+                    // Set tenant ID of the IDP by considering it is same as appTenantID.
+                    prepStmt.setInt(10, appTenantId);
+                }
+
+            } else {
+                prepStmt.setString(7, authorizedOrganization);
                 if (OAuth2ServiceComponentHolder.isIDPIdColumnEnabled()) {
                     prepStmt.setString(8, authenticatedIDP);
+                    // Set tenant ID of the IDP by considering it is same as appTenantID.
+                    prepStmt.setInt(9, appTenantId);
                 }
-            } else {
-                if (OAuth2ServiceComponentHolder.isIDPIdColumnEnabled()) {
-                    prepStmt.setString(7, authenticatedIDP);
-                }
-            }
 
-            if (OAuth2ServiceComponentHolder.isIDPIdColumnEnabled()) {
-                prepStmt.setString(9, authenticatedIDP);
-                // Set tenant ID of the IDP by considering it is same as appTenantID.
-                prepStmt.setInt(10, appTenantId);
             }
-
             resultSet = prepStmt.executeQuery();
 
             if (resultSet.next()) {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuth2ServiceComponent.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuth2ServiceComponent.java
@@ -162,6 +162,7 @@ import static org.wso2.carbon.identity.oauth2.util.OAuth2Util.checkAudienceEnabl
 import static org.wso2.carbon.identity.oauth2.util.OAuth2Util.checkConsentedTokenColumnAvailable;
 import static org.wso2.carbon.identity.oauth2.util.OAuth2Util.checkIDPIdColumnAvailable;
 import static org.wso2.carbon.identity.oauth2.util.OAuth2Util.getJWTRenewWithoutRevokeAllowedGrantTypes;
+import static org.wso2.carbon.identity.oauth2.util.OAuth2Util.getOpaqueRenewWithoutRevokeAllowedGrantTypes;
 import static org.wso2.carbon.identity.oauth2.util.OAuth2Util.isAccessTokenExtendedTableExist;
 
 /**
@@ -336,6 +337,9 @@ public class OAuth2ServiceComponent {
             // Read and store the allowed grant types for JWT renew without revoke in OAuth2ServiceComponentHolder.
             OAuth2ServiceComponentHolder.setJwtRenewWithoutRevokeAllowedGrantTypes(
                     getJWTRenewWithoutRevokeAllowedGrantTypes());
+            // Read and store the allowed grant types for Opaque renew without revoke in OAuth2ServiceComponentHolder.
+            OAuth2ServiceComponentHolder.setOpaqueRenewWithoutRevokeAllowedGrantTypes(
+                    getOpaqueRenewWithoutRevokeAllowedGrantTypes());
 
             OAuth2ServiceComponentHolder.
                     setResponseModeProviders(OAuthServerConfiguration.getInstance().getSupportedResponseModes());

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuth2ServiceComponentHolder.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuth2ServiceComponentHolder.java
@@ -113,6 +113,7 @@ public class OAuth2ServiceComponentHolder {
     private List<Scope> oauthScopeBinding = new ArrayList<>();
     private ScopeClaimMappingDAO scopeClaimMappingDAO;
     private static List<String> jwtRenewWithoutRevokeAllowedGrantTypes = new ArrayList<>();
+    private static List<String> opaqueRenewWithoutRevokeAllowedGrantTypes = new ArrayList<>();
     private static ConsentServerConfigsManagementService consentServerConfigsManagementService;
     private static boolean restrictUnassignedScopes;
     private static ConfigurationContextService configurationContextService;
@@ -199,6 +200,26 @@ public class OAuth2ServiceComponentHolder {
     public static void setIDPIdColumnEnabled(boolean idpIdColumnEnabled) {
 
         OAuth2ServiceComponentHolder.idpIdColumnEnabled = idpIdColumnEnabled;
+    }
+
+    /**
+     * Get the list of grant types which are allowed to renew Opaque tokens without revoke.
+     *
+     * @return allowed grant types
+     */
+    public static List<String> getOpaqueRenewWithoutRevokeAllowedGrantTypes() {
+        return opaqueRenewWithoutRevokeAllowedGrantTypes;
+    }
+
+    /**
+     * Set the list of grant types which are allowed to renew Opaque tokens without revoke.
+     *
+     * @param opaqueRenewWithoutRevokeAllowedGrantTypes List of allowed grant types
+     */
+    public static void setOpaqueRenewWithoutRevokeAllowedGrantTypes(
+            List<String> opaqueRenewWithoutRevokeAllowedGrantTypes) {
+        OAuth2ServiceComponentHolder.opaqueRenewWithoutRevokeAllowedGrantTypes =
+                opaqueRenewWithoutRevokeAllowedGrantTypes;
     }
 
     public static boolean isConsentedTokenColumnEnabled() {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuer.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuer.java
@@ -1023,7 +1023,7 @@ public class JWTTokenIssuer extends OauthTokenIssuerImpl {
         return grantHandler.isOfTypeApplicationUser(tokReqMsgCtx);
     }
 
-    private JWTClaimsSet handleTokenBinding(JWTClaimsSet.Builder jwtClaimsSetBuilder,
+    protected JWTClaimsSet handleTokenBinding(JWTClaimsSet.Builder jwtClaimsSetBuilder,
                                             OAuthTokenReqMessageContext tokReqMsgCtx) {
 
         /**

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/OauthTokenIssuerImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/OauthTokenIssuerImpl.java
@@ -43,14 +43,8 @@ public class OauthTokenIssuerImpl implements OauthTokenIssuer {
     private boolean persistAccessTokenAlias = true;
 
     public String accessToken(OAuthTokenReqMessageContext tokReqMsgCtx) throws OAuthSystemException {
-        String renewWithoutRevokeConfig =
-                IdentityUtil.getProperty(RENEW_TOKEN_WITHOUT_REVOKING_EXISTING_ENABLE_CONFIG_FOR_OPAQUE);
-
-        boolean renewWithoutRevokingExistingEnabled = false;
-        if (renewWithoutRevokeConfig != null) {
-            renewWithoutRevokingExistingEnabled = Boolean.parseBoolean(
-                    renewWithoutRevokeConfig);
-        }
+        boolean renewWithoutRevokingExistingEnabled = Boolean.parseBoolean(
+                IdentityUtil.getProperty(RENEW_TOKEN_WITHOUT_REVOKING_EXISTING_ENABLE_CONFIG_FOR_OPAQUE));
 
         if (renewWithoutRevokingExistingEnabled && tokReqMsgCtx != null && tokReqMsgCtx.getTokenBinding() == null
                 && (OAuth2ServiceComponentHolder.getOpaqueRenewWithoutRevokeAllowedGrantTypes()

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/OauthTokenIssuerImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/OauthTokenIssuerImpl.java
@@ -43,8 +43,14 @@ public class OauthTokenIssuerImpl implements OauthTokenIssuer {
     private boolean persistAccessTokenAlias = true;
 
     public String accessToken(OAuthTokenReqMessageContext tokReqMsgCtx) throws OAuthSystemException {
-        boolean renewWithoutRevokingExistingEnabled = Boolean.parseBoolean(
-                IdentityUtil.getProperty(RENEW_TOKEN_WITHOUT_REVOKING_EXISTING_ENABLE_CONFIG_FOR_OPAQUE));
+        String renewWithoutRevokeConfig =
+                IdentityUtil.getProperty(RENEW_TOKEN_WITHOUT_REVOKING_EXISTING_ENABLE_CONFIG_FOR_OPAQUE);
+
+        boolean renewWithoutRevokingExistingEnabled = false;
+        if (renewWithoutRevokeConfig != null) {
+            renewWithoutRevokingExistingEnabled = Boolean.parseBoolean(
+                    renewWithoutRevokeConfig);
+        }
 
         if (renewWithoutRevokingExistingEnabled && tokReqMsgCtx != null && tokReqMsgCtx.getTokenBinding() == null
                 && (OAuth2ServiceComponentHolder.getOpaqueRenewWithoutRevokeAllowedGrantTypes()

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AbstractAuthorizationGrantHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AbstractAuthorizationGrantHandler.java
@@ -1115,7 +1115,7 @@ public abstract class AbstractAuthorizationGrantHandler implements Authorization
         return validityPeriodInMillis;
     }
 
-    private AccessTokenDO getExistingToken(OAuthTokenReqMessageContext tokenMsgCtx, OAuthCacheKey cacheKey)
+    protected AccessTokenDO getExistingToken(OAuthTokenReqMessageContext tokenMsgCtx, OAuthCacheKey cacheKey)
             throws IdentityOAuth2Exception {
         AccessTokenDO existingToken = null;
         OAuth2AccessTokenReqDTO tokenReq = tokenMsgCtx.getOauth2AccessTokenReqDTO();

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -5751,11 +5751,12 @@ public class OAuth2Util {
         Object value = IdentityConfigParser.getInstance().getConfiguration()
                 .get(RENEW_TOKEN_WITHOUT_REVOKING_EXISTING_ALLOWED_GRANT_TYPES_CONFIG_FOR_OPAQUE);
         if (value == null) {
-            allowedGrantTypes = new ArrayList<>(Arrays.asList(OAuthConstants.GrantTypes.CLIENT_CREDENTIALS));
-        } else if (value instanceof ArrayList) {
-            allowedGrantTypes = (ArrayList) value;
+            allowedGrantTypes = new ArrayList<>
+                    (Collections.singletonList(OAuthConstants.GrantTypes.CLIENT_CREDENTIALS));
+        } else if (value instanceof List) {
+            allowedGrantTypes = new ArrayList<>((List) value);
         } else {
-            allowedGrantTypes = new ArrayList<>(Collections.singletonList((String) value));
+            allowedGrantTypes = new ArrayList<>(Collections.singletonList(String.valueOf(value)));
         }
         if (log.isDebugEnabled()) {
             log.debug(

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -232,6 +232,7 @@ import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OAuth20Endpoi
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OAuth20Endpoints.OIDC_CONSENT_EP_URL;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OAuth20Endpoints.OIDC_WEB_FINGER_EP_URL;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.RENEW_TOKEN_WITHOUT_REVOKING_EXISTING_ALLOWED_GRANT_TYPES_CONFIG;
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.RENEW_TOKEN_WITHOUT_REVOKING_EXISTING_ALLOWED_GRANT_TYPES_CONFIG_FOR_OPAQUE;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.Scope.OAUTH2;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.SignatureAlgorithms.KID_HASHING_ALGORITHM;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.SignatureAlgorithms.PREVIOUS_KID_HASHING_ALGORITHM;
@@ -5732,9 +5733,35 @@ public class OAuth2Util {
             allowedGrantTypes = new ArrayList<>(Collections.singletonList((String) value));
         }
         if (log.isDebugEnabled()) {
-            log.debug("Allowed grant types for renewing token without revoking existing token: " + allowedGrantTypes);
+            log.debug("Allowed grant types for renewing JWT token without revoking existing token: "
+                    + allowedGrantTypes);
         }
 
+        return allowedGrantTypes;
+    }
+
+    /**
+     * Get allowed grant type list for renewing token without revoking existing token.
+     *
+     * @return Allowed grant type list.
+     */
+    public static ArrayList<String> getOpaqueRenewWithoutRevokeAllowedGrantTypes() {
+
+        ArrayList<String> allowedGrantTypes;
+        Object value = IdentityConfigParser.getInstance().getConfiguration()
+                .get(RENEW_TOKEN_WITHOUT_REVOKING_EXISTING_ALLOWED_GRANT_TYPES_CONFIG_FOR_OPAQUE);
+        if (value == null) {
+            allowedGrantTypes = new ArrayList<>(Arrays.asList(OAuthConstants.GrantTypes.CLIENT_CREDENTIALS));
+        } else if (value instanceof ArrayList) {
+            allowedGrantTypes = (ArrayList) value;
+        } else {
+            allowedGrantTypes = new ArrayList<>(Collections.singletonList((String) value));
+        }
+        if (log.isDebugEnabled()) {
+            log.debug(
+                    "Allowed grant types for renewing Opaque token without revoking existing token: "
+                            + allowedGrantTypes);
+        }
         return allowedGrantTypes;
     }
 


### PR DESCRIPTION
### Purpose
As per the current implementation, when a new access token is generated, the previous access token will be revoked right away. This effort add the support to have customisations where multiple active access tokens can be present at a given time.

### Related To
https://github.com/wso2/api-manager/issues/2807