### PR TITLE
Unit test for fst cache versioning

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/cache/CacheEntryVersioningAssert.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/cache/CacheEntryVersioningAssert.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth.cache;
+
+import org.nustaq.serialization.annotations.Version;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Reusable assertion helper that enforces the FST serialization-compatibility contract on classes
+ * extending {@code org.wso2.carbon.identity.core.cache.CacheEntry}:
+ * <ul>
+ *   <li>Every field declared at the time versioning was introduced (the "v0 baseline") must still
+ *       exist, in the SAME declaration order, and must NOT carry {@code @Version}.</li>
+ *   <li>Every field declared outside the baseline must carry {@code @Version(n)} with n >= 1 and
+ *       must appear AFTER all baseline fields in source declaration order.</li>
+ *   <li>The total number of {@code @Version}-annotated fields must match the expected count, so
+ *       deletion of a versioned field is also caught.</li>
+ * </ul>
+ * The helper is class-agnostic — callers supply the target class and its frozen baseline.
+ *
+ * <p>Note on declaration order: {@code Class#getDeclaredFields()} does not formally guarantee
+ * source order, but all mainstream JVMs (HotSpot/OpenJDK) return fields in declaration order, and
+ * FST's own versioning contract relies on that same ordering, so this assertion is consistent
+ * with the runtime behaviour the cache entries depend on.</p>
+ */
+final class CacheEntryVersioningAssert {
+
+    private CacheEntryVersioningAssert() {
+    }
+
+    static void assertFieldVersioning(Class<?> target, List<String> v0Baseline, int expectedVersionedCount) {
+
+        List<String> violations = new ArrayList<>();
+        List<Field> declared = declaredInstanceFields(target);
+        Set<String> declaredNames = new HashSet<>();
+        for (Field f : declared) {
+            declaredNames.add(f.getName());
+        }
+
+        int baselineLimit = Math.min(v0Baseline.size(), declared.size());
+        for (int i = 0; i < baselineLimit; i++) {
+            Field field = declared.get(i);
+            String expected = v0Baseline.get(i);
+            String actual = field.getName();
+            if (!actual.equals(expected)) {
+                violations.add("Field at declaration position " + i + " is '" + actual +
+                        "' but the v0 baseline expects '" + expected +
+                        "'. Baseline fields must retain their original declaration order — " +
+                        "reordering, renaming, or inserting unversioned fields breaks FST deserialization " +
+                        "of previously persisted entries.");
+            }
+            if (field.isAnnotationPresent(Version.class)) {
+                violations.add("Baseline field '" + actual + "' must NOT carry @Version. " +
+                        "Baseline fields are the pre-versioning snapshot; do not retrofit @Version on them.");
+            }
+        }
+
+        int versionedCount = 0;
+        for (int i = v0Baseline.size(); i < declared.size(); i++) {
+            Field field = declared.get(i);
+            String name = field.getName();
+            if (!field.isAnnotationPresent(Version.class)) {
+                violations.add("Field '" + name + "' at declaration position " + i +
+                        " is declared after the v0 baseline but does not carry @Version. " +
+                        "Every new field added to " + target.getSimpleName() +
+                        " MUST be annotated with @Version(n) and appended after all baseline fields.");
+            } else {
+                versionedCount++;
+                int v = field.getAnnotation(Version.class).value();
+                if (v < 1) {
+                    violations.add("Field '" + name + "' has @Version(" + v + "); value must be >= 1.");
+                }
+            }
+        }
+
+        for (String expected : v0Baseline) {
+            if (!declaredNames.contains(expected)) {
+                violations.add("Baseline field '" + expected + "' is missing from " + target.getSimpleName() +
+                        ". Existing fields must never be removed or renamed — doing so breaks deserialization " +
+                        "of cache entries already persisted in IDN_AUTH_SESSION_STORE.");
+            }
+        }
+
+        if (versionedCount != expectedVersionedCount) {
+            violations.add("Expected " + expectedVersionedCount + " @Version-annotated field(s) on " +
+                    target.getSimpleName() + " but found " + versionedCount +
+                    ". If this change is intentional, update the expected count in the test's data provider.");
+        }
+
+        if (!violations.isEmpty()) {
+            StringBuilder msg = new StringBuilder("FST versioning contract violated on ")
+                    .append(target.getName()).append(':');
+            for (String v : violations) {
+                msg.append("\n  - ").append(v);
+            }
+            throw new AssertionError(msg.toString());
+        }
+    }
+
+    static void assertBaselinePresent(Class<?> target, List<String> v0Baseline) {
+
+        List<String> declaredOrder = new ArrayList<>();
+        for (Field field : declaredInstanceFields(target)) {
+            declaredOrder.add(field.getName());
+        }
+        Set<String> declaredSet = new HashSet<>(declaredOrder);
+
+        List<String> missing = new ArrayList<>();
+        for (String expected : v0Baseline) {
+            if (!declaredSet.contains(expected)) {
+                missing.add(expected);
+            }
+        }
+        if (!missing.isEmpty()) {
+            throw new AssertionError("Baseline fields missing from " + target.getName() + ": " + missing +
+                    ". Renaming/removing these fields breaks FST deserialization of previously persisted entries.");
+        }
+
+        int baselineLimit = Math.min(v0Baseline.size(), declaredOrder.size());
+        List<String> orderViolations = new ArrayList<>();
+        for (int i = 0; i < baselineLimit; i++) {
+            String expected = v0Baseline.get(i);
+            String actual = declaredOrder.get(i);
+            if (!actual.equals(expected)) {
+                orderViolations.add("position " + i + ": expected '" + expected + "', found '" + actual + "'");
+            }
+        }
+        if (!orderViolations.isEmpty()) {
+            throw new AssertionError("Baseline field order drift on " + target.getName() + ": " +
+                    orderViolations + ". Baseline fields must retain their original declaration order.");
+        }
+    }
+
+    private static List<Field> declaredInstanceFields(Class<?> target) {
+
+        List<Field> result = new ArrayList<>();
+        for (Field field : target.getDeclaredFields()) {
+            if (!isIgnored(field)) {
+                result.add(field);
+            }
+        }
+        return Collections.unmodifiableList(result);
+    }
+
+    private static boolean isIgnored(Field field) {
+
+        int mods = field.getModifiers();
+        if (Modifier.isStatic(mods) || Modifier.isTransient(mods)) {
+            return true;
+        }
+        if (field.isSynthetic()) {
+            return true;
+        }
+        String name = field.getName();
+        return name.startsWith("$") || "serialVersionUID".equals(name);
+    }
+}

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/cache/CacheEntryVersioningTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/cache/CacheEntryVersioningTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth.cache;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Class-agnostic guardrail test for FST-serialized CacheEntry subclasses.
+ * <p>
+ * Each row in {@link #cacheEntries()} declares: the target class, the frozen v0 baseline field list
+ * (in original declaration order), and the expected number of {@code @Version}-annotated fields.
+ * To extend coverage to another cache entry, add one row — no new test class required.
+ */
+public class CacheEntryVersioningTest {
+
+    private static final List<String> AUTHORIZATION_GRANT_CACHE_ENTRY_V0_BASELINE = Collections.unmodifiableList(
+            Arrays.asList(
+                    "codeId",
+                    "authorizationCode",
+                    "tokenId",
+                    "userAttributes",
+                    "nonceValue",
+                    "pkceCodeChallenge",
+                    "pkceCodeChallengeMethod",
+                    "acrValue",
+                    "selectedAcrValue",
+                    "amrList",
+                    "essentialClaims",
+                    "authTime",
+                    "maxAge",
+                    "requestObject",
+                    "hasNonOIDCClaims",
+                    "mappedRemoteClaims",
+                    "subjectClaim",
+                    "tokenBindingValue",
+                    "sessionContextIdentifier",
+                    "oidcSessionId",
+                    "isRequestObjectFlow",
+                    "accessTokenExtendedAttributes",
+                    "isApiBasedAuthRequest",
+                    "impersonator",
+                    "federatedTokens",
+                    "audiences",
+                    "customClaims",
+                    "isPreIssueAccessTokenActionsExecuted",
+                    "isPreIssueIDTokenActionsExecuted",
+                    "preIssueIDTokenActionDTO"
+            ));
+
+    @DataProvider(name = "cacheEntries")
+    public Object[][] cacheEntries() {
+
+        return new Object[][] {
+                {
+                        AuthorizationGrantCacheEntry.class,
+                        AUTHORIZATION_GRANT_CACHE_ENTRY_V0_BASELINE,
+                        1
+                }
+        };
+    }
+
+    @Test(dataProvider = "cacheEntries")
+    public void testFieldVersioningContract(Class<?> target, List<String> v0Baseline, int expectedVersionedCount) {
+
+        CacheEntryVersioningAssert.assertFieldVersioning(target, v0Baseline, expectedVersionedCount);
+    }
+
+    @Test(dataProvider = "cacheEntries")
+    public void testBaselineFieldOrderPreserved(Class<?> target, List<String> v0Baseline,
+                                                int expectedVersionedCount) {
+
+        CacheEntryVersioningAssert.assertBaselinePresent(target, v0Baseline);
+    }
+}

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/cache/CacheEntryVersioningTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/cache/CacheEntryVersioningTest.java
@@ -20,6 +20,7 @@ package org.wso2.carbon.identity.oauth.cache;
 
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+import org.wso2.carbon.identity.oauth2.device.cache.DeviceAuthorizationGrantCacheEntry;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -68,6 +69,13 @@ public class CacheEntryVersioningTest {
                     "preIssueIDTokenActionDTO"
             ));
 
+    private static final List<String> DEVICE_AUTHORIZATION_GRANT_CACHE_ENTRY_V0_BASELINE =
+            Collections.unmodifiableList(Arrays.asList(
+                    "userAttributes",
+                    "mappedRemoteClaims",
+                    "impersonator"
+            ));
+
     @DataProvider(name = "cacheEntries")
     public Object[][] cacheEntries() {
 
@@ -75,6 +83,11 @@ public class CacheEntryVersioningTest {
                 {
                         AuthorizationGrantCacheEntry.class,
                         AUTHORIZATION_GRANT_CACHE_ENTRY_V0_BASELINE,
+                        2
+                },
+                {
+                        DeviceAuthorizationGrantCacheEntry.class,
+                        DEVICE_AUTHORIZATION_GRANT_CACHE_ENTRY_V0_BASELINE,
                         1
                 }
         };

--- a/components/org.wso2.carbon.identity.oauth/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.identity.oauth/src/test/resources/testng.xml
@@ -83,6 +83,7 @@
             <class name="org.wso2.carbon.identity.oauth.dao.OAuthAppDAOTest"/>
             <class name="org.wso2.carbon.identity.oauth2.dao.RevokedTokenDAOImplTest"/>
             <class name="org.wso2.carbon.identity.oauth.dao.OAuthConsumerDAOTest"/>
+            <class name="org.wso2.carbon.identity.oauth.cache.CacheEntryVersioningTest"/>
             <class name="org.wso2.carbon.identity.oauth.event.AbstractOAuthEventInterceptorTest"/>
             <class name="org.wso2.carbon.identity.oauth.listener.ClaimCacheRemoveListenerTest"/>
             <class name="org.wso2.carbon.identity.oauth.listener.ClaimMetaDataCacheRemoveListenerTest"/>

--- a/components/org.wso2.carbon.identity.oauth/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.identity.oauth/src/test/resources/testng.xml
@@ -84,6 +84,7 @@
             <class name="org.wso2.carbon.identity.oauth.dao.OAuthAppDAOTest"/>
             <class name="org.wso2.carbon.identity.oauth2.dao.RevokedTokenDAOImplTest"/>
             <class name="org.wso2.carbon.identity.oauth.dao.OAuthConsumerDAOTest"/>
+            <class name="org.wso2.carbon.identity.oauth.cache.CacheEntryVersioningTest"/>
             <class name="org.wso2.carbon.identity.oauth.event.AbstractOAuthEventInterceptorTest"/>
             <class name="org.wso2.carbon.identity.oauth.listener.ClaimCacheRemoveListenerTest"/>
             <class name="org.wso2.carbon.identity.oauth.listener.ClaimMetaDataCacheRemoveListenerTest"/>


### PR DESCRIPTION
### Proposed changes in this pull request

This covers unit tests for cache versioning related to the FST serializer. Currently, support is limited to the AuthorizationGrantCache and DeviceGrantCache.

The two test methods in CacheEntryVersioningTest.java:                                                                                                                                                   
                                                                                                                                                                                                           
  ---                                                                                                                                                                                                      
  testFieldVersioningContract (line 96)
                                                                                                                                                                                                           
  Enforces the full FST versioning contract on each cache entry class: 
  - Every field in the v0 baseline must still exist, in the same declaration order, and must not have @Version                                                                                             
  - Every field added after the baseline must have @Version(n) where n ≥ 1                                                                                                                                 
  - The total count of @Version-annotated fields must exactly match expectedVersionedCount                                                                                                                 
                                                                                                                                                                                                           
  This is the strict guardrail — it catches someone adding a new field without @Version, which would break FST deserialization of older cached objects.
                                                                                                                                                                                                           
  ---                                                                  
  testBaselineFieldOrderPreserved (line 102)                                                                                                                                                               
                                                                       
  A lighter sanity check — it only verifies that the baseline fields still exist in their original declaration order. It doesn't inspect @Version annotations or care about new fields.
                                                                                                                                                                                                           
  This catches destructive changes like renaming, reordering, or removing a field that was part of the v0 snapshot, which would break backward compatibility with already-serialized cache entries.        
                                                                                                                                                                                                           
  ---                                                                                                                                                                                                      
  Together: the first test guards forward additions (new fields must be versioned), and the second guards backward stability (existing baseline fields must not move or disappear).
                                                                                                  
