### PR TITLE
Fix missing orgHandle and incorrect organization depth in Pre-Issue Access Token Action

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/action/execution/PreIssueAccessTokenRequestBuilderTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/action/execution/PreIssueAccessTokenRequestBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2024-2025, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -58,6 +58,7 @@ import org.wso2.carbon.identity.openidconnect.CustomClaimsCallbackHandler;
 import org.wso2.carbon.identity.openidconnect.util.ClaimHandlerUtil;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
+import org.wso2.carbon.identity.organization.management.service.model.MinimalOrganization;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -88,6 +89,8 @@ public class PreIssueAccessTokenRequestBuilderTest {
 
     private static final String ORG_NAME = "test.com";
     private static final String ORG_ID = "2364283-349o34nnv-92713972nx";
+    private static final String ORG_HANDLE = "testhandle";
+    private static final int ORG_DEPTH = 1;
     private PreIssueAccessTokenRequestBuilder preIssueAccessTokenRequestBuilder;
 
     private MockedStatic<ClaimHandlerUtil> claimHandlerUtilMockedStatic;
@@ -177,10 +180,9 @@ public class PreIssueAccessTokenRequestBuilderTest {
     public void testBuildActionExecutionRequest()
             throws ActionExecutionRequestBuilderException, OrganizationManagementException {
 
-        org.wso2.carbon.identity.organization.management.service.model.Organization actualOrg =
-                new org.wso2.carbon.identity.organization.management.service.model.Organization();
-        actualOrg.setId(ORG_ID);
-        actualOrg.setName(ORG_NAME);
+        MinimalOrganization minimalOrganization =
+                new MinimalOrganization.Builder().id(ORG_ID).name(ORG_NAME).organizationHandle(ORG_HANDLE)
+                        .depth(ORG_DEPTH).build();
 
         try (MockedStatic<OAuthComponentServiceHolder> oAuthComponentServiceHolder =
                      mockStatic(OAuthComponentServiceHolder.class)) {
@@ -189,7 +191,8 @@ public class PreIssueAccessTokenRequestBuilderTest {
                     .thenReturn(mockOAuthComponentServiceHolder);
             when(mockOAuthComponentServiceHolder.getOrganizationManager()).thenReturn(mockOrganizationManager);
             when(mockOrganizationManager.resolveOrganizationId(ORG_NAME)).thenReturn(ORG_ID);
-            when(mockOrganizationManager.getOrganization(ORG_ID, false, false)).thenReturn(actualOrg);
+            when(mockOrganizationManager.getMinimalOrganization(ORG_ID, TENANT_DOMAIN_TEST)).thenReturn(
+                    minimalOrganization);
 
             ActionExecutionRequest actionExecutionRequest = preIssueAccessTokenRequestBuilder.
                     buildActionExecutionRequest(

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/action/execution/PreIssueAccessTokenRequestBuilderTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/action/execution/PreIssueAccessTokenRequestBuilderTest.java
@@ -69,6 +69,8 @@ import java.util.List;
 import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
@@ -191,8 +193,8 @@ public class PreIssueAccessTokenRequestBuilderTest {
                     .thenReturn(mockOAuthComponentServiceHolder);
             when(mockOAuthComponentServiceHolder.getOrganizationManager()).thenReturn(mockOrganizationManager);
             when(mockOrganizationManager.resolveOrganizationId(ORG_NAME)).thenReturn(ORG_ID);
-            when(mockOrganizationManager.getMinimalOrganization(ORG_ID, TENANT_DOMAIN_TEST)).thenReturn(
-                    minimalOrganization);
+            when(mockOrganizationManager.getMinimalOrganization(eq(ORG_ID), anyString()))
+                    .thenReturn(minimalOrganization);
 
             ActionExecutionRequest actionExecutionRequest = preIssueAccessTokenRequestBuilder.
                     buildActionExecutionRequest(

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/action/execution/PreIssueAccessTokenRequestBuilderTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/action/execution/PreIssueAccessTokenRequestBuilderTest.java
@@ -70,7 +70,7 @@ import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
@@ -193,7 +193,7 @@ public class PreIssueAccessTokenRequestBuilderTest {
                     .thenReturn(mockOAuthComponentServiceHolder);
             when(mockOAuthComponentServiceHolder.getOrganizationManager()).thenReturn(mockOrganizationManager);
             when(mockOrganizationManager.resolveOrganizationId(ORG_NAME)).thenReturn(ORG_ID);
-            when(mockOrganizationManager.getMinimalOrganization(eq(ORG_ID), anyString()))
+            when(mockOrganizationManager.getMinimalOrganization(anyString(), nullable(String.class)))
                     .thenReturn(minimalOrganization);
 
             ActionExecutionRequest actionExecutionRequest = preIssueAccessTokenRequestBuilder.


### PR DESCRIPTION
### Purpose
To correct the organization metadata returned in the Pre-Issue Access Token Action response, ensuring that sub-organization depth is accurately resolved and the `orgHandle` value is included.

### Goals
* Return the actual depth of the organization (e.g., `1` for a direct sub-organization, not always `0`).
* Include the `orgHandle` field in the response payload for better organization identification.

### Approach
* Updated the logic to resolve the correct depth of sub-organizations instead of defaulting to `0`.
* Modified the response builder to append the `orgHandle` value when constructing the `organization` object in the token action payload.

## Related Issues
  - https://github.com/wso2/product-is/issues/25836
