### PR TITLE
[6.14.x] Skip tenant validation for oauth endpoints

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.oauth.scope/src/main/java/org/wso2/carbon/identity/oauth/scope/endpoint/impl/ScopesApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.server.oauth.scope/src/main/java/org/wso2/carbon/identity/oauth/scope/endpoint/impl/ScopesApiServiceImpl.java
@@ -291,9 +291,9 @@ public class ScopesApiServiceImpl extends ScopesApiService {
     private static URI buildURIForHeader(String scopeName) {
 
         URI location;
-        String context = IdentityTenantUtil.isTenantQualifiedUrlsEnabled() ? SERVER_API_PATH_COMPONENT + scopeName :
+        String context = IdentityTenantUtil.isTenantQualifiedUrlsEnabled() ?
                 String.format(TENANT_CONTEXT_PATH_COMPONENT, getTenantDomainFromContext()) + SERVER_API_PATH_COMPONENT
-                        + scopeName;
+                        + scopeName : SERVER_API_PATH_COMPONENT + scopeName;
         if (LOG.isDebugEnabled()) {
             LOG.debug("Building URI for scope: " + scopeName + " with context: " + context);
         }                

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -4007,6 +4007,11 @@ public class OAuth2Util {
     public static String getIdTokenIssuer(String tenantDomain) throws IdentityOAuth2Exception {
 
         if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled()) {
+            // When skipping tenant validation for OAuth endpoints, the request context may not match
+            // the app's tenant domain, so we need to use the app's tenant domain to build the issuer.
+            if (IdentityTenantUtil.skipTenantValidationForOAuthEndpoints()) {
+                return getIssuerLocation(tenantDomain);
+            }
             try {
                 return ServiceURLBuilder.create().addPath(OAUTH2_TOKEN_EP_URL).build().getAbsolutePublicURL();
             } catch (URLBuilderException e) {
@@ -4613,7 +4618,8 @@ public class OAuth2Util {
      */
     public static void validateRequestTenantDomain(String tenantDomainOfApp) throws InvalidOAuthClientException {
 
-        if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled()) {
+        if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled()
+                && !IdentityTenantUtil.skipTenantValidationForOAuthEndpoints()) {
 
             String tenantDomainFromContext = IdentityTenantUtil.resolveTenantDomain();
             if (!StringUtils.equals(tenantDomainFromContext, tenantDomainOfApp)) {
@@ -4638,7 +4644,8 @@ public class OAuth2Util {
     public static void validateRequestTenantDomain(String tenantDomainOfApp, OAuth2AccessTokenReqDTO tokenReqDTO)
             throws InvalidOAuthClientException {
 
-        if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled()) {
+        if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled()
+                && !IdentityTenantUtil.skipTenantValidationForOAuthEndpoints()) {
 
             Optional<String> contextTenantDomainFromTokenReqDTO = getContextTenantDomainFromTokenReqDTO(tokenReqDTO);
             String tenantDomainFromContext;

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -4010,6 +4010,10 @@ public class OAuth2Util {
             // When skipping tenant validation for OAuth endpoints, the request context may not match
             // the app's tenant domain, so we need to use the app's tenant domain to build the issuer.
             if (IdentityTenantUtil.skipTenantValidationForOAuthEndpoints()) {
+                if(log.isDebugEnabled()) {
+                    log.debug("Skipping tenant validation for common OAuth endpoint. Using tenant domain: " +
+                            tenantDomain + " to build the issuer.");
+                }
                 return getIssuerLocation(tenantDomain);
             }
             try {

--- a/pom.xml
+++ b/pom.xml
@@ -856,7 +856,7 @@
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!-- Carbon Identity Framework version -->
-        <carbon.identity.framework.version>5.27.11</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.27.16</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.17.5, 6.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 


### PR DESCRIPTION
This pull request updates tenant validation logic in the OAuth2 utility class and bumps the Carbon Identity Framework version. The main focus is to allow skipping tenant validation for OAuth endpoints when configured, improving flexibility for multi-tenant environments.

**Tenant Validation Logic Updates:**

* Updated `getIdTokenIssuer` in `OAuth2Util.java` to use the application's tenant domain when tenant validation is skipped for OAuth endpoints, ensuring the issuer is correctly set in such scenarios.
* Modified tenant domain validation in both `validateRequestTenantDomain` methods in `OAuth2Util.java` to bypass validation when skipping is enabled, preventing unnecessary validation failures. [[1]](diffhunk://#diff-9d4b1a340ecdbc719edf565e22baf522bb4738051645d22ce50930875ccc151dL4616-R4622) [[2]](diffhunk://#diff-9d4b1a340ecdbc719edf565e22baf522bb4738051645d22ce50930875ccc151dL4641-R4648)

**Dependency Updates:**

* Upgraded `carbon.identity.framework.version` in `pom.xml` from `5.27.11` to `5.27.16` for improved stability and compatibility.