### PR TITLE
Clear OAuth cache using persisted token scopes on revoke

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthUtil.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthUtil.java
@@ -50,6 +50,7 @@ import org.wso2.carbon.identity.oauth.cache.AuthorizationGrantCacheKey;
 import org.wso2.carbon.identity.oauth.cache.OAuthCache;
 import org.wso2.carbon.identity.oauth.cache.OAuthCacheKey;
 import org.wso2.carbon.identity.oauth.common.OAuthConstants;
+import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
 import org.wso2.carbon.identity.oauth.dao.OAuthAppDO;
 import org.wso2.carbon.identity.oauth.dto.OAuthConsumerAppDTO;
 import org.wso2.carbon.identity.oauth.event.OAuthEventInterceptor;
@@ -62,6 +63,7 @@ import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2ServerException;
 import org.wso2.carbon.identity.oauth2.dao.OAuthTokenPersistenceFactory;
 import org.wso2.carbon.identity.oauth2.dao.SharedAppResolveDAO;
+import org.wso2.carbon.identity.oauth2.dto.OAuthRevocationRequestDTO;
 import org.wso2.carbon.identity.oauth2.model.AccessTokenDO;
 import org.wso2.carbon.identity.oauth2.model.AuthzCodeDO;
 import org.wso2.carbon.identity.oauth2.model.OAuthAppInfo;
@@ -1575,6 +1577,51 @@ public final class OAuthUtil {
         } catch (org.wso2.carbon.user.api.UserStoreException e) {
             throw new UserStoreException("Failed to retrieve the user store domain for the parent user with ID: "
                     + parentUserId + " in tenant domain: " + tenantDomain, e);
+        }
+    }
+
+    /**
+     * Triggers a cache clearance for the original scopes associated with a token.
+     * This is necessary because the scopes in the provided {@code accessTokenDO} might have been
+     * filtered or mutated during the request lifecycle. Fetch the original scopes from the
+     * database to ensure the cache is cleared using the correct keys.
+     *
+     * @param tokenBindingReference The token binding identifier.
+     * @param accessTokenDO        The current (potentially mutated) access token object.
+     * @param revokeRequestDTO     The revocation request details containing the consumer key.
+     */
+    public static void clearOAuthCacheUsingPersistedScopes(String tokenBindingReference, AccessTokenDO accessTokenDO,
+                                                           OAuthRevocationRequestDTO revokeRequestDTO) {
+
+        if (OAuthServerConfiguration.getInstance().getAllowedScopes().isEmpty()) {
+            return;
+        }
+
+        String accessToken = accessTokenDO.getAccessToken();
+        if (StringUtils.isBlank(accessToken)) {
+            return;
+        }
+
+        try {
+            // The in-memory scopes may be mutated during validation. To avoid cache-key
+            // mismatches, retrieve the original scopes from the database before clearing
+            // the OAuth cache.
+            AccessTokenDO dbTokenDO = OAuthTokenPersistenceFactory.getInstance()
+                    .getAccessTokenDAO()
+                    .getAccessToken(accessToken, true);
+            if (dbTokenDO == null || dbTokenDO.getScope() == null || dbTokenDO.getScope().length == 0) {
+                return;
+            }
+
+            String dbTokenScopeString = OAuth2Util.buildScopeString(dbTokenDO.getScope());
+            OAuthUtil.clearOAuthCache(revokeRequestDTO.getConsumerKey(),
+                    accessTokenDO.getAuthzUser(), dbTokenScopeString, tokenBindingReference);
+            OAuthUtil.clearOAuthCache(revokeRequestDTO.getConsumerKey(),
+                    accessTokenDO.getAuthzUser(), dbTokenScopeString);
+
+        } catch (IdentityOAuth2Exception e) {
+            LOG.error("Error while clearing cache entries for extended scopes. Consumer key: "
+                    + revokeRequestDTO.getConsumerKey(), e);
         }
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/OAuth2Service.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/OAuth2Service.java
@@ -743,6 +743,8 @@ public class OAuth2Service extends AbstractAdmin {
                                 OAuth2Util.buildScopeString(accessTokenDO.getScope()));
                         OAuthUtil.clearOAuthCache(revokeRequestDTO.getConsumerKey(), accessTokenDO.getAuthzUser());
                         OAuthUtil.clearOAuthCache(accessTokenDO);
+                        OAuthUtil.clearOAuthCacheUsingPersistedScopes(tokenBindingReference,
+                                accessTokenDO, revokeRequestDTO);
                         String scope = OAuth2Util.buildScopeString(accessTokenDO.getScope());
                         synchronized ((revokeRequestDTO.getConsumerKey() + ":" + userId + ":" + scope + ":"
                                 + tokenBindingReference).intern()) {

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/OAuthUtilTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/OAuthUtilTest.java
@@ -46,6 +46,7 @@ import org.wso2.carbon.identity.oauth.cache.AuthorizationGrantCache;
 import org.wso2.carbon.identity.oauth.cache.CacheEntry;
 import org.wso2.carbon.identity.oauth.cache.OAuthCache;
 import org.wso2.carbon.identity.oauth.cache.OAuthCacheKey;
+import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
 import org.wso2.carbon.identity.oauth.internal.OAuthComponentServiceHolder;
 import org.wso2.carbon.identity.oauth.internal.util.AccessTokenEventUtil;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
@@ -54,6 +55,7 @@ import org.wso2.carbon.identity.oauth2.dao.AuthorizationCodeDAO;
 import org.wso2.carbon.identity.oauth2.dao.AuthorizationCodeDAOImpl;
 import org.wso2.carbon.identity.oauth2.dao.OAuthTokenPersistenceFactory;
 import org.wso2.carbon.identity.oauth2.dao.TokenManagementDAO;
+import org.wso2.carbon.identity.oauth2.dto.OAuthRevocationRequestDTO;
 import org.wso2.carbon.identity.oauth2.model.AccessTokenDO;
 import org.wso2.carbon.identity.oauth2.model.AuthzCodeDO;
 import org.wso2.carbon.identity.oauth2.model.OAuthAppInfo;
@@ -806,6 +808,246 @@ public class OAuthUtilTest {
 
             // Should not throw; IdentityOAuth2Exception is caught and logged internally.
             OAuthUtil.removeAuthzGrantCacheForUser(userName, userStoreManager);
+        }
+    }
+
+    @Test
+    public void testClearOAuthCacheUsingPersistedScopes_WhenAllowedScopesIsEmpty() throws Exception {
+
+        try (MockedStatic<OAuthServerConfiguration> oAuthServerConfigStatic =
+                     mockStatic(OAuthServerConfiguration.class)) {
+            OAuthServerConfiguration mockServerConfig = mock(OAuthServerConfiguration.class);
+            oAuthServerConfigStatic.when(OAuthServerConfiguration::getInstance).thenReturn(mockServerConfig);
+            when(mockServerConfig.getAllowedScopes()).thenReturn(Collections.emptyList());
+
+            OAuthTokenPersistenceFactory mockFactory = mock(OAuthTokenPersistenceFactory.class);
+            oAuthTokenPersistenceFactory.when(OAuthTokenPersistenceFactory::getInstance).thenReturn(mockFactory);
+            AccessTokenDAO mockAccessTokenDAO = mock(AccessTokenDAO.class);
+
+            AccessTokenDO accessTokenDO = new AccessTokenDO();
+            accessTokenDO.setAccessToken("testAccessToken");
+            OAuthRevocationRequestDTO revokeRequestDTO = mock(OAuthRevocationRequestDTO.class);
+
+            OAuthUtil.clearOAuthCacheUsingPersistedScopes("tokenBindingRef",
+             accessTokenDO, revokeRequestDTO);
+
+            verify(mockAccessTokenDAO, never()).getAccessToken(anyString(), anyBoolean());
+        }
+    }
+
+    @Test
+    public void testClearOAuthCacheUsingPersistedScopes_WhenAccessTokenIsBlank() throws Exception {
+
+        try (MockedStatic<OAuthServerConfiguration> oAuthServerConfigStatic =
+                     mockStatic(OAuthServerConfiguration.class)) {
+            OAuthServerConfiguration mockServerConfig = mock(OAuthServerConfiguration.class);
+            oAuthServerConfigStatic.when(OAuthServerConfiguration::getInstance).thenReturn(mockServerConfig);
+            when(mockServerConfig.getAllowedScopes()).thenReturn(Collections.singletonList("openid"));
+
+            OAuthTokenPersistenceFactory mockFactory = mock(OAuthTokenPersistenceFactory.class);
+            oAuthTokenPersistenceFactory.when(OAuthTokenPersistenceFactory::getInstance).thenReturn(mockFactory);
+            AccessTokenDAO mockAccessTokenDAO = mock(AccessTokenDAO.class);
+
+            // Access token is not set — defaults to null (blank).
+            AccessTokenDO accessTokenDO = new AccessTokenDO();
+            OAuthRevocationRequestDTO revokeRequestDTO = mock(OAuthRevocationRequestDTO.class);
+
+            OAuthUtil.clearOAuthCacheUsingPersistedScopes("tokenBindingRef",
+             accessTokenDO, revokeRequestDTO);
+
+            verify(mockAccessTokenDAO, never()).getAccessToken(anyString(), anyBoolean());
+        }
+    }
+
+    @Test
+    public void testClearOAuthCacheUsingPersistedScopes_WhenDbTokenIsNull() throws Exception {
+
+        try (MockedStatic<OAuthServerConfiguration> oAuthServerConfigStatic =
+                     mockStatic(OAuthServerConfiguration.class);
+             MockedStatic<OAuthUtil> mockedOAuthUtil = mockStatic(OAuthUtil.class)) {
+            OAuthServerConfiguration mockServerConfig = mock(OAuthServerConfiguration.class);
+            oAuthServerConfigStatic.when(OAuthServerConfiguration::getInstance).thenReturn(mockServerConfig);
+            when(mockServerConfig.getAllowedScopes()).thenReturn(Collections.singletonList("openid"));
+
+            OAuthTokenPersistenceFactory mockFactory = mock(OAuthTokenPersistenceFactory.class);
+            oAuthTokenPersistenceFactory.when(OAuthTokenPersistenceFactory::getInstance).thenReturn(mockFactory);
+            AccessTokenDAO mockAccessTokenDAO = mock(AccessTokenDAO.class);
+            when(mockFactory.getAccessTokenDAO()).thenReturn(mockAccessTokenDAO);
+            when(mockAccessTokenDAO.getAccessToken("testAccessToken", true)).thenReturn(null);
+
+            mockedOAuthUtil.when(() -> OAuthUtil.clearOAuthCacheUsingPersistedScopes(
+                    anyString(), any(AccessTokenDO.class), any(OAuthRevocationRequestDTO.class)))
+                    .thenCallRealMethod();
+
+            AccessTokenDO accessTokenDO = new AccessTokenDO();
+            accessTokenDO.setAccessToken("testAccessToken");
+            OAuthRevocationRequestDTO revokeRequestDTO = mock(OAuthRevocationRequestDTO.class);
+
+            OAuthUtil.clearOAuthCacheUsingPersistedScopes("tokenBindingRef", accessTokenDO, revokeRequestDTO);
+
+            mockedOAuthUtil.verify(() -> OAuthUtil.clearOAuthCache(
+                    anyString(), any(AuthenticatedUser.class), anyString(), anyString()), never());
+            mockedOAuthUtil.verify(() -> OAuthUtil.clearOAuthCache(
+                    anyString(), any(AuthenticatedUser.class), anyString()), never());
+        }
+    }
+
+    @Test
+    public void testClearOAuthCacheUsingPersistedScopes_WhenDbTokenScopeIsNull() throws Exception {
+
+        try (MockedStatic<OAuthServerConfiguration> oAuthServerConfigStatic =
+                     mockStatic(OAuthServerConfiguration.class);
+             MockedStatic<OAuthUtil> mockedOAuthUtil = mockStatic(OAuthUtil.class)) {
+            OAuthServerConfiguration mockServerConfig = mock(OAuthServerConfiguration.class);
+            oAuthServerConfigStatic.when(OAuthServerConfiguration::getInstance).thenReturn(mockServerConfig);
+            when(mockServerConfig.getAllowedScopes()).thenReturn(Collections.singletonList("openid"));
+
+            OAuthTokenPersistenceFactory mockFactory = mock(OAuthTokenPersistenceFactory.class);
+            oAuthTokenPersistenceFactory.when(OAuthTokenPersistenceFactory::getInstance).thenReturn(mockFactory);
+            AccessTokenDAO mockAccessTokenDAO = mock(AccessTokenDAO.class);
+            when(mockFactory.getAccessTokenDAO()).thenReturn(mockAccessTokenDAO);
+
+            AccessTokenDO dbTokenDO = new AccessTokenDO();
+            dbTokenDO.setScope(null);
+            when(mockAccessTokenDAO.getAccessToken("testAccessToken",
+             true)).thenReturn(dbTokenDO);
+
+            mockedOAuthUtil.when(() -> OAuthUtil.clearOAuthCacheUsingPersistedScopes(
+                    anyString(), any(AccessTokenDO.class), any(OAuthRevocationRequestDTO.class)))
+                    .thenCallRealMethod();
+
+            AccessTokenDO accessTokenDO = new AccessTokenDO();
+            accessTokenDO.setAccessToken("testAccessToken");
+            OAuthRevocationRequestDTO revokeRequestDTO = mock(OAuthRevocationRequestDTO.class);
+
+            OAuthUtil.clearOAuthCacheUsingPersistedScopes("tokenBindingRef",
+             accessTokenDO, revokeRequestDTO);
+
+            mockedOAuthUtil.verify(() -> OAuthUtil.clearOAuthCache(
+                    anyString(), any(AuthenticatedUser.class), anyString(), anyString()), never());
+            mockedOAuthUtil.verify(() -> OAuthUtil.clearOAuthCache(
+                    anyString(), any(AuthenticatedUser.class), anyString()), never());
+        }
+    }
+
+    @Test
+    public void testClearOAuthCacheUsingPersistedScopes_WhenDbTokenScopeIsEmpty() throws Exception {
+
+        try (MockedStatic<OAuthServerConfiguration> oAuthServerConfigStatic =
+                     mockStatic(OAuthServerConfiguration.class);
+             MockedStatic<OAuthUtil> mockedOAuthUtil = mockStatic(OAuthUtil.class)) {
+            OAuthServerConfiguration mockServerConfig = mock(OAuthServerConfiguration.class);
+            oAuthServerConfigStatic.when(OAuthServerConfiguration::getInstance).thenReturn(mockServerConfig);
+            when(mockServerConfig.getAllowedScopes()).thenReturn(Collections.singletonList("openid"));
+
+            OAuthTokenPersistenceFactory mockFactory = mock(OAuthTokenPersistenceFactory.class);
+            oAuthTokenPersistenceFactory.when(OAuthTokenPersistenceFactory::getInstance).thenReturn(mockFactory);
+            AccessTokenDAO mockAccessTokenDAO = mock(AccessTokenDAO.class);
+            when(mockFactory.getAccessTokenDAO()).thenReturn(mockAccessTokenDAO);
+
+            AccessTokenDO dbTokenDO = new AccessTokenDO();
+            dbTokenDO.setScope(new String[0]);
+            when(mockAccessTokenDAO.getAccessToken("testAccessToken",
+             true)).thenReturn(dbTokenDO);
+
+            mockedOAuthUtil.when(() -> OAuthUtil.clearOAuthCacheUsingPersistedScopes(
+                    anyString(), any(AccessTokenDO.class), any(OAuthRevocationRequestDTO.class)))
+                    .thenCallRealMethod();
+
+            AccessTokenDO accessTokenDO = new AccessTokenDO();
+            accessTokenDO.setAccessToken("testAccessToken");
+            OAuthRevocationRequestDTO revokeRequestDTO = mock(OAuthRevocationRequestDTO.class);
+
+            OAuthUtil.clearOAuthCacheUsingPersistedScopes("tokenBindingRef",
+             accessTokenDO, revokeRequestDTO);
+
+            mockedOAuthUtil.verify(() -> OAuthUtil.clearOAuthCache(
+                    anyString(), any(AuthenticatedUser.class), anyString(), anyString()), never());
+            mockedOAuthUtil.verify(() -> OAuthUtil.clearOAuthCache(
+                    anyString(), any(AuthenticatedUser.class), anyString()), never());
+        }
+    }
+
+    @Test
+    public void testClearOAuthCacheUsingPersistedScopes_ClearsCacheWithPersistedScopes() throws Exception {
+
+        String tokenBindingReference = "tokenBindingRef";
+        String accessToken = "testAccessToken";
+        String consumerKey = "testConsumerKey";
+        String[] dbScopes = {"scope1", "scope2"};
+        String dbScopeString = "scope1 scope2";
+
+        try (MockedStatic<OAuthServerConfiguration> oAuthServerConfigStatic =
+                     mockStatic(OAuthServerConfiguration.class);
+             MockedStatic<OAuthUtil> mockedOAuthUtil = mockStatic(OAuthUtil.class)) {
+            OAuthServerConfiguration mockServerConfig = mock(OAuthServerConfiguration.class);
+            oAuthServerConfigStatic.when(OAuthServerConfiguration::getInstance).thenReturn(mockServerConfig);
+            when(mockServerConfig.getAllowedScopes()).thenReturn(Collections.singletonList("scope1"));
+
+            OAuthTokenPersistenceFactory mockFactory = mock(OAuthTokenPersistenceFactory.class);
+            oAuthTokenPersistenceFactory.when(OAuthTokenPersistenceFactory::getInstance).thenReturn(mockFactory);
+            AccessTokenDAO mockAccessTokenDAO = mock(AccessTokenDAO.class);
+            when(mockFactory.getAccessTokenDAO()).thenReturn(mockAccessTokenDAO);
+
+            AccessTokenDO dbTokenDO = new AccessTokenDO();
+            dbTokenDO.setScope(dbScopes);
+            when(mockAccessTokenDAO.getAccessToken(accessToken, true)).thenReturn(dbTokenDO);
+
+            oAuth2Util.when(() -> OAuth2Util.buildScopeString(dbScopes)).thenReturn(dbScopeString);
+
+            mockedOAuthUtil.when(() -> OAuthUtil.clearOAuthCacheUsingPersistedScopes(
+                    anyString(), any(AccessTokenDO.class), any(OAuthRevocationRequestDTO.class)))
+                    .thenCallRealMethod();
+
+            AuthenticatedUser authzUser = mock(AuthenticatedUser.class);
+            AccessTokenDO accessTokenDO = new AccessTokenDO();
+            accessTokenDO.setAccessToken(accessToken);
+            accessTokenDO.setAuthzUser(authzUser);
+
+            OAuthRevocationRequestDTO revokeRequestDTO = mock(OAuthRevocationRequestDTO.class);
+            when(revokeRequestDTO.getConsumerKey()).thenReturn(consumerKey);
+
+            OAuthUtil.clearOAuthCacheUsingPersistedScopes(tokenBindingReference, accessTokenDO, revokeRequestDTO);
+
+            mockedOAuthUtil.verify(() -> OAuthUtil.clearOAuthCache(
+                    eq(consumerKey), eq(authzUser), eq(dbScopeString), eq(tokenBindingReference)), times(1));
+            mockedOAuthUtil.verify(() -> OAuthUtil.clearOAuthCache(
+                    eq(consumerKey), eq(authzUser), eq(dbScopeString)), times(1));
+        }
+    }
+
+    @Test
+    public void testClearOAuthCacheUsingPersistedScopes_WhenDaoThrowsException() throws Exception {
+
+        try (MockedStatic<OAuthServerConfiguration> oAuthServerConfigStatic =
+                     mockStatic(OAuthServerConfiguration.class);
+             MockedStatic<OAuthUtil> mockedOAuthUtil = mockStatic(OAuthUtil.class)) {
+            OAuthServerConfiguration mockServerConfig = mock(OAuthServerConfiguration.class);
+            oAuthServerConfigStatic.when(OAuthServerConfiguration::getInstance).thenReturn(mockServerConfig);
+            when(mockServerConfig.getAllowedScopes()).thenReturn(Collections.singletonList("openid"));
+
+            OAuthTokenPersistenceFactory mockFactory = mock(OAuthTokenPersistenceFactory.class);
+            oAuthTokenPersistenceFactory.when(OAuthTokenPersistenceFactory::getInstance).thenReturn(mockFactory);
+            AccessTokenDAO mockAccessTokenDAO = mock(AccessTokenDAO.class);
+            when(mockFactory.getAccessTokenDAO()).thenReturn(mockAccessTokenDAO);
+            when(mockAccessTokenDAO.getAccessToken(anyString(), anyBoolean()))
+                    .thenThrow(new IdentityOAuth2Exception("DAO error"));
+
+            mockedOAuthUtil.when(() -> OAuthUtil.clearOAuthCacheUsingPersistedScopes(
+                    anyString(), any(AccessTokenDO.class), any(OAuthRevocationRequestDTO.class)))
+                    .thenCallRealMethod();
+
+            AccessTokenDO accessTokenDO = new AccessTokenDO();
+            accessTokenDO.setAccessToken("testAccessToken");
+            OAuthRevocationRequestDTO revokeRequestDTO = mock(OAuthRevocationRequestDTO.class);
+            when(revokeRequestDTO.getConsumerKey()).thenReturn("testConsumerKey");
+
+            // Exception should be caught and logged internally, not propagated.
+            OAuthUtil.clearOAuthCacheUsingPersistedScopes("tokenBindingRef",
+             accessTokenDO, revokeRequestDTO);
+
+            mockedOAuthUtil.verify(() -> OAuthUtil.clearOAuthCache(
+                    anyString(), any(AuthenticatedUser.class), anyString(), anyString()), never());
         }
     }
 


### PR DESCRIPTION
## Purpose
During token revocation, the in-memory `accessTokenDO` may have had its scopes mutated or filtered earlier in the request lifecycle. The existing cache-clearing path uses those (potentially mutated) scopes as part of the cache key, so entries originally cached under the persisted scopes can be left behind.

## Related Issue
N/A

## Implementation
- Added `OAuthUtil.clearOAuthCacheUsingPersistedScopes(...)` which:
  - Returns early if `OAuthServerConfiguration#getAllowedScopes` is empty or the access token is blank.
  - Fetches the access token from `OAuthTokenPersistenceFactory.getAccessTokenDAO().getAccessToken(token, true)` to obtain the original persisted scopes.
  - Builds the scope string from the persisted scopes and calls `clearOAuthCache` for both the `(consumerKey, authzUser, scope, tokenBindingReference)` and `(consumerKey, authzUser, scope)` key variants.
  - Catches `IdentityOAuth2Exception` from the DAO and logs it without propagating.
- Wired the new helper into `OAuth2Service#revokeTokenByOAuthClient`, called right after the existing `clearOAuthCache` invocations.
- Added unit tests in `OAuthUtilTest` covering:
  - Empty `allowedScopes` short-circuit.
  - Blank access token short-circuit.
  - DB token lookup returning `null`.
  - DB token returning `null` scope array.
  - DB token returning empty scope array.
  - Happy path: cache cleared with persisted scopes for both key variants.
  - DAO throwing `IdentityOAuth2Exception` is swallowed and no cache clear is invoked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced OAuth token revocation with improved cache clearing mechanism to ensure complete invalidation of revoked tokens.

* **Tests**
  * Added comprehensive unit tests covering token revocation cache clearing scenarios, including edge cases and exception handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->