### PR TITLE
Fix missing isk claim in ID token for Device Code App Native Auth flow

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/AuthzUtil.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/AuthzUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2025-2026, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -4988,6 +4988,7 @@ public class AuthzUtil {
         if (oAuthMessage.getProperty(IMPERSONATING_ACTOR) != null) {
             cacheEntry.setImpersonator(oAuthMessage.getProperty(IMPERSONATING_ACTOR).toString());
         }
+        cacheEntry.setSessionContextIdentifier(sessionDataCacheEntry.getSessionContextIdentifier());
 
         DeviceAuthorizationGrantCache.getInstance().addToCache(cacheKey, cacheEntry);
     }

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/util/AuthzUtilTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/util/AuthzUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2025-2026, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -118,6 +118,9 @@ import org.wso2.carbon.identity.oauth.endpoint.util.factory.Oauth2ScopeServiceFa
 import org.wso2.carbon.identity.oauth.endpoint.util.factory.SSOConsentServiceFactory;
 import org.wso2.carbon.identity.oauth.rar.model.AuthorizationDetail;
 import org.wso2.carbon.identity.oauth.rar.model.AuthorizationDetails;
+import org.wso2.carbon.identity.oauth2.device.cache.DeviceAuthorizationGrantCache;
+import org.wso2.carbon.identity.oauth2.device.cache.DeviceAuthorizationGrantCacheEntry;
+import org.wso2.carbon.identity.oauth2.device.cache.DeviceAuthorizationGrantCacheKey;
 import org.wso2.carbon.identity.oauth.tokenprocessor.TokenPersistenceProcessor;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2ClientException;
 import org.wso2.carbon.identity.oauth2.OAuth2ScopeService;
@@ -216,6 +219,8 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.FileAssert.fail;
+import static org.wso2.carbon.identity.common.testng.TestConstants.SESSION_ID;
+import static org.wso2.carbon.identity.oauth2.device.constants.Constants.DEVICE_CODE;
 import static org.wso2.carbon.identity.oauth2.util.OAuth2Util.EXP;
 import static org.wso2.carbon.identity.oauth2.util.OAuth2Util.NBF;
 import static org.wso2.carbon.identity.openidconnect.OIDCRequestObjectUtil.REQUEST_PARAM_VALUE_BUILDER;
@@ -2861,5 +2866,40 @@ public class AuthzUtilTest extends TestOAuthEndpointBase {
                         any(AuthenticatedUser.class))).thenReturn(new ConsentClaimsData());
 
         when(mockedSSOConsentService.isSSOConsentManagementEnabled(any())).thenReturn(isConsentMgtEnabled);
+    }
+
+    @Test(description = "Test addUserAttributesToCache copies sessionContextIdentifier to device code cache entry.")
+    public void testAddUserAttributesToCacheCopiesSessionContextIdentifier() throws Exception {
+
+        AuthenticatedUser loggedInUser = mock(AuthenticatedUser.class);
+        when(loggedInUser.getUserAttributes()).thenReturn(new HashMap<>());
+
+        SessionDataCacheEntry sessionDataCacheEntry = mock(SessionDataCacheEntry.class);
+        when(sessionDataCacheEntry.getLoggedInUser()).thenReturn(loggedInUser);
+        when(sessionDataCacheEntry.getSessionContextIdentifier()).thenReturn(SESSION_ID);
+
+        OAuthMessage mockOAuthMessage = mock(OAuthMessage.class);
+        when(mockOAuthMessage.getSessionDataCacheEntry()).thenReturn(sessionDataCacheEntry);
+        when(mockOAuthMessage.getProperty(any())).thenReturn(null);
+
+        ArgumentCaptor<DeviceAuthorizationGrantCacheEntry> cacheEntryCaptor =
+                ArgumentCaptor.forClass(DeviceAuthorizationGrantCacheEntry.class);
+
+        try (MockedStatic<DeviceAuthorizationGrantCache> mockedDeviceCache =
+                     mockStatic(DeviceAuthorizationGrantCache.class)) {
+
+            DeviceAuthorizationGrantCache mockCache = mock(DeviceAuthorizationGrantCache.class);
+            mockedDeviceCache.when(DeviceAuthorizationGrantCache::getInstance).thenReturn(mockCache);
+
+            Method method = AuthzUtil.class.getDeclaredMethod(
+                    "addUserAttributesToCache", OAuthMessage.class, String.class);
+            method.setAccessible(true);
+            method.invoke(null, mockOAuthMessage, DEVICE_CODE);
+
+            verify(mockCache).addToCache(any(DeviceAuthorizationGrantCacheKey.class), cacheEntryCaptor.capture());
+            DeviceAuthorizationGrantCacheEntry capturedEntry = cacheEntryCaptor.getValue();
+            assertEquals(capturedEntry.getSessionContextIdentifier(), SESSION_ID,
+                    "sessionContextIdentifier should be copied from SessionDataCacheEntry");
+        }
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/pom.xml
+++ b/components/org.wso2.carbon.identity.oauth/pom.xml
@@ -57,6 +57,11 @@
             <groupId>commons-lang.wso2</groupId>
             <artifactId>commons-lang</artifactId>
         </dependency>
+        <dependency>
+            <groupId>de.ruedigermoeller</groupId>
+            <artifactId>fst</artifactId>
+            <scope>provided</scope>
+        </dependency>
          <dependency>
             <groupId>org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/device/cache/DeviceAuthorizationGrantCacheEntry.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/device/cache/DeviceAuthorizationGrantCacheEntry.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.oauth2.device.cache;
 
+import org.nustaq.serialization.annotations.Version;
 import org.wso2.carbon.identity.application.common.model.ClaimMapping;
 import org.wso2.carbon.identity.oauth.cache.CacheEntry;
 
@@ -33,6 +34,8 @@ public class DeviceAuthorizationGrantCacheEntry extends CacheEntry {
     private Map<ClaimMapping, String> userAttributes;
     private Map<ClaimMapping, String> mappedRemoteClaims;
     private String impersonator;
+
+    @Version(1)
     private String sessionContextIdentifier;
 
     public DeviceAuthorizationGrantCacheEntry(Map<ClaimMapping, String> userAttributes) {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/device/cache/DeviceAuthorizationGrantCacheEntry.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/device/cache/DeviceAuthorizationGrantCacheEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com)
+ * Copyright (c) 2023-2026, WSO2 LLC. (https://www.wso2.com)
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -33,6 +33,7 @@ public class DeviceAuthorizationGrantCacheEntry extends CacheEntry {
     private Map<ClaimMapping, String> userAttributes;
     private Map<ClaimMapping, String> mappedRemoteClaims;
     private String impersonator;
+    private String sessionContextIdentifier;
 
     public DeviceAuthorizationGrantCacheEntry(Map<ClaimMapping, String> userAttributes) {
 
@@ -78,5 +79,15 @@ public class DeviceAuthorizationGrantCacheEntry extends CacheEntry {
     public void setImpersonator(String impersonator) {
 
         this.impersonator = impersonator;
+    }
+
+    public String getSessionContextIdentifier() {
+
+        return sessionContextIdentifier;
+    }
+
+    public void setSessionContextIdentifier(String sessionContextIdentifier) {
+
+        this.sessionContextIdentifier = sessionContextIdentifier;
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuer.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2025, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2017-2026, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -128,6 +128,7 @@ import static org.wso2.carbon.identity.oauth2.Oauth2ScopeConstants.CONSOLE_SCOPE
 import static org.wso2.carbon.identity.oauth2.Oauth2ScopeConstants.INTERNAL_SCOPE_PREFIX;
 import static org.wso2.carbon.identity.oauth2.Oauth2ScopeConstants.SYSTEM_SCOPE;
 import static org.wso2.carbon.identity.oauth2.device.constants.Constants.DEVICE_FLOW_GRANT_TYPE;
+import static org.wso2.carbon.identity.oauth2.token.handlers.grant.RefreshGrantHandler.SESSION_IDENTIFIER;
 import static org.wso2.carbon.identity.oauth2.util.OAuth2Util.EXTENDED_REFRESH_TOKEN_DEFAULT_TIME;
 import static org.wso2.carbon.identity.oauth2.util.OAuth2Util.INTERNAL_LOGIN_SCOPE;
 import static org.wso2.carbon.identity.oauth2.util.OAuth2Util.validateRequestTenantDomainWithOrgHierarchy;
@@ -225,6 +226,11 @@ public class AccessTokenIssuer {
             AuthorizationGrantCacheEntry authorizationGrantCacheEntry =
                     getAuthzGrantCacheEntryFromDeviceCode(tokenReqDTO);
             persistImpersonationInfoToTokenReqCtx(authorizationGrantCacheEntry, tokReqMsgCtx);
+            if (authorizationGrantCacheEntry != null
+                    && authorizationGrantCacheEntry.getSessionContextIdentifier() != null) {
+                tokReqMsgCtx.addProperty(SESSION_IDENTIFIER,
+                        authorizationGrantCacheEntry.getSessionContextIdentifier());
+            }
         }
 
         triggerPreListeners(tokenReqDTO, tokReqMsgCtx, isRefreshRequest);
@@ -829,6 +835,8 @@ public class AccessTokenIssuer {
                 authorizationGrantCacheEntry.setMappedRemoteClaims(cacheEntry
                         .getMappedRemoteClaims());
             }
+            authorizationGrantCacheEntry.setSessionContextIdentifier(
+                    cacheEntry.getSessionContextIdentifier());
             persistImpersonationInfoToAuthzGrantCacheEntry(cacheEntry, authorizationGrantCacheEntry);
             return Optional.of(authorizationGrantCacheEntry);
         }

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/TestConstants.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/TestConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2025, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2017-2026, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -28,6 +28,7 @@ public class TestConstants {
     public static final String ATTRIBUTE_CONSUMER_INDEX = "1234567890";
     public static final String SAMPLE_NAME_ID_FORMAT = "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress";
     public static final String SESSION_ID = "sessionId4567890";
+    public static final String DEVICE_CODE = "test-device-code";
     public static final String SAMPLE_SERVER_URL = "https://localhost:9443/server";
     public static final String CLAIM_URI1 = "http://wso2.org/claimuri1";
     public static final String CLAIM_URI2 = "http://wso2.org/claimuri2";
@@ -75,6 +76,7 @@ public class TestConstants {
     public static final String ACCESS_TOKEN = "d43e8da324a33bdc941b9b95cad6a6a2";
     public static final String REFRESH_TOKEN = "2881c5a375d03dc0ba12787386451b29";
     public static final String APP_TYPE = "oauth2";
+    public static final String ISK_CLAIM_VALUE = "session-key";
 
     //UnAuthorized Client for Implicit Grant
     public static final String CLIENT_ID_UNAUTHORIZED_CLIENT = "dabfba9390aa423f8b04332794d83614";

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuerTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2025, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2017-2026, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -26,6 +26,9 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.wso2.carbon.identity.oauth.dao.OAuthAppDO;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
+import org.wso2.carbon.identity.oauth2.device.cache.DeviceAuthorizationGrantCache;
+import org.wso2.carbon.identity.oauth2.device.cache.DeviceAuthorizationGrantCacheEntry;
+import org.wso2.carbon.identity.oauth2.device.cache.DeviceAuthorizationGrantCacheKey;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2AccessTokenReqDTO;
 import org.wso2.carbon.identity.oauth2.token.handlers.grant.AuthorizationGrantHandler;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
@@ -37,6 +40,8 @@ import org.wso2.carbon.identity.oauth2.dto.OAuth2AccessTokenRespDTO;
 import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
 
 import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -44,6 +49,8 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.GrantTypes.REFRESH_TOKEN;
+import static org.wso2.carbon.identity.oauth2.TestConstants.DEVICE_CODE;
+import static org.wso2.carbon.identity.oauth2.TestConstants.SESSION_ID;
 
 import org.apache.commons.logging.Log;
 import java.lang.reflect.Field;
@@ -131,7 +138,7 @@ public class AccessTokenIssuerTest {
     }
 
     @Test
-        public void testValidateGrantExceptionLogsSanitizedError() throws Exception {
+    public void testValidateGrantExceptionLogsSanitizedError() throws Exception {
 
         // Enable debug at JUL level so that commons-logging Jdk14Logger reports debug enabled.
         java.util.logging.Logger.getLogger(AccessTokenIssuer.class.getName())
@@ -166,7 +173,7 @@ public class AccessTokenIssuerTest {
             Assert.assertTrue(resp.isError());
             Assert.assertEquals(resp.getErrorMsg(), "sensitive message");
         }
-        }
+    }
 
     @Test
     public void testHandleTokenBindingForRefreshTokenGrant() throws Exception {
@@ -185,6 +192,36 @@ public class AccessTokenIssuerTest {
 
         method.invoke(issuer, tokenReqDTO, REFRESH_TOKEN, tokReqMsgCtx, oAuthAppDO);
         Mockito.verify(tokReqMsgCtx, never()).setTokenBinding(any());
+    }
+
+    @Test
+    public void testGetAuthzGrantCacheEntryFromDeviceCodeCopiesSessionContextIdentifier() throws Exception {
+
+        DeviceAuthorizationGrantCacheEntry deviceCacheEntry = new DeviceAuthorizationGrantCacheEntry(new HashMap<>());
+        deviceCacheEntry.setSessionContextIdentifier(SESSION_ID);
+
+        try (MockedStatic<DeviceAuthorizationGrantCache> mockedDeviceCache =
+                     Mockito.mockStatic(DeviceAuthorizationGrantCache.class)) {
+
+            DeviceAuthorizationGrantCache mockCache = Mockito.mock(DeviceAuthorizationGrantCache.class);
+            mockedDeviceCache.when(DeviceAuthorizationGrantCache::getInstance).thenReturn(mockCache);
+            when(mockCache.getValueFromCache(any(DeviceAuthorizationGrantCacheKey.class))).thenReturn(deviceCacheEntry);
+
+            AccessTokenIssuer issuer = Mockito.mock(AccessTokenIssuer.class, Mockito.CALLS_REAL_METHODS);
+
+            Method method = AccessTokenIssuer.class.getDeclaredMethod(
+                    "getAuthzGrantCacheEntryFromDeviceCode", String.class);
+            method.setAccessible(true);
+
+            @SuppressWarnings("unchecked")
+            Optional<AuthorizationGrantCacheEntry> result =
+                    (Optional<AuthorizationGrantCacheEntry>) method.invoke(issuer, DEVICE_CODE);
+
+            Assert.assertTrue(result.isPresent(),
+                    "AuthorizationGrantCacheEntry should be present when device code cache has an entry");
+            Assert.assertEquals(result.get().getSessionContextIdentifier(), SESSION_ID,
+                    "sessionContextIdentifier should be copied from DeviceAuthorizationGrantCacheEntry");
+        }
     }
 
 //    @BeforeMethod

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/openidconnect/DefaultIDTokenBuilderTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/openidconnect/DefaultIDTokenBuilderTest.java
@@ -37,6 +37,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.wso2.carbon.base.MultitenantConstants;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.identity.action.execution.api.service.ActionExecutorService;
 import org.wso2.carbon.identity.application.authentication.framework.AuthenticationMethodNameTranslator;
 import org.wso2.carbon.identity.application.authentication.framework.internal.impl.AuthenticationMethodNameTranslatorImpl;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
@@ -119,7 +120,9 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCClaims.PHONE_NUMBER_VERIFIED;
+import static org.wso2.carbon.identity.oauth2.device.constants.Constants.DEVICE_FLOW_GRANT_TYPE;
 import static org.wso2.carbon.identity.oauth2.test.utils.CommonTestUtils.setFinalStatic;
+import static org.wso2.carbon.identity.oauth2.token.handlers.grant.RefreshGrantHandler.SESSION_IDENTIFIER;
 import static org.wso2.carbon.utils.multitenancy.MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
 import static org.wso2.carbon.utils.multitenancy.MultitenantConstants.SUPER_TENANT_ID;
 
@@ -137,6 +140,7 @@ public class DefaultIDTokenBuilderTest {
     private static final String CLIENT_ID = TestConstants.CLIENT_ID;
     private static final String EC_CLIENT_ID  = TestConstants.EC_CLIENT_ID;
     private static final String ACCESS_TOKEN = TestConstants.ACCESS_TOKEN;
+    private static final String ISK_CLAIM_VALUE = TestConstants.ISK_CLAIM_VALUE;
     private static final String DUMMY_TOKEN_ENDPOINT = "https://localhost:9443/oauth2/token";
     private DefaultIDTokenBuilder defaultIDTokenBuilder;
     private OAuthTokenReqMessageContext messageContext;
@@ -352,6 +356,30 @@ public class DefaultIDTokenBuilderTest {
         Assert.assertTrue(issueTime <= (new Date()).getTime());
         Assert.assertNull(IdentityUtil.threadLocalProperties.get().get(IdentityCoreConstants.IS_SYSTEM_APPLICATION),
                 "Thread local should be cleaned up after ID token building.");
+    }
+
+    @Test
+    public void testBuildIDTokenForDeviceCodeGrantWithSessionIdentifier() throws Exception {
+
+        when(OrganizationManagementUtil.isOrganization(anyString())).thenReturn(false);
+
+        OAuth2AccessTokenRespDTO deviceTokenRespDTO = new OAuth2AccessTokenRespDTO();
+        deviceTokenRespDTO.setAccessToken(ACCESS_TOKEN);
+
+        AuthenticatedUser deviceUser = getDefaultAuthenticatedUserFederatedUser();
+        OAuthTokenReqMessageContext deviceMessageContext = getTokenReqMessageContextForUser(deviceUser, CLIENT_ID);
+        deviceMessageContext.getOauth2AccessTokenReqDTO().setGrantType(DEVICE_FLOW_GRANT_TYPE);
+        deviceMessageContext.addProperty(SESSION_IDENTIFIER, ISK_CLAIM_VALUE);
+
+        OAuthAppDO entry = getOAuthAppDO(CLIENT_ID);
+        AppInfoCache.getInstance().addToCache(CLIENT_ID, entry);
+
+        mockRealmService();
+        String idToken = defaultIDTokenBuilder.buildIDToken(deviceMessageContext, deviceTokenRespDTO);
+        JWTClaimsSet claims = SignedJWT.parse(idToken).getJWTClaimsSet();
+        Assert.assertEquals(claims.getAudience().get(0), CLIENT_ID);
+        Assert.assertEquals(claims.getClaim("isk"), ISK_CLAIM_VALUE,
+                "isk claim should be present in ID token for device code grant when SESSION_IDENTIFIER is set.");
     }
 
     @Test
@@ -687,6 +715,7 @@ public class DefaultIDTokenBuilderTest {
                 .setUserRealm(realmService.getTenantUserRealm(SUPER_TENANT_ID));
         IdpMgtServiceComponentHolder.getInstance().setRealmService(realmService);
         OAuthComponentServiceHolder.getInstance().setRealmService(realmService);
+        OAuthComponentServiceHolder.getInstance().setActionExecutorService(mock(ActionExecutorService.class));
         TestUtil.mockRealmInIdentityTenantUtil(TestConstants.TENANT_ID, TestConstants.TENANT_DOMAIN);
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -626,6 +626,13 @@
                 <artifactId>org.wso2.carbon.identity.multi.attribute.login.mgt</artifactId>
                 <version>${carbon.identity.framework.version}</version>
             </dependency>
+            <dependency>
+                <groupId>de.ruedigermoeller</groupId>
+                <artifactId>fst</artifactId>
+                <version>${de.ruedigermoeller.fst.version}</version>
+                <scope>provided</scope>
+            </dependency>
+
             <!--Test Dependencies-->
             <dependency>
                 <groupId>junit</groupId>
@@ -1140,6 +1147,8 @@
 
         <!--Identity Apps-->
         <authentication.portal.version>1.0.51</authentication.portal.version>
+
+        <de.ruedigermoeller.fst.version>2.56</de.ruedigermoeller.fst.version>
     </properties>
 
 </project>


### PR DESCRIPTION
### Proposed changes in this pull request
$subject

Issues: https://github.com/wso2/product-is/issues/27473

The isk claim was absent from ID tokens issued via the Device Code grant when App Native Authentication was enabled.

**Root cause:** The session context identifier was never propagated through the Device Code flow's cache pipeline.

1. `DeviceAuthorizationGrantCacheEntry` had no `sessionContextIdentifier` field, so it was dropped when user attributes were cached after device authorization.
2. `AccessTokenIssuer.getAuthzGrantCacheEntryFromDeviceCode()` did not copy `sessionContextIdentifier` when converting `DeviceAuthorizationGrantCacheEntry` to `AuthorizationGrantCacheEntry`.
3. The `SESSION_IDENTIFIER` property was never set on `OAuthTokenReqMessageContext` before ID token building, so DefaultIDTokenBuilder's fallback lookup also returned null on the first token request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session context propagation in device authorization and token issuance flows so the session identifier is preserved across device-code steps and reflected during token issuance.
* **New Features**
  * ID tokens issued for device-flow requests can carry the session identifier (isk) claim for stronger session linking.
* **Tests**
  * Added/extended unit tests covering device-flow session propagation.
* **Chores**
  * Updated build metadata for serialization handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->