### PR TITLE
Fix error logs when removing keys from oauth app

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -5062,7 +5062,13 @@ public class OAuth2Util {
 
             OAuthAppDO appDO = getAppInformationByClientId(consumerKey);
             return StringUtils.equals(appDO.getTokenType(), JWT);
-
+        } catch (InvalidOAuthClientException e) {
+            // This can happen when the OAuth app is removed before the service provider deletion triggers cache cleanup
+            if (log.isDebugEnabled()) {
+                log.debug("OAuth application not found for consumer key: " + consumerKey +
+                        ". The application may have been already deleted.", e);
+            }
+            return false;
         } catch (IdentityException e) {
             log.error("Error while retrieving the application information for the consumer key: " + consumerKey, e);
             return false;


### PR DESCRIPTION
### Purpose

Handle InvalidOAuthClientException gracefully in OAuth2Util.isNonPersistentTokenEnabled() to avoid error logs when the OAuth app has already been deleted.
This fix downgrade the error to a debug-level log since this is an expected race condition during key removal.

Fixes: https://github.com/wso2/api-manager/issues/4860