### PR TITLE
Implement conditional literal character matching in callback URL validation

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
+++ b/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
@@ -133,7 +133,7 @@ public final class OAuthConstants {
 
     //Constants used for OAuth/OpenID Connect Configuration UI
     public static final String CALLBACK_URL_REGEXP_PREFIX = "regexp=";
-
+    public static final String CALLBACK_ENFORCE_LITERAL_CHARACTERS = "OAuth.Callback.EnforceLiteralCharacters";
 
     public static final String LOOPBACK_IP_REGEX = "(.*127\\.0\\.0\\.1.*|.*\\[::1].*)";
     public static final String LOOPBACK_IP_PORT_REGEX = "(?<=127\\.0\\.0\\.1|\\[::1])(:[0-9]{1,5})";

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/validators/AbstractResponseTypeRequestValidator.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/validators/AbstractResponseTypeRequestValidator.java
@@ -24,6 +24,7 @@ import org.apache.commons.logging.LogFactory;
 import org.owasp.encoder.Encode;
 import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.oauth.common.OAuth2ErrorCodes;
 import org.wso2.carbon.identity.oauth.common.OAuthConstants;
 import org.wso2.carbon.identity.oauth.common.exception.InvalidOAuthClientException;
@@ -273,6 +274,26 @@ public abstract class AbstractResponseTypeRequestValidator implements ResponseTy
                         OAuthConstants.LOOPBACK_IP_PORT_REGEX, "");
             }
         }
-        return (regexp != null && callbackURI.matches(regexp)) || registeredCallbackUrl.equals(callbackURI);
+        if (regexp == null) {
+            return registeredCallbackUrl.equals(callbackURI);
+        }
+        if (isLiteralCharactersEnforcedInCallback()) {
+            /*
+            Escape (.), (+), (?) only when followed by a letter/digit (so .com, .org, etc. get escaped),
+            but don't touch .* or .+ or .{n} .
+            */
+            String escapedSpecialCharRegexp = regexp
+                    .replaceAll("(?<!\\\\)\\.(?=[A-Za-z0-9])", "\\\\.")
+                    .replaceAll("(?<!\\\\)\\+(?=[A-Za-z0-9])", "\\\\+")
+                    .replaceAll("(?<!\\\\)\\?(?=[A-Za-z0-9])", "\\\\?");
+            return callbackURI.matches(escapedSpecialCharRegexp);
+        }
+        return callbackURI.matches(regexp);
+    }
+
+    private boolean isLiteralCharactersEnforcedInCallback() {
+        String enforceLiteralCharactersInCallbackValue = IdentityUtil.getProperty(
+                OAuthConstants.CALLBACK_ENFORCE_LITERAL_CHARACTERS);
+        return Boolean.parseBoolean(enforceLiteralCharactersInCallbackValue);
     }
 }


### PR DESCRIPTION
## Description 

This pull request updates the callback URI validation logic in the OAuth2 authorization request validator. The main change is an improvement to how regular expressions are handled to ensure more accurate matching of callback URIs.

Callback URI validation improvements:

- The code now escapes., ?, + in the regular expression only when they are followed by a letter or digit (e.g., .com, .org), which prevents unintended matches and avoids interfering with wildcard patterns like .* or .+ or .{n}. when the particular configuration is enabled.
- The validation logic now checks for the presence of a regular expression: if none is provided, it falls back to a direct string comparison between the registered and provided callback URIs.

## Testing
Reproduced the Issue following the steps in [1]

Applied the fix as in [2] and locally tested the fix. Managed to resolve the issue and now an error message is displayed as expected with the malformed URL.

This behavior can be reverted using the following config

```
[oauth.callback]
enforce_literal_characters=false
```
[1] https://github.com/wso2-enterprise/wso2-apim-internal/issues/14791
[2] https://github.com/wso2-enterprise/wso2-apim-internal/issues/14798 

## Related Issue:
- https://github.com/wso2-enterprise/wso2-apim-internal/issues/14813

## Related PRs:
- https://github.com/wso2/carbon-identity-framework/pull/7832
- https://github.com/wso2/product-apim/pull/14021

