### PR TITLE
Add batch clearing of session store entries

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthUtil.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthUtil.java
@@ -1275,12 +1275,18 @@ public final class OAuthUtil {
                     .getAuthorizationCodeDAO().getAuthorizationCodesByUserForOpenidScope(authenticatedUser);
             
             // Retrieve the tokens and auth codes associated with domain-qualified usernames.
+            // Skip if the domain-qualified name is the same as the original (e.g., PRIMARY user store
+            // where addDomainToName returns the name unchanged), to avoid duplicate queries and
+            // redundant cache evictions.
             if (!userName.contains(UserCoreConstants.DOMAIN_SEPARATOR)) {
-                authenticatedUser.setUserName(IdentityUtil.addDomainToName(userName, userStoreDomain));
-                accessTokenDOSet.addAll(OAuthTokenPersistenceFactory.getInstance().getAccessTokenDAO()
-                        .getAccessTokensByUserForOpenidScope(authenticatedUser, true));
-                authorizationCodeDOSet.addAll(OAuthTokenPersistenceFactory.getInstance().getAuthorizationCodeDAO()
-                        .getAuthorizationCodesByUserForOpenidScope(authenticatedUser));
+                String domainQualifiedName = IdentityUtil.addDomainToName(userName, userStoreDomain);
+                if (!StringUtils.equals(userName, domainQualifiedName)) {
+                    authenticatedUser.setUserName(domainQualifiedName);
+                    accessTokenDOSet.addAll(OAuthTokenPersistenceFactory.getInstance().getAccessTokenDAO()
+                            .getAccessTokensByUserForOpenidScope(authenticatedUser, true));
+                    authorizationCodeDOSet.addAll(OAuthTokenPersistenceFactory.getInstance()
+                            .getAuthorizationCodeDAO().getAuthorizationCodesByUserForOpenidScope(authenticatedUser));
+                }
             }
             clearAuthzCodeGrantCachesForTokens(accessTokenDOSet, null);
             clearAuthzCodeGrantCachesForCodes(authorizationCodeDOSet, null);
@@ -1326,28 +1332,46 @@ public final class OAuthUtil {
                                                           String tenantDomain) {
 
         if (CollectionUtils.isNotEmpty(authorizationCodeDOSet)) {
+            List<String> codeIds = new ArrayList<>();
             for (AuthzCodeDO authorizationCodeDO : authorizationCodeDOSet) {
                 String authorizationCode = authorizationCodeDO.getAuthorizationCode();
-                String authzCodeId = authorizationCodeDO.getAuthzCodeId();
                 AuthorizationGrantCacheKey cacheKey = new AuthorizationGrantCacheKey(authorizationCode);
-                AuthorizationGrantCache.getInstance().clearCacheEntryByCodeId(cacheKey, authzCodeId, tenantDomain);
+                if (tenantDomain != null) {
+                    AuthorizationGrantCache.getInstance().clearCacheEntry(cacheKey, tenantDomain);
+                } else {
+                    AuthorizationGrantCache.getInstance().clearCacheEntry(cacheKey);
+                }
+                String authzCodeId = authorizationCodeDO.getAuthzCodeId();
+                if (StringUtils.isNotBlank(authzCodeId)) {
+                    codeIds.add(authzCodeId);
+                }
             }
+            AuthorizationGrantCache.getInstance().clearFromSessionStoreBatch(codeIds);
         }
     }
 
     private static void clearAuthzCodeGrantCachesForTokens(Set<AccessTokenDO> accessTokenDOSet, String tenantDomain) {
 
         if (CollectionUtils.isNotEmpty(accessTokenDOSet)) {
+            List<String> tokenIds = new ArrayList<>();
             for (AccessTokenDO accessTokenDO : accessTokenDOSet) {
                 if (StringUtils.equalsIgnoreCase(OAuthConstants.GrantTypes.PASSWORD,
                         accessTokenDO.getGrantType())) {
                     continue;
                 }
                 String accessToken = accessTokenDO.getAccessToken();
-                String tokenId = accessTokenDO.getTokenId();
                 AuthorizationGrantCacheKey cacheKey = new AuthorizationGrantCacheKey(accessToken);
-                AuthorizationGrantCache.getInstance().clearCacheEntryByTokenId(cacheKey, tokenId, tenantDomain);
+                if (tenantDomain != null) {
+                    AuthorizationGrantCache.getInstance().clearCacheEntry(cacheKey, tenantDomain);
+                } else {
+                    AuthorizationGrantCache.getInstance().clearCacheEntry(cacheKey);
+                }
+                String tokenId = accessTokenDO.getTokenId();
+                if (StringUtils.isNotBlank(tokenId)) {
+                    tokenIds.add(tokenId);
+                }
             }
+            AuthorizationGrantCache.getInstance().clearFromSessionStoreBatch(tokenIds);
         }
     }
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/cache/AuthorizationGrantCache.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/cache/AuthorizationGrantCache.java
@@ -36,6 +36,7 @@ import org.wso2.carbon.identity.oauth2.util.TokenMgtUtil;
 import org.wso2.carbon.utils.CarbonUtils;
 
 import java.text.ParseException;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -356,6 +357,19 @@ public class AuthorizationGrantCache extends
         if (StringUtils.isNotBlank(id)) {
             SessionDataStore.getInstance().clearSessionData(id, AUTHORIZATION_GRANT_CACHE_NAME);
         }
+    }
+
+    /**
+     * Clears cache entries from SessionDataStore for a batch of IDs in a single database operation.
+     *
+     * @param ids List of token/code IDs to clear from the session store.
+     */
+    public void clearFromSessionStoreBatch(List<String> ids) {
+
+        if (ids == null || ids.isEmpty()) {
+            return;
+        }
+        SessionDataStore.getInstance().clearSessionDataBatch(ids, AUTHORIZATION_GRANT_CACHE_NAME);
     }
 
     /**


### PR DESCRIPTION
This pull request improves the cache eviction logic in the OAuth module to make authorization code and token cache clearing more efficient and robust. The main changes include preventing redundant cache operations for domain-qualified usernames and introducing batch cache clearing to reduce database operations.

**Improvements to cache eviction logic:**

* Updated `removeAuthzGrantCacheForUser` in `OAuthUtil.java` to avoid duplicate queries and redundant cache evictions by checking if the domain-qualified username is different from the original username before proceeding.

**Batch cache clearing enhancements:**

* Refactored `clearAuthzCodeGrantCachesForCodes` and `clearAuthzCodeGrantCachesForTokens` in `OAuthUtil.java` to collect code/token IDs and clear them from the session store in batches, reducing the number of database operations.
* Added a new `clearFromSessionStoreBatch` method to `AuthorizationGrantCache.java` to support batch clearing of cache entries by a list of IDs.
* Imported `List` in `AuthorizationGrantCache.java` to support the new batch method.

### Related Issue
- https://github.com/wso2/product-is/issues/27576

### Related PRs
- https://github.com/wso2/carbon-identity-framework/pull/8027

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Eliminated redundant database queries and cache evictions for domain-qualified usernames in authentication operations.

* **Performance**
  * Improved cache eviction efficiency by switching from individual entry clearing to batch operations for authorization grants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->