### PR TITLE
Add refresh token support for impersonation flow

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/tokenprocessor/DefaultRefreshTokenGrantProcessor.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/tokenprocessor/DefaultRefreshTokenGrantProcessor.java
@@ -29,6 +29,7 @@ import org.wso2.carbon.identity.oauth2.dao.OAuthTokenPersistenceFactory;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2AccessTokenReqDTO;
 import org.wso2.carbon.identity.oauth2.internal.OAuth2ServiceComponentHolder;
 import org.wso2.carbon.identity.oauth2.model.AccessTokenDO;
+import org.wso2.carbon.identity.oauth2.model.AccessTokenExtendedAttributes;
 import org.wso2.carbon.identity.oauth2.model.RefreshTokenValidationDataDO;
 import org.wso2.carbon.identity.oauth2.token.OAuthTokenReqMessageContext;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
@@ -36,6 +37,7 @@ import org.wso2.carbon.identity.openidconnect.OIDCClaimUtil;
 
 import java.sql.Timestamp;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import java.util.UUID;
 
@@ -118,6 +120,9 @@ public class DefaultRefreshTokenGrantProcessor implements RefreshTokenGrantProce
                 tokReqMsgCtx.setConsentedToken(true);
             }
         }
+        accessTokenDO.setAccessTokenExtendedAttributes(
+                new AccessTokenExtendedAttributes(
+                        new HashMap<>(tokenReq.getAccessTokenExtendedAttributes().getParameters())));
         return accessTokenDO;
     }
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/OAuth2Constants.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/OAuth2Constants.java
@@ -53,6 +53,7 @@ public class OAuth2Constants {
     public static final String OAUTH_CODE_PERSISTENCE_ENABLE = "OAuth.EnableAuthCodePersistence";
     public static final String OAUTH_ENABLE_REVOKE_TOKEN_HEADERS = "OAuth.EnableRevokeTokenHeadersInResponse";
     public static final String IMPERSONATED_REFRESH_TOKEN_ENABLE = "OAuth.ImpersonatedRefreshToken.Enable";
+    public static final boolean DEFAULT_IMPERSONATED_REFRESH_TOKEN_ENABLED = true;
     public static final String CONSOLE_CALLBACK_URL_FROM_SERVER_CONFIGS = "Console.CallbackURL";
     public static final String MY_ACCOUNT_CALLBACK_URL_FROM_SERVER_CONFIGS = "MyAccount.CallbackURL";
     public static final String TENANT_DOMAIN_PLACEHOLDER = "{TENANT_DOMAIN}";

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuer.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuer.java
@@ -695,6 +695,7 @@ public class JWTTokenIssuer extends OauthTokenIssuerImpl {
                     tokenReqMessageContext.getOauth2AccessTokenReqDTO().getAccessTokenExtendedAttributes()
                             .getParameters();
             if (customClaims != null && !customClaims.isEmpty()) {
+                customClaims.remove(OAuthConstants.IMPERSONATING_ACTOR);
                 for (Map.Entry<String, String> entry : customClaims.entrySet()) {
                     jwtClaimsSetBuilder.claim(entry.getKey(), entry.getValue());
                 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AbstractAuthorizationGrantHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AbstractAuthorizationGrantHandler.java
@@ -90,7 +90,6 @@ import static org.wso2.carbon.identity.oauth.common.OAuthConstants.RENEW_TOKEN_W
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.TokenBindings.NONE;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.TokenStates.TOKEN_STATE_ACTIVE;
 import static org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration.JWT_TOKEN_TYPE;
-import static org.wso2.carbon.identity.oauth2.OAuth2Constants.IMPERSONATED_REFRESH_TOKEN_ENABLE;
 import static org.wso2.carbon.identity.oauth2.util.OAuth2Util.EXTENDED_REFRESH_TOKEN_DEFAULT_TIME;
 import static org.wso2.carbon.identity.oauth2.util.OAuth2Util.JWT;
 
@@ -937,7 +936,7 @@ public abstract class AbstractAuthorizationGrantHandler implements Authorization
             }
             if (supportedGrantTypes.contains(OAuthConstants.GrantTypes.REFRESH_TOKEN)) {
                 if (!tokenReqMessageContext.isImpersonationRequest()
-                        || Boolean.parseBoolean(IdentityUtil.getProperty(IMPERSONATED_REFRESH_TOKEN_ENABLE))) {
+                        || OAuth2Util.isImpersonatedRefreshTokenEnabled()) {
                     tokenRespDTO.setRefreshToken(existingAccessTokenDO.getRefreshToken());
                 }
             } else {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/RefreshGrantHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/RefreshGrantHandler.java
@@ -276,6 +276,7 @@ public class RefreshGrantHandler extends AbstractAuthorizationGrantHandler {
         tokReqMsgCtx.setScope(validationBean.getScope());
         tokReqMsgCtx.getOauth2AccessTokenReqDTO().setAccessTokenExtendedAttributes(
                 validationBean.getAccessTokenExtendedAttributes());
+        propagateImpersonationInfo(tokReqMsgCtx);
         if (StringUtils.isNotBlank(validationBean.getTokenBindingReference()) && !NONE
                 .equals(validationBean.getTokenBindingReference())) {
             Optional<TokenBinding> tokenBindingOptional = OAuthTokenPersistenceFactory.getInstance()
@@ -303,6 +304,23 @@ public class RefreshGrantHandler extends AbstractAuthorizationGrantHandler {
         }
         if (sessionId != null) {
             tokReqMsgCtx.addProperty(SESSION_IDENTIFIER, sessionId);
+        }
+    }
+
+    private void propagateImpersonationInfo(OAuthTokenReqMessageContext tokenReqMessageContext) {
+
+        if (tokenReqMessageContext != null && tokenReqMessageContext.getOauth2AccessTokenReqDTO() != null &&
+                tokenReqMessageContext.getOauth2AccessTokenReqDTO().getAccessTokenExtendedAttributes() != null) {
+            String impersonator = tokenReqMessageContext.getOauth2AccessTokenReqDTO()
+                    .getAccessTokenExtendedAttributes().getParameters()
+                    .get(OAuthConstants.IMPERSONATING_ACTOR);
+            if (StringUtils.isNotBlank(impersonator)) {
+                tokenReqMessageContext.setImpersonationRequest(true);
+                tokenReqMessageContext.addProperty(OAuthConstants.IMPERSONATING_ACTOR, impersonator);
+                if (log.isDebugEnabled()) {
+                    log.debug("Impersonation request identified for the user: " + impersonator);
+                }
+            }
         }
     }
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -5883,6 +5883,19 @@ public class OAuth2Util {
     }
 
     /**
+     * Check if impersonated refresh token is enabled.
+     *
+     * @return True if impersonated refresh token is enabled.
+     */
+    public static boolean isImpersonatedRefreshTokenEnabled() {
+
+        if (IdentityUtil.getProperty(OAuth2Constants.IMPERSONATED_REFRESH_TOKEN_ENABLE) != null) {
+            return Boolean.parseBoolean(IdentityUtil.getProperty(OAuth2Constants.IMPERSONATED_REFRESH_TOKEN_ENABLE));
+        }
+        return OAuth2Constants.DEFAULT_IMPERSONATED_REFRESH_TOKEN_ENABLED;
+    }
+
+    /**
      * Check if token persistence is enabled.
      *
      * @return True if token persistence is enabled.


### PR DESCRIPTION
### Proposed changes in this pull request
Issue: https://github.com/wso2/product-is/issues/25778

This pull request introduces enhancements and refactoring to the impersonated refresh token feature in the OAuth2 implementation. The main focus is on improving how impersonation requests are detected and handled, ensuring consistent propagation of impersonation information, and making the configuration for enabling impersonated refresh tokens more robust and clear.

**Impersonation Feature Improvements:**

* Added a new utility method `isImpersonatedRefreshTokenEnabled()` in `OAuth2Util` to centralize and simplify checking whether impersonated refresh tokens are enabled, with support for a default value.


**Impersonation Information Propagation:**

* Added `propagateImpersonationInfo()` in `RefreshGrantHandler` to detect and mark impersonation requests by inspecting extended attributes, ensuring impersonation context is set correctly during token generation. [[1]](diffhunk://#diff-2dad3e7460a1c3e8e1ec626d036d2f787288efcab5dfce14c9d2703befe42155R279) [[2]](diffhunk://#diff-2dad3e7460a1c3e8e1ec626d036d2f787288efcab5dfce14c9d2703befe42155R310-R326)

**Refactoring and Code Consistency:**

* Updated `AbstractAuthorizationGrantHandler` to use the new utility method for checking impersonated refresh token enablement, replacing direct property access for improved code clarity and maintainability. [[1]](diffhunk://#diff-179df1a422d3b4188d94a7ba94f9fcda13659515bd0a971d57014eb7c9a2e8b0L93) [[2]](diffhunk://#diff-179df1a422d3b4188d94a7ba94f9fcda13659515bd0a971d57014eb7c9a2e8b0L940-R939)

**Token Attribute Handling:**

* Ensured that extended attributes are properly set and propagated in `DefaultRefreshTokenGrantProcessor`, improving how custom token attributes are handled during token creation. [[1]](diffhunk://#diff-3e23e220c42796106519c06b93c60071e40300cb58f9f313afff40e864e36753R32-R40) [[2]](diffhunk://#diff-3e23e220c42796106519c06b93c60071e40300cb58f9f313afff40e864e36753R123-R125)
* Modified `JWTTokenIssuer` to remove the impersonating actor from custom claims before issuing JWTs, preventing unintended exposure of impersonation details.