### PR TITLE
Clear OAuth cache using persisted scopes during token revocation

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthUtil.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthUtil.java
@@ -50,6 +50,7 @@ import org.wso2.carbon.identity.oauth.cache.AuthorizationGrantCacheKey;
 import org.wso2.carbon.identity.oauth.cache.OAuthCache;
 import org.wso2.carbon.identity.oauth.cache.OAuthCacheKey;
 import org.wso2.carbon.identity.oauth.common.OAuthConstants;
+import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
 import org.wso2.carbon.identity.oauth.dao.OAuthAppDO;
 import org.wso2.carbon.identity.oauth.dto.OAuthConsumerAppDTO;
 import org.wso2.carbon.identity.oauth.event.OAuthEventInterceptor;
@@ -62,6 +63,8 @@ import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2ServerException;
 import org.wso2.carbon.identity.oauth2.dao.OAuthTokenPersistenceFactory;
 import org.wso2.carbon.identity.oauth2.dao.SharedAppResolveDAO;
+import org.wso2.carbon.identity.oauth2.dto.OAuthRevocationRequestDTO;
+import org.wso2.carbon.identity.oauth2.internal.OAuth2ServiceComponentHolder;
 import org.wso2.carbon.identity.oauth2.model.AccessTokenDO;
 import org.wso2.carbon.identity.oauth2.model.AuthzCodeDO;
 import org.wso2.carbon.identity.oauth2.model.OAuthAppInfo;
@@ -1575,6 +1578,59 @@ public final class OAuthUtil {
         } catch (org.wso2.carbon.user.api.UserStoreException e) {
             throw new UserStoreException("Failed to retrieve the user store domain for the parent user with ID: "
                     + parentUserId + " in tenant domain: " + tenantDomain, e);
+        }
+    }
+
+    /**
+     * Triggers a cache clearance for the original scopes associated with a token.
+     * This is necessary because the scopes in the provided {@code accessTokenDO} might have been
+     * filtered or mutated during the request lifecycle. Fetch the original scopes from the
+     * database to ensure the cache is cleared using the correct keys.
+     *
+     * @param tokenBindingReference The token binding identifier.
+     * @param accessTokenDO        The current (potentially mutated) access token object.
+     * @param revokeRequestDTO     The revocation request details containing the consumer key.
+     */
+    public static void clearOAuthCacheUsingPersistedScopes(String tokenBindingReference, AccessTokenDO accessTokenDO,
+                                                           OAuthRevocationRequestDTO revokeRequestDTO) {
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Clearing OAuth cache for persisted scopes. Consumer key: " + revokeRequestDTO.getConsumerKey());
+        }
+
+        if (OAuthServerConfiguration.getInstance().getAllowedScopes().isEmpty()) {
+            return;
+        }
+
+        String accessToken = accessTokenDO.getAccessToken();
+        if (StringUtils.isBlank(accessToken)) {
+            return;
+        }
+
+        try {
+            // The in-memory scopes may be mutated during validation. To avoid cache-key
+            // mismatches, retrieve the original scopes from the database before clearing
+            // the OAuth cache.
+            AccessTokenDO dbTokenDO = OAuth2ServiceComponentHolder.getInstance().getTokenProvider()
+                    .getVerifiedAccessToken(accessToken, true);
+            if (dbTokenDO == null || dbTokenDO.getScope() == null || dbTokenDO.getScope().length == 0) {
+                return;
+            }
+
+            String dbTokenScopeString = OAuth2Util.buildScopeString(dbTokenDO.getScope());
+            OAuthUtil.clearOAuthCache(revokeRequestDTO.getConsumerKey(),
+                    accessTokenDO.getAuthzUser(), dbTokenScopeString, tokenBindingReference);
+            OAuthUtil.clearOAuthCache(revokeRequestDTO.getConsumerKey(),
+                    accessTokenDO.getAuthzUser(), dbTokenScopeString);
+
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Successfully cleared OAuth cache entries for consumer key: " +
+                        revokeRequestDTO.getConsumerKey());
+            }
+
+        } catch (IdentityOAuth2Exception e) {
+            LOG.error("Error while clearing cache entries for extended scopes. Consumer key: "
+                    + revokeRequestDTO.getConsumerKey(), e);
         }
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/OAuth2Service.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/OAuth2Service.java
@@ -749,6 +749,8 @@ public class OAuth2Service extends AbstractAdmin {
                             getRevocationProcessor(revokeRequestDTO.getConsumerKey(), tenantDomain)
                                     .revokeAccessToken(revokeRequestDTO, accessTokenDO);
                         }
+                        OAuthUtil.clearOAuthCacheUsingPersistedScopes(tokenBindingReference,
+                                accessTokenDO, revokeRequestDTO);
                         addRevokeResponseHeaders(revokeResponseDTO,
                                 revokeRequestDTO.getToken(),
                                 accessTokenDO.getRefreshToken(),

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/OAuthUtilTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/OAuthUtilTest.java
@@ -36,6 +36,7 @@ import org.wso2.carbon.identity.application.common.model.ServiceProvider;
 import org.wso2.carbon.identity.application.common.model.User;
 import org.wso2.carbon.identity.application.mgt.ApplicationConstants;
 import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
+import org.wso2.carbon.identity.base.IdentityConstants;
 import org.wso2.carbon.identity.common.testng.WithCarbonHome;
 import org.wso2.carbon.identity.common.testng.WithRealmService;
 import org.wso2.carbon.identity.core.util.IdentityDatabaseUtil;
@@ -46,14 +47,23 @@ import org.wso2.carbon.identity.oauth.cache.AuthorizationGrantCache;
 import org.wso2.carbon.identity.oauth.cache.CacheEntry;
 import org.wso2.carbon.identity.oauth.cache.OAuthCache;
 import org.wso2.carbon.identity.oauth.cache.OAuthCacheKey;
+import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
+import org.wso2.carbon.identity.oauth.dao.OAuthAppDO;
+import org.wso2.carbon.identity.oauth.dto.OAuthConsumerAppDTO;
+import org.wso2.carbon.identity.oauth.event.OAuthEventInterceptor;
 import org.wso2.carbon.identity.oauth.internal.OAuthComponentServiceHolder;
 import org.wso2.carbon.identity.oauth.internal.util.AccessTokenEventUtil;
+import org.wso2.carbon.identity.oauth.util.ClaimCache;
+import org.wso2.carbon.identity.oauth.util.ClaimCacheKey;
+import org.wso2.carbon.identity.oauth2.IdentityOAuth2ClientException;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
+import org.wso2.carbon.identity.oauth2.IdentityOAuth2ServerException;
 import org.wso2.carbon.identity.oauth2.dao.AccessTokenDAO;
 import org.wso2.carbon.identity.oauth2.dao.AuthorizationCodeDAO;
 import org.wso2.carbon.identity.oauth2.dao.AuthorizationCodeDAOImpl;
 import org.wso2.carbon.identity.oauth2.dao.OAuthTokenPersistenceFactory;
 import org.wso2.carbon.identity.oauth2.dao.TokenManagementDAO;
+import org.wso2.carbon.identity.oauth2.dto.OAuthRevocationRequestDTO;
 import org.wso2.carbon.identity.oauth2.model.AccessTokenDO;
 import org.wso2.carbon.identity.oauth2.model.AuthzCodeDO;
 import org.wso2.carbon.identity.oauth2.model.OAuthAppInfo;
@@ -806,6 +816,538 @@ public class OAuthUtilTest {
 
             // Should not throw; IdentityOAuth2Exception is caught and logged internally.
             OAuthUtil.removeAuthzGrantCacheForUser(userName, userStoreManager);
+        }
+    }
+
+    @Test
+    public void testClearOAuthCacheUsingPersistedScopes_WhenAllowedScopesIsEmpty() throws Exception {
+
+        try (MockedStatic<OAuthServerConfiguration> oAuthServerConfigStatic =
+                     mockStatic(OAuthServerConfiguration.class)) {
+            OAuthServerConfiguration mockServerConfig = mock(OAuthServerConfiguration.class);
+            oAuthServerConfigStatic.when(OAuthServerConfiguration::getInstance).thenReturn(mockServerConfig);
+            when(mockServerConfig.getAllowedScopes()).thenReturn(Collections.emptyList());
+
+            AccessTokenDO accessTokenDO = new AccessTokenDO();
+            accessTokenDO.setAccessToken("testAccessToken");
+            OAuthRevocationRequestDTO revokeRequestDTO = mock(OAuthRevocationRequestDTO.class);
+
+            OAuthUtil.clearOAuthCacheUsingPersistedScopes("tokenBindingRef",
+             accessTokenDO, revokeRequestDTO);
+
+            oAuth2Util.verify(() -> OAuth2Util.findAccessToken(anyString(), anyBoolean()), never());
+        }
+    }
+
+    @Test
+    public void testClearOAuthCacheUsingPersistedScopes_WhenAccessTokenIsBlank() throws Exception {
+
+        try (MockedStatic<OAuthServerConfiguration> oAuthServerConfigStatic =
+                     mockStatic(OAuthServerConfiguration.class)) {
+            OAuthServerConfiguration mockServerConfig = mock(OAuthServerConfiguration.class);
+            oAuthServerConfigStatic.when(OAuthServerConfiguration::getInstance).thenReturn(mockServerConfig);
+            when(mockServerConfig.getAllowedScopes()).thenReturn(Collections.singletonList("openid"));
+
+            // Access token is not set — defaults to null (blank).
+            AccessTokenDO accessTokenDO = new AccessTokenDO();
+            OAuthRevocationRequestDTO revokeRequestDTO = mock(OAuthRevocationRequestDTO.class);
+
+            OAuthUtil.clearOAuthCacheUsingPersistedScopes("tokenBindingRef",
+             accessTokenDO, revokeRequestDTO);
+
+            oAuth2Util.verify(() -> OAuth2Util.findAccessToken(anyString(), anyBoolean()), never());
+        }
+    }
+
+    @Test
+    public void testClearOAuthCacheUsingPersistedScopes_WhenDbTokenIsNull() throws Exception {
+
+        try (MockedStatic<OAuthServerConfiguration> oAuthServerConfigStatic =
+                     mockStatic(OAuthServerConfiguration.class);
+             MockedStatic<OAuthUtil> mockedOAuthUtil = mockStatic(OAuthUtil.class)) {
+            OAuthServerConfiguration mockServerConfig = mock(OAuthServerConfiguration.class);
+            oAuthServerConfigStatic.when(OAuthServerConfiguration::getInstance).thenReturn(mockServerConfig);
+            when(mockServerConfig.getAllowedScopes()).thenReturn(Collections.singletonList("openid"));
+
+            oAuth2Util.when(() -> OAuth2Util.findAccessToken(eq("testAccessToken"), eq(true))).thenReturn(null);
+
+            mockedOAuthUtil.when(() -> OAuthUtil.clearOAuthCacheUsingPersistedScopes(
+                    anyString(), any(AccessTokenDO.class), any(OAuthRevocationRequestDTO.class)))
+                    .thenCallRealMethod();
+
+            AccessTokenDO accessTokenDO = new AccessTokenDO();
+            accessTokenDO.setAccessToken("testAccessToken");
+            OAuthRevocationRequestDTO revokeRequestDTO = mock(OAuthRevocationRequestDTO.class);
+
+            OAuthUtil.clearOAuthCacheUsingPersistedScopes("tokenBindingRef", accessTokenDO, revokeRequestDTO);
+
+            mockedOAuthUtil.verify(() -> OAuthUtil.clearOAuthCache(
+                    anyString(), any(AuthenticatedUser.class), anyString(), anyString()), never());
+            mockedOAuthUtil.verify(() -> OAuthUtil.clearOAuthCache(
+                    anyString(), any(AuthenticatedUser.class), anyString()), never());
+        }
+    }
+
+    @Test
+    public void testClearOAuthCacheUsingPersistedScopes_WhenDbTokenScopeIsNull() throws Exception {
+
+        try (MockedStatic<OAuthServerConfiguration> oAuthServerConfigStatic =
+                     mockStatic(OAuthServerConfiguration.class);
+             MockedStatic<OAuthUtil> mockedOAuthUtil = mockStatic(OAuthUtil.class)) {
+            OAuthServerConfiguration mockServerConfig = mock(OAuthServerConfiguration.class);
+            oAuthServerConfigStatic.when(OAuthServerConfiguration::getInstance).thenReturn(mockServerConfig);
+            when(mockServerConfig.getAllowedScopes()).thenReturn(Collections.singletonList("openid"));
+
+            AccessTokenDO dbTokenDO = new AccessTokenDO();
+            dbTokenDO.setScope(null);
+            oAuth2Util.when(() -> OAuth2Util.findAccessToken(eq("testAccessToken"), eq(true))).thenReturn(dbTokenDO);
+
+            mockedOAuthUtil.when(() -> OAuthUtil.clearOAuthCacheUsingPersistedScopes(
+                    anyString(), any(AccessTokenDO.class), any(OAuthRevocationRequestDTO.class)))
+                    .thenCallRealMethod();
+
+            AccessTokenDO accessTokenDO = new AccessTokenDO();
+            accessTokenDO.setAccessToken("testAccessToken");
+            OAuthRevocationRequestDTO revokeRequestDTO = mock(OAuthRevocationRequestDTO.class);
+
+            OAuthUtil.clearOAuthCacheUsingPersistedScopes("tokenBindingRef",
+             accessTokenDO, revokeRequestDTO);
+
+            mockedOAuthUtil.verify(() -> OAuthUtil.clearOAuthCache(
+                    anyString(), any(AuthenticatedUser.class), anyString(), anyString()), never());
+            mockedOAuthUtil.verify(() -> OAuthUtil.clearOAuthCache(
+                    anyString(), any(AuthenticatedUser.class), anyString()), never());
+        }
+    }
+
+    @Test
+    public void testClearOAuthCacheUsingPersistedScopes_WhenDbTokenScopeIsEmpty() throws Exception {
+
+        try (MockedStatic<OAuthServerConfiguration> oAuthServerConfigStatic =
+                     mockStatic(OAuthServerConfiguration.class);
+             MockedStatic<OAuthUtil> mockedOAuthUtil = mockStatic(OAuthUtil.class)) {
+            OAuthServerConfiguration mockServerConfig = mock(OAuthServerConfiguration.class);
+            oAuthServerConfigStatic.when(OAuthServerConfiguration::getInstance).thenReturn(mockServerConfig);
+            when(mockServerConfig.getAllowedScopes()).thenReturn(Collections.singletonList("openid"));
+
+            AccessTokenDO dbTokenDO = new AccessTokenDO();
+            dbTokenDO.setScope(new String[0]);
+            oAuth2Util.when(() -> OAuth2Util.findAccessToken(eq("testAccessToken"), eq(true))).thenReturn(dbTokenDO);
+
+            mockedOAuthUtil.when(() -> OAuthUtil.clearOAuthCacheUsingPersistedScopes(
+                    anyString(), any(AccessTokenDO.class), any(OAuthRevocationRequestDTO.class)))
+                    .thenCallRealMethod();
+
+            AccessTokenDO accessTokenDO = new AccessTokenDO();
+            accessTokenDO.setAccessToken("testAccessToken");
+            OAuthRevocationRequestDTO revokeRequestDTO = mock(OAuthRevocationRequestDTO.class);
+
+            OAuthUtil.clearOAuthCacheUsingPersistedScopes("tokenBindingRef",
+             accessTokenDO, revokeRequestDTO);
+
+            mockedOAuthUtil.verify(() -> OAuthUtil.clearOAuthCache(
+                    anyString(), any(AuthenticatedUser.class), anyString(), anyString()), never());
+            mockedOAuthUtil.verify(() -> OAuthUtil.clearOAuthCache(
+                    anyString(), any(AuthenticatedUser.class), anyString()), never());
+        }
+    }
+
+    @Test
+    public void testClearOAuthCacheUsingPersistedScopes_ClearsCacheWithPersistedScopes() throws Exception {
+
+        String tokenBindingReference = "tokenBindingRef";
+        String accessToken = "testAccessToken";
+        String consumerKey = "testConsumerKey";
+        String[] dbScopes = {"scope1", "scope2"};
+        String dbScopeString = "scope1 scope2";
+
+        try (MockedStatic<OAuthServerConfiguration> oAuthServerConfigStatic =
+                     mockStatic(OAuthServerConfiguration.class);
+             MockedStatic<OAuthUtil> mockedOAuthUtil = mockStatic(OAuthUtil.class)) {
+            OAuthServerConfiguration mockServerConfig = mock(OAuthServerConfiguration.class);
+            oAuthServerConfigStatic.when(OAuthServerConfiguration::getInstance).thenReturn(mockServerConfig);
+            when(mockServerConfig.getAllowedScopes()).thenReturn(Collections.singletonList("scope1"));
+
+            AccessTokenDO dbTokenDO = new AccessTokenDO();
+            dbTokenDO.setScope(dbScopes);
+            oAuth2Util.when(() -> OAuth2Util.findAccessToken(eq(accessToken), eq(true))).thenReturn(dbTokenDO);
+
+            oAuth2Util.when(() -> OAuth2Util.buildScopeString(dbScopes)).thenReturn(dbScopeString);
+
+            mockedOAuthUtil.when(() -> OAuthUtil.clearOAuthCacheUsingPersistedScopes(
+                    anyString(), any(AccessTokenDO.class), any(OAuthRevocationRequestDTO.class)))
+                    .thenCallRealMethod();
+
+            AuthenticatedUser authzUser = mock(AuthenticatedUser.class);
+            AccessTokenDO accessTokenDO = new AccessTokenDO();
+            accessTokenDO.setAccessToken(accessToken);
+            accessTokenDO.setAuthzUser(authzUser);
+
+            OAuthRevocationRequestDTO revokeRequestDTO = mock(OAuthRevocationRequestDTO.class);
+            when(revokeRequestDTO.getConsumerKey()).thenReturn(consumerKey);
+
+            OAuthUtil.clearOAuthCacheUsingPersistedScopes(tokenBindingReference, accessTokenDO, revokeRequestDTO);
+
+            mockedOAuthUtil.verify(() -> OAuthUtil.clearOAuthCache(
+                    eq(consumerKey), eq(authzUser), eq(dbScopeString), eq(tokenBindingReference)), times(1));
+            mockedOAuthUtil.verify(() -> OAuthUtil.clearOAuthCache(
+                    eq(consumerKey), eq(authzUser), eq(dbScopeString)), times(1));
+        }
+    }
+
+    @Test
+    public void testClearOAuthCacheUsingPersistedScopes_WhenDaoThrowsException() throws Exception {
+
+        try (MockedStatic<OAuthServerConfiguration> oAuthServerConfigStatic =
+                     mockStatic(OAuthServerConfiguration.class);
+             MockedStatic<OAuthUtil> mockedOAuthUtil = mockStatic(OAuthUtil.class)) {
+            OAuthServerConfiguration mockServerConfig = mock(OAuthServerConfiguration.class);
+            oAuthServerConfigStatic.when(OAuthServerConfiguration::getInstance).thenReturn(mockServerConfig);
+            when(mockServerConfig.getAllowedScopes()).thenReturn(Collections.singletonList("openid"));
+
+            oAuth2Util.when(() -> OAuth2Util.findAccessToken(anyString(), anyBoolean()))
+                    .thenThrow(new IdentityOAuth2Exception("DAO error"));
+
+            mockedOAuthUtil.when(() -> OAuthUtil.clearOAuthCacheUsingPersistedScopes(
+                    anyString(), any(AccessTokenDO.class), any(OAuthRevocationRequestDTO.class)))
+                    .thenCallRealMethod();
+
+            AccessTokenDO accessTokenDO = new AccessTokenDO();
+            accessTokenDO.setAccessToken("testAccessToken");
+            OAuthRevocationRequestDTO revokeRequestDTO = mock(OAuthRevocationRequestDTO.class);
+            when(revokeRequestDTO.getConsumerKey()).thenReturn("testConsumerKey");
+
+            // Exception should be caught and logged internally, not propagated.
+            OAuthUtil.clearOAuthCacheUsingPersistedScopes("tokenBindingRef",
+             accessTokenDO, revokeRequestDTO);
+
+            mockedOAuthUtil.verify(() -> OAuthUtil.clearOAuthCache(
+                    anyString(), any(AuthenticatedUser.class), anyString(), anyString()), never());
+        }
+    }
+
+    @Test
+    public void testGetRandomNumberSecure_WithSHA1() throws Exception {
+
+        try (MockedStatic<IdentityUtil> identityUtil = mockStatic(IdentityUtil.class)) {
+            identityUtil.when(() -> IdentityUtil.getProperty(IdentityConstants.OAuth.ENABLE_SHA256_PARAMS))
+                    .thenReturn("false");
+            String result = OAuthUtil.getRandomNumberSecure();
+            assertTrue(StringUtils.isNotBlank(result), "Generated secure random string should not be blank.");
+        }
+    }
+
+    @Test
+    public void testGetRandomNumberSecure_WithSHA256() throws Exception {
+
+        try (MockedStatic<IdentityUtil> identityUtil = mockStatic(IdentityUtil.class)) {
+            identityUtil.when(() -> IdentityUtil.getProperty(IdentityConstants.OAuth.ENABLE_SHA256_PARAMS))
+                    .thenReturn("true");
+            String result = OAuthUtil.getRandomNumberSecure();
+            assertTrue(StringUtils.isNotBlank(result), "Generated secure random string should not be blank.");
+        }
+    }
+
+    @Test
+    public void testHandleError_WithNullException() {
+
+        IdentityOAuthAdminException exception = OAuthUtil.handleError("test error message", null);
+        assertNotNull(exception);
+        assertEquals(exception.getMessage(), "test error message");
+    }
+
+    @Test
+    public void testHandleError_WithException() {
+
+        Exception cause = new RuntimeException("cause");
+        IdentityOAuthAdminException exception = OAuthUtil.handleError("test error message", cause);
+        assertNotNull(exception);
+        assertEquals(exception.getMessage(), "test error message");
+        assertEquals(exception.getCause(), cause);
+    }
+
+    @Test
+    public void testHandleErrorWithExceptionType_WithNullException() {
+
+        IdentityOAuthAdminException exception = OAuthUtil.handleErrorWithExceptionType("test message", null);
+        assertNotNull(exception);
+        assertEquals(exception.getMessage(), "test message");
+    }
+
+    @Test
+    public void testHandleErrorWithExceptionType_WithClientException() {
+
+        IdentityOAuth2ClientException cause = new IdentityOAuth2ClientException("CLIENT_ERROR_CODE", "client error");
+        IdentityOAuthAdminException exception = OAuthUtil.handleErrorWithExceptionType("test message", cause);
+        assertNotNull(exception);
+        assertTrue(exception instanceof IdentityOAuthClientException,
+                "Should return IdentityOAuthClientException for IdentityOAuth2ClientException.");
+        assertEquals(exception.getErrorCode(), "CLIENT_ERROR_CODE");
+    }
+
+    @Test
+    public void testHandleErrorWithExceptionType_WithServerException() {
+
+        IdentityOAuth2ServerException cause = new IdentityOAuth2ServerException("SERVER_ERROR_CODE", "server error");
+        IdentityOAuthAdminException exception = OAuthUtil.handleErrorWithExceptionType("test message", cause);
+        assertNotNull(exception);
+        assertTrue(exception instanceof IdentityOAuthServerException,
+                "Should return IdentityOAuthServerException for IdentityOAuth2ServerException.");
+        assertEquals(exception.getErrorCode(), "SERVER_ERROR_CODE");
+    }
+
+    @Test
+    public void testHandleErrorWithExceptionType_WithGenericOAuth2Exception() {
+
+        IdentityOAuth2Exception cause = new IdentityOAuth2Exception("GENERIC_ERROR_CODE", "generic error");
+        IdentityOAuthAdminException exception = OAuthUtil.handleErrorWithExceptionType("test message", cause);
+        assertNotNull(exception);
+        assertEquals(exception.getErrorCode(), "GENERIC_ERROR_CODE");
+    }
+
+    @Test
+    public void testHandleErrorWithExceptionType_WithBlankErrorCode() {
+
+        IdentityOAuth2Exception cause = new IdentityOAuth2Exception("generic error");
+        IdentityOAuthAdminException exception = OAuthUtil.handleErrorWithExceptionType("test message", cause);
+        assertNotNull(exception);
+    }
+
+    @Test
+    public void testBuildConsumerAppDTO() {
+
+        OAuthAppDO appDO = new OAuthAppDO();
+        appDO.setApplicationName("TestApp");
+        appDO.setCallbackUrl("https://example.com/callback");
+        appDO.setOauthConsumerKey("test-consumer-key");
+        appDO.setOauthConsumerSecret("test-consumer-secret");
+        appDO.setOauthVersion("OAuth-2.0");
+        appDO.setGrantTypes("authorization_code implicit");
+        appDO.setScopeValidators(new String[]{"validator1"});
+        appDO.setState("ACTIVE");
+        appDO.setPkceMandatory(true);
+        appDO.setPkceSupportPlain(false);
+        appDO.setHybridFlowEnabled(false);
+        appDO.setUserAccessTokenExpiryTime(3600L);
+        appDO.setApplicationAccessTokenExpiryTime(7200L);
+        appDO.setRefreshTokenExpiryTime(86400L);
+        appDO.setIdTokenExpiryTime(3600L);
+        appDO.setTokenType("JWT");
+
+        org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser user =
+                new org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser();
+        user.setUserName("testUser");
+        user.setTenantDomain("carbon.super");
+        user.setUserStoreDomain("PRIMARY");
+        appDO.setUser(user);
+
+        OAuthConsumerAppDTO dto = OAuthUtil.buildConsumerAppDTO(appDO);
+
+        assertNotNull(dto);
+        assertEquals(dto.getApplicationName(), "TestApp");
+        assertEquals(dto.getCallbackUrl(), "https://example.com/callback");
+        assertEquals(dto.getOauthConsumerKey(), "test-consumer-key");
+        assertEquals(dto.getOauthConsumerSecret(), "test-consumer-secret");
+        assertEquals(dto.getOAuthVersion(), "OAuth-2.0");
+        assertEquals(dto.getGrantTypes(), "authorization_code implicit");
+        assertEquals(dto.getState(), "ACTIVE");
+        assertTrue(dto.getPkceMandatory());
+        assertEquals(dto.getUserAccessTokenExpiryTime(), 3600L);
+        assertEquals(dto.getApplicationAccessTokenExpiryTime(), 7200L);
+        assertEquals(dto.getRefreshTokenExpiryTime(), 86400L);
+        assertEquals(dto.getIdTokenExpiryTime(), 3600L);
+        assertEquals(dto.getTokenType(), "JWT");
+    }
+
+    @Test
+    public void testClearOAuthCache_WithAccessTokenDO() {
+
+        String accessToken = "test-access-token-do";
+        OAuthCacheKey oAuthCacheKey = new OAuthCacheKey(accessToken);
+        OAuthCache oAuthCache = getOAuthCache(oAuthCacheKey);
+
+        assertNotNull(oAuthCache.getValueFromCache(oAuthCacheKey),
+                "Should have cached value before clearing.");
+
+        AccessTokenDO accessTokenDO = new AccessTokenDO();
+        accessTokenDO.setAccessToken(accessToken);
+        AuthenticatedUser authzUser = new AuthenticatedUser();
+        authzUser.setTenantDomain("carbon.super");
+        accessTokenDO.setAuthzUser(authzUser);
+
+        OAuthUtil.clearOAuthCache(accessTokenDO);
+
+        assertNull(oAuthCache.getValueFromCache(oAuthCacheKey),
+                "Cache entry should be cleared after calling clearOAuthCache with AccessTokenDO.");
+        oAuthCache.clear(-1234);
+    }
+
+    @Test
+    public void testClearOAuthCacheByTenant() {
+
+        String cacheKey = "tenant-specific-cache-key";
+        String tenantDomain = "carbon.super";
+        OAuthCacheKey oAuthCacheKey = new OAuthCacheKey(cacheKey);
+        OAuthCache oAuthCache = getOAuthCache(oAuthCacheKey);
+
+        assertNotNull(oAuthCache.getValueFromCache(oAuthCacheKey),
+                "Should have cached value before clearing.");
+
+        OAuthUtil.clearOAuthCacheByTenant(cacheKey, tenantDomain);
+
+        assertNull(oAuthCache.getValueFromCache(oAuthCacheKey),
+                "Cache entry should be cleared by tenant-specific cache clearing.");
+        oAuthCache.clear(-1234);
+    }
+
+    @Test
+    public void testBuildCacheKeyStringForToken() {
+
+        String clientId = "client-id";
+        String scope = "openid";
+        String userId = "user-id";
+        String idp = "LOCAL";
+        String tokenBindingRef = "binding-ref";
+        String expectedKey = "expectedCacheKey";
+
+        oAuth2Util.when(() -> OAuth2Util.buildCacheKeyStringForTokenWithUserId(
+                clientId, scope, userId, idp, tokenBindingRef)).thenReturn(expectedKey);
+
+        String result = OAuthUtil.buildCacheKeyStringForToken(clientId, scope, userId, idp, tokenBindingRef);
+
+        assertEquals(result, expectedKey);
+        oAuth2Util.verify(() -> OAuth2Util.buildCacheKeyStringForTokenWithUserId(
+                clientId, scope, userId, idp, tokenBindingRef), times(1));
+    }
+
+    @Test
+    public void testInvokePreRevocationBySystemListeners_AccessTokenDO_WhenInterceptorEnabled() throws Exception {
+
+        OAuthEventInterceptor interceptor = mock(OAuthEventInterceptor.class);
+        when(interceptor.isEnabled()).thenReturn(true);
+        OAuthComponentServiceHolder.getInstance().addOauthEventInterceptorProxy(interceptor);
+
+        AccessTokenDO accessTokenDO = new AccessTokenDO();
+        Map<String, Object> params = new HashMap<>();
+
+        OAuthUtil.invokePreRevocationBySystemListeners(accessTokenDO, params);
+
+        verify(interceptor, times(1)).onPreTokenRevocationBySystem(accessTokenDO, params);
+        OAuthComponentServiceHolder.getInstance().addOauthEventInterceptorProxy(null);
+    }
+
+    @Test
+    public void testInvokePreRevocationBySystemListeners_AccessTokenDO_WhenInterceptorNull() throws Exception {
+
+        OAuthComponentServiceHolder.getInstance().addOauthEventInterceptorProxy(null);
+
+        AccessTokenDO accessTokenDO = new AccessTokenDO();
+        Map<String, Object> params = new HashMap<>();
+
+        // Should complete without exception when interceptor is null.
+        OAuthUtil.invokePreRevocationBySystemListeners(accessTokenDO, params);
+    }
+
+    @Test
+    public void testInvokePreRevocationBySystemListeners_AccessTokenDO_WhenInterceptorThrowsException()
+            throws Exception {
+
+        OAuthEventInterceptor interceptor = mock(OAuthEventInterceptor.class);
+        when(interceptor.isEnabled()).thenReturn(true);
+        Mockito.doThrow(new IdentityOAuth2Exception("interceptor error"))
+                .when(interceptor).onPreTokenRevocationBySystem(any(AccessTokenDO.class), any());
+        OAuthComponentServiceHolder.getInstance().addOauthEventInterceptorProxy(interceptor);
+
+        AccessTokenDO accessTokenDO = new AccessTokenDO();
+        Map<String, Object> params = new HashMap<>();
+
+        // Exception should be swallowed and logged, not propagated.
+        OAuthUtil.invokePreRevocationBySystemListeners(accessTokenDO, params);
+        OAuthComponentServiceHolder.getInstance().addOauthEventInterceptorProxy(null);
+    }
+
+    @Test
+    public void testInvokePostRevocationBySystemListeners_AccessTokenDO_WhenInterceptorEnabled() throws Exception {
+
+        OAuthEventInterceptor interceptor = mock(OAuthEventInterceptor.class);
+        when(interceptor.isEnabled()).thenReturn(true);
+        OAuthComponentServiceHolder.getInstance().addOauthEventInterceptorProxy(interceptor);
+
+        AccessTokenDO accessTokenDO = new AccessTokenDO();
+        Map<String, Object> params = new HashMap<>();
+
+        OAuthUtil.invokePostRevocationBySystemListeners(accessTokenDO, params);
+
+        verify(interceptor, times(1)).onPostTokenRevocationBySystem(accessTokenDO, params);
+        OAuthComponentServiceHolder.getInstance().addOauthEventInterceptorProxy(null);
+    }
+
+    @Test
+    public void testInvokePostRevocationBySystemListeners_AccessTokenDO_WhenInterceptorThrowsException()
+            throws Exception {
+
+        OAuthEventInterceptor interceptor = mock(OAuthEventInterceptor.class);
+        when(interceptor.isEnabled()).thenReturn(true);
+        Mockito.doThrow(new IdentityOAuth2Exception("interceptor error"))
+                .when(interceptor).onPostTokenRevocationBySystem(any(AccessTokenDO.class), any());
+        OAuthComponentServiceHolder.getInstance().addOauthEventInterceptorProxy(interceptor);
+
+        AccessTokenDO accessTokenDO = new AccessTokenDO();
+        Map<String, Object> params = new HashMap<>();
+
+        // Exception should be swallowed and logged, not propagated.
+        OAuthUtil.invokePostRevocationBySystemListeners(accessTokenDO, params);
+        OAuthComponentServiceHolder.getInstance().addOauthEventInterceptorProxy(null);
+    }
+
+    @Test
+    public void testInvokePreRevocationBySystemListeners_UserUUID_WhenInterceptorEnabled() throws Exception {
+
+        OAuthEventInterceptor interceptor = mock(OAuthEventInterceptor.class);
+        when(interceptor.isEnabled()).thenReturn(true);
+        OAuthComponentServiceHolder.getInstance().addOauthEventInterceptorProxy(interceptor);
+
+        String userUUID = "test-user-uuid";
+        Map<String, Object> params = new HashMap<>();
+
+        OAuthUtil.invokePreRevocationBySystemListeners(userUUID, params);
+
+        verify(interceptor, times(1)).onPreTokenRevocationBySystem(userUUID, params);
+        OAuthComponentServiceHolder.getInstance().addOauthEventInterceptorProxy(null);
+    }
+
+    @Test
+    public void testInvokePostRevocationBySystemListeners_UserUUID_WhenInterceptorEnabled() throws Exception {
+
+        OAuthEventInterceptor interceptor = mock(OAuthEventInterceptor.class);
+        when(interceptor.isEnabled()).thenReturn(true);
+        OAuthComponentServiceHolder.getInstance().addOauthEventInterceptorProxy(interceptor);
+
+        String userUUID = "test-user-uuid";
+        Map<String, Object> params = new HashMap<>();
+
+        OAuthUtil.invokePostRevocationBySystemListeners(userUUID, params);
+
+        verify(interceptor, times(1)).onPostTokenRevocationBySystem(userUUID, params);
+        OAuthComponentServiceHolder.getInstance().addOauthEventInterceptorProxy(null);
+    }
+
+    @Test
+    public void testRemoveUserClaimsFromCache() throws Exception {
+
+        String userName = "testUser";
+        UserStoreManager userStoreManager = mock(UserStoreManager.class);
+        when(userStoreManager.getTenantId()).thenReturn(-1234);
+        when(userStoreManager.getRealmConfiguration()).thenReturn(mock(RealmConfiguration.class));
+
+        try (MockedStatic<ClaimCache> claimCacheStatic = mockStatic(ClaimCache.class)) {
+            ClaimCache claimCache = mock(ClaimCache.class);
+            claimCacheStatic.when(ClaimCache::getInstance).thenReturn(claimCache);
+
+            boolean result = OAuthUtil.removeUserClaimsFromCache(userName, userStoreManager);
+
+            assertTrue(result, "removeUserClaimsFromCache should return true.");
+            verify(claimCache, times(1)).clearCacheEntry(any(ClaimCacheKey.class), anyInt());
         }
     }
 


### PR DESCRIPTION
## Purpose
During token revocation, in-memory token scopes can be mutated during the request lifecycle, causing cache-key mismatches and stale OAuth cache entries. This change ensures cache is cleared using the original persisted scopes from the database.

## Related Issue
Continuation of https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/3071

## Diff from #3071
- **Placement of cache clearance call in `OAuth2Service.java`**: The `clearOAuthCacheUsingPersistedScopes` call is placed **after** the token revocation (`revokeAccessToken`) completes, rather than before the `synchronized` revocation block as in #3071. This ensures the token is fully revoked before clearing cache entries.
- **Expanded test coverage in `OAuthUtilTest.java`**: Beyond the `clearOAuthCacheUsingPersistedScopes` tests from #3071, this PR adds comprehensive unit tests for: `getRandomNumberSecure` (SHA1/SHA256), `handleError`, `handleErrorWithExceptionType` (client/server/generic exceptions), `buildConsumerAppDTO`, `clearOAuthCache` (with `AccessTokenDO`), `clearOAuthCacheByTenant`, `buildCacheKeyStringForToken`, `invokePreRevocationBySystemListeners`, `invokePostRevocationBySystemListeners`, and `removeUserClaimsFromCache`.

## Implementation
- Added `clearOAuthCacheUsingPersistedScopes` method in `OAuthUtil.java` that retrieves original scopes from the database via `TokenProvider.getVerifiedAccessToken` and clears cache using those scopes.
- Invoked the new method in `OAuth2Service.revokeTokenByOAuthClient` after the access token is revoked.
- Added 20+ unit tests in `OAuthUtilTest.java` covering the new method and improving coverage for existing utility methods.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced token revocation handling with improved cache clearing using persisted token scope information to maintain consistent OAuth authentication state.

* **Tests**
  * Added extensive test coverage for OAuth token revocation, cache management operations, scope handling, and error scenarios to ensure reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->