### PR TITLE
Improve error message for invalid client in org context

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/OAuth2Service.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/OAuth2Service.java
@@ -461,7 +461,13 @@ public class OAuth2Service extends AbstractAdmin {
             OAuth2AccessTokenRespDTO tokenRespDTO = new OAuth2AccessTokenRespDTO();
             tokenRespDTO.setError(true);
             tokenRespDTO.setErrorCode(OAuth2ErrorCodes.INVALID_CLIENT);
-            tokenRespDTO.setErrorMsg("Invalid Client");
+            String errorMessage = "Invalid Client";
+            String appOrgId = PrivilegedCarbonContext.getThreadLocalCarbonContext()
+                    .getApplicationResidentOrganizationId();
+            if (StringUtils.isNotEmpty(appOrgId)) {
+                errorMessage = "Application is not available in the organization.";
+            }
+            tokenRespDTO.setErrorMsg(errorMessage);
             return tokenRespDTO;
         } catch (IdentityOAuth2ClientException e) {
             if (log.isDebugEnabled()) {

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/OAuth2ServiceTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/OAuth2ServiceTest.java
@@ -600,6 +600,31 @@ public class OAuth2ServiceTest {
     }
 
     @Test
+    public void testIssueAccessTokenWithOrgContextReturnsOrgSpecificError() throws IdentityException {
+
+        try (MockedStatic<IdentityTenantUtil> identityTenantUtil = mockStatic(IdentityTenantUtil.class);
+             MockedStatic<AccessTokenIssuer> accessTokenIssuer = mockStatic(AccessTokenIssuer.class)) {
+            identityTenantUtil.when(() -> IdentityTenantUtil.getTenantId(anyString())).thenReturn(-1234);
+            identityTenantUtil.when(() -> IdentityTenantUtil.getTenantDomain(-1234)).thenReturn("carbon.super");
+            AccessTokenIssuer mockAccessTokenIssuer = mock(AccessTokenIssuer.class);
+            accessTokenIssuer.when(AccessTokenIssuer::getInstance).thenReturn(mockAccessTokenIssuer);
+            when(mockAccessTokenIssuer.issue(any(OAuth2AccessTokenReqDTO.class)))
+                    .thenThrow(new InvalidOAuthClientException("application.not.found"));
+
+            PrivilegedCarbonContext.getThreadLocalCarbonContext()
+                    .setApplicationResidentOrganizationId("some-org-id");
+            try {
+                OAuth2AccessTokenRespDTO respDTO = oAuth2Service.issueAccessToken(new OAuth2AccessTokenReqDTO());
+                assertEquals(respDTO.getErrorCode(), OAuth2ErrorCodes.INVALID_CLIENT);
+                assertEquals(respDTO.getErrorMsg(), "Application is not available in the organization.");
+            } finally {
+                PrivilegedCarbonContext.getThreadLocalCarbonContext()
+                        .setApplicationResidentOrganizationId(null);
+            }
+        }
+    }
+
+    @Test
     public void testIsPKCESupportEnabled() {
 
         try (MockedStatic<OAuth2Util> oAuth2Util = mockStatic(OAuth2Util.class)) {


### PR DESCRIPTION
## Summary
- Returns a more descriptive error message ("Application is not available in the organization.") when an OAuth client is not found in an organization context, instead of the generic "Invalid Client" message.
- Adds unit test to verify the org-context-specific error message behavior.

Fixes https://github.com/wso2/product-is/issues/27163

## Test plan
- [x] Unit test added for org context error message
- [ ] Verify with a multi-org setup that the improved error message is returned when accessing an app not shared to the organization

🤖 Generated with [Claude Code](https://claude.com/claude-code)