### PR TITLE
Add changes required for FAPI 2.0 compliance

### DIFF
--- a/components/org.wso2.carbon.identity.discovery/src/main/java/org/wso2/carbon/identity/discovery/DiscoveryConstants.java
+++ b/components/org.wso2.carbon.identity.discovery/src/main/java/org/wso2/carbon/identity/discovery/DiscoveryConstants.java
@@ -384,4 +384,14 @@ public class DiscoveryConstants {
      * @see <a href='https://datatracker.ietf.org/doc/html/rfc9396.txt#name-metadata'>rfc9396</a>
      */
     public static final String AUTHORIZATION_DETAILS_TYPES_SUPPORTED = "authorization_details_types_supported";
+
+    /**
+     * authorization_response_iss_parameter_supported
+     * OPTIONAL. Boolean value specifying whether the OP supports the "iss" parameter in the
+     * Authorization Response. This allows RPs to securely determine the issuer of the response.
+     * If omitted, the default value is false.
+     * @see <a href="https://datatracker.ietf.org/doc/html/rfc9207#as_metadata">rfc9207</a>
+     */
+    public static final String AUTHORIZATION_RESPONSE_ISS_PARAMETER_SUPPORTED =
+            "authorization_response_iss_parameter_supported";
 }

--- a/components/org.wso2.carbon.identity.discovery/src/main/java/org/wso2/carbon/identity/discovery/OIDProviderConfigResponse.java
+++ b/components/org.wso2.carbon.identity.discovery/src/main/java/org/wso2/carbon/identity/discovery/OIDProviderConfigResponse.java
@@ -86,6 +86,7 @@ public class OIDProviderConfigResponse {
     private String mtlsTokenEndpoint;
     private String mtlsPushedAuthorizationRequestEndpoint;
     private String[] authorizationDetailsTypesSupported;
+    private Boolean authorizationResponseIssParameterSupported;
 
     private static final String MUTUAL_TLS_ALIASES_ENABLED = "OAuth.MutualTLSAliases.Enabled";
 
@@ -541,6 +542,16 @@ public class OIDProviderConfigResponse {
         this.authorizationDetailsTypesSupported = authorizationDetailsTypesSupported;
     }
 
+    public Boolean getAuthorizationResponseIssParameterSupported() {
+
+        return authorizationResponseIssParameterSupported;
+    }
+
+    public void setAuthorizationResponseIssParameterSupported(Boolean authorizationResponseIssParameterSupported) {
+
+        this.authorizationResponseIssParameterSupported = authorizationResponseIssParameterSupported;
+    }
+
     public Map<String, Object> getConfigMap() {
         Map<String, Object> configMap = new HashMap<String, Object>();
         configMap.put(DiscoveryConstants.ISSUER.toLowerCase(), this.issuer);
@@ -617,6 +628,8 @@ public class OIDProviderConfigResponse {
         }
         configMap.put(DiscoveryConstants.AUTHORIZATION_DETAILS_TYPES_SUPPORTED,
                 this.authorizationDetailsTypesSupported);
+        configMap.put(DiscoveryConstants.AUTHORIZATION_RESPONSE_ISS_PARAMETER_SUPPORTED,
+                this.authorizationResponseIssParameterSupported);
         return configMap;
     }
 }

--- a/components/org.wso2.carbon.identity.discovery/src/main/java/org/wso2/carbon/identity/discovery/builders/ProviderConfigBuilder.java
+++ b/components/org.wso2.carbon.identity.discovery/src/main/java/org/wso2/carbon/identity/discovery/builders/ProviderConfigBuilder.java
@@ -159,6 +159,10 @@ public class ProviderConfigBuilder {
         if (authorizationDetailTypes != null && !authorizationDetailTypes.isEmpty()) {
             providerConfig
                     .setAuthorizationDetailsTypesSupported(authorizationDetailTypes.stream().toArray(String[]::new));
+            // `authorization_response_iss` should be true for FAPI 2.0 compliance.
+            if (OAuth2Util.isFapi2Enabled()) {
+                providerConfig.setAuthorizationResponseIssParameterSupported(Boolean.TRUE);
+            }
         }
         return providerConfig;
     }

--- a/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
+++ b/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
@@ -339,6 +339,19 @@ public final class OAuthConstants {
     }
 
     /**
+     * Define FAPI versions.
+     */
+    public static class FAPIVersions {
+
+        public static final String FAPI1_ADVANCED = "1";
+        public static final String FAPI2 = "2";
+
+        private FAPIVersions() {
+
+        }
+    }
+
+    /**
      * Define OAuth1.0a request parameters.
      */
     public static class OAuth10AParams {

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/par/OAuth2ParEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/par/OAuth2ParEndpoint.java
@@ -324,7 +324,7 @@ public class OAuth2ParEndpoint {
             OAuthAuthzRequest oAuthAuthzRequest = getOAuthAuthzRequest(request);
             RequestObject requestObject = validateRequestObject(oAuthAuthzRequest);
             Map<String, String> oauthParams = overrideRequestObjectParams(request, requestObject);
-            if (isFapiConformant(oAuthAuthzRequest.getClientId())) {
+            if (isFapiConformant(oAuthAuthzRequest.getClientId()) && OAuth2Util.isFapi1Enabled()) {
                 EndpointUtil.validateFAPIAllowedResponseTypeAndMode(oauthParams.get(RESPONSE_TYPE),
                         oauthParams.get(RESPONSE_MODE));
                 validatePKCEParameters(oauthParams);
@@ -403,8 +403,8 @@ public class OAuth2ParEndpoint {
                         throw new ParClientException(OAuth2ErrorCodes.INVALID_REQUEST,
                                 ParConstants.INVALID_REQUEST_OBJECT);
                     }
-                } else if (isFapiConformant(oAuthAuthzRequest.getClientId())) {
-                    /* Mandate request object for FAPI requests
+                } else if (isFapiConformant(oAuthAuthzRequest.getClientId()) && OAuth2Util.isFapi1Enabled()) {
+                    /* Mandate request object for FAPI 1.0 Advanced requests
                     https://openid.net/specs/openid-financial-api-part-2-1_0.html#authorization-server (5.2.2-1) */
                     throw new ParClientException(OAuth2ErrorCodes.INVALID_REQUEST, ParConstants.REQUEST_OBJECT_MISSING);
                 }

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
@@ -1928,7 +1928,7 @@ public class EndpointUtil {
     }
 
     /**
-     * Validate the response mode against the response type as per FAPI spec.
+     * Validate the response mode against the response type as per FAPI 1.0 Advanced spec.
      * shall require;
      * 1. the response_type value code id_token, or
      * 2. the response_type value code in conjunction with the response_mode value jwt;

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/par/OAuth2ParEndpointTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/par/OAuth2ParEndpointTest.java
@@ -536,5 +536,7 @@ public class OAuth2ParEndpointTest extends TestOAuthEndpointBase {
                 new HashMap<String, RequestObjectBuilder>() {{
                     put("request_param_value_builder", new RequestParamRequestObjectBuilder());
                 }});
+        lenient().when(mockOAuthServerConfiguration.getFapiVersion()).thenReturn("1");
+
     }
 }

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/util/AuthzUtilTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/util/AuthzUtilTest.java
@@ -1386,6 +1386,7 @@ public class AuthzUtilTest extends TestOAuthEndpointBase {
                 oAuth2Util.when(() -> OAuth2Util.getAppInformationByClientId(oAuth2Parameters.getClientId(),
                         oAuth2Parameters.getTenantDomain())).thenReturn(appDO);
                 oAuth2Util.when(() -> OAuth2Util.isFapiConformantApp(any())).thenReturn(true);
+                oAuth2Util.when(() -> OAuth2Util.isFapi1Enabled()).thenReturn(true);
 
                 mockEndpointUtil(false, endpointUtil);
                 when(oAuth2Service.isPKCESupportEnabled()).thenReturn(false);

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/resources/repository/conf/identity/identity.xml
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/resources/repository/conf/identity/identity.xml
@@ -324,6 +324,9 @@
             <SkipUserConsent>false</SkipUserConsent>
             <!-- Sign the ID Token with Service Provider Tenant Private Key-->
             <SignJWTWithSPKey>false</SignJWTWithSPKey>
+            <FAPI>
+                <FAPIVersion>1</FAPIVersion>
+            </FAPI>
 
         </OpenIDConnect>
 

--- a/components/org.wso2.carbon.identity.oauth.par/src/main/java/org/wso2/carbon/identity/oauth/par/common/ParConstants.java
+++ b/components/org.wso2.carbon.identity.oauth.par/src/main/java/org/wso2/carbon/identity/oauth/par/common/ParConstants.java
@@ -47,6 +47,7 @@ public class ParConstants {
     public static final String INVALID_REQUEST_OBJECT = "Unable to build a valid Request Object from the" +
             " pushed authorization request.";
     public static final String REQUEST_OBJECT_MISSING = "Request object is missing.";
+    public static final String PAR_STATE = "parRequestState";
 
     private ParConstants() {
 

--- a/components/org.wso2.carbon.identity.oauth.par/src/main/java/org/wso2/carbon/identity/oauth/par/core/ParRequestBuilder.java
+++ b/components/org.wso2.carbon.identity.oauth.par/src/main/java/org/wso2/carbon/identity/oauth/par/core/ParRequestBuilder.java
@@ -54,6 +54,9 @@ public class ParRequestBuilder implements OAuthAuthorizationRequestBuilder {
         try {
             params = ParAuthServiceComponentDataHolder.getInstance().getParAuthService()
                     .retrieveParams(uuid, request.getParameter(OAuthConstants.OAuth20Params.CLIENT_ID));
+            if (params.containsKey(OAuthConstants.OAuth20Params.STATE)) {
+                request.setAttribute(ParConstants.PAR_STATE, params.get(OAuthConstants.OAuth20Params.STATE));
+            }
         } catch (ParClientException e) {
             throw new ParAuthFailureException(e.getErrorCode(), e.getMessage(), e);
         } catch (ParCoreException e) {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
@@ -215,6 +215,7 @@ public class OAuthServerConfiguration {
     private String[] supportedClaims = null;
     private boolean isFapiCiba = false;
     private boolean isFapiSecurity = false;
+    private String fapiVersion = OAuthConstants.FAPIVersions.FAPI1_ADVANCED;
     private Map<String, Properties> supportedClientAuthHandlerData = new HashMap<>();
     private String saml2TokenCallbackHandlerName = null;
     private String saml2BearerTokenUserType;
@@ -244,6 +245,7 @@ public class OAuthServerConfiguration {
     private boolean addTenantDomainToIdTokenEnabled = false;
     private boolean addUserstoreDomainToIdTokenEnabled = false;
     private boolean requestObjectEnabled = true;
+    private boolean useEntityIDAsIssuer = false;
 
     //default token types
     public static final String DEFAULT_TOKEN_TYPE = "Default";
@@ -1711,6 +1713,10 @@ public class OAuthServerConfiguration {
 
     public String getUserInfoJWTSignatureAlgorithm() {
         return userInfoJWTSignatureAlgorithm;
+    }
+
+    public boolean getIsUseEntityIDAsIssuerEnabled() {
+        return useEntityIDAsIssuer;
     }
 
     /**
@@ -3722,6 +3728,14 @@ public class OAuthServerConfiguration {
                 isJWTSignedWithSPKey = Boolean.parseBoolean(openIDConnectConfigElem.getFirstChildWithName(
                         getQNameWithIdentityNS(ConfigElements.OPENID_CONNECT_SIGN_JWT_WITH_SP_KEY)).getText().trim());
             }
+
+            if (openIDConnectConfigElem.getFirstChildWithName(
+                    getQNameWithIdentityNS(ConfigElements.OPENID_CONNECT_USE_ENTITY_ID_AS_ISSUER)) != null) {
+                useEntityIDAsIssuer = Boolean.parseBoolean(openIDConnectConfigElem.getFirstChildWithName(
+                                getQNameWithIdentityNS(ConfigElements.OPENID_CONNECT_USE_ENTITY_ID_AS_ISSUER)).
+                        getText().trim());
+            }
+
             if (openIDConnectConfigElem
                     .getFirstChildWithName(getQNameWithIdentityNS(ConfigElements.SUPPORTED_CLAIMS)) != null) {
                 String supportedClaimStr = openIDConnectConfigElem
@@ -3789,6 +3803,10 @@ public class OAuthServerConfiguration {
                     isFapiSecurity =
                             Boolean.parseBoolean(fapiElem.getFirstChildWithName(getQNameWithIdentityNS
                                     (ConfigElements.ENABLE_FAPI_SECURITY_PROFILE)).getText().trim());
+                }
+                if (fapiElem.getFirstChildWithName(getQNameWithIdentityNS(ConfigElements.FAPI_VERSION)) != null) {
+                    fapiVersion = fapiElem.getFirstChildWithName(getQNameWithIdentityNS(
+                            ConfigElements.FAPI_VERSION)).getText().trim();
                 }
             }
             if (openIDConnectConfigElem.getFirstChildWithName(getQNameWithIdentityNS(ConfigElements
@@ -4225,6 +4243,14 @@ public class OAuthServerConfiguration {
         return isFapiSecurity;
     }
 
+    /**
+     * This method returns the FAPI version supported by the server configured in identity.xml.
+     */
+    public String getFapiVersion() {
+
+        return fapiVersion;
+    }
+
     public boolean isGlobalRbacScopeIssuerEnabled() {
 
         return globalRbacScopeIssuerEnabled;
@@ -4404,6 +4430,7 @@ public class OAuthServerConfiguration {
                 "ReturnOnlyAppAssociatedRolesInUserInfo";
 
         public static final String OPENID_CONNECT_SIGN_JWT_WITH_SP_KEY = "SignJWTWithSPKey";
+        public static final String OPENID_CONNECT_USE_ENTITY_ID_AS_ISSUER = "UseEntityIdAsIssuer";
         public static final String OPENID_CONNECT_IDTOKEN_CUSTOM_CLAIM_CALLBACK_HANDLER =
                 "IDTokenCustomClaimsCallBackHandler";
         public static final String OPENID_CONNECT_CONVERT_ORIGINAL_CLAIMS_FROM_ASSERTIONS_TO_OIDCDIALECT =
@@ -4612,6 +4639,7 @@ public class OAuthServerConfiguration {
 
         // FAPI Configurations
         private static final String FAPI = "FAPI";
+        private static final String FAPI_VERSION = "FAPIVersion";
 
         private static final String SKIP_OIDC_CLAIMS_FOR_CLIENT_CREDENTIAL_GRANT =
                 "SkipOIDCClaimsForClientCredentialGrant";

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -4770,8 +4770,15 @@ public class OAuth2Util {
         if (IdentityTenantUtil.shouldUseTenantQualifiedURLs() && StringUtils.isEmpty(PrivilegedCarbonContext.
                 getThreadLocalCarbonContext().getApplicationResidentOrganizationId())) {
             try {
-                return isMtlsRequest ? OAuthURL.getOAuth2MTLSTokenEPUrl() :
-                        ServiceURLBuilder.create().addPath(OAUTH2_TOKEN_EP_URL).build().getAbsolutePublicURL();
+                /* Returning residentIdpEntityId as issuer when useEntityIDAsIssuer configuration is enabled or
+                   FAPI 2.0 is enabled. */
+                if (OAuthServerConfiguration.getInstance().getIsUseEntityIDAsIssuerEnabled() || isFapi2Enabled()) {
+                    return getResidentIdpEntityId(tenantDomain);
+                }
+                if (isMtlsRequest) {
+                    return OAuthURL.getOAuth2MTLSTokenEPUrl();
+                }
+                return ServiceURLBuilder.create().addPath(OAUTH2_TOKEN_EP_URL).build().getAbsolutePublicURL();
             } catch (URLBuilderException e) {
                 String errorMsg = String.format("Error while building the absolute url of the context: '%s',  for the" +
                         " tenant domain: '%s'", OAUTH2_TOKEN_EP_URL, tenantDomain);
@@ -4786,6 +4793,11 @@ public class OAuth2Util {
             throws IdentityOAuth2Exception {
 
         if (IdentityTenantUtil.shouldUseTenantQualifiedURLs()) {
+            /* Returning residentIdpEntityId as issuer when useEntityIDAsIssuer configuration is enabled or
+               FAPI 2.0 is enabled. */
+            if (OAuthServerConfiguration.getInstance().getIsUseEntityIDAsIssuerEnabled() || isFapi2Enabled()) {
+                return getResidentIdpEntityId(tenantDomain);
+            }
             try {
                 return isMtlsRequest ? OAuthURL.getOAuth2MTLSTokenEPUrl() :
                         ServiceURLBuilder.create().addPath(OAUTH2_TOKEN_EP_URL).setSkipDomainBranding(
@@ -5751,6 +5763,27 @@ public class OAuth2Util {
         String tenantDomain = getTenantDomain();
         OAuthAppDO oAuthAppDO = OAuth2Util.getAppInformationByClientId(clientId, tenantDomain);
         return oAuthAppDO.isFapiConformanceEnabled();
+    }
+
+    /**
+     * Check whether FAPI 1.0 Advanced is enabled in the server.
+     *
+     * @return Whether FAPI 1.0 Advanced is enabled in the server.
+     */
+    public static boolean isFapi1Enabled() {
+
+        return OAuthConstants.FAPIVersions.FAPI1_ADVANCED.equals(
+                OAuthServerConfiguration.getInstance().getFapiVersion());
+    }
+
+    /**
+     * Check whether FAPI 2.0 is enabled in the server.
+     *
+     * @return Whether FAPI 2.0 is enabled in the server.
+     */
+    public static boolean isFapi2Enabled() {
+
+        return OAuthConstants.FAPIVersions.FAPI2.equals(OAuthServerConfiguration.getInstance().getFapiVersion());
     }
 
     /**

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuerTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuerTest.java
@@ -410,7 +410,10 @@ public class JWTTokenIssuerTest {
             mockCustomClaimsCallbackHandler();
             oAuth2Util.when(() -> OAuth2Util.getAppInformationByClientId(anyString(), anyString())).thenReturn(appDO);
             oAuth2Util.when(OAuth2Util::getIDTokenIssuer).thenReturn(ID_TOKEN_ISSUER);
+            oAuth2Util.when(() -> OAuth2Util.getIssuerLocation(anyString())).thenReturn(ID_TOKEN_ISSUER);
             oAuth2Util.when(() -> OAuth2Util.getIdTokenIssuer(anyString(), anyBoolean())).thenReturn(ID_TOKEN_ISSUER);
+            oAuth2Util.when(() -> OAuth2Util.getIdTokenIssuer(anyString(), anyString(), anyBoolean())).
+                    thenReturn(ID_TOKEN_ISSUER);
             oAuth2Util.when(() -> OAuth2Util.getOIDCAudience(anyString(), any())).thenReturn(Collections.singletonList
                     (DUMMY_CLIENT_ID));
             oAuth2Util.when(OAuth2Util::isTokenPersistenceEnabled).thenReturn(true);
@@ -520,6 +523,8 @@ public class JWTTokenIssuerTest {
             oAuth2Util.when(() -> OAuth2Util.getCertificate(anyString(), anyInt())).thenReturn(cert);
             oAuth2Util.when(() -> OAuth2Util.getThumbPrintWithPrevAlgorithm(any(), anyBoolean())).thenCallRealMethod();
             oAuth2Util.when(() -> OAuth2Util.getIdTokenIssuer(any(), anyBoolean()))
+                    .thenAnswer((Answer<Void>) invocation -> null);
+            oAuth2Util.when(() -> OAuth2Util.getIdTokenIssuer(any(), any(), anyBoolean()))
                     .thenAnswer((Answer<Void>) invocation -> null);
             oAuth2Util.when(() -> OAuth2Util.getKID(any(Certificate.class), any(JWSAlgorithm.class), anyString()))
                     .thenAnswer((Answer<Void>) invocation -> null);


### PR DESCRIPTION
### Add changes required for FAPI 2.0 compliance

This PR contains the changes required to make WSO2 IS-7.1 FAPI 2.0 conformant.

Related Issues: https://github.com/wso2/product-is/issues/25863

### Changes Introduced

- authorization_response_iss_parameter_supported parameter is added to open-id configuration when FAPI 2.0 is enabled.
- 'iss' parameter is sent in the authorization response as a query parameter when FAPI 2.0 is enabled.
- 'state' parameter sent in the par request object is prioritized over the 'state' parameter sent in the authorization request.
- Change error codes for FAPI 2.0 compliant apps
- Add support for callback urls with query parameters
- Use custom url as the issuer (IDTokenIssuerID should be configured to https://<is_host>/oauth2/oidcdiscovery/)
- Support using ResidentIDPEntityId as the issuer


### New Configurations

**identity.xml**

 - OAuth.OpenIDConnect.FAPI.FAPIVersion : Determines the FAPI Version supported by the server. Accepts "1" or "2" as values
 - OAuth.OpenIDConnect.UseEntityIdAsIssuer : Enable using ResidentIDPEntityId as the issuer. Boolean


