### PR TITLE
[Next]Update agent application naming to include agent name from claims

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/listener/UserApplicationCreationListener.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/listener/UserApplicationCreationListener.java
@@ -123,7 +123,11 @@ public class UserApplicationCreationListener extends AbstractIdentityUserOperati
 
             // Only create the OAuth2/OIDC application if this is a user-serving agent
             if (isUserServingAgent) {
-                createAgentApplication(username, tenantDomain);
+                String agentName = claims != null ? claims.get(OAuth2Constants.AGENT_NAME_CLAIM_URI) : null;
+                if (StringUtils.isBlank(agentName)) {
+                        agentName = "agent";
+                }
+                createAgentApplication(username, tenantDomain, agentName);
             } else {
                 if (log.isDebugEnabled()) {
                     log.debug("Skipping application creation for non-user-serving agent");
@@ -205,13 +209,13 @@ public class UserApplicationCreationListener extends AbstractIdentityUserOperati
         return true;
     }
 
-    private void createAgentApplication(String username, String tenantDomain)
+    private void createAgentApplication(String username, String tenantDomain, String agentName)
             throws IdentityApplicationManagementException, NullPointerException {
 
         // Create a new ServiceProvider (Application).
         ServiceProvider serviceProvider = new ServiceProvider();
-        serviceProvider.setApplicationName(OAuth2Constants.DEFAULT_AGENT_IDENTITY_USERSTORE_NAME
-                + "-" + username);
+        String usernameSuffix = username.length() >= 4 ? username.substring(0, 4) : username;
+        serviceProvider.setApplicationName(agentName + "-" + usernameSuffix);
         serviceProvider.setDescription("Agent application auto-created for agent.");
         serviceProvider.setTemplateId("agent-application");
         serviceProvider.setAPIBasedAuthenticationEnabled(true);

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/OAuth2Constants.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/OAuth2Constants.java
@@ -62,6 +62,7 @@ public class OAuth2Constants {
     public static final String AGENT_IDENTITY_ENABLE = "AgentIdentity.Enabled";
     public static final String AGENT_IDENTITY_USERSTORE_NAME = "AgentIdentity.Userstore";
     public static final String DEFAULT_AGENT_IDENTITY_USERSTORE_NAME = "AGENT";
+    public static final String AGENT_NAME_CLAIM_URI = "http://wso2.org/claims/agent/Name";
     public static final String STORE_OPERATION = "STORE";
     public static final String SKIP_REFRESH_TOKEN_PERSISTENT = "npr:skipRefreshTokenPersistent";
 

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/listener/UserApplicationCreationListenerTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/listener/UserApplicationCreationListenerTest.java
@@ -31,12 +31,14 @@ import org.wso2.carbon.identity.application.mgt.inbound.dto.ApplicationDTO;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.oauth.internal.OAuthComponentServiceHolder;
+import org.wso2.carbon.identity.oauth2.OAuth2Constants;
 import org.wso2.carbon.identity.testutil.IdentityBaseTest;
 import org.wso2.carbon.user.core.UserStoreException;
 import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
 import org.wso2.carbon.user.core.common.User;
 
 import java.util.HashMap;
+import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -47,6 +49,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.openMocks;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
@@ -283,6 +286,120 @@ public class UserApplicationCreationListenerTest extends IdentityBaseTest {
             assertTrue(e.getMessage().contains("Agent application deletion failed for agent"),
                     "Exception message should indicate agent application deletion failure");
         }
+    }
+
+    @Test
+    public void testDoPostAddUserWithID_ApplicationNameWithAgentNameFromClaims()
+            throws UserStoreException, IdentityApplicationManagementException {
+
+        String agentName = "MyAgent";
+        String username = "0796b8ac-c867-4f71-8dba-fd08b8ed2383";
+        Map<String, String> claims = new HashMap<>();
+        claims.put(OAuth2Constants.AGENT_NAME_CLAIM_URI, agentName);
+
+        setupCommonMocks();
+        setupAgentUserMocks();
+        when(user.getUsername()).thenReturn(username);
+
+        boolean result = listener.doPostAddUserWithID(user, "password", new String[]{"role1"},
+                claims, null, userStoreManager);
+
+        assertTrue(result, "Listener should return true after successful application creation");
+
+        ArgumentCaptor<ApplicationDTO> applicationDTOCaptor =
+                ArgumentCaptor.forClass(ApplicationDTO.class);
+        verify(applicationManagementService).createApplication(applicationDTOCaptor.capture(),
+                eq(TENANT_DOMAIN), eq(username));
+
+        ApplicationDTO capturedAppDTO = applicationDTOCaptor.getValue();
+        assertNotNull(capturedAppDTO, "ApplicationDTO should not be null");
+        assertNotNull(capturedAppDTO.getServiceProvider(), "ServiceProvider should not be null");
+
+        String applicationName = capturedAppDTO.getServiceProvider().getApplicationName();
+        assertEquals(applicationName, "MyAgent-0796",
+                "Application name should be in format {agentName}-{first4CharsOfUsername}");
+    }
+
+    @Test
+    public void testDoPostAddUserWithID_ApplicationNameWithMissingAgentNameClaim()
+            throws UserStoreException, IdentityApplicationManagementException {
+
+        String username = "0796b8ac-c867-4f71-8dba-fd08b8ed2383";
+        Map<String, String> claims = new HashMap<>();
+        // Agent name claim is not present
+
+        setupCommonMocks();
+        setupAgentUserMocks();
+        when(user.getUsername()).thenReturn(username);
+
+        boolean result = listener.doPostAddUserWithID(user, "password", new String[]{"role1"},
+                claims, null, userStoreManager);
+
+        assertTrue(result, "Listener should return true after successful application creation");
+
+        ArgumentCaptor<ApplicationDTO> applicationDTOCaptor =
+                ArgumentCaptor.forClass(ApplicationDTO.class);
+        verify(applicationManagementService).createApplication(applicationDTOCaptor.capture(),
+                eq(TENANT_DOMAIN), eq(username));
+
+        ApplicationDTO capturedAppDTO = applicationDTOCaptor.getValue();
+        String applicationName = capturedAppDTO.getServiceProvider().getApplicationName();
+        assertEquals(applicationName, "agent-0796",
+                "Application name should fallback to 'agent' when claim is missing");
+    }
+
+    @Test
+    public void testDoPostAddUserWithID_ApplicationNameWithBlankAgentNameClaim()
+            throws UserStoreException, IdentityApplicationManagementException {
+
+        String username = "0796b8ac-c867-4f71-8dba-fd08b8ed2383";
+        Map<String, String> claims = new HashMap<>();
+        claims.put(OAuth2Constants.AGENT_NAME_CLAIM_URI, "   "); // Blank agent name
+
+        setupCommonMocks();
+        setupAgentUserMocks();
+        when(user.getUsername()).thenReturn(username);
+
+        boolean result = listener.doPostAddUserWithID(user, "password", new String[]{"role1"},
+                claims, null, userStoreManager);
+
+        assertTrue(result, "Listener should return true after successful application creation");
+
+        ArgumentCaptor<ApplicationDTO> applicationDTOCaptor =
+                ArgumentCaptor.forClass(ApplicationDTO.class);
+        verify(applicationManagementService).createApplication(applicationDTOCaptor.capture(),
+                eq(TENANT_DOMAIN), eq(username));
+
+        ApplicationDTO capturedAppDTO = applicationDTOCaptor.getValue();
+        String applicationName = capturedAppDTO.getServiceProvider().getApplicationName();
+        assertEquals(applicationName, "agent-0796",
+                "Application name should fallback to 'agent' when claim is blank");
+    }
+
+    @Test
+    public void testDoPostAddUserWithID_ApplicationNameWithNullClaims()
+            throws UserStoreException, IdentityApplicationManagementException {
+
+        String username = "0796b8ac-c867-4f71-8dba-fd08b8ed2383";
+
+        setupCommonMocks();
+        setupAgentUserMocks();
+        when(user.getUsername()).thenReturn(username);
+
+        boolean result = listener.doPostAddUserWithID(user, "password", new String[]{"role1"},
+                null, null, userStoreManager);
+
+        assertTrue(result, "Listener should return true after successful application creation");
+
+        ArgumentCaptor<ApplicationDTO> applicationDTOCaptor =
+                ArgumentCaptor.forClass(ApplicationDTO.class);
+        verify(applicationManagementService).createApplication(applicationDTOCaptor.capture(),
+                eq(TENANT_DOMAIN), eq(username));
+
+        ApplicationDTO capturedAppDTO = applicationDTOCaptor.getValue();
+        String applicationName = capturedAppDTO.getServiceProvider().getApplicationName();
+        assertEquals(applicationName, "agent-0796",
+                "Application name should fallback to 'agent' when claims are null");
     }
 
     private void setupCommonMocks() throws UserStoreException {


### PR DESCRIPTION
## Description

  Updated the agent application naming convention in `UserApplicationCreationListener` to use a more descriptive format that includes the agent name from user claims.

  ## Changes
  - Modified `createAgentApplication()` to accept agent name as a parameter
  - Extract agent name from claim `http://wso2.org/claims/agent/Name` in `doPostAddUserWithID()`
  - Updated application name format from `username` to `{agentName}-{first4CharsOfUsername}`
  - Added fallback to `"agent"` when agent name claim is not available
  - Removed unused import `org.wso2.carbon.identity.oauth2.OAuth2Constants`

  ## Application Name Format
  **Before:** `AGENT-0796b8ac-c867-4f71-8dba-fd08b8ed2383`

  **After:** `MyAgent-0796` (where `MyAgent` is from claims, `0796` is first 4 chars of username)

  **Fallback:** `agent-0796` (when agent name claim is missing or blank)
  
  Issue:- https://github.com/wso2/product-is/issues/27653
 