### PR TITLE
Update dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -530,6 +530,16 @@
                 <groupId>io.swagger</groupId>
                 <artifactId>swagger-jaxrs</artifactId>
                 <version>${swagger-jaxrs.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-api</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.commons</groupId>
+                        <artifactId>commons-lang3</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.jaxrs</groupId>
@@ -952,7 +962,7 @@
         <jackson-databind.version>2.13.2.1</jackson-databind.version>
         <com.fasterxml.jackson.version>2.13.2</com.fasterxml.jackson.version>
         <spring-web.version>4.3.29.RELEASE</spring-web.version>
-        <swagger-jaxrs.version>1.6.2</swagger-jaxrs.version>
+        <swagger-jaxrs.version>1.6.11</swagger-jaxrs.version>
 
         <!--Test Dependencies-->
         <junit.version>4.13.1</junit.version>


### PR DESCRIPTION
This pull request updates the Swagger JAX-RS dependency in the `pom.xml` and refines its transitive dependencies. The main changes are an upgrade to the Swagger JAX-RS version and the exclusion of two libraries that were previously included transitively.

Dependency management improvements:

* Upgraded the `swagger-jaxrs` dependency version from `1.6.2` to `1.6.11` for improved features and bug fixes.
* Added exclusions for `slf4j-api` and `commons-lang3` from the `swagger-jaxrs` dependency to prevent unwanted transitive dependencies.