### PR TITLE
 improve user already gave consent method

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/AuthzUtil.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/AuthzUtil.java
@@ -3910,7 +3910,10 @@ public class AuthzUtil {
             throws OAuthSystemException {
 
         try {
-            return EndpointUtil.isUserAlreadyConsentedForOAuthScopes(user, oauth2Params) &&
+            // if the consent is skipped in the server side or in the SP side,
+            // we don't need to check whether user already approved or not.
+            return !isConsentSkipped(oauth2Params) &&
+                    EndpointUtil.isUserAlreadyConsentedForOAuthScopes(user, oauth2Params) &&
                     OAuth2ServiceComponentHolder.getInstance().getAuthorizationDetailsService()
                             .isUserAlreadyConsentedForAuthorizationDetails(user, oauth2Params);
         } catch (IdentityOAuth2ScopeException | IdentityOAuthAdminException e) {


### PR DESCRIPTION
Public Issue: https://github.com/wso2/product-is/issues/25742

This pull request updates the logic for checking if a user has already approved OAuth scopes in the `AuthzUtil.java` utility class. The main change is to ensure that if consent is skipped either on the server side or service provider side, the check for prior user approval is bypassed.

Logic update for user consent checks:

* Modified `isUserAlreadyApproved` to first check if consent is skipped using `isConsentSkipped(oauth2Params)`. If consent is skipped, the method returns `false` without checking prior user approval. This makes the consent check more robust and prevents unnecessary approval checks when consent is not required.

Consent Skipped Flow


https://github.com/user-attachments/assets/1c5d3c70-5743-4371-ab7d-0cc6633f354a

Consent enabled flow

https://github.com/user-attachments/assets/589acbd5-4fd4-4eec-b9af-7b1be9cdaa85


