### PR TITLE
Enable the issuer selection feature by removing the configuration

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImpl.java
@@ -158,8 +158,6 @@ public class OAuthAdminServiceImpl {
     private static final String SCOPE_VALIDATION_REGEX = "^[^?#/()]*$";
     private static final int MAX_RETRY_ATTEMPTS = 3;
     private static final String BASE_URL_PLACEHOLDER = "<PROTOCOL>://<HOSTNAME>:<PORT>";
-    private static final String ISSUER_SELECTION_ENABLED_FOR_SUB_ORG_APPS =
-            "OAuth.AllowIssuerSelectionForSubOrgApplications";
 
     /**
      * Registers an consumer secret against the logged in user. A given user can only have a single
@@ -607,13 +605,10 @@ public class OAuthAdminServiceImpl {
                          If the app is not registering under a primary organization, and it is not a fragment app,
                          validate the issuer organization and set the issuer org of the app.
                         */
-                        if (Boolean.parseBoolean(
-                                IdentityUtil.getProperty(ISSUER_SELECTION_ENABLED_FOR_SUB_ORG_APPS))) {
-                            if (isSubOrg && !application.getIsFragmentApp()) {
-                                String orgId = OAuth2ServiceComponentHolder.getInstance().getOrganizationManager().
-                                        resolveOrganizationId(tenantDomain);
-                                resolveApplicationLevelTokenIssuerConfig(application, app, tenantDomain, orgId);
-                            }
+                        if (isSubOrg && !application.getIsFragmentApp()) {
+                            String orgId = OAuth2ServiceComponentHolder.getInstance().getOrganizationManager().
+                                    resolveOrganizationId(tenantDomain);
+                            resolveApplicationLevelTokenIssuerConfig(application, app, tenantDomain, orgId);
                         }
                     }
                     dao.addOAuthApplication(app);
@@ -1132,13 +1127,10 @@ public class OAuthAdminServiceImpl {
                  If the app is not updating under a primary organization, and it is not a fragment app,
                  validate the issuer organization and set the issuer org of the app.
                 */
-                if (Boolean.parseBoolean(
-                        IdentityUtil.getProperty(ISSUER_SELECTION_ENABLED_FOR_SUB_ORG_APPS))) {
-                    if (isSubOrg && !consumerAppDTO.getIsFragmentApp()) {
-                        String orgId = OAuth2ServiceComponentHolder.getInstance().getOrganizationManager().
-                                resolveOrganizationId(tenantDomain);
-                        resolveApplicationLevelTokenIssuerConfig(consumerAppDTO, oAuthAppDO, tenantDomain, orgId);
-                    }
+                if (isSubOrg && !consumerAppDTO.getIsFragmentApp()) {
+                    String orgId = OAuth2ServiceComponentHolder.getInstance().getOrganizationManager().
+                            resolveOrganizationId(tenantDomain);
+                    resolveApplicationLevelTokenIssuerConfig(consumerAppDTO, oAuthAppDO, tenantDomain, orgId);
                 }
             } catch (OrganizationManagementException e) {
                 throw handleError("Error while resolving organization for tenant: " + tenantDomain, e);

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImplTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImplTest.java
@@ -144,8 +144,6 @@ public class OAuthAdminServiceImplTest {
     private static final String USER_ID = "user:id";
     private static final String USER_NAME = "admin";
     private static final String TEST_ORG_ID = "test-org-id";
-    private static final String ISSUER_SELECTION_ENABLED_FOR_SUB_ORG_APPS =
-            "OAuth.AllowIssuerSelectionForSubOrgApplications";
 
     @Mock
     private RealmConfiguration realmConfiguration;
@@ -1879,8 +1877,6 @@ public class OAuthAdminServiceImplTest {
                         doNothing().when(mock).addOAuthApplication(any(OAuthAppDO.class));
                     })) {
                 mockUserstore(identityUtil, oAuthComponentServiceHolder);
-                identityUtil.when(() -> IdentityUtil.getProperty(ISSUER_SELECTION_ENABLED_FOR_SUB_ORG_APPS))
-                        .thenReturn(String.valueOf(true));
                 oAuthAdminServiceImpl.registerOAuthApplicationData(oAuthConsumerAppDTO);
             }
             if (expectIssuerResolutionCalled) {
@@ -1960,8 +1956,6 @@ public class OAuthAdminServiceImplTest {
                     mockUserstore(identityUtil, oAuthComponentServiceHolder);
                     identityUtil.when(() -> IdentityUtil.addDomainToName(anyString(), anyString()))
                             .thenCallRealMethod();
-                    identityUtil.when(() -> IdentityUtil.getProperty(ISSUER_SELECTION_ENABLED_FOR_SUB_ORG_APPS))
-                            .thenReturn(String.valueOf(true));
                     OAuthAdminServiceImpl oAuthAdminServiceImpl = new OAuthAdminServiceImpl();
                     oAuthAdminServiceImpl.updateConsumerApplication(oAuthConsumerAppDTO);
                 }


### PR DESCRIPTION
### Proposed changes in this pull request

- $subject
- Related to https://github.com/wso2/product-is/issues/27619

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This pull request enables issuer selection for sub-organization OAuth applications by removing the configuration-based feature gate. The code deletes the feature-flag check and invokes organization ID resolution and application-level issuer configuration resolution unconditionally for sub-organization applications that are not fragment apps during both registration and update flows. Corresponding tests were adjusted to remove test wiring for the removed configuration flag. No public API signatures or exported entity declarations were changed. The outcome is simplified behavior: issuer selection for applicable sub-organization apps is now always executed without relying on a configuration property.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->