### PR TITLE
[6.14.x] Prevent caching consumer app in secret regenerate flow

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -2261,6 +2261,25 @@ public class OAuth2Util {
     }
 
     /**
+     * Get Oauth application information without using caching the fetched value
+     *
+     * @param clientId Consumer key of the application
+     * @return Oauth app information
+     * @throws IdentityOAuth2Exception when an error occurs while retrieving app information from the database.
+     * @throws InvalidOAuthClientException when the provided clientId does not correspond to a valid OAuth application.
+     */
+    public static OAuthAppDO getAppInformationByClientIdWithoutCaching(String clientId)
+            throws IdentityOAuth2Exception, InvalidOAuthClientException {
+
+        OAuthAppDO oAuthAppDO = AppInfoCache.getInstance().getValueFromCache(clientId);
+        if (oAuthAppDO != null) {
+            return oAuthAppDO;
+        } else {
+            return new OAuthAppDAO().getAppInformation(clientId);
+        }
+    }
+
+    /**
      * Get the tenant domain of an oauth application
      *
      * @param oAuthAppDO
@@ -5071,7 +5090,8 @@ public class OAuth2Util {
                 return false;
             }
 
-            OAuthAppDO appDO = getAppInformationByClientId(consumerKey);
+            // Avoid caching the app info as app info might be removed from cache prior to this in some cases.
+            OAuthAppDO appDO = getAppInformationByClientIdWithoutCaching(consumerKey);
             return StringUtils.equals(appDO.getTokenType(), JWT);
         } catch (InvalidOAuthClientException e) {
             // This can happen when the OAuth app is removed before the service provider deletion triggers cache cleanup

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -2270,7 +2270,9 @@ public class OAuth2Util {
      */
     public static OAuthAppDO getAppInformationByClientIdWithoutCaching(String clientId)
             throws IdentityOAuth2Exception, InvalidOAuthClientException {
-
+        if (log.isDebugEnabled()) {
+            log.debug("Retrieving OAuth app information for client id without caching.");
+        }
         OAuthAppDO oAuthAppDO = AppInfoCache.getInstance().getValueFromCache(clientId);
         if (oAuthAppDO != null) {
             return oAuthAppDO;


### PR DESCRIPTION
### Proposed changes in this pull request

This PR fixes an issue where token hashing didn't work due to caching consumer app when regenerating the secret.

Related issue: https://github.com/wso2/api-manager/issues/4953
