### PR TITLE
Fix Multiple Access Token feature customization failure

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuer.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuer.java
@@ -808,7 +808,7 @@ public class JWTTokenIssuer extends OauthTokenIssuerImpl {
         return grantHandler.isOfTypeApplicationUser();
     }
 
-    private JWTClaimsSet handleTokenBinding(JWTClaimsSet.Builder jwtClaimsSetBuilder,
+    protected JWTClaimsSet handleTokenBinding(JWTClaimsSet.Builder jwtClaimsSetBuilder,
                                             OAuthTokenReqMessageContext tokReqMsgCtx) {
         /**
          * If OAuth.JWT.RenewTokenWithoutRevokingExisting is enabled from configurations, and current token


### PR DESCRIPTION
### Purpose
This PR fixes an issue in Multiple Access Token feature customization. Enabling the renew_token_without_revoking_existing config causes the token issuance flow to skip the existing token check, bypassing this custom logic.

### Implementation Approach
Make the handleTokenBinding method in JWTTokenIssuer class protected so that anyone can extend this method to modify their customizations.

Fixes: https://github.com/wso2/api-manager/issues/4063