### PR TITLE
Add SunPKCS11 HSM provider pinning to JWSSigner for Hardware Security Module support

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuer.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuer.java
@@ -62,8 +62,8 @@ import org.wso2.carbon.identity.openidconnect.util.ClaimHandlerUtil;
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
 
 import java.security.Key;
+import java.security.PrivateKey;
 import java.security.cert.Certificate;
-import java.security.interfaces.RSAPrivateKey;
 import java.text.ParseException;
 import java.util.Arrays;
 import java.util.Calendar;
@@ -662,7 +662,7 @@ public class JWTTokenIssuer extends OauthTokenIssuerImpl {
             jwtClaimsSet = setSignerRealm(tenantDomain, jwtClaimsSet);
 
             Key privateKey = getPrivateKey(tenantDomain, tenantId);
-            JWSSigner signer = OAuth2Util.createJWSSigner((RSAPrivateKey) privateKey);
+            JWSSigner signer = OAuth2Util.createJWSSigner((PrivateKey) privateKey);
             JWSHeader.Builder headerBuilder = new JWSHeader.Builder((JWSAlgorithm) signatureAlgorithm);
             String certThumbPrint;
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -3552,13 +3552,9 @@ public class OAuth2Util {
         // Pin JWSSigner to the SunPKCS11 provider so that Nimbus uses the HSM for signing.
         if (isHSMEnabled()) {
             Provider hsmProvider = getHSMProvider();
-            if (hsmProvider != null) {
-                signer.getJCAContext().setProvider(hsmProvider);
-                if (log.isDebugEnabled()) {
-                    log.debug("HSM enabled - pinned JWSSigner to provider: " + hsmProvider.getName());
-                }
-            } else {
-                log.warn("HSM keystore is enabled but no SunPKCS11 provider was found in the JVM.");
+            signer.getJCAContext().setProvider(hsmProvider);
+            if (log.isDebugEnabled()) {
+                log.debug("HSM enabled - pinned JWSSigner to provider: " + hsmProvider.getName());
             }
         }
         return signer;
@@ -3580,7 +3576,8 @@ public class OAuth2Util {
      * The provider is registered by Carbon Kernel's {@code KeyStoreManager.getHSMKeyStore()}
      * during server startup.
      *
-     * @return the first SunPKCS11-* provider, or {@code null} if none is registered.
+     * @return the first SunPKCS11-* provider.
+     * @throws IllegalStateException if no SunPKCS11 provider is registered.
      */
     private static Provider getHSMProvider() {
 
@@ -3589,7 +3586,8 @@ public class OAuth2Util {
                 return p;
             }
         }
-        return null;
+        throw new IllegalStateException("HSM keystore is enabled but no SunPKCS11 provider was found "
+                + "in the JVM. Ensure the PKCS#11 provider is configured and registered during server startup.");
     }
 
     /**

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -196,13 +196,13 @@ import java.security.Key;
 import java.security.KeyStoreException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.security.interfaces.ECPublicKey;
-import java.security.interfaces.RSAPrivateKey;
 import java.security.interfaces.RSAPublicKey;
 import java.sql.Timestamp;
 import java.text.ParseException;
@@ -3529,7 +3529,7 @@ public class OAuth2Util {
      * @param privateKey RSA Private key.
      * @return JWSSigner
      */
-    public static JWSSigner createJWSSigner(RSAPrivateKey privateKey) {
+    public static JWSSigner createJWSSigner(PrivateKey privateKey) {
 
         boolean allowWeakKey = Boolean.parseBoolean(System.getProperty(ALLOW_WEAK_RSA_SIGNER_KEY));
         if (allowWeakKey && log.isDebugEnabled()) {
@@ -3593,7 +3593,7 @@ public class OAuth2Util {
             }
 
             Key privateKey = getPrivateKey(tenantDomain);
-            JWSSigner signer = OAuth2Util.createJWSSigner((RSAPrivateKey) privateKey);
+            JWSSigner signer = OAuth2Util.createJWSSigner((PrivateKey) privateKey);
             JWSHeader.Builder headerBuilder = new JWSHeader.Builder((JWSAlgorithm) signatureAlgorithm);
             headerBuilder.keyID(getKID(getCertificate(tenantDomain), signatureAlgorithm, tenantDomain));
             Certificate certificate = getCertificate(tenantDomain);

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -64,6 +64,7 @@ import org.apache.oltu.oauth2.common.exception.OAuthSystemException;
 import org.apache.oltu.oauth2.common.utils.OAuthUtils;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.wso2.carbon.base.ServerConfiguration;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.application.authentication.framework.exception.FrameworkException;
 import org.wso2.carbon.identity.application.authentication.framework.exception.UserIdNotFoundException;
@@ -197,6 +198,8 @@ import java.security.KeyStoreException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
+import java.security.Provider;
+import java.security.Security;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.CertificateException;
@@ -429,6 +432,10 @@ public class OAuth2Util {
 
     private static final String BASIC_AUTHORIZATION_PREFIX = "Basic ";
     private static final String BEARER_AUTHORIZATION_PREFIX = "Bearer ";
+
+    // HSM / SunPKCS11 constants
+    private static final String HSM_KEYSTORE_ENABLED = "Security.HSMKeyStore.Enabled";
+    private static final String SUN_PKCS11_PREFIX = "SunPKCS11-";
 
     private static final List<String> PORTAL_APP_IDS = Arrays.asList(
             ApplicationConstants.MY_ACCOUNT_APPLICATION_CLIENT_ID,
@@ -3525,9 +3532,13 @@ public class OAuth2Util {
 
     /**
      * Create JWSSigner using the server level configurations and return.
+     * <p>
+     * When HSM keystore is enabled ({@code Security.HSMKeyStore.Enabled}), the signer's
+     * JCA context is pinned to the registered SunPKCS11 provider so that Nimbus
+     * delegates all cryptographic operations to the hardware security module.
      *
-     * @param privateKey RSA Private key.
-     * @return JWSSigner
+     * @param privateKey Private key (may be a PKCS#11 opaque handle).
+     * @return JWSSigner configured for the appropriate provider.
      */
     public static JWSSigner createJWSSigner(PrivateKey privateKey) {
 
@@ -3536,7 +3547,49 @@ public class OAuth2Util {
             log.debug("System flag 'allow_weak_rsa_signer_key' is  enabled. So weak keys (key length less than 2048) " +
                     " will be allowed for signing.");
         }
-        return new RSASSASigner(privateKey, allowWeakKey);
+        JWSSigner signer = new RSASSASigner(privateKey, allowWeakKey);
+
+        // Pin JWSSigner to the SunPKCS11 provider so that Nimbus uses the HSM for signing.
+        if (isHSMEnabled()) {
+            Provider hsmProvider = getHSMProvider();
+            if (hsmProvider != null) {
+                signer.getJCAContext().setProvider(hsmProvider);
+                if (log.isDebugEnabled()) {
+                    log.debug("HSM enabled - pinned JWSSigner to provider: " + hsmProvider.getName());
+                }
+            } else {
+                log.warn("HSM keystore is enabled but no SunPKCS11 provider was found in the JVM.");
+            }
+        }
+        return signer;
+    }
+
+    /**
+     * Check whether HSM-based keystore is enabled via {@code Security.HSMKeyStore.Enabled}
+     * in carbon.xml (sourced from deployment.toml).
+     *
+     * @return {@code true} if HSM keystore is enabled.
+     */
+    private static boolean isHSMEnabled() {
+
+        return Boolean.parseBoolean(ServerConfiguration.getInstance().getFirstProperty(HSM_KEYSTORE_ENABLED));
+    }
+
+    /**
+     * Auto-detect the configured SunPKCS11 provider from the JVM.
+     * The provider is registered by Carbon Kernel's {@code KeyStoreManager.getHSMKeyStore()}
+     * during server startup.
+     *
+     * @return the first SunPKCS11-* provider, or {@code null} if none is registered.
+     */
+    private static Provider getHSMProvider() {
+
+        for (Provider p : Security.getProviders()) {
+            if (p.getName().startsWith(SUN_PKCS11_PREFIX)) {
+                return p;
+            }
+        }
+        return null;
     }
 
     /**


### PR DESCRIPTION
## Add SunPKCS11 HSM provider pinning to JWSSigner for Hardware Security Module support

### Proposed changes in this pull request

- Changed `createJWSSigner()` parameter type from `RSAPrivateKey` to `PrivateKey` to support PKCS#11 opaque key handles from HSM devices.
- Updated all call sites in `OAuth2Util.signJWTWithRSA()` and `JWTTokenIssuer.signJWTWithRSA()` to cast to `PrivateKey` instead of `RSAPrivateKey`.
- Added HSM provider pinning logic in `createJWSSigner()` — when `Security.HSMKeyStore.Enabled` is `true` in `deployment.toml`, the signer's JCA context is automatically pinned to the registered `SunPKCS11` provider so Nimbus delegates all cryptographic operations to the hardware security module.
- Added `isHSMEnabled()` helper to read HSM configuration from `ServerConfiguration`.
- Added `getHSMProvider()` helper to auto-detect the registered `SunPKCS11-*` provider from the JVM.
- Added `ServerConfiguration`, `java.security.Provider`, and `java.security.Security` imports.
- Added `HSM_KEYSTORE_ENABLED` and `SUN_PKCS11_PREFIX` constants.

### When should this PR be merged

- This PR can be merged after code review approval.
- No breaking changes — when HSM is not enabled (default), the behavior is identical to the existing implementation. The `RSASSASigner` constructor accepts `PrivateKey` (parent type), so non-HSM setups are unaffected.
- Carbon Kernel must have the corresponding `KeyStoreManager.getHSMKeyStore()` support for runtime HSM functionality.

### Follow up actions

- Verify end-to-end JWT signing with a SunPKCS11-configured HSM (e.g., SoftHSM) on a staging IS/APIM deployment.
- Update `deployment.toml` documentation to include the `[security.hsm_keystore]` configuration block.

## Developer Checklist (Mandatory)

- [ ] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact.

### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description.
- [ ] **Is the PR labeled correctly?**

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled.

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests.
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/).

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components.
- [ ] **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won't regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

#### Security

- [ ] **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
- [ ] **Are all UI and API inputs run through forms or serializers?**
- [ ] **Are all external inputs validated and sanitized appropriately?**
- [ ] **Does all branching logic have a default case?**
- [ ] **Does this solution handle outliers and edge cases gracefully?**
- [ ] **Are all external communications secured and restricted to SSL?**

#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes should be documented.
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented.
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This pull request adds support for Hardware Security Module (HSM) integration to the OAuth2 JWT signing flow by allowing the signing logic to work with opaque PKCS#11 key handles and to route cryptographic operations to a SunPKCS11 provider when configured.

Changes
- Modified createJWSSigner() to accept java.security.PrivateKey (instead of RSAPrivateKey) to support PKCS#11 opaque keys from HSMs.
- Updated call sites (JWTTokenIssuer.signJWTWithRSA and OAuth2Util.signJWTWithRSA) to cast retrieved keys to PrivateKey.
- When Security.HSMKeyStore.Enabled is true, pin the Nimbus JWSSigner JCA context to the first registered SunPKCS11-* provider so signing is delegated to the HSM.
- Added helper methods isHSMEnabled() (reads HSM config from ServerConfiguration) and getHSMProvider() (locates a SunPKCS11-* provider), plus related imports and constants.
- Includes developer/reviewer checklists and notes about follow-ups.

Impact
- No change in behavior when HSM is disabled; existing non-HSM signing continues unchanged.
- Runtime HSM usage requires the Carbon Kernel to provide KeyStoreManager.getHSMKeyStore() support.
- Follow-ups recommended: end-to-end verification with a SunPKCS11-configured HSM (e.g., SoftHSM) and documentation updates for deployment.toml HSM configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->