### PR TITLE
[Cleanup] Remove consent token column check

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/handlers/util/ResponseTypeHandlerUtil.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/handlers/util/ResponseTypeHandlerUtil.java
@@ -665,16 +665,15 @@ public class ResponseTypeHandlerUtil {
         newTokenBean.setGrantType(grantType);
         /* If the existing token is available, the consented token flag will be extracted from that. Otherwise,
         from the current grant. */
-        if (OAuth2ServiceComponentHolder.isConsentedTokenColumnEnabled()) {
-            if (existingTokenBean != null) {
-                newTokenBean.setIsConsentedToken(existingTokenBean.isConsentedToken());
-            } else {
-                if (OIDCClaimUtil.isConsentBasedClaimFilteringApplicable(grantType)) {
-                    newTokenBean.setIsConsentedToken(true);
-                }
+        if (existingTokenBean != null) {
+            newTokenBean.setIsConsentedToken(existingTokenBean.isConsentedToken());
+        } else {
+            if (OIDCClaimUtil.isConsentBasedClaimFilteringApplicable(grantType)) {
+                newTokenBean.setIsConsentedToken(true);
             }
-            oauthAuthzMsgCtx.setConsentedToken(newTokenBean.isConsentedToken());
         }
+        oauthAuthzMsgCtx.setConsentedToken(newTokenBean.isConsentedToken());
+
         newTokenBean.setAccessToken(getNewAccessToken(oauthAuthzMsgCtx, oauthIssuerImpl));
         setRefreshTokenDetails(oauthAuthzMsgCtx, oAuthAppBean, existingTokenBean, newTokenBean, oauthIssuerImpl,
                 timestamp);

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuth2ServiceComponent.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuth2ServiceComponent.java
@@ -159,7 +159,6 @@ import javax.xml.stream.XMLStreamReader;
 import static org.wso2.carbon.identity.oauth2.Oauth2ScopeConstants.PERMISSIONS_BINDING_TYPE;
 import static org.wso2.carbon.identity.oauth2.device.constants.Constants.DEVICE_FLOW_GRANT_TYPE;
 import static org.wso2.carbon.identity.oauth2.util.OAuth2Util.checkAudienceEnabled;
-import static org.wso2.carbon.identity.oauth2.util.OAuth2Util.checkConsentedTokenColumnAvailable;
 import static org.wso2.carbon.identity.oauth2.util.OAuth2Util.getJWTRenewWithoutRevokeAllowedGrantTypes;
 import static org.wso2.carbon.identity.oauth2.util.OAuth2Util.isAccessTokenExtendedTableExist;
 
@@ -453,18 +452,6 @@ public class OAuth2ServiceComponent {
             log.debug("IDN_OAUTH2_ACCESS_TOKEN_EXTENDED table is available Setting " +
                     "isAccessTokenExtendedTableExist to true.");
             OAuth2ServiceComponentHolder.setTokenExtendedTableExist(true);
-        }
-
-        boolean isConsentedTokenColumnAvailable = checkConsentedTokenColumnAvailable();
-        OAuth2ServiceComponentHolder.setConsentedTokenColumnEnabled(isConsentedTokenColumnAvailable);
-        if (log.isDebugEnabled()) {
-            if (isConsentedTokenColumnAvailable) {
-                log.debug("CONSENTED_TOKEN column is available in IDN_OAUTH2_ACCESS_TOKEN table. Hence setting " +
-                        "consentedColumnAvailable to true.");
-            } else {
-                log.debug("CONSENTED_TOKEN column is not available in IDN_OAUTH2_ACCESS_TOKEN table. Hence " +
-                        "setting consentedColumnAvailable to false.");
-            }
         }
         if (OAuthServerConfiguration.getInstance().isGlobalRbacScopeIssuerEnabled()) {
             bundleContext.registerService(ScopeValidator.class, new RoleBasedScopeIssuer(), null);

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuth2ServiceComponentHolder.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuth2ServiceComponentHolder.java
@@ -213,11 +213,27 @@ public class OAuth2ServiceComponentHolder {
         OAuth2ServiceComponentHolder.idpIdColumnEnabled = idpIdColumnEnabled;
     }
 
+    /**
+     * Check whether CONSENTED_TOKEN column is enabled in the OAuth2 token DB tables.
+     *
+     * @return true if enabled, false otherwise.
+     * @deprecated deprecated since Consent_token column is available in all the relevant tables
+     * from WSO2 IS 7.0.0 onwards.
+     */
+    @Deprecated
     public static boolean isConsentedTokenColumnEnabled() {
 
         return consentedTokenColumnEnabled;
     }
 
+    /**
+     * Set whether CONSENTED_TOKEN column is enabled in the OAuth2 token DB tables.
+     *
+     * @param consentedTokenColumnEnabled true if enabled, false otherwise.
+     * @deprecated deprecated since Consent_token column is available in all the relevant tables
+     * from WSO2 IS 7.0.0 onwards.
+     */
+    @Deprecated
     public static void setConsentedTokenColumnEnabled(boolean consentedTokenColumnEnabled) {
 
         OAuth2ServiceComponentHolder.consentedTokenColumnEnabled = consentedTokenColumnEnabled;

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuer.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuer.java
@@ -1152,16 +1152,14 @@ public class JWTTokenIssuer extends OauthTokenIssuerImpl {
                 throw new IdentityOAuth2Exception("User id not found for user: "
                         + authenticatedUser.getLoggableMaskedUserId(), e);
             }
-            if (OAuth2ServiceComponentHolder.isConsentedTokenColumnEnabled()) {
-                boolean isConsented;
-                if (tokenReqMessageContext != null) {
-                    isConsented = tokenReqMessageContext.isConsentedToken();
-                } else {
-                    isConsented = authAuthzReqMessageContext.isConsentedToken();
-                }
-                // when no persistence of tokens, there is no existing token to check the consented value for.
-                jwtClaimsSetBuilder.claim(OAuth2Constants.IS_CONSENTED, isConsented);
+            boolean isConsented;
+            if (tokenReqMessageContext != null) {
+                isConsented = tokenReqMessageContext.isConsentedToken();
+            } else {
+                isConsented = authAuthzReqMessageContext.isConsentedToken();
             }
+            // when no persistence of tokens, there is no existing token to check the consented value for.
+            jwtClaimsSetBuilder.claim(OAuth2Constants.IS_CONSENTED, isConsented);
             jwtClaimsSetBuilder.claim(OAuth2Constants.IS_FEDERATED, authenticatedUser.isFederatedUser());
         }
     }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AbstractAuthorizationGrantHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AbstractAuthorizationGrantHandler.java
@@ -644,14 +644,12 @@ public abstract class AbstractAuthorizationGrantHandler implements Authorization
 
         /* If the existing token is available, the consented token flag will be extracted from that. Otherwise,
         from the current grant. */
-        if (OAuth2ServiceComponentHolder.isConsentedTokenColumnEnabled()) {
-            if (existingTokenBean != null) {
-                tokReqMsgCtx.setConsentedToken(existingTokenBean.isConsentedToken());
-            } else {
-                if (OIDCClaimUtil.isConsentBasedClaimFilteringApplicable(
-                        tokReqMsgCtx.getOauth2AccessTokenReqDTO().getGrantType())) {
-                    tokReqMsgCtx.setConsentedToken(true);
-                }
+        if (existingTokenBean != null) {
+            tokReqMsgCtx.setConsentedToken(existingTokenBean.isConsentedToken());
+        } else {
+            if (OIDCClaimUtil.isConsentBasedClaimFilteringApplicable(
+                    tokReqMsgCtx.getOauth2AccessTokenReqDTO().getGrantType())) {
+                tokReqMsgCtx.setConsentedToken(true);
             }
         }
         OAuthAppDO oAuthAppBean = getoAuthApp(consumerKey);

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -5180,10 +5180,14 @@ public class OAuth2Util {
      * Check whether the CONSENTED_TOKEN column is available in IDN_OAUTH2_ACCESS_TOKEN table.
      *
      * @return True if the column is available.
+     * @deprecated deprecated since Consent_Token column is available in all the relevant tables
+     * from WSO2 IS 7.0.0 onwards.
      */
+    @Deprecated
     public static boolean checkConsentedTokenColumnAvailable() {
 
-        return FrameworkUtils.isTableColumnExists("IDN_OAUTH2_ACCESS_TOKEN", "CONSENTED_TOKEN");
+        log.debug("checkConsentedTokenColumnAvailable method is deprecated and always returns true.");
+        return true;
     }
 
     /**

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/AbstractUserInfoResponseBuilder.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/AbstractUserInfoResponseBuilder.java
@@ -293,17 +293,13 @@ public abstract class AbstractUserInfoResponseBuilder implements UserInfoRespons
             AccessTokenDO accessTokenDO = OAuth2ServiceComponentHolder.getInstance().getTokenProvider()
                     .getVerifiedAccessToken(accessToken, false);
             grantType = getGrantType(accessTokenDO);
-            if (OAuth2ServiceComponentHolder.isConsentedTokenColumnEnabled()) {
-                // Get the Access Token details from the database/cache to check if the token is consented or not.
-                boolean isConsentedToken = accessTokenDO.isConsentedToken();
-                return OIDCClaimUtil.filterUserClaimsBasedOnConsent(userClaims, user, clientId, tenantDomain, grantType,
-                        getServiceProvider(tenantDomain, clientId), isConsentedToken);
-            }
+            // Get the Access Token details from the database/cache to check if the token is consented or not.
+            boolean isConsentedToken = accessTokenDO.isConsentedToken();
+            return OIDCClaimUtil.filterUserClaimsBasedOnConsent(userClaims, user, clientId, tenantDomain, grantType,
+                    getServiceProvider(tenantDomain, clientId), isConsentedToken);
         } catch (IdentityOAuth2Exception e) {
             throw new UserInfoEndpointException("An error occurred while fetching the access token details.", e);
         }
-        return OIDCClaimUtil.filterUserClaimsBasedOnConsent(userClaims, user, clientId, tenantDomain, grantType,
-                getServiceProvider(tenantDomain, clientId));
     }
 
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/OIDCClaimUtil.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/OIDCClaimUtil.java
@@ -45,7 +45,6 @@ import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
 import org.wso2.carbon.identity.oauth.dao.OAuthAppDO;
 import org.wso2.carbon.identity.oauth.internal.OAuthComponentServiceHolder;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
-import org.wso2.carbon.identity.oauth2.internal.OAuth2ServiceComponentHolder;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 import org.wso2.carbon.identity.openidconnect.internal.OpenIDConnectServiceComponentHolder;
 import org.wso2.carbon.identity.organization.management.organization.user.sharing.util.OrganizationSharedUserUtil;
@@ -232,6 +231,7 @@ public class OIDCClaimUtil {
     /**
      * Filter user claims based on consent with the highest priority {@link OpenIDConnectClaimFilter}. Consent based
      * user claims filtering can be configured at the global level, as well as the service provider level.
+     * @deprecated consent based user claims filtering is now supported at the access token level.
      */
     public static Map<String, Object> filterUserClaimsBasedOnConsent(Map<String, Object> userClaims,
                                                                      AuthenticatedUser authenticatedUser,
@@ -288,23 +288,18 @@ public class OIDCClaimUtil {
                                                                      ServiceProvider serviceProvider,
                                                                      boolean isConsentedToken) {
 
-        if (!OAuth2ServiceComponentHolder.isConsentedTokenColumnEnabled()) {
-            return filterUserClaimsBasedOnConsent(userClaims, authenticatedUser, clientId, spTenantDomain, grantType,
-                    serviceProvider);
+        if (isConsentedToken && !FrameworkUtils.isConsentPageSkippedForSP(serviceProvider)) {
+            return OpenIDConnectServiceComponentHolder.getInstance()
+                    .getHighestPriorityOpenIDConnectClaimFilter()
+                    .getClaimsFilteredByUserConsent(userClaims, authenticatedUser, clientId, spTenantDomain);
         } else {
-            if (isConsentedToken && !FrameworkUtils.isConsentPageSkippedForSP(serviceProvider)) {
-                return OpenIDConnectServiceComponentHolder.getInstance()
-                        .getHighestPriorityOpenIDConnectClaimFilter()
-                        .getClaimsFilteredByUserConsent(userClaims, authenticatedUser, clientId, spTenantDomain);
-            } else {
-                if (log.isDebugEnabled()) {
-                    String msg = "Filtering user claims based on consent skipped for grant type. Returning " +
-                            "original user claims for user:%s, for clientId:%s of tenantDomain:%s";
-                    log.debug(String.format(msg, authenticatedUser.toFullQualifiedUsername(),
-                            clientId, spTenantDomain));
-                }
-                return userClaims;
+            if (log.isDebugEnabled()) {
+                String msg = "Filtering user claims based on consent skipped for grant type. Returning " +
+                        "original user claims for user:%s, for clientId:%s of tenantDomain:%s";
+                log.debug(String.format(msg, authenticatedUser.toFullQualifiedUsername(),
+                        clientId, spTenantDomain));
             }
+            return userClaims;
         }
     }
 

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuerTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuerTest.java
@@ -467,7 +467,6 @@ public class JWTTokenIssuerTest {
             assertNull(jwtClaimSet.getClaim(OAuth2Constants.IS_CONSENTED));
             assertNull(jwtClaimSet.getClaim(OAuth2Constants.IS_FEDERATED));
             // The entity_id claim and is_consented are mandatory claims in the JWT when token persistence is disabled.
-            OAuth2ServiceComponentHolder.setConsentedTokenColumnEnabled(true);
             oAuth2Util.when(OAuth2Util::isTokenPersistenceEnabled).thenReturn(false);
             jwtClaimSet = jwtTokenIssuer.createJWTClaimSet(
                     (OAuthAuthzReqMessageContext) authzReqMessageContext,


### PR DESCRIPTION
### Proposed changes in this pull request

Checking for Consent token column in oauth2 access token is not needed anymore cause Consent token column is always there in 7.x Identity server via migration or new installments. 

Migration PR: https://github.com/wso2-enterprise/identity-migration-resources/pull/244

This pull request removes conditional logic and feature flags related to the `CONSENTED_TOKEN` column from the OAuth2 token codebase, reflecting that this column is now always present in all relevant tables from WSO2 IS 7.0.0 onwards. The changes simplify code paths, remove unnecessary checks, and deprecate feature flag methods, resulting in cleaner and more maintainable code.


### Deprecation and cleanup of feature flag methods
* Deprecated `OAuth2ServiceComponentHolder.isConsentedTokenColumnEnabled()` and `OAuth2ServiceComponentHolder.setConsentedTokenColumnEnabled()` methods, updating their documentation to clarify that the feature flag is obsolete.
* Deprecated `OAuth2Util.checkConsentedTokenColumnAvailable()` method, making it always return `true` and logging its deprecation.
* Removed references and calls to the feature flag setup and check logic in `OAuth2ServiceComponent.java`, including related debug logging. [[1]](diffhunk://#diff-cd13e64520941cf7428522614b9904083191a650fa14c66726bda0caedf2f6acL162) [[2]](diffhunk://#diff-cd13e64520941cf7428522614b9904083191a650fa14c66726bda0caedf2f6acL457-L468)
