### PR TITLE
Enable modification of sub-attributes in complex OIDC claims & fix org switch default resolution in pre-issue id token action

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/action/preissueidtoken/execution/PreIssueIDTokenRequestBuilder.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/action/preissueidtoken/execution/PreIssueIDTokenRequestBuilder.java
@@ -318,8 +318,17 @@ public class PreIssueIDTokenRequestBuilder implements ActionExecutionRequestBuil
         userBuilder.organization(resolveUserAuthenticatedOrganization(authenticatedUser));
 
         if (OAuthConstants.GrantTypes.ORGANIZATION_SWITCH.equals(grantType)) {
-            userBuilder.accessingOrganization(buildOrganization(authenticatedUser.getAccessingOrganization(),
-                    authenticatedUser.getTenantDomain()));
+            Organization accessingOrg;
+            if (authenticatedUser.getAccessingOrganization() != null) {
+                accessingOrg = buildOrganization(authenticatedUser.getAccessingOrganization(),
+                        authenticatedUser.getTenantDomain());
+                // In case of org switch, if accessing org is not set, it means user is switching to root org.
+            } else {
+                accessingOrg = buildOrganization(
+                        resolveOrganizationId(authenticatedUser.getTenantDomain()),
+                        authenticatedUser.getTenantDomain());
+            }
+            userBuilder.accessingOrganization(accessingOrg);
         }
         return userBuilder.build();
     }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/action/preissueidtoken/execution/PreIssueIDTokenRequestBuilder.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/action/preissueidtoken/execution/PreIssueIDTokenRequestBuilder.java
@@ -63,7 +63,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import javax.servlet.http.HttpServletRequestWrapper;
 
@@ -207,24 +206,45 @@ public class PreIssueIDTokenRequestBuilder implements ActionExecutionRequestBuil
 
     private List<String> getRemoveOrReplacePaths(Map<String, Object> oidcClaims) {
 
-        List<String> removeOrReplacePaths =  oidcClaims.entrySet().stream()
-                .filter(entry -> entry.getValue() instanceof String ||
-                        entry.getValue() instanceof Number ||
-                        entry.getValue() instanceof Boolean || entry.getValue() instanceof List ||
-                        entry.getValue() instanceof String[])
-                .map(this::generatePathForClaim)
-                .collect(Collectors.toList());
+        List<String> removeOrReplacePaths = new ArrayList<>();
+        for (Map.Entry<String, Object> entry : oidcClaims.entrySet()) {
+
+            String basePath = CLAIMS_PATH_PREFIX + entry.getKey();
+            Object value = entry.getValue();
+
+            removeOrReplacePaths.add(basePath);
+            if (value instanceof String || value instanceof Number || value instanceof Boolean) {
+                continue;
+            }
+            if (value instanceof List || value instanceof String[]) {
+                removeOrReplacePaths.add(basePath + "/");
+                continue;
+            }
+
+            // Handle nested objects
+            if (value instanceof Map) {
+                collectNestedClaimPaths(basePath, value, removeOrReplacePaths);
+            }
+        }
         removeOrReplacePaths.add(CLAIMS_PATH_PREFIX + AccessToken.ClaimNames.AUD.getName() + "/");
         return removeOrReplacePaths;
     }
 
-    private String generatePathForClaim(Map.Entry<String, Object> entry) {
+    private void collectNestedClaimPaths(String basePath, Object value, List<String> paths) {
 
-        String basePath = CLAIMS_PATH_PREFIX + entry.getKey();
-        if (entry.getValue() instanceof List || entry.getValue() instanceof String[]) {
-            basePath += "/";
+        if (value instanceof Map) {
+            Map<?, ?> map = (Map<?, ?>) value;
+
+            for (Map.Entry<?, ?> entry : map.entrySet()) {
+                if (!(entry.getKey() instanceof String)) {
+                    continue;
+                }
+                String childPath = basePath + "/" + entry.getKey();
+                paths.add(childPath);
+
+                collectNestedClaimPaths(childPath, entry.getValue(), paths);
+            }
         }
-        return basePath;
     }
 
     private AllowedOperation createAllowedOperation(Operation op, List<String> paths) {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/action/preissueidtoken/execution/PreIssueIDTokenResponseProcessor.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/action/preissueidtoken/execution/PreIssueIDTokenResponseProcessor.java
@@ -54,6 +54,7 @@ import org.wso2.carbon.identity.openidconnect.action.preissueidtoken.model.PreIs
 import org.wso2.carbon.utils.DiagnosticLog;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -455,9 +456,15 @@ public class PreIssueIDTokenResponseProcessor implements ActionExecutionResponse
                                                        IDToken requestIDToken,
                                                        IDTokenDTO responseIDTokenDTO) {
 
-       ClaimPathInfo claimPathInfo = parseOperationPath(operation.getPath());
-       IDToken.Claim claim = requestIDToken.getClaim(claimPathInfo.getClaimName());
+        List<String> pathSegments = extractNestedClaimPath(operation.getPath());
 
+        // Nested removal
+        if (pathSegments.size() > 1) {
+            return removeNestedClaim(pathSegments, requestIDToken, responseIDTokenDTO, operation);
+        }
+
+        ClaimPathInfo claimPathInfo = parseOperationPath(operation.getPath());
+        IDToken.Claim claim = requestIDToken.getClaim(claimPathInfo.getClaimName());
         if (claim == null) {
             return new OperationExecutionResult(operation, OperationExecutionResult.Status.FAILURE,
                     "Claim not found.");
@@ -469,6 +476,57 @@ public class PreIssueIDTokenResponseProcessor implements ActionExecutionResponse
         } else {
             return removePrimitiveTypeClaim(operation, claimPathInfo, responseIDTokenDTO);
         }
+    }
+
+    private OperationExecutionResult removeNestedClaim(List<String> pathSegments, IDToken requestIDToken,
+                                                       IDTokenDTO responseIDTokenDTO,
+                                                       PerformableOperation operation) {
+
+        String rootClaimName = pathSegments.get(0);
+        List<String> nestedPath = pathSegments.subList(1, pathSegments.size());
+
+        IDToken.Claim rootClaim = requestIDToken.getClaim(rootClaimName);
+        if (rootClaim == null || !(rootClaim.getValue() instanceof Map)) {
+            return new OperationExecutionResult(operation, OperationExecutionResult.Status.FAILURE,
+                    "Root claim is not a complex object.");
+        }
+
+        Map<String, Object> rootValue = new HashMap<>((Map<String, Object>) rootClaim.getValue());
+        boolean removed = removeFromNestedMap(rootValue, nestedPath, 0);
+        if (!removed) {
+            return new OperationExecutionResult(operation, OperationExecutionResult.Status.FAILURE,
+                    "Nested claim not found.");
+        }
+
+        if (rootValue.isEmpty()) {
+            responseIDTokenDTO.getCustomOIDCClaims().remove(rootClaimName);
+        } else {
+            responseIDTokenDTO.getCustomOIDCClaims().put(rootClaimName, rootValue);
+        }
+
+        return new OperationExecutionResult(operation, OperationExecutionResult.Status.SUCCESS,
+                "Nested claim removed.");
+    }
+
+    private boolean removeFromNestedMap(Map<String, Object> current, List<String> path, int index) {
+
+        String key = path.get(index);
+        if (index == path.size() - 1) {
+            return current.remove(key) != null;
+        }
+
+        Object next = current.get(key);
+        if (!(next instanceof Map)) {
+            return false;
+        }
+
+        return removeFromNestedMap((Map<String, Object>) next, path, index + 1);
+    }
+
+    private List<String> extractNestedClaimPath(String operationPath) {
+
+        String relativePath = operationPath.substring(CLAIMS_PATH_PREFIX.length());
+        return List.of(relativePath.split("/"));
     }
 
     private OperationExecutionResult removeClaimValueAtIndexFromArrayTypeClaim(PerformableOperation operation,
@@ -570,6 +628,13 @@ public class PreIssueIDTokenResponseProcessor implements ActionExecutionResponse
                                                         IDToken requestIDToken,
                                                         IDTokenDTO responseIDTokenDTO) {
 
+        List<String> pathSegments = extractNestedClaimPath(operation.getPath());
+
+        // Nested replace
+        if (pathSegments.size() > 1) {
+            return replaceNestedClaim(pathSegments, requestIDToken, responseIDTokenDTO, operation);
+        }
+
         ClaimPathInfo claimPathInfo = parseOperationPath(operation.getPath());
         IDToken.Claim claim = requestIDToken.getClaim(claimPathInfo.getClaimName());
 
@@ -583,6 +648,63 @@ public class PreIssueIDTokenResponseProcessor implements ActionExecutionResponse
         } else {
             return replacePrimitiveTypeClaim(operation, claimPathInfo, responseIDTokenDTO);
         }
+    }
+
+    private OperationExecutionResult replaceNestedClaim(List<String> pathSegments, IDToken requestIDToken,
+                                                        IDTokenDTO responseIDTokenDTO,
+                                                        PerformableOperation operation) {
+
+        String rootClaimName = pathSegments.get(0);
+        List<String> nestedPath = pathSegments.subList(1, pathSegments.size());
+
+        IDToken.Claim rootClaim = requestIDToken.getClaim(rootClaimName);
+        if (rootClaim == null || !(rootClaim.getValue() instanceof Map)) {
+            return new OperationExecutionResult(operation, OperationExecutionResult.Status.FAILURE,
+                    "Root claim is not a complex object.");
+        }
+
+        Map<String, Object> rootValue = new HashMap<>((Map<String, Object>) rootClaim.getValue());
+
+        boolean replaced = replaceInNestedMap(rootValue, nestedPath, 0, operation.getValue());
+        if (!replaced) {
+            return new OperationExecutionResult(operation, OperationExecutionResult.Status.FAILURE,
+                    "Nested claim not found.");
+        }
+
+        if (rootValue.isEmpty()) {
+            responseIDTokenDTO.getCustomOIDCClaims().remove(rootClaimName);
+        } else {
+            responseIDTokenDTO.getCustomOIDCClaims().put(rootClaimName, rootValue);
+        }
+
+        return new OperationExecutionResult(operation, OperationExecutionResult.Status.SUCCESS,
+                "Nested claim replaced.");
+    }
+
+    private boolean replaceInNestedMap(Map<String, Object> current, List<String> path, int index, Object newValue) {
+
+        String key = path.get(index);
+
+        if (index == path.size() - 1) {
+            if (newValue == null) {
+                return current.remove(key) != null;
+            }
+            current.put(key, newValue);
+            return true;
+        }
+
+        Object next = current.get(key);
+        if (!(next instanceof Map)) {
+            return false;
+        }
+        boolean updated = replaceInNestedMap((Map<String, Object>) next, path, index + 1, newValue);
+
+        Map<String, Object> nextMap = (Map<String, Object>) next;
+        if (updated && nextMap.isEmpty()) {
+            current.remove(key);
+        }
+
+        return updated;
     }
 
     private OperationExecutionResult replaceClaimValueAtIndexFromArrayTypeClaim(PerformableOperation operation,

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/action/preissueidtoken/execution/PreIssueIDTokenResponseProcessor.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/action/preissueidtoken/execution/PreIssueIDTokenResponseProcessor.java
@@ -470,7 +470,7 @@ public class PreIssueIDTokenResponseProcessor implements ActionExecutionResponse
         List<String> pathSegments = extractNestedClaimPath(operation.getPath());
 
         // Nested removal
-        if (pathSegments.size() > 1) {
+        if (pathSegments.size() > 1 && !isArrayIndexPath(pathSegments)) {
             return removeNestedClaim(pathSegments, requestIDToken, responseIDTokenDTO, operation);
         }
 
@@ -642,7 +642,7 @@ public class PreIssueIDTokenResponseProcessor implements ActionExecutionResponse
         List<String> pathSegments = extractNestedClaimPath(operation.getPath());
 
         // Nested replace
-        if (pathSegments.size() > 1) {
+        if (pathSegments.size() > 1 && !isArrayIndexPath(pathSegments)) {
             return replaceNestedClaim(pathSegments, requestIDToken, responseIDTokenDTO, operation);
         }
 
@@ -811,6 +811,25 @@ public class PreIssueIDTokenResponseProcessor implements ActionExecutionResponse
 
         Matcher matcher = STRING_OR_URI_PATTERN.matcher(input);
         return matcher.matches();
+    }
+
+    private boolean isArrayIndexPath(List<String> pathSegments) {
+
+        if (pathSegments.size() != 2) {
+            return false;
+        }
+
+        String lastSegment = pathSegments.get(1);
+        if (LAST_ELEMENT_CHARACTER.equals(lastSegment)) {
+            return true;
+        }
+
+        try {
+            Integer.parseInt(lastSegment);
+            return true;
+        } catch (NumberFormatException e) {
+            return false;
+        }
     }
 
     private ClaimPathInfo parseOperationPath(String operationPath) {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/action/preissueidtoken/execution/PreIssueIDTokenResponseProcessor.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/action/preissueidtoken/execution/PreIssueIDTokenResponseProcessor.java
@@ -352,7 +352,9 @@ public class PreIssueIDTokenResponseProcessor implements ActionExecutionResponse
             }
 
             Object claimValue = claim.getValue();
-            if (isValidPrimitiveValue(claimValue) || isValidListValue(claimValue)) {
+            if (isValidPrimitiveValue(claimValue)
+                    || isValidListValue(claimValue)
+                    || isValidMapValue(claimValue)) {
                 responseIDTokenDTO.getCustomOIDCClaims().put(claim.getName(), claim.getValue());
                 return new OperationExecutionResult(operation, OperationExecutionResult.Status.SUCCESS, "Claim added.");
             } else {
@@ -401,6 +403,15 @@ public class PreIssueIDTokenResponseProcessor implements ActionExecutionResponse
         }
         List<?> list = (List<?>) value;
         return list.stream().allMatch(item -> item instanceof String);
+    }
+
+    private boolean isValidMapValue(Object value) {
+
+        if (!(value instanceof Map<?, ?>)) {
+            return false;
+        }
+        Map<?, ?> map = (Map<?, ?>) value;
+        return true;
     }
 
     private OperationExecutionResult handleRemoveOperation(PerformableOperation operation, IDToken requestedIDToken,

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/openidconnect/action/preissueidtoken/execution/PreIssueIDTokenRequestBuilderTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/openidconnect/action/preissueidtoken/execution/PreIssueIDTokenRequestBuilderTest.java
@@ -1629,6 +1629,7 @@ public class PreIssueIDTokenRequestBuilderTest {
 
     @Test
     public void testGetRemoveOrReplacePathsWithDeeplyNestedClaims() throws ActionExecutionRequestBuilderException {
+
         Map<String, Object> customClaims = new HashMap<>();
         customClaims.put("simple", "value");
         Map<String, Object> level1 = new HashMap<>();
@@ -1665,6 +1666,7 @@ public class PreIssueIDTokenRequestBuilderTest {
 
     @Test
     public void testGetRemoveAndReplacePathsWithArrays() throws ActionExecutionRequestBuilderException {
+
         Map<String, Object> customClaims = new HashMap<>();
         customClaims.put("array_claim", new String[]{"val1", "val2"});
 

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/openidconnect/action/preissueidtoken/execution/PreIssueIDTokenRequestBuilderTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/openidconnect/action/preissueidtoken/execution/PreIssueIDTokenRequestBuilderTest.java
@@ -1662,4 +1662,29 @@ public class PreIssueIDTokenRequestBuilderTest {
                 .getPaths();
         assertComplexPaths(replacePaths);
     }
+
+    @Test
+    public void testGetRemoveAndReplacePathsWithArrays() throws ActionExecutionRequestBuilderException {
+        Map<String, Object> customClaims = new HashMap<>();
+        customClaims.put("array_claim", new String[]{"val1", "val2"});
+
+        IDTokenDTO idTokenDTO = getMockIDTokenDTO();
+        idTokenDTO.setCustomOIDCClaims(customClaims);
+
+        FlowContext flowContext = FlowContext.create()
+                .add(TOKEN_REQUEST_MESSAGE_CONTEXT, getMockTokenMessageContext())
+                .add(ID_TOKEN_DTO, idTokenDTO)
+                .add(REQUEST_TYPE, REQUEST_TYPE_TOKEN);
+
+        ActionExecutionRequest request = preIssueIDTokenRequestBuilder.buildActionExecutionRequest(
+                flowContext, null);
+        List<String> removePaths = request.getAllowedOperations().get(1).getPaths();
+        List<String> replacePaths = request.getAllowedOperations().get(2).getPaths();
+
+        Assert.assertTrue(removePaths.contains("/idToken/claims/array_claim"));
+        Assert.assertTrue(removePaths.contains("/idToken/claims/array_claim/"));
+
+        Assert.assertTrue(replacePaths.contains("/idToken/claims/array_claim"));
+        Assert.assertTrue(replacePaths.contains("/idToken/claims/array_claim/"));
+    }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/openidconnect/action/preissueidtoken/execution/PreIssueIDTokenRequestBuilderTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/openidconnect/action/preissueidtoken/execution/PreIssueIDTokenRequestBuilderTest.java
@@ -739,6 +739,7 @@ public class PreIssueIDTokenRequestBuilderTest {
         Assert.assertNotNull(actionExecutionRequest);
         PreIssueIDTokenEvent event = (PreIssueIDTokenEvent) actionExecutionRequest.getEvent();
         Assert.assertNotNull(event.getUser());
+        Assert.assertNotNull(event.getUser().getAccessingOrganization());
     }
 
     @Test

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/openidconnect/action/preissueidtoken/execution/PreIssueIDTokenRequestBuilderTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/openidconnect/action/preissueidtoken/execution/PreIssueIDTokenRequestBuilderTest.java
@@ -1197,6 +1197,19 @@ public class PreIssueIDTokenRequestBuilderTest {
         return idTokenDTO;
     }
 
+    private void assertComplexPaths(List<String> paths) {
+
+        Assert.assertTrue(paths.contains("/idToken/claims/simple"));
+        Assert.assertTrue(paths.contains("/idToken/claims/nested"));
+        Assert.assertTrue(paths.contains("/idToken/claims/nested/intermediate"));
+        Assert.assertTrue(paths.contains("/idToken/claims/nested/intermediate/leaf"));
+
+        Assert.assertTrue(paths.contains("/idToken/claims/list_claim"));
+        Assert.assertTrue(paths.contains("/idToken/claims/list_claim/"));
+
+        Assert.assertTrue(paths.contains("/idToken/claims/aud/"));
+    }
+
     @Test
     public void buildActionExecutionRequestWithMultipleHeadersForTokenFlow()
             throws ActionExecutionRequestBuilderException {
@@ -1612,5 +1625,41 @@ public class PreIssueIDTokenRequestBuilderTest {
         Assert.assertEquals(request.getAdditionalHeaders().size(), 2);
         Assert.assertNotNull(request.getAdditionalParams());
         Assert.assertEquals(request.getAdditionalParams().size(), 2);
+    }
+
+    @Test
+    public void testGetRemoveOrReplacePathsWithDeeplyNestedClaims() throws ActionExecutionRequestBuilderException {
+        Map<String, Object> customClaims = new HashMap<>();
+        customClaims.put("simple", "value");
+        Map<String, Object> level1 = new HashMap<>();
+        Map<String, Object> level2 = new HashMap<>();
+        level2.put("leaf", "value");
+        level1.put("intermediate", level2);
+        customClaims.put("nested", level1);
+        customClaims.put("list_claim", Arrays.asList("a", "b"));
+
+        IDTokenDTO idTokenDTO = getMockIDTokenDTO();
+        idTokenDTO.setCustomOIDCClaims(customClaims);
+
+        FlowContext flowContext = FlowContext.create()
+                .add(TOKEN_REQUEST_MESSAGE_CONTEXT, getMockTokenMessageContext())
+                .add(ID_TOKEN_DTO, idTokenDTO)
+                .add(REQUEST_TYPE, REQUEST_TYPE_TOKEN);
+        ActionExecutionRequest request = preIssueIDTokenRequestBuilder.buildActionExecutionRequest(
+                flowContext, null);
+
+        List<String> removePaths = request.getAllowedOperations().stream()
+                .filter(op -> op.getOp() == Operation.REMOVE)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("REMOVE operation not found"))
+                .getPaths();
+        assertComplexPaths(removePaths);
+
+        List<String> replacePaths = request.getAllowedOperations().stream()
+                .filter(op -> op.getOp() == Operation.REPLACE)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("REPLACE operation not found"))
+                .getPaths();
+        assertComplexPaths(replacePaths);
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/openidconnect/action/preissueidtoken/execution/PreIssueIDTokenRequestBuilderTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/openidconnect/action/preissueidtoken/execution/PreIssueIDTokenRequestBuilderTest.java
@@ -281,6 +281,30 @@ public class PreIssueIDTokenRequestBuilderTest {
     }
 
     @Test
+    public void testCollectNestedClaimPathsWithInvalidKeys() throws ActionExecutionRequestBuilderException {
+
+        Map<String, Object> customClaims = new HashMap<>();
+        Map<Object, Object> invalidKeyMap = new HashMap<>();
+        invalidKeyMap.put(123, "value");
+        invalidKeyMap.put("valid", "value");
+        customClaims.put("parent", invalidKeyMap);
+
+        IDTokenDTO idTokenDTO = getMockIDTokenDTO();
+        idTokenDTO.setCustomOIDCClaims(customClaims);
+
+        FlowContext flowContext = FlowContext.create()
+                .add(TOKEN_REQUEST_MESSAGE_CONTEXT, getMockTokenMessageContext())
+                .add(ID_TOKEN_DTO, idTokenDTO)
+                .add(REQUEST_TYPE, REQUEST_TYPE_TOKEN);
+        ActionExecutionRequest request = preIssueIDTokenRequestBuilder.
+                buildActionExecutionRequest(flowContext, null);
+        List<String> paths = request.getAllowedOperations().get(1).getPaths();
+
+        Assert.assertTrue(paths.contains("/idToken/claims/parent/valid"));
+        Assert.assertFalse(paths.contains("/idToken/claims/parent/123"));
+    }
+
+    @Test
     public void testBuildActionExecutionRequestWithMultipleScopes() throws ActionExecutionRequestBuilderException {
 
         OAuth2AccessTokenReqDTO tokenReqDTO = getMockOAuth2AccessTokenReqDTO();

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/openidconnect/action/preissueidtoken/execution/PreIssueIDTokenResponseProcessorTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/openidconnect/action/preissueidtoken/execution/PreIssueIDTokenResponseProcessorTest.java
@@ -758,17 +758,14 @@ public class PreIssueIDTokenResponseProcessorTest {
     public void testProcessSuccessResponse_RemoveClaim_FromArrayWithValidIndex()
             throws ActionExecutionResponseProcessorException {
 
-        Map<String, Object> nestedValue = new HashMap<>();
-        nestedValue.put("0", "value1");
-        nestedValue.put("1", "value2");
-
+        List<String> arrayValue = new ArrayList<>(Arrays.asList("value1", "value2"));
         IDToken.Builder tokenBuilder = new IDToken.Builder()
                 .addClaim(IDToken.ClaimNames.ISS.getName(), ORIGINAL_ISS)
                 .addClaim(IDToken.ClaimNames.SUB.getName(), ORIGINAL_SUB)
                 .addClaim(IDToken.ClaimNames.AUD.getName(), Arrays.asList(ORIGINAL_AUD))
                 .addClaim(IDToken.ClaimNames.EXP.getName(), ORIGINAL_EXP)
                 .addClaim(IDToken.ClaimNames.IAT.getName(), ORIGINAL_IAT)
-                .addClaim("arrayClaim", nestedValue);
+                .addClaim("arrayClaim", arrayValue);
 
         List<PerformableOperation> operationsToPerform = new ArrayList<>();
         operationsToPerform.add(createPerformableOperation(Operation.REMOVE,
@@ -792,7 +789,7 @@ public class PreIssueIDTokenResponseProcessorTest {
                 new OAuthTokenReqMessageContext(new OAuth2AccessTokenReqDTO());
         IDTokenDTO idTokenDTO = new IDTokenDTO();
         Map<String, Object> customClaims = new HashMap<>();
-        customClaims.put("arrayClaim", new HashMap<>(nestedValue));
+        customClaims.put("arrayClaim", new ArrayList<>(arrayValue));
         idTokenDTO.setCustomOIDCClaims(customClaims);
         idTokenDTO.setAudience(new ArrayList<>(Arrays.asList(ORIGINAL_AUD)));
 
@@ -803,10 +800,9 @@ public class PreIssueIDTokenResponseProcessorTest {
         processor.processSuccessResponse(flowContext, responseContext);
         IDTokenDTO resultDTO = tokenMessageContext.getPreIssueIDTokenActionDTO();
         assertNotNull(resultDTO.getCustomOIDCClaims());
-        Map<String, Object> resultArray =
-                (Map<String, Object>) resultDTO.getCustomOIDCClaims().get("arrayClaim");
-        assertNull(resultArray.get("0"));
-        assertEquals(resultArray.size(), 1);
+        List<String> arrayClaimValue = (List<String>) resultDTO.getCustomOIDCClaims().get("arrayClaim");
+        assertEquals(arrayClaimValue.size(), 1);
+        assertEquals(arrayClaimValue.get(0), "value2");
     }
 
     @Test
@@ -905,17 +901,14 @@ public class PreIssueIDTokenResponseProcessorTest {
     public void testProcessSuccessResponse_ReplaceClaim_InArrayWithValidIndex()
             throws ActionExecutionResponseProcessorException {
 
-        Map<String, Object> nestedValue = new HashMap<>();
-        nestedValue.put("0", "value1");
-        nestedValue.put("1", "value2");
-
+        List<String> arrayValue = new ArrayList<>(Arrays.asList("value1", "value2"));
         IDToken.Builder tokenBuilder = new IDToken.Builder()
                 .addClaim(IDToken.ClaimNames.ISS.getName(), ORIGINAL_ISS)
                 .addClaim(IDToken.ClaimNames.SUB.getName(), ORIGINAL_SUB)
                 .addClaim(IDToken.ClaimNames.AUD.getName(), Arrays.asList(ORIGINAL_AUD))
                 .addClaim(IDToken.ClaimNames.EXP.getName(), ORIGINAL_EXP)
                 .addClaim(IDToken.ClaimNames.IAT.getName(), ORIGINAL_IAT)
-                .addClaim("arrayClaim", nestedValue);
+                .addClaim("arrayClaim", arrayValue);
 
         List<PerformableOperation> operationsToPerform = new ArrayList<>();
         operationsToPerform.add(createPerformableOperation(Operation.REPLACE,
@@ -939,7 +932,7 @@ public class PreIssueIDTokenResponseProcessorTest {
                 new OAuthTokenReqMessageContext(new OAuth2AccessTokenReqDTO());
         IDTokenDTO idTokenDTO = new IDTokenDTO();
         Map<String, Object> customClaims = new HashMap<>();
-        customClaims.put("arrayClaim", new HashMap<>(nestedValue));
+        customClaims.put("arrayClaim", new ArrayList<>(arrayValue));
         idTokenDTO.setCustomOIDCClaims(customClaims);
         idTokenDTO.setAudience(new ArrayList<>(Arrays.asList(ORIGINAL_AUD)));
 
@@ -950,9 +943,9 @@ public class PreIssueIDTokenResponseProcessorTest {
         processor.processSuccessResponse(flowContext, responseContext);
         IDTokenDTO resultDTO = tokenMessageContext.getPreIssueIDTokenActionDTO();
         assertNotNull(resultDTO.getCustomOIDCClaims());
-        Map<String, Object> resultArray = (Map<String, Object>) resultDTO.getCustomOIDCClaims().get("arrayClaim");
-        assertEquals(resultArray.get("0"), "replacedValue");
-        assertFalse(resultArray.containsValue("value1"));
+        List<String> arrayClaimValue = (List<String>) resultDTO.getCustomOIDCClaims().get("arrayClaim");
+        assertTrue(arrayClaimValue.contains("replacedValue"));
+        assertFalse(arrayClaimValue.contains("value1"));
     }
 
     @Test

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/openidconnect/action/preissueidtoken/execution/PreIssueIDTokenResponseProcessorTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/openidconnect/action/preissueidtoken/execution/PreIssueIDTokenResponseProcessorTest.java
@@ -641,6 +641,27 @@ public class PreIssueIDTokenResponseProcessorTest {
     }
 
     @Test
+    public void testProcessSuccessResponse_AddClaim_WithValidArrayValue()
+            throws ActionExecutionResponseProcessorException {
+
+        List<String> arrayValue = Arrays.asList("value1", "value2", "value3");
+        IDToken.Claim newClaim = new IDToken.Claim("user_permissions", arrayValue);
+        List<PerformableOperation> operationsToPerform = new ArrayList<>();
+        operationsToPerform.add(createPerformableOperation(Operation.ADD,
+                CLAIMS_PATH_PREFIX + TAIL_CHARACTER, newClaim));
+
+        IDTokenDTO idTokenDTO = executeProcessSuccessResponseForToken(operationsToPerform, new HashMap<>());
+        assertNotNull(idTokenDTO.getCustomOIDCClaims());
+        assertTrue(idTokenDTO.getCustomOIDCClaims().containsKey("user_permissions"));
+        Object addedValue = idTokenDTO.getCustomOIDCClaims().get("user_permissions");
+        assertTrue(addedValue instanceof List, "The added claim value should be processed as a List.");
+
+        List<?> resultedList = (List<?>) addedValue;
+        assertEquals(resultedList.size(), 3);
+        assertEquals(resultedList, arrayValue, "The added list elements should match the values.");
+    }
+
+    @Test
     public void testProcessSuccessResponse_AddClaim_InvalidConversion()
             throws ActionExecutionResponseProcessorException {
 

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/openidconnect/action/preissueidtoken/execution/PreIssueIDTokenResponseProcessorTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/openidconnect/action/preissueidtoken/execution/PreIssueIDTokenResponseProcessorTest.java
@@ -625,7 +625,7 @@ public class PreIssueIDTokenResponseProcessorTest {
     }
 
     @Test
-    public void testProcessSuccessResponse_AddClaim_WithInvalidObjectValue()
+    public void testProcessSuccessResponse_AddClaim_WithValidObjectValue()
             throws ActionExecutionResponseProcessorException {
 
         List<PerformableOperation> operationsToPerform = new ArrayList<>();
@@ -636,7 +636,8 @@ public class PreIssueIDTokenResponseProcessorTest {
 
         IDTokenDTO idTokenDTO = executeProcessSuccessResponseForToken(operationsToPerform, new HashMap<>());
         assertNotNull(idTokenDTO.getCustomOIDCClaims());
-        assertNull(idTokenDTO.getCustomOIDCClaims().get("complexClaim"));
+        assertNotNull(idTokenDTO.getCustomOIDCClaims().get("complexClaim"));
+        assertEquals(idTokenDTO.getCustomOIDCClaims().get("complexClaim"), complexObject);
     }
 
     @Test
@@ -736,13 +737,17 @@ public class PreIssueIDTokenResponseProcessorTest {
     public void testProcessSuccessResponse_RemoveClaim_FromArrayWithValidIndex()
             throws ActionExecutionResponseProcessorException {
 
+        Map<String, Object> nestedValue = new HashMap<>();
+        nestedValue.put("0", "value1");
+        nestedValue.put("1", "value2");
+
         IDToken.Builder tokenBuilder = new IDToken.Builder()
                 .addClaim(IDToken.ClaimNames.ISS.getName(), ORIGINAL_ISS)
                 .addClaim(IDToken.ClaimNames.SUB.getName(), ORIGINAL_SUB)
                 .addClaim(IDToken.ClaimNames.AUD.getName(), Arrays.asList(ORIGINAL_AUD))
                 .addClaim(IDToken.ClaimNames.EXP.getName(), ORIGINAL_EXP)
                 .addClaim(IDToken.ClaimNames.IAT.getName(), ORIGINAL_IAT)
-                .addClaim("arrayClaim", Arrays.asList("value1", "value2"));
+                .addClaim("arrayClaim", nestedValue);
 
         List<PerformableOperation> operationsToPerform = new ArrayList<>();
         operationsToPerform.add(createPerformableOperation(Operation.REMOVE,
@@ -766,7 +771,7 @@ public class PreIssueIDTokenResponseProcessorTest {
                 new OAuthTokenReqMessageContext(new OAuth2AccessTokenReqDTO());
         IDTokenDTO idTokenDTO = new IDTokenDTO();
         Map<String, Object> customClaims = new HashMap<>();
-        customClaims.put("arrayClaim", new ArrayList<>(Arrays.asList("value1", "value2")));
+        customClaims.put("arrayClaim", new HashMap<>(nestedValue));
         idTokenDTO.setCustomOIDCClaims(customClaims);
         idTokenDTO.setAudience(new ArrayList<>(Arrays.asList(ORIGINAL_AUD)));
 
@@ -777,9 +782,10 @@ public class PreIssueIDTokenResponseProcessorTest {
         processor.processSuccessResponse(flowContext, responseContext);
         IDTokenDTO resultDTO = tokenMessageContext.getPreIssueIDTokenActionDTO();
         assertNotNull(resultDTO.getCustomOIDCClaims());
-        List<String> arrayClaimValue = (List<String>) resultDTO.getCustomOIDCClaims().get("arrayClaim");
-        assertEquals(arrayClaimValue.size(), 1);
-        assertEquals(arrayClaimValue.get(0), "value2");
+        Map<String, Object> resultArray =
+                (Map<String, Object>) resultDTO.getCustomOIDCClaims().get("arrayClaim");
+        assertNull(resultArray.get("0"));
+        assertEquals(resultArray.size(), 1);
     }
 
     @Test
@@ -878,13 +884,17 @@ public class PreIssueIDTokenResponseProcessorTest {
     public void testProcessSuccessResponse_ReplaceClaim_InArrayWithValidIndex()
             throws ActionExecutionResponseProcessorException {
 
+        Map<String, Object> nestedValue = new HashMap<>();
+        nestedValue.put("0", "value1");
+        nestedValue.put("1", "value2");
+
         IDToken.Builder tokenBuilder = new IDToken.Builder()
                 .addClaim(IDToken.ClaimNames.ISS.getName(), ORIGINAL_ISS)
                 .addClaim(IDToken.ClaimNames.SUB.getName(), ORIGINAL_SUB)
                 .addClaim(IDToken.ClaimNames.AUD.getName(), Arrays.asList(ORIGINAL_AUD))
                 .addClaim(IDToken.ClaimNames.EXP.getName(), ORIGINAL_EXP)
                 .addClaim(IDToken.ClaimNames.IAT.getName(), ORIGINAL_IAT)
-                .addClaim("arrayClaim", Arrays.asList("value1", "value2"));
+                .addClaim("arrayClaim", nestedValue);
 
         List<PerformableOperation> operationsToPerform = new ArrayList<>();
         operationsToPerform.add(createPerformableOperation(Operation.REPLACE,
@@ -908,7 +918,7 @@ public class PreIssueIDTokenResponseProcessorTest {
                 new OAuthTokenReqMessageContext(new OAuth2AccessTokenReqDTO());
         IDTokenDTO idTokenDTO = new IDTokenDTO();
         Map<String, Object> customClaims = new HashMap<>();
-        customClaims.put("arrayClaim", new ArrayList<>(Arrays.asList("value1", "value2")));
+        customClaims.put("arrayClaim", new HashMap<>(nestedValue));
         idTokenDTO.setCustomOIDCClaims(customClaims);
         idTokenDTO.setAudience(new ArrayList<>(Arrays.asList(ORIGINAL_AUD)));
 
@@ -919,9 +929,9 @@ public class PreIssueIDTokenResponseProcessorTest {
         processor.processSuccessResponse(flowContext, responseContext);
         IDTokenDTO resultDTO = tokenMessageContext.getPreIssueIDTokenActionDTO();
         assertNotNull(resultDTO.getCustomOIDCClaims());
-        List<String> arrayClaimValue = (List<String>) resultDTO.getCustomOIDCClaims().get("arrayClaim");
-        assertTrue(arrayClaimValue.contains("replacedValue"));
-        assertFalse(arrayClaimValue.contains("value1"));
+        Map<String, Object> resultArray = (Map<String, Object>) resultDTO.getCustomOIDCClaims().get("arrayClaim");
+        assertEquals(resultArray.get("0"), "replacedValue");
+        assertFalse(resultArray.containsValue("value1"));
     }
 
     @Test


### PR DESCRIPTION
This pull request improves the handling of nested claims in the pre-issue id token action. It introduces support for remove and replace operations on nested claim structures, and enables add custom object claims to the id token

**Nested Claim Support and Path Handling:**

* Added recursive logic in `PreIssueIDTokenRequestBuilder` to generate paths for nested claims, enabling precise targeting of sub-claims within complex objects.
* Implemented extraction and handling of nested claim paths in remove and replace operations, allowing modifications deep within claim hierarchies in `PreIssueIDTokenResponseProcessor`.

**Remove and Replace Operations for Nested Claims:**

* Added `removeNestedClaim` and `replaceNestedClaim` methods to recursively remove or update values within nested claim maps, ensuring correct updates and cleanup of empty parent claims. 

**Validation and Primitive Type Handling:**

* Introduced `isValidMapValue` to allow maps (objects) as valid claim values, extending support for complex claim types in addition to primitives and lists.

**Other Improvements**
- Improved organization switching logic in user resolution to handle cases where the accessing organization is not set, defaulting to the root organization