### PR TITLE
Fix tenant domain inconsistency between cache and DAO layers

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AbstractAuthorizationGrantHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AbstractAuthorizationGrantHandler.java
@@ -610,7 +610,7 @@ public abstract class AbstractAuthorizationGrantHandler implements Authorization
     private AccessTokenDO createNewTokenBean(OAuthTokenReqMessageContext tokReqMsgCtx, AccessTokenDO existingTokenBean,
                                              OauthTokenIssuer oauthTokenIssuer) throws IdentityOAuth2Exception {
 
-        String tenantDomain = tokReqMsgCtx.getOauth2AccessTokenReqDTO().getTenantDomain();
+        String tenantDomain = OAuth2Util.getUserResidentTenantDomain(tokReqMsgCtx.getAuthorizedUser());
 
         OAuth2AccessTokenReqDTO tokenReq = tokReqMsgCtx.getOauth2AccessTokenReqDTO();
         validateGrantTypeParam(tokenReq);


### PR DESCRIPTION
### Proposed changes in this pull request
$subject

Issue: https://github.com/wso2/product-is/issues/27233

We identified a cache inconsistency. When the tenantID is set, we derive the tenant domain from the request DTO [1]. However, when persisting to the database, we set the user’s resident domain [2].

[1] https://github.com/wso2-extensions/identity-inbound-auth-oauth/blob/84afd75e95b3361e331253c204fb95fdcf670a04/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AbstractAuthorizationGrantHandler.java#L625

[2] https://github.com/wso2-extensions/identity-inbound-auth-oauth/blob/84afd75e95b3361e331253c204fb95fdcf670a04/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dao/AccessTokenDAOImpl.java#L215

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tenant domain resolution during token generation to use the authorized user's resident tenant context instead of request-provided values, ensuring accurate multi-tenant token handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->