### PR TITLE
Fix token introspect config logic

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/TokenValidationHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/TokenValidationHandler.java
@@ -543,7 +543,7 @@ public class TokenValidationHandler {
                         !tenantDomain.equalsIgnoreCase(accessTokenDO.getAuthzUser().getTenantDomain()) &&
                         StringUtils.isEmpty(accessTokenDO.getAuthzUser().getAccessingOrganization())) {
                     throw new IllegalArgumentException("Invalid Access Token. ACTIVE access token is not found.");
-                } else if ((!isCrossTenantTokenIntrospectionAllowed || !allowCrossTenantIntrospectionForSubOrgTokens) &&
+                } else if (!isCrossTenantTokenIntrospectionAllowed && !allowCrossTenantIntrospectionForSubOrgTokens &&
                         accessTokenDO != null && StringUtils.isNotEmpty(
                         accessTokenDO.getAuthzUser().getAccessingOrganization())) {
                     // Previously, cases where accessTokenDO.getAuthzUser().getAccessingOrganization() was not empty


### PR DESCRIPTION
### Purpose
Fix the OAuth token introspection configuration logic to align with the intended behavior.

### Behavior
**`allow_cross_tenant = true`**
- Cross-tenant token introspection is allowed.
- Tokens issued for sub-organizations of another root can also be introspected.

**`allow_cross_tenant = false`, `allow_cross_sub_orgs = true`**
- Cross-tenant token introspection is not allowed.
- Tokens issued for sub-organizations of another root can be introspected.
- Preserves backward compatibility.

**`allow_cross_tenant = false`, `allow_cross_sub_orgs = false`**
- Cross-tenant token introspection is not allowed.
- Tokens issued for sub-organizations of another root cannot be introspected.

### Related PRs
- https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2848
- https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2859