### PR TITLE
Add new method to retrieve the string value of the refresh token allowed configuration for a grant type

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
@@ -1934,6 +1934,20 @@ public class OAuthServerConfiguration {
     }
 
     /**
+     * Return the value of whether the refresh token is allowed for this grant type. Default value will be returned
+     * if there is no tag or empty tag.
+     *
+     * @param grantType Name of the Grant type.
+     * @param defaultValue Default value to be returned if there is no tag or empty tag.
+     * @return True or False if there is a value. Null otherwise.
+     */
+    public String getValueForIsRefreshTokenAllowed(String grantType, String defaultValue) {
+
+        Boolean isRefreshTokenAllowed = refreshTokenAllowedGrantTypes.get(grantType);
+        return isRefreshTokenAllowed == null ? defaultValue : isRefreshTokenAllowed.toString();
+    }
+
+    /**
      * Returns whether user consent is required for the particular grant type.
      *
      * @param grantType

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfigurationTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfigurationTest.java
@@ -22,6 +22,7 @@ import org.apache.commons.lang.ArrayUtils;
 import org.mockito.MockedStatic;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.wso2.carbon.identity.common.testng.WithCarbonHome;
 import org.wso2.carbon.identity.core.util.IdentityConfigParser;
@@ -524,6 +525,23 @@ public class OAuthServerConfigurationTest {
 
         Assert.assertFalse(OAuthServerConfiguration.getInstance()
                 .isReturnOnlyAppAssociatedRolesInUserInfo());
+    }
+
+    @DataProvider(name = "getDataForRefreshTokenAllowedGrants")
+    public Object[][] getDataForRefreshTokenAllowedGrants() {
+
+        return new Object[][]{
+                {"test_grant", null, null},
+                {"organization_switch", null, "true"}
+        };
+    }
+
+    @Test(dataProvider = "getDataForRefreshTokenAllowedGrants")
+    public void testGetValueForIsRefreshTokenAllowed(String grantType, String defaultValue, String expectedValue) {
+
+        String refreshAllowed = OAuthServerConfiguration.getInstance().
+                getValueForIsRefreshTokenAllowed(grantType, defaultValue);
+        Assert.assertEquals(refreshAllowed, expectedValue);
     }
 
 

--- a/components/org.wso2.carbon.identity.oauth/src/test/resources/repository/conf/identity/identity.xml
+++ b/components/org.wso2.carbon.identity.oauth/src/test/resources/repository/conf/identity/identity.xml
@@ -226,6 +226,11 @@
                 <GrantTypeHandlerImplClass>org.wso2.carbon.identity.oauth2.token.handlers.grant.idTokenNotAllowedGrantHandler</GrantTypeHandlerImplClass>
                 <IdTokenAllowed>false</IdTokenAllowed>
             </SupportedGrantType>
+            <SupportedGrantType>
+                <GrantTypeName>organization_switch</GrantTypeName>
+                <GrantTypeHandlerImplClass>org.wso2.carbon.identity.oauth2.grant.organizationswitch.OrganizationSwitchGrant</GrantTypeHandlerImplClass>
+                <IsRefreshTokenAllowed>true</IsRefreshTokenAllowed>
+            </SupportedGrantType>
         </SupportedGrantTypes>
         <OAuthCallbackHandlers>
             <OAuthCallbackHandler Class="org.wso2.carbon.identity.oauth2.test.utils.TestDefaultCallbackHandler"/>


### PR DESCRIPTION
### Proposed changes in this pull request

- $subject
- Part of the fix for : https://github.com/wso2/product-is/issues/23998