### PR TITLE
Add CodeRabbit configuration

### DIFF
--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -1,0 +1,27 @@
+language: en-US
+inheritance: true
+tone_instructions: |
+  Use neutral, business-focused language. Describe changes by functional outcomes
+  (e.g., stability, clarity, dependency updates, input validation) and avoid naming
+  specific vulnerability types, exploit categories, or attack techniques.
+reviews:
+  profile: chill
+  high_level_summary: true
+  high_level_summary_instructions: |
+    Create a clear, concise summary of the changes introduced in this pull request.
+    Use neutral, business-focused wording that avoids specific security vulnerability
+    names or exploit categories. Highlight the intent of the change in terms of
+    outcomes (for example "improve stability", "refactor logic for clarity",
+    "update dependency handling", "fix issue with input validation"). Avoid
+    explicit details about specific security vulnerability types. Do not include
+    technical exploit terminology in this summary.
+  auto_title_instructions: |
+    Generate a concise and descriptive title for this pull request using neutral
+    terminology. Do not use phrases that name specific security vulnerability types
+    or exploit categories. Focus on what was changed or improved (for example
+    "Correct behavior in authentication logic", "Update cache handling for
+    performance", "Fix edge case in parser", "Improve boundary validations").
+    Ensure the title reflects the business or functional intent without explicit
+    security exploit language.
+  auto_review:
+    ignore_usernames: ["wso2-jenkins-bot"]


### PR DESCRIPTION
## Purpose
Introduce a repository-level CodeRabbit configuration so that PR review output, auto-generated high-level summaries, and auto-generated titles use neutral, business-focused wording that reflects functional intent.

## Related Issue
N/A

## Implementation
- Added `.coderabbit.yml` at the repository root.
- Set `language: en-US` and a `tone_instructions` block that keeps review comments neutral and outcome-focused.
- Enabled `reviews.high_level_summary` and supplied `high_level_summary_instructions` to shape the auto-generated PR summary.
- Added `auto_title_instructions` to guide auto-generated PR titles toward neutral, functional wording.
- Kept `reviews.profile: chill` and added `auto_review.ignore_usernames` for the Jenkins bot.
- Relied on CodeRabbit's per-key override behavior, so any settings not specified here continue to inherit from the organization-level configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development tooling configuration for code review automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->