### PR TITLE
Fix Filter internal organization scopes for root organization users

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
@@ -366,6 +366,8 @@ public class OAuthServerConfiguration {
 
     private final List<String> restrictedQueryParameters = new ArrayList<>();
 
+    private boolean removeInternalOrgScopesForRootOrg = false;
+
     private OAuthServerConfiguration() {
         buildOAuthServerConfiguration();
     }
@@ -605,6 +607,23 @@ public class OAuthServerConfiguration {
 
         // Read config for removing internal prefix from mapped roles attribute in JWT tokens.
         parseRemoveInternalPrefixFromMappedRolesAttributeInToken(oauthElem);
+
+        //Read config for removing internal_org_ scopes for root org
+        parseRemoveInternalOrgScopesForRootOrg(oauthElem);
+    }
+
+    private void parseRemoveInternalOrgScopesForRootOrg(OMElement oauthConfigElem) {
+
+        OMElement removeInternalOrgScopesForRootOrgElem = oauthConfigElem.getFirstChildWithName(
+                getQNameWithIdentityNS(ConfigElements.REMOVE_INTERNAL_ORG_SCOPES_FOR_ROOT_ORG));
+
+        if (removeInternalOrgScopesForRootOrgElem != null) {
+            removeInternalOrgScopesForRootOrg = Boolean.parseBoolean(
+                    removeInternalOrgScopesForRootOrgElem.getText().trim());
+        }
+    }
+    public boolean isRemoveInternalOrgScopesForRootOrgEnabled() {
+        return removeInternalOrgScopesForRootOrg;
     }
 
     /**
@@ -4659,6 +4678,7 @@ public class OAuthServerConfiguration {
         private static final String RETURN_SP_ID_TO_APPLICATION = "ReturnSpIdToApplication";
         private static final String REMOVE_INTERNAL_PREFIX_FROM_MAPPED_ROLES_ATTRIBUTE =
                 "RemoveInternalPrefixFromMappedRolesAttributeInToken";
+        public static final String REMOVE_INTERNAL_ORG_SCOPES_FOR_ROOT_ORG = "RemoveInternalOrgScopesForRootOrg";
     }
 
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
@@ -366,7 +366,7 @@ public class OAuthServerConfiguration {
 
     private final List<String> restrictedQueryParameters = new ArrayList<>();
 
-    private boolean removeInternalOrgScopesForRootOrg = false;
+    private boolean disableInternalOrgScopeIssuanceForRootOrg = false;
 
     private OAuthServerConfiguration() {
         buildOAuthServerConfiguration();
@@ -609,21 +609,21 @@ public class OAuthServerConfiguration {
         parseRemoveInternalPrefixFromMappedRolesAttributeInToken(oauthElem);
 
         //Read config for removing internal_org_ scopes for root org
-        parseRemoveInternalOrgScopesForRootOrg(oauthElem);
+        parseDisableInternalOrgScopeIssuanceForRootOrg(oauthElem);
     }
 
-    private void parseRemoveInternalOrgScopesForRootOrg(OMElement oauthConfigElem) {
+    private void parseDisableInternalOrgScopeIssuanceForRootOrg(OMElement oauthConfigElem) {
 
-        OMElement removeInternalOrgScopesForRootOrgElem = oauthConfigElem.getFirstChildWithName(
-                getQNameWithIdentityNS(ConfigElements.REMOVE_INTERNAL_ORG_SCOPES_FOR_ROOT_ORG));
+        OMElement disableInternalOrgScopeIssuanceForRootOrgElem = oauthConfigElem.getFirstChildWithName(
+                getQNameWithIdentityNS(ConfigElements.DISABLE_INTERNAL_ORG_SCOPES_ISSUANCE_FOR_ROOT_ORG));
 
-        if (removeInternalOrgScopesForRootOrgElem != null) {
-            removeInternalOrgScopesForRootOrg = Boolean.parseBoolean(
-                    removeInternalOrgScopesForRootOrgElem.getText().trim());
+        if (disableInternalOrgScopeIssuanceForRootOrgElem != null) {
+            disableInternalOrgScopeIssuanceForRootOrg = Boolean.parseBoolean(
+                    disableInternalOrgScopeIssuanceForRootOrgElem.getText().trim());
         }
     }
-    public boolean isRemoveInternalOrgScopesForRootOrgEnabled() {
-        return removeInternalOrgScopesForRootOrg;
+    public boolean isRemoveInternalOrgScopesIssuanceForRootOrgEnabled() {
+        return disableInternalOrgScopeIssuanceForRootOrg;
     }
 
     /**
@@ -4678,7 +4678,7 @@ public class OAuthServerConfiguration {
         private static final String RETURN_SP_ID_TO_APPLICATION = "ReturnSpIdToApplication";
         private static final String REMOVE_INTERNAL_PREFIX_FROM_MAPPED_ROLES_ATTRIBUTE =
                 "RemoveInternalPrefixFromMappedRolesAttributeInToken";
-        public static final String REMOVE_INTERNAL_ORG_SCOPES_FOR_ROOT_ORG = "RemoveInternalOrgScopesForRootOrg";
+        public static final String DISABLE_INTERNAL_ORG_SCOPES_ISSUANCE_FOR_ROOT_ORG = "DisableInternalOrgScopesIssuanceForRootOrg";
     }
 
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
@@ -4678,7 +4678,8 @@ public class OAuthServerConfiguration {
         private static final String RETURN_SP_ID_TO_APPLICATION = "ReturnSpIdToApplication";
         private static final String REMOVE_INTERNAL_PREFIX_FROM_MAPPED_ROLES_ATTRIBUTE =
                 "RemoveInternalPrefixFromMappedRolesAttributeInToken";
-        public static final String DISABLE_INTERNAL_ORG_SCOPES_ISSUANCE_FOR_ROOT_ORG = "DisableInternalOrgScopesIssuanceForRootOrg";
+        public static final String DISABLE_INTERNAL_ORG_SCOPES_ISSUANCE_FOR_ROOT_ORG =
+                "DisableInternalOrgScopesIssuanceForRootOrg";
     }
 
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
@@ -623,6 +623,7 @@ public class OAuthServerConfiguration {
         }
     }
     public boolean isRemoveInternalOrgScopesIssuanceForRootOrgEnabled() {
+    
         return disableInternalOrgScopeIssuanceForRootOrg;
     }
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/validationhandler/impl/RoleBasedScopeValidationHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/validationhandler/impl/RoleBasedScopeValidationHandler.java
@@ -108,7 +108,7 @@ public class RoleBasedScopeValidationHandler implements ScopeValidationHandler {
                 associatedScopes.addAll(internalOrgScopes);
             } else {
                 if (OAuthServerConfiguration.getInstance().isRemoveInternalOrgScopesIssuanceForRootOrgEnabled()) {
-                    // Remove Organization scopes issues for the root organization
+                    // Remove Organization scopes issues for the root organization.
                     associatedScopes.removeIf(scope ->
                             scope.startsWith(Oauth2ScopeConstants.INTERNAL_ORG_SCOPE_PREFIX));
                 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/validationhandler/impl/RoleBasedScopeValidationHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/validationhandler/impl/RoleBasedScopeValidationHandler.java
@@ -29,6 +29,7 @@ import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.oauth.common.OAuthConstants;
+import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
 import org.wso2.carbon.identity.oauth.internal.OAuthComponentServiceHolder;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2ClientException;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
@@ -105,6 +106,12 @@ public class RoleBasedScopeValidationHandler implements ScopeValidationHandler {
                         .collect(Collectors.toList());
                 associatedScopes.removeIf(scope -> scope.startsWith(Oauth2ScopeConstants.INTERNAL_SCOPE_PREFIX));
                 associatedScopes.addAll(internalOrgScopes);
+            } else {
+                if (OAuthServerConfiguration.getInstance().isRemoveInternalOrgScopesForRootOrgEnabled()) {
+                    // Remove Organization scopes issues for the root organization
+                    associatedScopes.removeIf(scope ->
+                            scope.startsWith(Oauth2ScopeConstants.INTERNAL_ORG_SCOPE_PREFIX));
+                }
             }
             List<String> filteredScopes = appAuthorizedScopes.stream().filter(associatedScopes::contains)
                     .collect(Collectors.toList());

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/validationhandler/impl/RoleBasedScopeValidationHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/validationhandler/impl/RoleBasedScopeValidationHandler.java
@@ -98,11 +98,7 @@ public class RoleBasedScopeValidationHandler implements ScopeValidationHandler {
                 return new ArrayList<>();
             }
             List<String> associatedScopes = AuthzUtil.getAssociatedScopesForRoles(filteredRoleIds, tenantDomain);
-            /*
-            TODO: Refactor this to drop internal_ scopes when getting associated scopes for roles.
-            When user is not accessing the resident organization, retain only the internal_org_ scopes
-            from system scopes.
-            */
+
             if (StringUtils.isNotBlank(scopeValidationContext.getAuthenticatedUser().getAccessingOrganization())) {
                 List<String> internalOrgScopes = associatedScopes.stream()
                         .filter(scope -> scope.startsWith(Oauth2ScopeConstants.INTERNAL_ORG_SCOPE_PREFIX))

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/validationhandler/impl/RoleBasedScopeValidationHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/validationhandler/impl/RoleBasedScopeValidationHandler.java
@@ -107,7 +107,7 @@ public class RoleBasedScopeValidationHandler implements ScopeValidationHandler {
                 associatedScopes.removeIf(scope -> scope.startsWith(Oauth2ScopeConstants.INTERNAL_SCOPE_PREFIX));
                 associatedScopes.addAll(internalOrgScopes);
             } else {
-                if (OAuthServerConfiguration.getInstance().isRemoveInternalOrgScopesForRootOrgEnabled()) {
+                if (OAuthServerConfiguration.getInstance().isRemoveInternalOrgScopesIssuanceForRootOrgEnabled()) {
                     // Remove Organization scopes issues for the root organization
                     associatedScopes.removeIf(scope ->
                             scope.startsWith(Oauth2ScopeConstants.INTERNAL_ORG_SCOPE_PREFIX));


### PR DESCRIPTION
This PR introduces a mechanism to filter out `internal_org_` scopes when a user is accessing the root organization. Currently, these scopes, which are intended for sub-organizations, can appear in the root organization context.

**Changes**
Introduced a new configuration `RemoveInternalOrgScopesForRootOrg` in OAuthServerConfiguration.

Updated RoleBasedScopeValidationHandler to check this configuration.

If enabled, `internal_org_ ` prefixed scopes are removed from the associated scopes list when the user is in the root organization.

**Backward Compatibility**
The configuration defaults to false.

Existing deployments will retain current behavior (scopes are not removed) unless explicitly enabled in identity.xml.

issue: [wso2/product-is#24880](https://github.com/wso2/product-is/issues/24880)