### PR TITLE
Fix getting SUCCESS_COMPLETED as flowStatus for some error scenarios in App Native Authentication

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/AuthzUtil.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/AuthzUtil.java
@@ -4834,7 +4834,7 @@ public class AuthzUtil {
         request.setAttribute(AUTH_SERVICE_RESPONSE, authServiceResponse);
     }
 
-    private static void raiseApiBasedClientError(String errorMsg) throws AuthServiceClientException {
+    private static void handleApiBasedAuthError(String errorMsg) throws AuthServiceClientException {
         if (StringUtils.isBlank(errorMsg)) {
             errorMsg = AuthServiceConstants.ErrorMessage.ERROR_INVALID_AUTH_REQUEST.description();
         }
@@ -4892,7 +4892,7 @@ public class AuthzUtil {
                         if (isRedirectToClient(location)) {
                             if (isErrorIncluded(queryParams)) {
                                 String errorMsg = getErrorMessageForApiBasedClientError(queryParams, true);
-                                raiseApiBasedClientError(errorMsg);
+                                handleApiBasedAuthError(errorMsg);
                             } else {
                                 SuccessCompleteAuthResponse successCompleteAuthResponse =
                                         new SuccessCompleteAuthResponse(queryParams);
@@ -4905,7 +4905,7 @@ public class AuthzUtil {
                              we can assume it is an error scenario which redirects to the error page. Therefore,
                              we need to handle the response as an API based error response.*/
                             String errorMsg = getErrorMessageForApiBasedClientError(queryParams, false);
-                            raiseApiBasedClientError(errorMsg);
+                            handleApiBasedAuthError(errorMsg);
                         }
                     }
                 }

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/AuthzUtil.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/AuthzUtil.java
@@ -4834,6 +4834,14 @@ public class AuthzUtil {
         request.setAttribute(AUTH_SERVICE_RESPONSE, authServiceResponse);
     }
 
+    private static void raiseApiBasedClientError(String errorMsg) throws AuthServiceClientException {
+        if (StringUtils.isBlank(errorMsg)) {
+            errorMsg = AuthServiceConstants.ErrorMessage.ERROR_INVALID_AUTH_REQUEST.description();
+        }
+        throw new AuthServiceClientException(
+                AuthServiceConstants.ErrorMessage.ERROR_INVALID_AUTH_REQUEST.code(), errorMsg);
+    }
+
     public static Response handleApiBasedAuthenticationResponse(OAuthMessage oAuthMessage, Response oauthResponse) {
 
         // API based auth response transformation has already been handled no need for further handling.
@@ -4882,21 +4890,22 @@ public class AuthzUtil {
                                     "Error while extracting query params from provided url.", e);
                         }
                         if (isRedirectToClient(location)) {
-                            SuccessCompleteAuthResponse successCompleteAuthResponse =
-                                    new SuccessCompleteAuthResponse(queryParams);
-                            String jsonPayload = new Gson().toJson(successCompleteAuthResponse);
-                            oAuthMessage.getRequest().setAttribute(IS_API_BASED_AUTH_HANDLED, true);
-                            return Response.status(HttpServletResponse.SC_OK).entity(jsonPayload).build();
+                            if (isErrorIncluded(queryParams)) {
+                                String errorMsg = getErrorMessageForApiBasedClientError(queryParams, true);
+                                raiseApiBasedClientError(errorMsg);
+                            } else {
+                                SuccessCompleteAuthResponse successCompleteAuthResponse =
+                                        new SuccessCompleteAuthResponse(queryParams);
+                                String jsonPayload = new Gson().toJson(successCompleteAuthResponse);
+                                oAuthMessage.getRequest().setAttribute(IS_API_BASED_AUTH_HANDLED, true);
+                                return Response.status(HttpServletResponse.SC_OK).entity(jsonPayload).build();
+                            }
                         } else {
                             /* At this point if the location header doesn't indicate a redirection to the client
                              we can assume it is an error scenario which redirects to the error page. Therefore,
                              we need to handle the response as an API based error response.*/
-                            String errorMsg = getErrorMessageForApiBasedClientError(queryParams);
-                            if (StringUtils.isBlank(errorMsg)) {
-                                errorMsg = AuthServiceConstants.ErrorMessage.ERROR_INVALID_AUTH_REQUEST.description();
-                            }
-                            throw new AuthServiceClientException(
-                                    AuthServiceConstants.ErrorMessage.ERROR_INVALID_AUTH_REQUEST.code(), errorMsg);
+                            String errorMsg = getErrorMessageForApiBasedClientError(queryParams, false);
+                            raiseApiBasedClientError(errorMsg);
                         }
                     }
                 }
@@ -4974,10 +4983,25 @@ public class AuthzUtil {
         return true;
     }
 
-    private static String getErrorMessageForApiBasedClientError(Map<String, String> params) {
 
-        String oauthErrorCode = params.get(OAuthConstants.OAUTH_ERROR_CODE);
-        String oauthErrorMsg = params.get(OAuthConstants.OAUTH_ERROR_MESSAGE);
+    private static boolean isErrorIncluded(Map<String, String> queryParams) {
+
+        return queryParams.containsKey(OAuthConstants.OAUTH_ERROR) ||
+                queryParams.containsKey(OAuthConstants.OAUTH_ERROR_DESCRIPTION);
+    }
+
+    private static String getErrorMessageForApiBasedClientError(Map<String, String> params,
+                                                                boolean isRedirectedToClient) {
+
+        String oauthErrorCode;
+        String oauthErrorMsg;
+        if (isRedirectedToClient) {
+            oauthErrorCode = params.get(OAuthConstants.OAUTH_ERROR);
+            oauthErrorMsg = params.get(OAuthConstants.OAUTH_ERROR_DESCRIPTION);
+        } else {
+            oauthErrorCode = params.get(OAuthConstants.OAUTH_ERROR_CODE);
+            oauthErrorMsg = params.get(OAuthConstants.OAUTH_ERROR_MESSAGE);
+        }
 
         if (StringUtils.isBlank(oauthErrorCode)) {
             return oauthErrorMsg != null ? oauthErrorMsg : StringUtils.EMPTY;

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/util/AuthzUtilTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/util/AuthzUtilTest.java
@@ -74,6 +74,7 @@ import org.wso2.carbon.identity.application.authentication.framework.model.Authe
 import org.wso2.carbon.identity.application.authentication.framework.model.CommonAuthResponseWrapper;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
+import org.wso2.carbon.identity.application.authentication.framework.util.auth.service.AuthServiceConstants;
 import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
 import org.wso2.carbon.identity.application.common.model.ClaimMapping;
 import org.wso2.carbon.identity.application.common.model.ServiceProvider;
@@ -154,6 +155,7 @@ import java.security.Key;
 import java.security.KeyStore;
 import java.security.interfaces.RSAPrivateKey;
 import java.sql.Connection;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collections;
@@ -200,6 +202,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.FileAssert.fail;
@@ -313,6 +316,7 @@ public class AuthzUtilTest extends TestOAuthEndpointBase {
     private static final String INVALID_CLIENT_ID = "invalidId";
     private static final String SP_DISPLAY_NAME = "DisplayName";
     private static final String SP_NAME = "Name";
+    private static final String IS_API_BASED_AUTH_HANDLED = "isApiBasedAuthHandled";
     private static final int MILLISECONDS_PER_SECOND = 1000;
     private static final int TIME_MARGIN_IN_SECONDS = 3000;
 
@@ -2023,5 +2027,190 @@ public class AuthzUtilTest extends TestOAuthEndpointBase {
                         any(AuthenticatedUser.class))).thenReturn(new ConsentClaimsData());
 
         when(mockedSSOConsentService.isSSOConsentManagementEnabled(any())).thenReturn(isConsentMgtEnabled);
+    }
+
+
+    @DataProvider(name = "provideApiBasedAuthResponseData")
+    public Object[][] provideApiBasedAuthResponseData() {
+
+        return new Object[][]{
+                // Success scenario - no errors, redirect to client
+                {"http://localhost:8080/redirect?code=auth_code_123&state=state_value", false},
+
+                // Client redirect with error
+                {"http://localhost:8080/redirect?error=invalid_request&error_description=Invalid%20request", false},
+
+                // Internal redirect to error page (non-client redirect)
+                {ERROR_PAGE_URL + "?oauthErrorCode=server_error&oauthErrorMsg=Server%20error%20occurred", false},
+
+                // Already handled scenario
+                {"http://localhost:8080/redirect?code=auth_code_123", true},
+
+                // Empty location header
+                {null, false},
+
+                // Blank location
+                {"", false}
+        };
+    }
+
+    // Test whether AuthzUtil.handleApiBasedAuthenticationResponse method return original response or
+    // another based on different scenarios when Flow_status is null.
+    @Test(dataProvider = "provideApiBasedAuthResponseData")
+    public void testHandleApiBasedAuthenticationResponse(String locationUrl, boolean alreadyHandled) throws Exception {
+
+        try (MockedStatic<OAuth2Util.OAuthURL> oAuthURL = mockStatic(OAuth2Util.OAuthURL.class)) {
+
+            // Mock OAuth2Util.OAuthURL methods
+            oAuthURL.when(OAuth2Util.OAuthURL::getOAuth2ErrorPageUrl).thenReturn(ERROR_PAGE_URL);
+
+            // Mock the request and response
+            Map<String, Object> requestAttributes = new HashMap<>();
+            if (alreadyHandled) {
+                requestAttributes.put(IS_API_BASED_AUTH_HANDLED, true);
+            }
+            requestAttributes.put(FrameworkConstants.RequestParams.FLOW_STATUS, null);
+
+            mockHttpRequest(new HashMap<>(), requestAttributes, HttpMethod.POST);
+            when(oAuthMessage.getRequest()).thenReturn(httpServletRequest);
+
+            // Mock the OAuth response with location header
+            Response mockOAuthResponse = mock(Response.class);
+            MultivaluedMap<String, Object> metadata = mock(MultivaluedMap.class);
+            when(mockOAuthResponse.getMetadata()).thenReturn(metadata);
+            when(mockOAuthResponse.getStatus()).thenReturn(HttpServletResponse.SC_FOUND);
+
+            if (locationUrl != null) {
+                List<Object> locationHeader = new ArrayList<>();
+                locationHeader.add(locationUrl);
+                when(metadata.get("Location")).thenReturn(locationHeader);
+            } else {
+                when(metadata.get("Location")).thenReturn(null);
+            }
+
+            Response response = AuthzUtil.handleApiBasedAuthenticationResponse(oAuthMessage, mockOAuthResponse);
+
+            assertNotNull(response);
+
+            if (alreadyHandled) {
+                // When already handled, should return the original response
+                assertEquals(response, mockOAuthResponse,
+                        "Response should be the original when already handled.");
+            } else if (locationUrl == null || StringUtils.isBlank(locationUrl)) {
+                // When no location or blank location, should return original response
+                assertEquals(response, mockOAuthResponse,
+                        "Response should be the original when location is null or blank.");
+            } else {
+                // For non-API based auth flow (which this test simulates since we're not mocking it as API based),
+                // the method returns the original response
+                assertNotNull(response, "Response should not be null.");
+                assertNotEquals(response, mockOAuthResponse, "Response should not be specific.");
+            }
+        }
+    }
+
+    private static Map<String, String> getErrorResponsePayloadParams(String oauthErrorCode, String oauthErrorMsg) {
+
+        Map<String, String> errorPayload = new HashMap<>();
+        errorPayload.put("code", "ABA-60001");
+        errorPayload.put("message", AuthServiceConstants.ErrorMessage.ERROR_INVALID_AUTH_REQUEST.code());
+        String message = "";
+        if (StringUtils.isNotBlank(oauthErrorCode)) {
+            message = oauthErrorCode;
+        }
+        if (StringUtils.isNotBlank(oauthErrorMsg)) {
+            if (StringUtils.isNotBlank(oauthErrorCode)) {
+                message += " " + AuthServiceConstants.INTERNAL_ERROR_MSG_SEPARATOR + " ";
+            }
+            message += oauthErrorMsg;
+        }
+        errorPayload.put("description", message);
+        return errorPayload;
+    }
+
+
+    @DataProvider(name = "provideApiBasedAuthResponseWithLocationData")
+    public Object[][] provideApiBasedAuthResponseWithLocationData() {
+
+        Map<String, String> errorPayload1 = getErrorResponsePayloadParams(
+                "access_denied", "Denied access");
+        Map<String, String> errorPayload2 = getErrorResponsePayloadParams(
+                "invalid_request", "Missing parameter");
+        Map<String, String> errorPayload3 = getErrorResponsePayloadParams(
+                "unauthorized_client", "Client not authorized");
+        Map<String, String> errorPayload4 = getErrorResponsePayloadParams(
+                "server_error", "Internal server error");
+
+        // {locationUrl, expectedErrorPayloadParams, expectedStatus}
+        return new Object[][]{
+                // Success - redirect to client with authorization code
+                {"http://localhost:8080/redirect?code=authorization_code_xyz&state=test_state",
+                        null, HttpServletResponse.SC_OK},
+
+                // Success - redirect to client with multiple query params
+                {"http://localhost:8080/redirect?code=auth_code&state=state123&session_state=session_xyz",
+                        null, HttpServletResponse.SC_OK},
+
+                // Error - client redirect with OAuth error
+                {"http://localhost:8080/redirect?error=access_denied&error_description=Denied%20access&state=test",
+                        errorPayload1, HttpServletResponse.SC_BAD_REQUEST},
+
+                // Error - client redirect with invalid_request
+                {"http://localhost:8080/redirect?error=invalid_request&error_description=Missing%20parameter",
+                        errorPayload2, HttpServletResponse.SC_BAD_REQUEST},
+
+                // Error - internal redirect to error page
+                {ERROR_PAGE_URL + "?oauthErrorCode=unauthorized_client&oauthErrorMsg=Client%20not%20authorized",
+                        errorPayload3, HttpServletResponse.SC_BAD_REQUEST},
+
+                // Error - internal redirect with server error
+                {ERROR_PAGE_URL + "?oauthErrorCode=server_error&oauthErrorMsg=Internal%20server%20error",
+                        errorPayload4, HttpServletResponse.SC_BAD_REQUEST}
+        };
+    }
+
+    @Test(dataProvider = "provideApiBasedAuthResponseWithLocationData")
+    public void testHandleApiBasedAuthResponseLocationHandling(String locationUrl,
+                                                               Map<String, String> expectedErrorPayloadParams,
+                                                               int expectedStatus) throws Exception {
+
+        try (MockedStatic<OAuth2Util> oAuth2Util = mockStatic(OAuth2Util.class);
+             MockedStatic<OAuth2Util.OAuthURL> oAuthURL = mockStatic(OAuth2Util.OAuthURL.class)) {
+
+            Map<String, Object> requestAttributes = new HashMap<>();
+            mockHttpRequest(new HashMap<>(), requestAttributes, HttpMethod.POST);
+            when(oAuthMessage.getRequest()).thenReturn(httpServletRequest);
+
+            oAuth2Util.when(() -> OAuth2Util.isApiBasedAuthenticationFlow(any(HttpServletRequest.class)))
+                    .thenReturn(true);
+            oAuthURL.when(OAuth2Util.OAuthURL::getOAuth2ErrorPageUrl).thenReturn(ERROR_PAGE_URL);
+
+            Response mockOAuthResponse = mock(Response.class);
+            MultivaluedMap<String, Object> metadata = mock(MultivaluedMap.class);
+            when(mockOAuthResponse.getMetadata()).thenReturn(metadata);
+            when(mockOAuthResponse.getStatus()).thenReturn(HttpServletResponse.SC_FOUND);
+
+            List<Object> locationHeader = new ArrayList<>();
+            locationHeader.add(locationUrl);
+            when(metadata.get("Location")).thenReturn(locationHeader);
+
+            Response response = AuthzUtil.handleApiBasedAuthenticationResponse(oAuthMessage, mockOAuthResponse);
+
+            assertNotNull(response, "Response should not be null.");
+            assertEquals(response.getStatus(), expectedStatus, "Unexpected HTTP status code.");
+
+            String responsePayload = (String) response.getEntity();
+            if (expectedStatus == HttpServletResponse.SC_OK) {
+                assertTrue(responsePayload.contains("flowStatus") &&
+                                responsePayload.contains(AuthenticatorFlowStatus.SUCCESS_COMPLETED.toString()),
+                        "Response payload should indicate success flow status.");
+            } else {
+                for (String key : expectedErrorPayloadParams.keySet()) {
+                    assertTrue(responsePayload.contains(key) &&
+                                    responsePayload.contains(expectedErrorPayloadParams.get(key)),
+                            "Response payload should contain expected error parameters.");
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## Problem

In certain error scenarios during App Native Authentication, the system incorrectly returns `SUCCESS_COMPLETED` as the `flowStatus` instead of a failure state.

**Examples of affected scenarios:**
* **Mandatory PKCE:** The `code_challenge` or `code_challenge_method` is missing when PKCE is required.
* **Invalid Prompt Parameters:** The `prompt` parameter in the request payload is invalid (e.g., using `none` with other values or providing unsupported strings).

![Error Flow Screenshot](https://github.com/user-attachments/assets/090d1e63-fa26-4cc6-8d22-c0a392a65ea9)

## Root Cause

The authentication framework handles error redirections through two primary paths:
1.  **Internal Redirection:** Redirecting to the server’s internal error page.
2.  **External Redirection:** Redirecting back to the client’s `redirect_url` with error details appended as query parameters.

The current logic for building App Native (API-based) responses only checks if the flow is redirected to the **server error page**. If the flow redirects back to the **client side**, the system ignores the error parameters attached to the URL and defaults to a `SUCCESS_COMPLETED` status, failing to communicate the failure to the API caller.

## Solution

The logic has been updated to inspect the redirection URL even when it points to the client side. 

* **Error Detection:** The system now checks the redirection URL for error-related query parameters.
* **Exception Handling:** If errors are found, the function throws an `AuthServiceClientException`.
* **Standardized Response:** The flow now correctly responds with an **HTTP 400 Bad Request** and the corresponding error description.

![Solution Implementation](https://github.com/user-attachments/assets/031e1925-193f-44b9-9369-d3eb5cb6e4ad)

### Testing
* Added unit test scenarios to cover different redirection url cases.

## Before Merging
As the code changes the HTTP response for some App Native Requests, backward compatibility config should be included

### Related Issue
* https://github.com/wso2/product-is/issues/25463