### PR TITLE
[NP_AT] Access token validity in rt grant

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/RefreshGrantHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/RefreshGrantHandler.java
@@ -165,6 +165,11 @@ public class RefreshGrantHandler extends AbstractAuthorizationGrantHandler {
         }
 
         if (validationBean.isWithNotPersistedAT()) {
+            // If the refresh token is issued with an access token which is not persisted,
+            // then we need to calculate the validity period for the new access token based
+            // on the app configuration. since we cannot retrieve the issued time and validity period of the previous
+            // access token from the database.
+            // Setting this value used for pre issue access token actions.
             OAuthAppDO oAuthAppDO = getOAuthApp(tokenReq.getClientId(), validationBean.getAuthorizedUser().
                     getTenantDomain());
             tokReqMsgCtx.setValidityPeriod(getValidityPeriodInMillis(tokReqMsgCtx, oAuthAppDO));

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/RefreshGrantHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/RefreshGrantHandler.java
@@ -164,7 +164,13 @@ public class RefreshGrantHandler extends AbstractAuthorizationGrantHandler {
             return handleError(OAuth2ErrorCodes.INVALID_GRANT, "Refresh token is expired.", tokenReq);
         }
 
-        tokReqMsgCtx.setValidityPeriod(validationBean.getAccessTokenValidityInMillis());
+        if (validationBean.isWithNotPersistedAT()) {
+            OAuthAppDO oAuthAppDO = getOAuthApp(tokenReq.getClientId(), validationBean.getAuthorizedUser().
+                    getTenantDomain());
+            tokReqMsgCtx.setValidityPeriod(getValidityPeriodInMillis(tokReqMsgCtx, oAuthAppDO));
+        } else {
+            tokReqMsgCtx.setValidityPeriod(validationBean.getAccessTokenValidityInMillis());
+        }
 
         if (checkExecutePreIssueAccessTokensActions(validationBean, tokReqMsgCtx) ||
                 checkExecutePreIssueIdTokensActions(tokReqMsgCtx)) {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/DefaultOIDCClaimsCallbackHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/DefaultOIDCClaimsCallbackHandler.java
@@ -155,7 +155,8 @@ public class DefaultOIDCClaimsCallbackHandler implements CustomClaimsCallbackHan
         // Get any user attributes that were cached against the access token
         // Map<(http://wso2.org/claims/email, email), "peter@example.com">
         Map<ClaimMapping, String> userAttributes = getCachedUserAttributes(requestMsgCtx);
-        if ((userAttributes.isEmpty() || isOrganizationSwitchGrantType(requestMsgCtx))
+        if (userAttributes != null &&
+                (userAttributes.isEmpty() || isOrganizationSwitchGrantType(requestMsgCtx))
                 && (isLocalUser(requestMsgCtx.getAuthorizedUser())
                 || isOrganizationSsoUserSwitchingOrganization(requestMsgCtx.getAuthorizedUser())
                 || isOrganizationSSOUser(requestMsgCtx.getAuthorizedUser()))) {


### PR DESCRIPTION
### Proposed changes in this pull request
Issue: https://github.com/wso2/product-is/issues/24066
Fixes https://github.com/wso2/product-is/issues/27077

This pull request introduces improvements to token validity handling and user claim retrieval logic in the OAuth2 and OpenID Connect components. The changes enhance how access token validity is determined during refresh flows and make user attribute retrieval more robust, especially in scenarios involving organization switching.

Access Token Validity Handling:

* In `RefreshGrantHandler.java`, access token validity is now determined dynamically for tokens flagged as "not persisted," using the OAuth application's settings instead of a fixed validity period. This allows for more flexible token lifetimes based on application configuration.

User Claims Retrieval Logic:

* In `DefaultOIDCClaimsCallbackHandler.java`, the logic for retrieving cached user attributes has been improved by ensuring that the `userAttributes` map is checked for null before further processing. This prevents potential null pointer exceptions and improves robustness, especially when handling organization switch grant types.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of access token validity during refresh token operations
  * Fixed potential error condition in OpenID Connect user attribute processing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->