### PR TITLE
Make refresh token support for impersonation flow as True by default

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/OAuth2Constants.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/OAuth2Constants.java
@@ -53,6 +53,7 @@ public class OAuth2Constants {
     public static final String OAUTH_CODE_PERSISTENCE_ENABLE = "OAuth.EnableAuthCodePersistence";
     public static final String OAUTH_ENABLE_REVOKE_TOKEN_HEADERS = "OAuth.EnableRevokeTokenHeadersInResponse";
     public static final String IMPERSONATED_REFRESH_TOKEN_ENABLE = "OAuth.ImpersonatedRefreshToken.Enable";
+    public static final boolean DEFAULT_IMPERSONATED_REFRESH_TOKEN_ENABLED = true;
     public static final String CONSOLE_CALLBACK_URL_FROM_SERVER_CONFIGS = "Console.CallbackURL";
     public static final String MY_ACCOUNT_CALLBACK_URL_FROM_SERVER_CONFIGS = "MyAccount.CallbackURL";
     public static final String TENANT_DOMAIN_PLACEHOLDER = "{TENANT_DOMAIN}";

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AbstractAuthorizationGrantHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AbstractAuthorizationGrantHandler.java
@@ -937,8 +937,13 @@ public abstract class AbstractAuthorizationGrantHandler implements Authorization
             }
             if (supportedGrantTypes.contains(OAuthConstants.GrantTypes.REFRESH_TOKEN)) {
                 if (!tokenReqMessageContext.isImpersonationRequest()
-                        || Boolean.parseBoolean(IdentityUtil.getProperty(IMPERSONATED_REFRESH_TOKEN_ENABLE))) {
+                        || OAuth2Util.isImpersonatedRefreshTokenEnabled()) {
                     tokenRespDTO.setRefreshToken(existingAccessTokenDO.getRefreshToken());
+                } else {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Impersonation request is not allowed to have a refresh token for client_id : " +
+                                consumerKey + ", therefore not issuing a refresh token.");
+                    }
                 }
             } else {
                 if (log.isDebugEnabled()) {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -5888,6 +5888,23 @@ public class OAuth2Util {
     }
 
     /**
+     * Check if impersonated refresh token is enabled.
+     *
+     * @return True if impersonated refresh token is enabled.
+     */
+    public static boolean isImpersonatedRefreshTokenEnabled() {
+
+        if (IdentityUtil.getProperty(OAuth2Constants.IMPERSONATED_REFRESH_TOKEN_ENABLE) != null) {
+            return Boolean.parseBoolean(IdentityUtil.getProperty(OAuth2Constants.IMPERSONATED_REFRESH_TOKEN_ENABLE));
+        }
+        if (log.isDebugEnabled()) {
+            log.debug("Impersonated refresh token configuration not found, " +
+                    "using default: " + OAuth2Constants.DEFAULT_IMPERSONATED_REFRESH_TOKEN_ENABLED);
+        }
+        return OAuth2Constants.DEFAULT_IMPERSONATED_REFRESH_TOKEN_ENABLED;
+    }
+
+    /**
      * Check if token persistence is enabled.
      *
      * @return True if token persistence is enabled.

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/util/OAuth2UtilTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/util/OAuth2UtilTest.java
@@ -3177,6 +3177,26 @@ public class OAuth2UtilTest {
         assertEquals(OAuth2Util.getAppResidentTenantDomain(), expected);
     }
 
+    @DataProvider(name = "impersonatedRefreshTokenEnabledProvider")
+    public Object[][] impersonatedRefreshTokenEnabledProvider() {
+        return new Object[][]{
+                {"true", true},
+                {"false", false},
+                {null, true}
+        };
+    }
+
+    @Test(dataProvider = "impersonatedRefreshTokenEnabledProvider")
+    public void testIsImpersonatedRefreshTokenEnabled(String configValue, boolean expected) {
+
+        try (MockedStatic<IdentityUtil> identityUtil = mockStatic(IdentityUtil.class)) {
+
+            identityUtil.when(() -> IdentityUtil.getProperty(OAuth2Constants.IMPERSONATED_REFRESH_TOKEN_ENABLE))
+                    .thenReturn(configValue);
+            assertEquals(OAuth2Util.isImpersonatedRefreshTokenEnabled(), expected);
+        }
+    }
+
     @Test(expectedExceptions = IdentityOAuth2Exception.class,
             expectedExceptionsMessageRegExp = "Error occurred while resolving the tenant domain for the " +
                     "organization id.")


### PR DESCRIPTION
### Proposed changes in this pull request
Related Issue: https://github.com/wso2/product-is/issues/25778

This pull request introduces a configuration-driven approach for enabling or disabling impersonated refresh tokens in the OAuth2 module. The main change is the addition of a default setting and a utility method to centralize the logic for checking whether impersonated refresh tokens are allowed, improving maintainability and testability.

Configuration and Logic Improvements:
* Added `DEFAULT_IMPERSONATED_REFRESH_TOKEN_ENABLED` constant to `OAuth2Constants.TokenTypes`, setting the default value to `true` if the configuration is not explicitly set.
* Implemented the `OAuth2Util.isImpersonatedRefreshTokenEnabled()` method to check the configuration and fall back to the default value, including debug logging when the config is missing.

Authorization Grant Handling:
* Updated the refresh token issuance logic in `AbstractAuthorizationGrantHandler` to use the new utility method, ensuring consistent behavior and improved logging when impersonation requests are denied a refresh token.

Testing:
* Added unit tests for the new utility method in `OAuth2UtilTest`, covering cases for `true`, `false`, and `null` configuration values.