### PR TITLE
Fix spurious error logs when removing keys from developer portal

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuthApplicationMgtListener.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuthApplicationMgtListener.java
@@ -452,10 +452,19 @@ public class OAuthApplicationMgtListener extends AbstractApplicationMgtListener 
 
             AppInfoCache appInfoCache = AppInfoCache.getInstance();
             for (String oauthKey : consumerKeys) {
-                accessTokenDOSet.addAll(OAuthTokenPersistenceFactory.getInstance().getAccessTokenDAOImpl(oauthKey)
-                        .getActiveTokenSetWithTokenIdByConsumerKeyForOpenidScope(oauthKey));
-                authzCodeDOSet.addAll(OAuthTokenPersistenceFactory.getInstance()
-                        .getAuthorizationCodeDAO().getAuthorizationCodeDOSetByConsumerKeyForOpenidScope(oauthKey));
+                try {
+                    accessTokenDOSet.addAll(OAuthTokenPersistenceFactory.getInstance()
+                            .getAccessTokenDAOImpl(oauthKey)
+                            .getActiveTokenSetWithTokenIdByConsumerKeyForOpenidScope(oauthKey));
+                    authzCodeDOSet.addAll(OAuthTokenPersistenceFactory.getInstance()
+                            .getAuthorizationCodeDAO()
+                            .getAuthorizationCodeDOSetByConsumerKeyForOpenidScope(oauthKey));
+                } catch (IdentityOAuth2Exception e) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("OAuth application with consumer key: " + oauthKey + " may have been already " +
+                                "deleted. Skipping token and authorization code cache cleanup for this key.", e);
+                    }
+                }
                 // Remove client credential from AppInfoCache
                 appInfoCache.clearCacheEntry(oauthKey);
                 OAuthCache.getInstance().clearCacheEntry(new OAuthCacheKey(oauthKey));

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -5063,6 +5063,14 @@ public class OAuth2Util {
             OAuthAppDO appDO = getAppInformationByClientId(consumerKey);
             return StringUtils.equals(appDO.getTokenType(), JWT);
 
+        } catch (InvalidOAuthClientException e) {
+            // This can happen when the OAuth app has already been deleted (e.g., during DCR delete flow
+            // where the OAuth app is removed before the service provider deletion triggers cache cleanup).
+            if (log.isDebugEnabled()) {
+                log.debug("OAuth application not found for consumer key: " + consumerKey +
+                        ". The application may have been already deleted.", e);
+            }
+            return false;
         } catch (IdentityException e) {
             log.error("Error while retrieving the application information for the consumer key: " + consumerKey, e);
             return false;


### PR DESCRIPTION
## Summary
- Handle `InvalidOAuthClientException` gracefully in `OAuth2Util.isNonPersistentTokenEnabled()` to avoid error logs when the OAuth app has already been deleted during DCR delete flow
- Wrap token/authz code cache cleanup in `OAuthApplicationMgtListener.removeEntriesFromCache()` with try-catch to handle already-deleted OAuth apps
- Both changes downgrade the error to a debug-level log since this is an expected race condition during key removal

## Test plan
- [ ] Deploy patched API Manager and reproduce the key removal flow from developer portal
- [ ] Verify no error logs appear in `wso2carbon.log` after removing keys
- [ ] Verify key removal still functions correctly (HTTP 200 response)
- [ ] Run existing unit tests for `OAuthApplicationMgtListener` and `OAuth2Util`

Fixes: https://github.com/wso2/api-manager/issues/4860

🤖 Generated with [Claude Code](https://claude.com/claude-code)