### PR TITLE
Use MDC aware ExecutorService

### DIFF
--- a/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/backchannellogout/LogoutRequestSender.java
+++ b/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/backchannellogout/LogoutRequestSender.java
@@ -32,6 +32,7 @@ import org.apache.http.impl.client.HttpClients;
 import org.apache.http.message.BasicNameValuePair;
 import org.wso2.carbon.base.MultitenantConstants;
 import org.wso2.carbon.identity.base.IdentityConstants;
+import org.wso2.carbon.identity.core.ThreadLocalAwareThreadPoolExecutor;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.oauth.common.exception.InvalidOAuthClientException;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
@@ -48,7 +49,6 @@ import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 import javax.servlet.http.Cookie;
@@ -118,7 +118,7 @@ public class LogoutRequestSender {
             workQueue = new ArrayBlockingQueue<Runnable>(workQueueSizeInt);
         }
 
-        threadPool = new ThreadPoolExecutor(poolSizeInt, poolSizeInt, keepAliveTimeLong,
+        threadPool = new ThreadLocalAwareThreadPoolExecutor(poolSizeInt, poolSizeInt, keepAliveTimeLong,
                 TimeUnit.MILLISECONDS, workQueue);
 
         httpConnectTimeout = Integer.parseInt(httpConnectTimeoutProperty);


### PR DESCRIPTION
### Proposed changes in this pull request

This pull request updates the thread pool implementation in the `LogoutRequestSender` class to use a more context-aware executor, which can improve thread management and context propagation for OIDC session backchannel logout operations.

Thread pool improvements:

* Replaced the standard `ThreadPoolExecutor` with `ThreadLocalAwareThreadPoolExecutor` in `LogoutRequestSender` to enhance thread-local context handling during logout request processing.
* Updated import statements to include `ThreadLocalAwareThreadPoolExecutor` and remove the unused `ThreadPoolExecutor` import. [[1]](diffhunk://#diff-73d9a93b331ada15d0ee3edada79f3e356d6d232a9287865a2e401d1b98abd92R35) [[2]](diffhunk://#diff-73d9a93b331ada15d0ee3edada79f3e356d6d232a9287865a2e401d1b98abd92L51)

Related PRs
- https://github.com/wso2/carbon-identity-framework/pull/5720

### When should this PR be merged

[Please describe any preconditions that need to be addressed before we
can merge this pull request.]


### Follow up actions

[List any possible follow-up actions here; for instance, testing data
migrations, software that we need to install on staging and production
environments.]

-

## Developer Checklist (Mandatory)

- [x] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact.



### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description.
- [ ] **Is the PR labeled correctly?**

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled.

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests.
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/).

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components.
- [ ] **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

#### Security

- [ ] **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
- [ ] **Are all UI and API inputs run through forms or serializers?**
- [ ] **Are all external inputs validated and sanitized appropriately?**
- [ ] **Does all branching logic have a default case?**
- [ ] **Does this solution handle outliers and edge cases gracefully?**
- [ ] **Are all external communications secured and restricted to SSL?**

#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes should be documented.
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented.
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki.
