### PR TITLE
Configuration based revocation of SSO-session bound tokens.

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/bindings/impl/SSOSessionBasedTokenBinder.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/bindings/impl/SSOSessionBasedTokenBinder.java
@@ -129,7 +129,8 @@ public class SSOSessionBasedTokenBinder extends AbstractTokenBinder {
 
         try {
             String sessionIdentifier = getTokenBindingValue((HttpServletRequest) request);
-            if (!isSSOSessionValid(sessionIdentifier)) {
+            if (!OAuth2Util.isSessionBoundTokensAllowedAfterSessionExpiry() &&
+                    !isSSOSessionValid(sessionIdentifier)) {
                 return false;
             }
         } catch (OAuthSystemException e) {
@@ -145,10 +146,11 @@ public class SSOSessionBasedTokenBinder extends AbstractTokenBinder {
         log.debug("Validating SSO session-based token binding for OAuth2 access token request.");
         Optional<String> sessionIdentifier =
                 OAuth2Util.getTokenBindingValue(oAuth2AccessTokenReqDTO, COMMONAUTH_COOKIE);
-        if (isSSOSessionValid(sessionIdentifier.orElse(null))) {
-            return isValidTokenBinding(oAuth2AccessTokenReqDTO, bindingReference, COMMONAUTH_COOKIE);
+        if (!OAuth2Util.isSessionBoundTokensAllowedAfterSessionExpiry() &&
+                !isSSOSessionValid(sessionIdentifier.orElse(null))) {
+            return false;
         }
-        return false;
+        return isValidTokenBinding(oAuth2AccessTokenReqDTO, bindingReference, COMMONAUTH_COOKIE);
     }
 
     /**

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/RefreshGrantHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/RefreshGrantHandler.java
@@ -1027,10 +1027,21 @@ public class RefreshGrantHandler extends AbstractAuthorizationGrantHandler {
 
         // Validate SSO session bound token.
         if (OAuth2Constants.TokenBinderType.SSO_SESSION_BASED_TOKEN_BINDER.equals(oAuthAppDO.getTokenBindingType())) {
-            if (!isTokenBoundToActiveSSOSession(tokenBinding.getBindingValue(),
-                    validationDataDO.getAuthorizedUser())) {
+            
+            if (!OAuth2Util.isLegacySessionBoundTokenBehaviourEnabled()) {
+                if (!isTokenBoundToActiveSSOSession(tokenBinding.getBindingValue(),
+                        validationDataDO.getAuthorizedUser())) {
+                    // Revoke the SSO session bound access token if the session is invalid/terminated.
+                    revokeSSOSessionBoundToken(validationDataDO.getAccessToken());
+                    throw new IdentityOAuth2Exception("Token binding validation failed. Token is not bound to an " +
+                            "active SSO session.");
+                }
+            } else if (oAuthAppDO.isTokenRevocationWithIDPSessionTerminationEnabled()
+                        && !OAuth2Util.isSessionBoundTokensAllowedAfterSessionExpiry()
+                        && !isTokenBoundToActiveSSOSession(tokenBinding.getBindingValue(),
+                                validationDataDO.getAuthorizedUser())) {
                 // Revoke the SSO session bound access token if the session is invalid/terminated.
-                revokeSSOSessionBoundToken(oAuthAppDO, validationDataDO.getAccessToken());
+                revokeSSOSessionBoundToken(validationDataDO.getAccessToken());
                 throw new IdentityOAuth2Exception("Token binding validation failed. Token is not bound to an " +
                         "active SSO session.");
             }
@@ -1117,22 +1128,19 @@ public class RefreshGrantHandler extends AbstractAuthorizationGrantHandler {
      * Revoke the SSO session bound access token if the associated session is terminated.
      * This is only applicable for the applications that have enabled 'revokeTokensWhenIdPSessionTerminated'.
      *
-     * @param appDO                 OAuth application data object.
      * @param accessTokenIdentifier Access token identifier.
      */
-    private void revokeSSOSessionBoundToken(OAuthAppDO appDO, String accessTokenIdentifier) {
+    private void revokeSSOSessionBoundToken(String accessTokenIdentifier) {
 
         try {
-            if (appDO.isTokenRevocationWithIDPSessionTerminationEnabled()) {
-                AccessTokenDO accessTokenDO =
-                        OAuth2Util.getAccessTokenDOFromTokenIdentifier(accessTokenIdentifier, true);
-                OAuthUtil.clearOAuthCache(accessTokenDO);
-                OAuthRevocationRequestDTO revokeRequestDTO = new OAuthRevocationRequestDTO();
-                revokeRequestDTO.setConsumerKey(accessTokenDO.getConsumerKey());
-                revokeRequestDTO.setToken(accessTokenDO.getAccessToken());
-                OAuth2ServiceComponentHolder.getInstance().getRevocationProcessor()
-                        .revokeAccessToken(revokeRequestDTO, accessTokenDO);
-            }
+            AccessTokenDO accessTokenDO =
+                    OAuth2Util.getAccessTokenDOFromTokenIdentifier(accessTokenIdentifier, true);
+            OAuthUtil.clearOAuthCache(accessTokenDO);
+            OAuthRevocationRequestDTO revokeRequestDTO = new OAuthRevocationRequestDTO();
+            revokeRequestDTO.setConsumerKey(accessTokenDO.getConsumerKey());
+            revokeRequestDTO.setToken(accessTokenDO.getAccessToken());
+            OAuth2ServiceComponentHolder.getInstance().getRevocationProcessor()
+                    .revokeAccessToken(revokeRequestDTO, accessTokenDO);
         } catch (IdentityOAuth2Exception | UserIdNotFoundException e) {
             log.error("Error while revoking SSO session bound access token.", e);
         }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/RefreshGrantHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/RefreshGrantHandler.java
@@ -1027,8 +1027,10 @@ public class RefreshGrantHandler extends AbstractAuthorizationGrantHandler {
 
         // Validate SSO session bound token.
         if (OAuth2Constants.TokenBinderType.SSO_SESSION_BASED_TOKEN_BINDER.equals(oAuthAppDO.getTokenBindingType())) {
-            
-            if (!OAuth2Util.isLegacySessionBoundTokenBehaviourEnabled()) {
+
+            if (!OAuth2Util.isLegacySessionBoundTokenBehaviourEnabled()
+                    || (oAuthAppDO.isTokenRevocationWithIDPSessionTerminationEnabled()
+                    && !OAuth2Util.isSessionBoundTokensAllowedAfterSessionExpiry())) {
                 if (!isTokenBoundToActiveSSOSession(tokenBinding.getBindingValue(),
                         validationDataDO.getAuthorizedUser())) {
                     // Revoke the SSO session bound access token if the session is invalid/terminated.
@@ -1036,14 +1038,6 @@ public class RefreshGrantHandler extends AbstractAuthorizationGrantHandler {
                     throw new IdentityOAuth2Exception("Token binding validation failed. Token is not bound to an " +
                             "active SSO session.");
                 }
-            } else if (oAuthAppDO.isTokenRevocationWithIDPSessionTerminationEnabled()
-                        && !OAuth2Util.isSessionBoundTokensAllowedAfterSessionExpiry()
-                        && !isTokenBoundToActiveSSOSession(tokenBinding.getBindingValue(),
-                                validationDataDO.getAuthorizedUser())) {
-                // Revoke the SSO session bound access token if the session is invalid/terminated.
-                revokeSSOSessionBoundToken(validationDataDO.getAccessToken());
-                throw new IdentityOAuth2Exception("Token binding validation failed. Token is not bound to an " +
-                        "active SSO session.");
             }
         }
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -414,6 +414,10 @@ public class OAuth2Util {
 
     private static final String OIDC_IDP_ENTITY_ID = "IdPEntityId";
     private static final String DEFAULT_IDP_NAME = "default";
+    private static final String ENABLE_LEGACY_SESSION_BOUND_TOKEN_BEHAVIOUR =
+            "oauth.enableLegacySessionBoundTokenBehaviour";
+    private static final String ALLOW_SESSION_BOUND_TOKENS_AFTER_SESSION_EXPIRY =
+            "oauth.allowSessionBoundTokensAfterSessionExpiry";
 
     private OAuth2Util() {
 
@@ -6332,5 +6336,29 @@ public class OAuth2Util {
             }
         }
         return Optional.empty();
+    }
+
+    /**
+     * Check whether the legacy session bound token behaviour is enabled.
+     * Default behaviour is disabled.
+     *
+     * @return true if enabled, false otherwise.
+     */
+    public static boolean isLegacySessionBoundTokenBehaviourEnabled() {
+
+        return Boolean.parseBoolean(IdentityUtil.getProperty(ENABLE_LEGACY_SESSION_BOUND_TOKEN_BEHAVIOUR));
+    }
+
+    /**
+     * Check whether session bound tokens are allowed after session expiry.
+     * Default behaviour is disabled.
+     *
+     * @return true if enabled, false otherwise.
+     */
+    public static boolean isSessionBoundTokensAllowedAfterSessionExpiry() {
+
+        // This setting is only applicable if legacy session bound token behaviour is enabled.
+        return isLegacySessionBoundTokenBehaviourEnabled() &&
+                Boolean.parseBoolean(IdentityUtil.getProperty(ALLOW_SESSION_BOUND_TOKENS_AFTER_SESSION_EXPIRY));
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -416,7 +416,7 @@ public class OAuth2Util {
     private static final String DEFAULT_IDP_NAME = "default";
     private static final String ENABLE_LEGACY_SESSION_BOUND_TOKEN_BEHAVIOUR =
             "OAuth.EnableLegacySessionBoundTokenBehaviour";
-    private static final String ALLOW_SESSION_BOUND_TOKENS_AFTER_SESSION_EXPIRY =
+    private static final String ALLOW_SESSION_BOUND_TOKENS_AFTER_IDLE_SESSION_EXPIRY =
             "OAuth.AllowSessionBoundTokensAfterIdleSessionExpiry";
 
     private OAuth2Util() {
@@ -6359,6 +6359,6 @@ public class OAuth2Util {
 
         // This setting is only applicable if legacy session bound token behaviour is enabled.
         return isLegacySessionBoundTokenBehaviourEnabled() &&
-                Boolean.parseBoolean(IdentityUtil.getProperty(ALLOW_SESSION_BOUND_TOKENS_AFTER_SESSION_EXPIRY));
+                Boolean.parseBoolean(IdentityUtil.getProperty(ALLOW_SESSION_BOUND_TOKENS_AFTER_IDLE_SESSION_EXPIRY));
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -417,7 +417,7 @@ public class OAuth2Util {
     private static final String ENABLE_LEGACY_SESSION_BOUND_TOKEN_BEHAVIOUR =
             "OAuth.EnableLegacySessionBoundTokenBehaviour";
     private static final String ALLOW_SESSION_BOUND_TOKENS_AFTER_SESSION_EXPIRY =
-            "OAuth.AllowSessionBoundTokensAfterSessionExpiry";
+            "OAuth.AllowSessionBoundTokensAfterIdleSessionExpiry";
 
     private OAuth2Util() {
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -415,9 +415,9 @@ public class OAuth2Util {
     private static final String OIDC_IDP_ENTITY_ID = "IdPEntityId";
     private static final String DEFAULT_IDP_NAME = "default";
     private static final String ENABLE_LEGACY_SESSION_BOUND_TOKEN_BEHAVIOUR =
-            "oauth.enableLegacySessionBoundTokenBehaviour";
+            "OAuth.EnableLegacySessionBoundTokenBehaviour";
     private static final String ALLOW_SESSION_BOUND_TOKENS_AFTER_SESSION_EXPIRY =
-            "oauth.allowSessionBoundTokensAfterSessionExpiry";
+            "OAuth.AllowSessionBoundTokensAfterSessionExpiry";
 
     private OAuth2Util() {
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/TokenValidationHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/TokenValidationHandler.java
@@ -684,7 +684,18 @@ public class TokenValidationHandler {
 
                 // Validate SSO session bound token.
                 if (OAuth2Constants.TokenBinderType.SSO_SESSION_BASED_TOKEN_BINDER.equals(bindingType)) {
-                    if (!isTokenBoundToActiveSSOSession(accessTokenDO)) {
+                    OAuthAppDO appDO = OAuth2Util.getAppInformationByClientId(consumerKey,
+                            getAppResidentTenantDomain(accessTokenDO));
+                    if (!OAuth2Util.isLegacySessionBoundTokenBehaviourEnabled()
+                            && !isTokenBoundToActiveSSOSession(accessTokenDO)) {
+                        log.debug("Token is not bound to an active SSO session.");
+                        // Revoke the SSO session bound access token if the session is invalid/terminated.
+                        revokeSSOSessionBoundToken(accessTokenDO);
+                        introResp.setActive(false);
+                        return introResp;
+                    } else if (appDO.isTokenRevocationWithIDPSessionTerminationEnabled()
+                            && !OAuth2Util.isSessionBoundTokensAllowedAfterSessionExpiry()
+                            && !isTokenBoundToActiveSSOSession(accessTokenDO)) {
                         log.debug("Token is not bound to an active SSO session.");
                         // Revoke the SSO session bound access token if the session is invalid/terminated.
                         revokeSSOSessionBoundToken(accessTokenDO);
@@ -1095,18 +1106,13 @@ public class TokenValidationHandler {
 
         String consumerKey = accessTokenDO.getConsumerKey();
         try {
-            OAuthAppDO appDO = OAuth2Util.getAppInformationByClientId(consumerKey,
-                    getAppResidentTenantDomain(accessTokenDO));
-                    
-            if (appDO != null && appDO.isTokenRevocationWithIDPSessionTerminationEnabled()) {
-                OAuthUtil.clearOAuthCache(accessTokenDO);
-                OAuthRevocationRequestDTO revokeRequestDTO = new OAuthRevocationRequestDTO();
-                revokeRequestDTO.setConsumerKey(consumerKey);
-                revokeRequestDTO.setToken(accessTokenDO.getAccessToken());
-                OAuth2ServiceComponentHolder.getInstance().getRevocationProcessor()
-                        .revokeAccessToken(revokeRequestDTO, accessTokenDO);
-            }
-        } catch (InvalidOAuthClientException | IdentityOAuth2Exception | UserIdNotFoundException e) {
+            OAuthUtil.clearOAuthCache(accessTokenDO);
+            OAuthRevocationRequestDTO revokeRequestDTO = new OAuthRevocationRequestDTO();
+            revokeRequestDTO.setConsumerKey(consumerKey);
+            revokeRequestDTO.setToken(accessTokenDO.getAccessToken());
+            OAuth2ServiceComponentHolder.getInstance().getRevocationProcessor()
+                    .revokeAccessToken(revokeRequestDTO, accessTokenDO);
+        } catch (IdentityOAuth2Exception | UserIdNotFoundException e) {
             log.error("Error while revoking SSO session bound access token.", e);
         } 
     }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/TokenValidationHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/TokenValidationHandler.java
@@ -687,20 +687,15 @@ public class TokenValidationHandler {
                     OAuthAppDO appDO = OAuth2Util.getAppInformationByClientId(consumerKey,
                             getAppResidentTenantDomain(accessTokenDO));
                     if (!OAuth2Util.isLegacySessionBoundTokenBehaviourEnabled()
-                            && !isTokenBoundToActiveSSOSession(accessTokenDO)) {
-                        log.debug("Token is not bound to an active SSO session.");
-                        // Revoke the SSO session bound access token if the session is invalid/terminated.
-                        revokeSSOSessionBoundToken(accessTokenDO);
-                        introResp.setActive(false);
-                        return introResp;
-                    } else if (appDO.isTokenRevocationWithIDPSessionTerminationEnabled()
-                            && !OAuth2Util.isSessionBoundTokensAllowedAfterSessionExpiry()
-                            && !isTokenBoundToActiveSSOSession(accessTokenDO)) {
-                        log.debug("Token is not bound to an active SSO session.");
-                        // Revoke the SSO session bound access token if the session is invalid/terminated.
-                        revokeSSOSessionBoundToken(accessTokenDO);
-                        introResp.setActive(false);
-                        return introResp;
+                            || (appDO.isTokenRevocationWithIDPSessionTerminationEnabled()
+                            && !OAuth2Util.isSessionBoundTokensAllowedAfterSessionExpiry())) {
+                        if (!isTokenBoundToActiveSSOSession(accessTokenDO)) {
+                            log.debug("Token is not bound to an active SSO session.");
+                            // Revoke the SSO session bound access token if the session is invalid/terminated.
+                            revokeSSOSessionBoundToken(accessTokenDO);
+                            introResp.setActive(false);
+                            return introResp;
+                        }
                     }
                 }
             }

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/util/OAuth2UtilTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/util/OAuth2UtilTest.java
@@ -221,7 +221,7 @@ public class OAuth2UtilTest {
     private static final String COOKIE_HEADER = "Cookie";
     private static final String ENABLE_LEGACY_SESSION_BOUND_TOKEN_BEHAVIOUR =
             "OAuth.EnableLegacySessionBoundTokenBehaviour";
-    private static final String ALLOW_SESSION_BOUND_TOKENS_AFTER_SESSION_EXPIRY =
+    private static final String ALLOW_SESSION_BOUND_TOKENS_AFTER_IDLE_SESSION_EXPIRY =
             "OAuth.AllowSessionBoundTokensAfterIdleSessionExpiry";
     @Mock
     private OAuthServerConfiguration oauthServerConfigurationMock;
@@ -3585,7 +3585,7 @@ public class OAuth2UtilTest {
 
             identityUtil.when(() -> IdentityUtil.getProperty(ENABLE_LEGACY_SESSION_BOUND_TOKEN_BEHAVIOUR))
                     .thenReturn(legacyBehaviourValue);
-            identityUtil.when(() -> IdentityUtil.getProperty(ALLOW_SESSION_BOUND_TOKENS_AFTER_SESSION_EXPIRY))
+            identityUtil.when(() -> IdentityUtil.getProperty(ALLOW_SESSION_BOUND_TOKENS_AFTER_IDLE_SESSION_EXPIRY))
                     .thenReturn(allowAfterExpiryValue);
             boolean result = OAuth2Util.isSessionBoundTokensAllowedAfterSessionExpiry();
             Assert.assertEquals(result, expectedResult);

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/util/OAuth2UtilTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/util/OAuth2UtilTest.java
@@ -222,7 +222,7 @@ public class OAuth2UtilTest {
     private static final String ENABLE_LEGACY_SESSION_BOUND_TOKEN_BEHAVIOUR =
             "OAuth.EnableLegacySessionBoundTokenBehaviour";
     private static final String ALLOW_SESSION_BOUND_TOKENS_AFTER_SESSION_EXPIRY =
-            "OAuth.AllowSessionBoundTokensAfterSessionExpiry";
+            "OAuth.AllowSessionBoundTokensAfterIdleSessionExpiry";
     @Mock
     private OAuthServerConfiguration oauthServerConfigurationMock;
 

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/util/OAuth2UtilTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/util/OAuth2UtilTest.java
@@ -219,7 +219,10 @@ public class OAuth2UtilTest {
     private static final String TEST_COOKIE_NAME = "test-cookie";
     private static final String TEST_COOKIE_VALUE = "test-cookie-value";
     private static final String COOKIE_HEADER = "Cookie";
-
+    private static final String ENABLE_LEGACY_SESSION_BOUND_TOKEN_BEHAVIOUR =
+            "OAuth.EnableLegacySessionBoundTokenBehaviour";
+    private static final String ALLOW_SESSION_BOUND_TOKENS_AFTER_SESSION_EXPIRY =
+            "OAuth.AllowSessionBoundTokensAfterSessionExpiry";
     @Mock
     private OAuthServerConfiguration oauthServerConfigurationMock;
 
@@ -3531,4 +3534,63 @@ public class OAuth2UtilTest {
         Optional<String> tokenBindingValue = OAuth2Util.getTokenBindingValue(reqDTO, cookieName);
         assertEquals(tokenBindingValue, expectedValue);
     }
+
+    @DataProvider(name = "legacySessionBoundTokenBehaviourProvider")
+    public Object[][] legacySessionBoundTokenBehaviourProvider() {
+
+        return new Object[][]{
+                // propertyValue, expectedResult
+                {"true", true},
+                {"false", false},
+                {null, false},
+                {"", false},
+                {"invalid", false}
+        };
+    }
+
+    @Test(dataProvider = "legacySessionBoundTokenBehaviourProvider")
+    public void testIsLegacySessionBoundTokenBehaviourEnabled(String propertyValue, boolean expectedResult) {
+
+        try (MockedStatic<IdentityUtil> identityUtil = mockStatic(IdentityUtil.class)) {
+            identityUtil.when(() -> IdentityUtil.getProperty(ENABLE_LEGACY_SESSION_BOUND_TOKEN_BEHAVIOUR))
+                    .thenReturn(propertyValue);
+
+            boolean result = OAuth2Util.isLegacySessionBoundTokenBehaviourEnabled();
+            Assert.assertEquals(result, expectedResult);
+        }
+    }
+
+    @DataProvider(name = "sessionBoundTokensAfterSessionExpiryProvider")
+    public Object[][] sessionBoundTokensAfterSessionExpiryProvider() {
+
+        return new Object[][]{
+                // legacyBehaviourEnabled, allowAfterExpiryValue, expectedResult
+                {"true", "true", true},
+                {"true", "false", false},
+                {"true", null, false},
+                {"true", "", false},
+                {"true", "invalid", false},
+                {"false", "true", false},  // Should return false when legacy behaviour is disabled
+                {"false", "false", false},
+                {"false", null, false}
+        };
+    }
+
+    @Test(dataProvider = "sessionBoundTokensAfterSessionExpiryProvider")
+    public void testIsSessionBoundTokensAllowedAfterSessionExpiry(String legacyBehaviourValue,
+                                                                  String allowAfterExpiryValue,
+                                                                  boolean expectedResult) {
+
+        try (MockedStatic<IdentityUtil> identityUtil = mockStatic(IdentityUtil.class)) {
+
+            identityUtil.when(() -> IdentityUtil.getProperty(ENABLE_LEGACY_SESSION_BOUND_TOKEN_BEHAVIOUR))
+                    .thenReturn(legacyBehaviourValue);
+            identityUtil.when(() -> IdentityUtil.getProperty(ALLOW_SESSION_BOUND_TOKENS_AFTER_SESSION_EXPIRY))
+                    .thenReturn(allowAfterExpiryValue);
+            boolean result = OAuth2Util.isSessionBoundTokensAllowedAfterSessionExpiry();
+            Assert.assertEquals(result, expectedResult);
+        }
+    }
+
+
 }


### PR DESCRIPTION
This pull request introduces significant improvements to the handling of SSO session-based token binding and revocation logic in the OAuth2 implementation. The changes add new configuration options to control legacy session-bound token behavior and whether session-bound tokens are allowed after session expiry, and refactor relevant logic across validation, revocation, and tests to use these settings. This enhances flexibility for deployments and ensures more precise control over token revocation in various scenarios.

**Configuration and Utility Enhancements**
* Added two new configuration options: `OAuth.EnableLegacySessionBoundTokenBehaviour` and `OAuth.AllowSessionBoundTokensAfterSessionExpiry`, with corresponding utility methods `isLegacySessionBoundTokenBehaviourEnabled()` and `isSessionBoundTokensAllowedAfterSessionExpiry()` in `OAuth2Util`. These allow fine-grained control over legacy session-bound token behavior and token validity post session expiry. [[1]](diffhunk://#diff-9d4b1a340ecdbc719edf565e22baf522bb4738051645d22ce50930875ccc151dR417-R420) [[2]](diffhunk://#diff-9d4b1a340ecdbc719edf565e22baf522bb4738051645d22ce50930875ccc151dR6340-R6363)

**Core Logic Updates**
* Updated token validation and refresh grant logic to respect the new configuration options, ensuring that token revocation on session expiry is conditional based on both global and application-level settings. This includes changes in `RefreshGrantHandler` and `TokenValidationHandler` to use the new utility methods and refactored revocation method signatures. [[1]](diffhunk://#diff-2dad3e7460a1c3e8e1ec626d036d2f787288efcab5dfce14c9d2703befe42155R1030-R1042) [[2]](diffhunk://#diff-2dad3e7460a1c3e8e1ec626d036d2f787288efcab5dfce14c9d2703befe42155L1120-L1126) [[3]](diffhunk://#diff-2dad3e7460a1c3e8e1ec626d036d2f787288efcab5dfce14c9d2703befe42155L1135) [[4]](diffhunk://#diff-292e0301b0c034c146cc63adbd53f0b3a359c05f51d17c31f518418de5fea342R687-R691) [[5]](diffhunk://#diff-292e0301b0c034c146cc63adbd53f0b3a359c05f51d17c31f518418de5fea342R701) [[6]](diffhunk://#diff-292e0301b0c034c146cc63adbd53f0b3a359c05f51d17c31f518418de5fea342L1098-R1110)

* Added a helper method `isTokenRevocationWithIDPSessionTerminationEnabledForOAuthApp()` to encapsulate the logic for determining whether token revocation should occur after IDP session termination, considering both legacy and current configurations. [[1]](diffhunk://#diff-7a4a0822c14634188b4f91cc3f8cde8a19401b9cd954004ebaf3c22927b3d012R40) [[2]](diffhunk://#diff-7a4a0822c14634188b4f91cc3f8cde8a19401b9cd954004ebaf3c22927b3d012L322-R324) [[3]](diffhunk://#diff-7a4a0822c14634188b4f91cc3f8cde8a19401b9cd954004ebaf3c22927b3d012R499-R522)

**Token Binding Validation**
* Modified SSO session-based token binding validation to check the new configuration options before validating session status, ensuring correct behavior when legacy settings are enabled or disabled. [[1]](diffhunk://#diff-7f09e43ccf2f7621ac30d5785c3ad1964d9f6dbb4c18dda9f8e1f5dde9a0b79fL132-R133) [[2]](diffhunk://#diff-7f09e43ccf2f7621ac30d5785c3ad1964d9f6dbb4c18dda9f8e1f5dde9a0b79fL148-R154)

**Testing Enhancements**
* Refactored and expanded unit tests to cover all combinations of the new configuration options and app-level settings, improving test coverage for SSO session-bound token scenarios. [[1]](diffhunk://#diff-e03eb224d9c599772afe4b4a4927054c8eb7aa7900e5b23c23ffeb7da0ec542aL281-R298) [[2]](diffhunk://#diff-e03eb224d9c599772afe4b4a4927054c8eb7aa7900e5b23c23ffeb7da0ec542aL319-R328) [[3]](diffhunk://#diff-e03eb224d9c599772afe4b4a4927054c8eb7aa7900e5b23c23ffeb7da0ec542aR348-R351) [[4]](diffhunk://#diff-e03eb224d9c599772afe4b4a4927054c8eb7aa7900e5b23c23ffeb7da0ec542aL348-R362) [[5]](diffhunk://#diff-e03eb224d9c599772afe4b4a4927054c8eb7aa7900e5b23c23ffeb7da0ec542aL363-R378) [[6]](diffhunk://#diff-8c56936437014433a416350565c36931f7c00b1d1044cdcea2bd380c4b42248aL222-R225)