### PR TITLE
Update getLoggedInTenant order of retrieval

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImpl.java
@@ -1406,9 +1406,9 @@ public class OAuthAdminServiceImpl {
 
     private String getLoggedInTenant() {
 
-        return Optional.ofNullable(IdentityTenantUtil.getTenantDomainFromContext())
+        return Optional.ofNullable(PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain())
                 .filter(StringUtils::isNotBlank)
-                .orElseGet(() -> PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain());
+                .orElseGet(IdentityTenantUtil::getTenantDomainFromContext);
     }
 
     /**


### PR DESCRIPTION
## Purpose

In the root organization creation flow, the username in the context is the username of the admin user created during this flow [1], not the currently logged in user. 

The error in [2] is caused by retrieving this new admin's username [3] and looking for it in the currently logged in tenant.

With this fix, the tenant will be first retrieved from the context if available, which ensures the username and tenant are both from the context and avoids this error.

[1] https://github.com/wso2/identity-apps/blob/a1fb2ead655c803a947bafddfdbcb37cbdd44a1f/identity-apps-core/components/org.wso2.identity.apps.common/src/main/java/org/wso2/identity/apps/common/util/AppPortalUtils.java#L201
[2] https://github.com/wso2/product-is/issues/24943
[3] https://github.com/wso2-extensions/identity-inbound-auth-oauth/blob/master/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImpl.java#L624

## Related Issues

- https://github.com/wso2/product-is/issues/24943