### PR TITLE
Change Agent Application description

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/listener/UserApplicationCreationListener.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/listener/UserApplicationCreationListener.java
@@ -212,7 +212,7 @@ public class UserApplicationCreationListener extends AbstractIdentityUserOperati
         ServiceProvider serviceProvider = new ServiceProvider();
         serviceProvider.setApplicationName(OAuth2Constants.DEFAULT_AGENT_IDENTITY_USERSTORE_NAME
                 + "-" + username);
-        serviceProvider.setDescription("Agent application auto-created for agent using OAuth2 client credentials.");
+        serviceProvider.setDescription("Agent application auto-created for agent.");
         serviceProvider.setTemplateId("agent-application");
         serviceProvider.setAPIBasedAuthenticationEnabled(true);
         AssociatedRolesConfig associatedRolesConfig = new AssociatedRolesConfig();


### PR DESCRIPTION
Change the Agent Application description.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changes

Updated the description of the auto-created agent application in the user application creation listener. The description was simplified from a longer form that included specific implementation details to a shorter, generic description ("Agent application auto-created for agent.").

## Impact

This change simplifies the agent application's description to provide a more concise and generic identifier without implementation-specific details.

## Files Modified

- `components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/listener/UserApplicationCreationListener.java` (1 line changed)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->