### PR TITLE
Fix error log during application deletion by reordering cache cleanup

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuthApplicationMgtListener.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuthApplicationMgtListener.java
@@ -209,6 +209,9 @@ public class OAuthApplicationMgtListener extends AbstractApplicationMgtListener 
             throws IdentityOAuthAdminException, IdentityOAuth2Exception {
 
         Set<String> associatedOAuthConsumerKeys = getOAuthAppsAssociatedWithApplication(serviceProvider);
+        // Remove cache entries before deleting OAuth app data, since cache cleanup
+        // needs to look up app information that would no longer exist after deletion.
+        removeEntriesFromCache(associatedOAuthConsumerKeys);
         for (String consumerKey : associatedOAuthConsumerKeys) {
             if (log.isDebugEnabled()) {
                 log.debug("Removing OAuth application data for clientId: " + consumerKey + " associated with " +
@@ -216,7 +219,6 @@ public class OAuthApplicationMgtListener extends AbstractApplicationMgtListener 
             }
             OAuth2ServiceComponentHolder.getInstance().getOAuthAdminService().removeOAuthApplicationData(consumerKey);
         }
-        removeEntriesFromCache(associatedOAuthConsumerKeys);
     }
 
     public void onPreCreateInbound(ServiceProvider serviceProvider, boolean isUpdate) throws


### PR DESCRIPTION
## Summary

- Fixes spurious `InvalidOAuthClientException: application.not.found` ERROR log emitted when deleting applications from Devportal
- Root cause: `OAuthApplicationMgtListener.deleteAssociatedOAuthApps()` deleted OAuth app data before cleaning cache entries. The cache cleanup calls `OAuth2Util.isNonPersistentTokenEnabled()` which tries to look up the OAuth app by consumer key — but the app was already deleted
- Fix: Reorder `removeEntriesFromCache()` to run **before** `removeOAuthApplicationData()` so the lookup succeeds while app data still exists in the database

## Related Issue

Fixes https://github.com/wso2/api-manager/issues/4866

## Test plan

- [ ] Create an application in Devportal
- [ ] Generate production OAuth keys for the application
- [ ] Delete the application via `DELETE /api/am/devportal/v3/applications/{appId}`
- [ ] Verify HTTP 200 response
- [ ] Verify no `InvalidOAuthClientException` or `application.not.found` errors in `wso2carbon.log`
- [ ] Verify OAuth app, service provider, and cache entries are properly cleaned up

🤖 Generated with [Claude Code](https://claude.com/claude-code)