### PR TITLE
Add OAuth support for shared user direct login to sub-organizations

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
+++ b/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
@@ -195,6 +195,7 @@ public final class OAuthConstants {
     public static final String ID_TOKEN_SUBJECT_TOKEN = "id_token subject_token";
     public static final String IMPERSONATED_SUBJECT = "IMPERSONATED_SUBJECT";
     public static final String IMPERSONATING_ACTOR = "IMPERSONATING_ACTOR";
+    public static final String IS_SHARED_USER = "IS_SHARED_USER";
     public static final String IDTOKEN_TOKEN = "id_token token";
     public static final String ACTOR_TOKEN = "actor_token";
     public static final String SCOPE = "scope";

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/AuthzUtil.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/AuthzUtil.java
@@ -2428,6 +2428,10 @@ public class AuthzUtil {
 
         authorizationGrantCacheEntry.setAccessingOrganization(sessionDataCacheEntry.getLoggedInUser()
                 .getAccessingOrganization());
+        /*
+         * isSharedUser property of the authenticated user will be set to true in B2B login flows where user who is
+         * shared to a child organization is directly logging into the child organization.
+         */
         if (sessionDataCacheEntry.getLoggedInUser().isSharedUser()) {
             AccessTokenExtendedAttributes accessTokenExtendedAttributes =
                     authorizationGrantCacheEntry.getAccessTokenExtensionDO();

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/AuthzUtil.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/AuthzUtil.java
@@ -207,6 +207,7 @@ import static org.wso2.carbon.identity.application.authentication.framework.util
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.REQUEST_PARAM_SP;
 import static org.wso2.carbon.identity.client.attestation.mgt.utils.Constants.CLIENT_ATTESTATION_CONTEXT;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.IMPERSONATING_ACTOR;
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.IS_SHARED_USER;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.LogConstants.InputKeys.RESPONSE_TYPE;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OAuth20Params.CLIENT_ID;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OAuth20Params.REDIRECT_URI;
@@ -2424,7 +2425,30 @@ public class AuthzUtil {
         if (mappedRemoteClaims != null) {
             authorizationGrantCacheEntry.setMappedRemoteClaims(mappedRemoteClaims);
         }
+
+        authorizationGrantCacheEntry.setAccessingOrganization(sessionDataCacheEntry.getLoggedInUser()
+                .getAccessingOrganization());
+        if (sessionDataCacheEntry.getLoggedInUser().isSharedUser()) {
+            AccessTokenExtendedAttributes accessTokenExtendedAttributes =
+                    authorizationGrantCacheEntry.getAccessTokenExtensionDO();
+            accessTokenExtendedAttributes = addExtendedAttribute(IS_SHARED_USER,
+                    String.valueOf(sessionDataCacheEntry.getLoggedInUser().isSharedUser()),
+                    accessTokenExtendedAttributes);
+            authorizationGrantCacheEntry.setAccessTokenExtensionDO(accessTokenExtendedAttributes);
+        }
         oAuthMessage.setAuthorizationGrantCacheEntry(authorizationGrantCacheEntry);
+    }
+
+    private static AccessTokenExtendedAttributes addExtendedAttribute(
+            String key, String value, AccessTokenExtendedAttributes accessTokenExtendedAttributes) {
+
+        if (accessTokenExtendedAttributes == null) {
+            accessTokenExtendedAttributes = new AccessTokenExtendedAttributes(new HashMap<>());
+        }
+        if (key != null && value != null) {
+            accessTokenExtendedAttributes.getParameters().put(key, value);
+        }
+        return accessTokenExtendedAttributes;
     }
 
     /**

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/cache/AuthorizationGrantCacheEntry.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/cache/AuthorizationGrantCacheEntry.java
@@ -111,6 +111,13 @@ public class AuthorizationGrantCacheEntry extends CacheEntry {
     @Version(1)
     private String sessionDataKeyConsent;
 
+    /*
+     * This property will contain the accessing organization ID of the logged in user when shared users login to
+     * sub-organizations.
+     */
+    @Version(2)
+    private String accessingOrganization;
+
     public String getSubjectClaim() {
         return subjectClaim;
     }
@@ -451,6 +458,26 @@ public class AuthorizationGrantCacheEntry extends CacheEntry {
     public void setPreIssueIDTokenActionsExecuted(boolean preIssueIDTokenActionsExecuted) {
 
         isPreIssueIDTokenActionsExecuted = preIssueIDTokenActionsExecuted;
+    }
+
+    /**
+     * Set accessing organization.
+     *
+     * @param accessingOrganization accessing organization.
+     */
+    public void setAccessingOrganization(String accessingOrganization) {
+
+        this.accessingOrganization = accessingOrganization;
+    }
+
+    /**
+     * Get accessing organization.
+     *
+     * @return accessing organization.
+     */
+    public String getAccessingOrganization() {
+
+        return accessingOrganization;
     }
 
     /**

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/handlers/util/ResponseTypeHandlerUtil.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/handlers/util/ResponseTypeHandlerUtil.java
@@ -310,7 +310,8 @@ public class ResponseTypeHandlerUtil {
         authzCodeDO.setRequestedActor(authorizationReqDTO.getRequestedActor());
         String appResidentOrganizationId = PrivilegedCarbonContext.getThreadLocalCarbonContext()
                 .getApplicationResidentOrganizationId();
-        if (StringUtils.isNotBlank(appResidentOrganizationId)) {
+        // If the logged-in user is shared, resident and accessing orgs are already set.
+        if (StringUtils.isNotBlank(appResidentOrganizationId) && !authzCodeDO.getAuthorizedUser().isSharedUser()) {
             if (log.isDebugEnabled()) {
                 log.debug("Setting accessing organization id: " + appResidentOrganizationId +
                         " and user resident organization in the authorization code data object.");

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dao/AccessTokenDAOImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dao/AccessTokenDAOImpl.java
@@ -816,6 +816,7 @@ public class AccessTokenDAOImpl extends AbstractOAuthDAO implements AccessTokenD
                 accessTokenDO.setAccessToken(accessToken);
                 accessTokenDO.setRefreshToken(refreshToken);
                 accessTokenDO.setTokenId(tokenId);
+                accessTokenDO.getAuthzUser().setSharedUser(authzUser.isSharedUser());
                 accessTokenDO.getAuthzUser().setAccessingOrganization(authzUser.getAccessingOrganization());
                 accessTokenDO.getAuthzUser().setUserResidentOrganization(authzUser.getUserResidentOrganization());
             }
@@ -1032,8 +1033,13 @@ public class AccessTokenDAOImpl extends AbstractOAuthDAO implements AccessTokenD
                         isConsentedToken = resultSet.getBoolean(consentedTokenColumnIndex);
                     }
 
+                    AccessTokenExtendedAttributes accessTokenExtendedAttributes = new AccessTokenExtendedAttributes(
+                            getAccessTokenExtendedAttributeParameters(tokenId));
+                    boolean isSharedUser = Boolean.parseBoolean(accessTokenExtendedAttributes.getParameters().get(
+                                OAuthConstants.IS_SHARED_USER));
                     AuthenticatedUser user = OAuth2Util.createAuthenticatedUser(authorizedUser,
-                            userDomain, tenantDomain, authenticatedIDP, authorizedOrganization, appResideTenantId);
+                            userDomain, tenantDomain, authenticatedIDP, authorizedOrganization, appResideTenantId,
+                            isSharedUser);
                     ServiceProvider serviceProvider;
                     try {
                         serviceProvider = OAuth2ServiceComponentHolder.getApplicationMgtService().
@@ -1054,8 +1060,7 @@ public class AccessTokenDAOImpl extends AbstractOAuthDAO implements AccessTokenD
                     dataDO.setTenantID(tenantId);
                     dataDO.setIsConsentedToken(isConsentedToken);
                     dataDO.setAppResidentTenantId(appResideTenantId);
-                    dataDO.setAccessTokenExtendedAttributes(new AccessTokenExtendedAttributes(
-                            getAccessTokenExtendedAttributeParameters(tokenId)));
+                    dataDO.setAccessTokenExtendedAttributes(accessTokenExtendedAttributes);
 
                     if (StringUtils.isNotBlank(tokenBindingReference) && !NONE.equals(tokenBindingReference)) {
                         setTokenBindingToAccessTokenDO(dataDO, connection, tokenId);

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuer.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuer.java
@@ -916,6 +916,7 @@ public class JWTTokenIssuer extends OauthTokenIssuerImpl {
                             .getParameters();
             if (customClaims != null && !customClaims.isEmpty()) {
                 customClaims.remove(OAuthConstants.IMPERSONATING_ACTOR);
+                customClaims.remove(OAuthConstants.IS_SHARED_USER);
                 if (log.isDebugEnabled()) {
                     log.debug("Processing custom claims for JWT token. Total claims count: " + customClaims.size());
                 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AuthorizationCodeGrantHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AuthorizationCodeGrantHandler.java
@@ -22,6 +22,7 @@ import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.application.authentication.framework.exception.UserIdNotFoundException;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
@@ -30,6 +31,7 @@ import org.wso2.carbon.identity.base.IdentityConstants;
 import org.wso2.carbon.identity.base.IdentityException;
 import org.wso2.carbon.identity.central.log.mgt.utils.LogConstants;
 import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.oauth.OAuthUtil;
 import org.wso2.carbon.identity.oauth.cache.AuthorizationGrantCache;
@@ -54,6 +56,8 @@ import org.wso2.carbon.identity.oauth2.model.AuthzCodeDO;
 import org.wso2.carbon.identity.oauth2.rar.util.AuthorizationDetailsUtils;
 import org.wso2.carbon.identity.oauth2.token.OAuthTokenReqMessageContext;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
+import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
+import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
 import org.wso2.carbon.utils.DiagnosticLog;
 
 import java.util.HashMap;
@@ -313,14 +317,53 @@ public class AuthorizationCodeGrantHandler extends AbstractAuthorizationGrantHan
                 OAuthUtil.clearOAuthCache(tokenReqDTO.getClientId(), validationResult.getAuthzCodeDO().
                         getAuthorizedUser(), scope);
             }
-            // The user resident organization should be resolved for the organization SSO users.
-            resolveUserResidentOrgForOrganizationSSOUsers(validationResult.getAuthzCodeDO().getAuthorizedUser(),
+            resolveSharedUserDetails(validationResult.getAuthzCodeDO().getAuthorizedUser(),
                     tokenReqDTO.getAuthorizationCode());
+            // The user resident organization should be resolved for the organization SSO users.
+            resolveAccessingAndResidentOrgsForOrganizationSSOUsers(
+                    validationResult.getAuthzCodeDO().getAuthorizedUser(), tokenReqDTO.getAuthorizationCode());
             return validationResult.getAuthzCodeDO();
         } else {
             // This means an invalid authorization code was sent for validation. We return null since higher
             // layers expect a null value for an invalid authorization code.
             return null;
+        }
+    }
+
+    /**
+     * This method is responsible for resolving the accessing org, resident org and the is shared user property
+     * of the authenticated user when shared users login to sub-organizations via shared apps.
+     * @param authenticatedUser AuthenticatedUser object to be populated.
+     * @param authCode authorization code.
+     * @throws IdentityOAuth2Exception If an error occurs while resolving the orgazniation ID of user accessing or
+     * resident organization.
+     */
+    private void resolveSharedUserDetails(AuthenticatedUser authenticatedUser, String authCode)
+            throws IdentityOAuth2Exception {
+
+        AuthorizationGrantCacheEntry authorizationGrantCacheEntry = AuthorizationGrantCache.getInstance()
+                .getValueFromCacheByCode(new AuthorizationGrantCacheKey(authCode));
+        if (authorizationGrantCacheEntry.getAccessTokenExtensionDO() != null &&
+                authorizationGrantCacheEntry.getAccessTokenExtensionDO().getParameters() != null &&
+                Boolean.parseBoolean(authorizationGrantCacheEntry.getAccessTokenExtensionDO().getParameters().get(
+                        OAuthConstants.IS_SHARED_USER))) {
+           authenticatedUser.setSharedUser(true);
+           // For sub-org application based login flows, below values are already set. Hence, skipping.
+           if (StringUtils.isBlank(PrivilegedCarbonContext.getThreadLocalCarbonContext()
+                   .getApplicationResidentOrganizationId())) {
+               OrganizationManager organizationManager = OAuthComponentServiceHolder.getInstance()
+                       .getOrganizationManager();
+               try {
+                   authenticatedUser.setUserResidentOrganization(organizationManager.resolveOrganizationId(
+                           authenticatedUser.getTenantDomain()));
+               authenticatedUser.setAccessingOrganization(organizationManager.resolveOrganizationId(
+                       IdentityTenantUtil.resolveTenantDomain()));
+               } catch (OrganizationManagementException e) {
+                   throw new IdentityOAuth2Exception(
+                           "Error while resolving organization ID of the authenticated user: " +
+                                   authenticatedUser.getLoggableMaskedUserId(), e);
+               }
+           }
         }
     }
 
@@ -706,14 +749,21 @@ public class AuthorizationCodeGrantHandler extends AbstractAuthorizationGrantHan
         }
     }
 
-    private void resolveUserResidentOrgForOrganizationSSOUsers(AuthenticatedUser authenticatedUser, String authzCode) {
+    private void resolveAccessingAndResidentOrgsForOrganizationSSOUsers(
+            AuthenticatedUser authenticatedUser, String authzCode) {
 
         if (authenticatedUser.isFederatedUser() && FrameworkConstants.ORGANIZATION_LOGIN_IDP_NAME
                 .equals(authenticatedUser.getFederatedIdPName())) {
-            String userResideOrganization = resolveUserResidentOrganization(AuthorizationGrantCache.getInstance()
-                    .getValueFromCacheByCode(new AuthorizationGrantCacheKey(authzCode)).getUserAttributes());
-            authenticatedUser.setAccessingOrganization(userResideOrganization);
-            authenticatedUser.setUserResidentOrganization(userResideOrganization);
+            AuthorizationGrantCacheEntry authorizationGrantCacheEntry = AuthorizationGrantCache.getInstance()
+                    .getValueFromCacheByCode(new AuthorizationGrantCacheKey(authzCode));
+            String userResidentOrganization = resolveUserResidentOrganization(
+                    authorizationGrantCacheEntry.getUserAttributes());
+            String accessingOrganization = authorizationGrantCacheEntry.getAccessingOrganization();
+            if (StringUtils.isBlank(accessingOrganization)) {
+                accessingOrganization = userResidentOrganization;
+            }
+            authenticatedUser.setAccessingOrganization(accessingOrganization);
+            authenticatedUser.setUserResidentOrganization(userResidentOrganization);
         }
     }
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AuthorizationCodeGrantHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AuthorizationCodeGrantHandler.java
@@ -343,7 +343,8 @@ public class AuthorizationCodeGrantHandler extends AbstractAuthorizationGrantHan
 
         AuthorizationGrantCacheEntry authorizationGrantCacheEntry = AuthorizationGrantCache.getInstance()
                 .getValueFromCacheByCode(new AuthorizationGrantCacheKey(authCode));
-        if (authorizationGrantCacheEntry.getAccessTokenExtensionDO() != null &&
+        if (authorizationGrantCacheEntry != null &&
+                authorizationGrantCacheEntry.getAccessTokenExtensionDO() != null &&
                 authorizationGrantCacheEntry.getAccessTokenExtensionDO().getParameters() != null &&
                 Boolean.parseBoolean(authorizationGrantCacheEntry.getAccessTokenExtensionDO().getParameters().get(
                         OAuthConstants.IS_SHARED_USER))) {
@@ -756,6 +757,9 @@ public class AuthorizationCodeGrantHandler extends AbstractAuthorizationGrantHan
                 .equals(authenticatedUser.getFederatedIdPName())) {
             AuthorizationGrantCacheEntry authorizationGrantCacheEntry = AuthorizationGrantCache.getInstance()
                     .getValueFromCacheByCode(new AuthorizationGrantCacheKey(authzCode));
+            if (authorizationGrantCacheEntry == null) {
+                return;
+            }
             String userResidentOrganization = resolveUserResidentOrganization(
                     authorizationGrantCacheEntry.getUserAttributes());
             String accessingOrganization = authorizationGrantCacheEntry.getAccessingOrganization();

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -4871,6 +4871,7 @@ public class OAuth2Util {
                         "User id is not available for user: " + authzUser.getLoggableMaskedUserId(), e);
             }
         }
+        authenticatedUser.setSharedUser(authzUser.isSharedUser());
         if (StringUtils.isNotEmpty(authzUser.getAccessingOrganization())) {
             authenticatedUser.setAccessingOrganization(authzUser.getAccessingOrganization());
             authenticatedUser.setUserResidentOrganization(authzUser.getUserResidentOrganization());
@@ -4940,6 +4941,33 @@ public class OAuth2Util {
             throws IdentityOAuth2Exception {
 
         AuthenticatedUser authenticatedUser = createAuthenticatedUser(username, userStoreDomain, tenantDomain, idpName);
+        // For organization bound access tokens, the authenticated user should be populated considering below factors.
+        if (!OAuthConstants.AuthorizedOrganization.NONE.equals(accessingOrganization)) {
+            addOrganizationUserDetails(authenticatedUser, accessingOrganization, tenantDomain,
+                    IdentityTenantUtil.getTenantDomain(appTenantID), authenticatedUser.isFederatedUser());
+        }
+        return authenticatedUser;
+    }
+
+    /**
+     * Creates an instance of AuthenticatedUser{@link AuthenticatedUser} for the given parameters.
+     *
+     * @param username              Username of the user.
+     * @param userStoreDomain       User store domain.
+     * @param tenantDomain          Tenant domain.
+     * @param idpName               Idp name.
+     * @param accessingOrganization The organization where the user is authorized to access.
+     * @param appTenantID           The tenant ID of the application where user get authenticated.
+     * @param isSharedUser          Whether the user is a shared user.
+     * @return An instance of AuthenticatedUser{@link AuthenticatedUser}
+     * @throws IdentityOAuth2Exception If an error occurred while creating the authenticated user.
+     */
+    public static AuthenticatedUser createAuthenticatedUser(String username, String userStoreDomain, String
+            tenantDomain, String idpName, String accessingOrganization, int appTenantID, boolean isSharedUser)
+            throws IdentityOAuth2Exception {
+
+        AuthenticatedUser authenticatedUser = createAuthenticatedUser(username, userStoreDomain, tenantDomain, idpName);
+        authenticatedUser.setSharedUser(isSharedUser);
         // For organization bound access tokens, the authenticated user should be populated considering below factors.
         if (!OAuthConstants.AuthorizedOrganization.NONE.equals(accessingOrganization)) {
             addOrganizationUserDetails(authenticatedUser, accessingOrganization, tenantDomain,
@@ -6556,8 +6584,10 @@ public class OAuth2Util {
         authenticatedUser.setAccessingOrganization(accessingOrganization);
         String userResidentOrg = resolveOrganizationId(tenantDomain);
         authenticatedUser.setUserResidentOrganization(userResidentOrg);
-        if  (isOrgSSOFederation) {
-            // Set authorized user tenant domain to the tenant domain of the application.
+        if  (isOrgSSOFederation && !authenticatedUser.isSharedUser()) {
+            /* Set authorized user tenant domain to the tenant domain of the application.
+             * For shared users, tenant domain of the user resident organization is already set.
+             */
             authenticatedUser.setTenantDomain(appTenantDomain);
         }
     }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/DefaultOAuth2ScopeValidator.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/DefaultOAuth2ScopeValidator.java
@@ -114,7 +114,9 @@ public class DefaultOAuth2ScopeValidator {
         Set<String> requestedOIDCScopes = filterRequestedOIDCScopesByApp(appId, tenantDomain, requestedScopes);
 
         // When user is not accessing the resident organization, resolve the application id from the shared app table.
-        if (!AuthzUtil.isUserAccessingResidentOrganization(authzReqMessageContext.getAuthorizationReqDTO().getUser())) {
+        // However, for shared user direct login flow, no need to resolve the shared app id.
+        if (!AuthzUtil.isUserAccessingResidentOrganization(authzReqMessageContext.getAuthorizationReqDTO().getUser()) &&
+                !authzReqMessageContext.getAuthorizationReqDTO().getUser().isSharedUser()) {
             String orgId = authzReqMessageContext.getAuthorizationReqDTO().getUser().getAccessingOrganization();
             String appResideOrgId = resolveOrgIdByTenantDomain(tenantDomain);
             appId = SharedAppResolveDAO.resolveSharedApplication(appResideOrgId, appId, orgId);

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/DefaultIDTokenBuilder.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/DefaultIDTokenBuilder.java
@@ -241,6 +241,8 @@ public class DefaultIDTokenBuilder implements org.wso2.carbon.identity.openidcon
             AccessTokenExtendedAttributes accessTokenExtendedAttributes =
                     tokenReqMsgCtxt.getOauth2AccessTokenReqDTO().getAccessTokenExtendedAttributes();
             if (accessTokenExtendedAttributes != null && accessTokenExtendedAttributes.getParameters() != null) {
+                // This property should not be returned in the ID token.
+                accessTokenExtendedAttributes.getParameters().remove(OAuthConstants.IS_SHARED_USER);
                 for (Map.Entry<String, String> entry : accessTokenExtendedAttributes.getParameters().entrySet()) {
                     jwtClaimsSetBuilder.claim(entry.getKey(), entry.getValue());
                 }

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/cache/AuthorizationGrantCacheTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/cache/AuthorizationGrantCacheTest.java
@@ -187,6 +187,22 @@ public class AuthorizationGrantCacheTest {
     }
 
     @Test
+    public void testAccessingOrganizationGetterAndSetter() {
+
+        AuthorizationGrantCacheEntry entry = new AuthorizationGrantCacheEntry();
+        // Default value should be null when not set.
+        assertEquals(entry.getAccessingOrganization(), null);
+
+        String accessingOrgId = "shared-user-accessing-org";
+        entry.setAccessingOrganization(accessingOrgId);
+        assertEquals(entry.getAccessingOrganization(), accessingOrgId);
+
+        // Setting to null should clear the value.
+        entry.setAccessingOrganization(null);
+        assertEquals(entry.getAccessingOrganization(), null);
+    }
+
+    @Test
     public void testGetValueFromCacheByCode() throws IdentityOAuth2Exception {
 
         String authCode = "authCode";

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/authz/handlers/CodeResponseTypeHandlerTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/authz/handlers/CodeResponseTypeHandlerTest.java
@@ -25,6 +25,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
 import org.wso2.carbon.identity.central.log.mgt.internal.CentralLogMgtServiceComponentHolder;
 import org.wso2.carbon.identity.common.testng.WithCarbonHome;
@@ -37,6 +38,7 @@ import org.wso2.carbon.identity.oauth.common.OAuthConstants;
 import org.wso2.carbon.identity.oauth.dao.OAuthAppDAO;
 import org.wso2.carbon.identity.oauth.dao.OAuthAppDO;
 import org.wso2.carbon.identity.oauth.internal.OAuthComponentServiceHolder;
+import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.TestConstants;
 import org.wso2.carbon.identity.oauth2.authz.OAuthAuthzReqMessageContext;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2AuthorizeReqDTO;
@@ -130,6 +132,71 @@ public class CodeResponseTypeHandlerTest {
                 "Access token not Authorization code");
         Assert.assertEquals(oAuth2AuthorizeRespDTO.getCallbackURI()
                 , TEST_CALLBACK_URL, "Callback url not set");
+    }
+
+    @Test
+    public void testIssueWithSharedUserPreservesOrganizationDetails() throws Exception {
+
+        OAuthAppDO oAuthAppDO = new OAuthAppDO();
+        oAuthAppDO.setGrantTypes("implicit");
+        oAuthAppDO.setOauthConsumerKey(TEST_CONSUMER_KEY);
+        oAuthAppDO.setState("active");
+        AuthenticatedUser appUser = new AuthenticatedUser();
+        appUser.setUserStoreDomain("PRIMARY");
+        appUser.setUserName("testUser");
+        appUser.setFederatedIdPName(TestConstants.LOCAL_IDP);
+        oAuthAppDO.setUser(appUser);
+        oAuthAppDO.setApplicationName("testApp");
+
+        AppInfoCache appInfoCache = AppInfoCache.getInstance();
+        appInfoCache.addToCache(TEST_CONSUMER_KEY, oAuthAppDO);
+
+        // Set up shared user with pre-set organization details.
+        String originalAccessingOrg = "shared-user-accessing-org";
+        String originalResidentOrg = "shared-user-resident-org";
+        AuthenticatedUser sharedUser = new AuthenticatedUser();
+        sharedUser.setUserName("sharedUser");
+        sharedUser.setTenantDomain("carbon.super");
+        sharedUser.setUserStoreDomain("PRIMARY");
+        sharedUser.setUserId("shared-user-id");
+        sharedUser.setSharedUser(true);
+        sharedUser.setAccessingOrganization(originalAccessingOrg);
+        sharedUser.setUserResidentOrganization(originalResidentOrg);
+
+        authorizationReqDTO.setUser(sharedUser);
+        authAuthzReqMessageContext = new OAuthAuthzReqMessageContext(authorizationReqDTO);
+        authAuthzReqMessageContext.setApprovedScope(new String[]{"scope1", "scope2", OAuthConstants.Scope.OPENID});
+
+        // Simulate sub-organization application login by setting appResidentOrganizationId.
+        PrivilegedCarbonContext.getThreadLocalCarbonContext()
+                .setApplicationResidentOrganizationId("sub-org-app-resident-id");
+
+        try {
+            CodeResponseTypeHandler codeResponseTypeHandler = new CodeResponseTypeHandler();
+            codeResponseTypeHandler.init();
+            try {
+                OAuth2AuthorizeRespDTO oAuth2AuthorizeRespDTO =
+                        codeResponseTypeHandler.issue(authAuthzReqMessageContext);
+                Assert.assertNotNull(oAuth2AuthorizeRespDTO.getAuthorizationCode(),
+                        "Authorization code should be generated for shared user.");
+            } catch (IdentityOAuth2Exception e) {
+                // Only ignore DB-related exceptions due to incomplete DB setup in unit test environment.
+                if (!(e.getCause() instanceof java.sql.SQLException)) {
+                    throw e;
+                }
+            }
+
+            // Verify that the shared user's organization details are preserved (not overwritten).
+            // This assertion is valid even after an exception because the organization detail
+            // preservation logic executes before the DB write that may fail.
+            Assert.assertEquals(sharedUser.getAccessingOrganization(), originalAccessingOrg,
+                    "Shared user's accessing organization should not be overwritten.");
+            Assert.assertEquals(sharedUser.getUserResidentOrganization(), originalResidentOrg,
+                    "Shared user's resident organization should not be overwritten.");
+        } finally {
+            PrivilegedCarbonContext.getThreadLocalCarbonContext()
+                    .setApplicationResidentOrganizationId(null);
+        }
     }
 
     private OAuthAppDO getDefaultOAuthAppDO() {

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuerTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuerTest.java
@@ -349,6 +349,7 @@ public class JWTTokenIssuerTest {
         HashMap<String, String> params = new HashMap<>();
         params.put("testExtendingKey", "testExtendingValue");
         params.put(OAuthConstants.IMPERSONATING_ACTOR, "DUMMY_ACTOR");
+        params.put(OAuthConstants.IS_SHARED_USER, "true");
         accessTokenExtendedAttributes.setParameters(params);
         tokenReqDTO.setAccessTokenExtendedAttributes(accessTokenExtendedAttributes);
         OAuthTokenReqMessageContext tokenReqMessageContext = new OAuthTokenReqMessageContext(tokenReqDTO);
@@ -481,6 +482,8 @@ public class JWTTokenIssuerTest {
                 assertNotNull(jwtClaimSet.getClaim("testExtendingKey"));
                 assertEquals(jwtClaimSet.getClaim("testExtendingKey"), "testExtendingValue");
                 assertNull(jwtClaimSet.getClaim(OAuthConstants.IMPERSONATING_ACTOR));
+                assertNull(jwtClaimSet.getClaim(OAuthConstants.IS_SHARED_USER),
+                        "IS_SHARED_USER should be removed from JWT custom claims and not exposed in the token.");
             }
 
             if (tokenReqMessageContext != null

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AuthorizationCodeGrantHandlerTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AuthorizationCodeGrantHandlerTest.java
@@ -23,9 +23,14 @@ import org.mockito.MockedStatic;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
+import org.wso2.carbon.identity.application.common.model.Claim;
+import org.wso2.carbon.identity.application.common.model.ClaimMapping;
 import org.wso2.carbon.identity.base.IdentityException;
 import org.wso2.carbon.identity.common.testng.WithCarbonHome;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.oauth.cache.AppInfoCache;
 import org.wso2.carbon.identity.oauth.cache.OAuthCache;
 import org.wso2.carbon.identity.oauth.common.OAuthConstants;
@@ -33,15 +38,18 @@ import org.wso2.carbon.identity.oauth.common.exception.InvalidOAuthClientExcepti
 import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
 import org.wso2.carbon.identity.oauth.dao.OAuthAppDAO;
 import org.wso2.carbon.identity.oauth.dao.OAuthAppDO;
+import org.wso2.carbon.identity.oauth.internal.OAuthComponentServiceHolder;
 import org.wso2.carbon.identity.oauth.tokenprocessor.TokenPersistenceProcessor;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.TestConstants;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2AccessTokenReqDTO;
 import org.wso2.carbon.identity.oauth2.model.AccessTokenDO;
+import org.wso2.carbon.identity.oauth2.model.AccessTokenExtendedAttributes;
 import org.wso2.carbon.identity.oauth2.model.AuthzCodeDO;
 import org.wso2.carbon.identity.oauth2.token.OAuthTokenReqMessageContext;
 import org.wso2.carbon.identity.oauth2.token.OauthTokenIssuer;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
+import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
 
 import org.wso2.carbon.identity.oauth.cache.AuthorizationGrantCache;
 import org.wso2.carbon.identity.oauth.cache.AuthorizationGrantCacheEntry;
@@ -49,12 +57,16 @@ import org.wso2.carbon.identity.oauth.cache.AuthorizationGrantCacheKey;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -417,6 +429,205 @@ public class AuthorizationCodeGrantHandlerTest {
 
             assertNull(tokReqMsgCtx.getProperty(OAuthConstants.SESSION_DATA_KEY_CONSENT));
         }
+    }
+
+    /**
+     * Verifies that resolveSharedUserDetails marks the user as shared and resolves both resident and accessing
+     * organizations via OrganizationManager when the cache entry signals IS_SHARED_USER and there is no
+     * application resident organization in the carbon context (i.e. tenant-bound login flow).
+     */
+    @Test
+    public void testResolveSharedUserDetailsMarksUserSharedAndResolvesOrgs() throws Exception {
+
+        String authCode = "shared-user-auth-code";
+        String userTenantDomain = "user.tenant.com";
+        String accessingTenantDomain = "accessing.tenant.com";
+        String residentOrgId = "user-resident-org-id";
+        String accessingOrgId = "user-accessing-org-id";
+
+        AuthenticatedUser user = new AuthenticatedUser();
+        user.setUserName("sharedUser");
+        user.setTenantDomain(userTenantDomain);
+
+        Map<String, String> extensionParams = new HashMap<>();
+        extensionParams.put(OAuthConstants.IS_SHARED_USER, "true");
+        AccessTokenExtendedAttributes extendedAttributes = new AccessTokenExtendedAttributes(extensionParams);
+
+        AuthorizationGrantCacheEntry cacheEntry = new AuthorizationGrantCacheEntry();
+        cacheEntry.setAccessTokenExtensionDO(extendedAttributes);
+
+        OrganizationManager organizationManager = mock(OrganizationManager.class);
+        when(organizationManager.resolveOrganizationId(userTenantDomain)).thenReturn(residentOrgId);
+        when(organizationManager.resolveOrganizationId(accessingTenantDomain)).thenReturn(accessingOrgId);
+
+        OrganizationManager originalOrgManager = OAuthComponentServiceHolder.getInstance().getOrganizationManager();
+        OAuthComponentServiceHolder.getInstance().setOrganizationManager(organizationManager);
+
+        try (MockedStatic<AuthorizationGrantCache> mockCacheStatic = mockStatic(AuthorizationGrantCache.class);
+             MockedStatic<IdentityTenantUtil> identityTenantUtil = mockStatic(IdentityTenantUtil.class)) {
+
+            AuthorizationGrantCache mockCache = mock(AuthorizationGrantCache.class);
+            mockCacheStatic.when(AuthorizationGrantCache::getInstance).thenReturn(mockCache);
+            when(mockCache.getValueFromCacheByCode(any(AuthorizationGrantCacheKey.class))).thenReturn(cacheEntry);
+            identityTenantUtil.when(IdentityTenantUtil::resolveTenantDomain).thenReturn(accessingTenantDomain);
+
+            // Ensure no application resident organization is set (regular tenant flow).
+            PrivilegedCarbonContext.getThreadLocalCarbonContext().setApplicationResidentOrganizationId(null);
+
+            invokeResolveSharedUserDetails(user, authCode);
+
+            assertTrue(user.isSharedUser(), "User should be flagged as shared.");
+            assertEquals(user.getUserResidentOrganization(), residentOrgId);
+            assertEquals(user.getAccessingOrganization(), accessingOrgId);
+        } finally {
+            OAuthComponentServiceHolder.getInstance().setOrganizationManager(originalOrgManager);
+        }
+    }
+
+    /**
+     * Verifies that resolveSharedUserDetails sets the shared user flag but does NOT resolve organization details
+     * when the carbon context already has applicationResidentOrganizationId set (i.e. sub-org application login
+     * where these values are already populated upstream).
+     */
+    @Test
+    public void testResolveSharedUserDetailsSkipsOrgResolutionWhenAppResidentOrgIsSet() throws Exception {
+
+        String authCode = "shared-user-auth-code-suborg";
+        String preSetAccessingOrg = "pre-set-accessing-org";
+        String preSetResidentOrg = "pre-set-resident-org";
+
+        AuthenticatedUser user = new AuthenticatedUser();
+        user.setUserName("sharedUser");
+        user.setTenantDomain("user.tenant.com");
+        user.setAccessingOrganization(preSetAccessingOrg);
+        user.setUserResidentOrganization(preSetResidentOrg);
+
+        Map<String, String> extensionParams = new HashMap<>();
+        extensionParams.put(OAuthConstants.IS_SHARED_USER, "true");
+        AccessTokenExtendedAttributes extendedAttributes = new AccessTokenExtendedAttributes(extensionParams);
+
+        AuthorizationGrantCacheEntry cacheEntry = new AuthorizationGrantCacheEntry();
+        cacheEntry.setAccessTokenExtensionDO(extendedAttributes);
+
+        OrganizationManager organizationManager = mock(OrganizationManager.class);
+        OrganizationManager originalOrgManager = OAuthComponentServiceHolder.getInstance().getOrganizationManager();
+        OAuthComponentServiceHolder.getInstance().setOrganizationManager(organizationManager);
+
+        try (MockedStatic<AuthorizationGrantCache> mockCacheStatic = mockStatic(AuthorizationGrantCache.class)) {
+
+            AuthorizationGrantCache mockCache = mock(AuthorizationGrantCache.class);
+            mockCacheStatic.when(AuthorizationGrantCache::getInstance).thenReturn(mockCache);
+            when(mockCache.getValueFromCacheByCode(any(AuthorizationGrantCacheKey.class))).thenReturn(cacheEntry);
+
+            // Simulate sub-organization application login by setting the resident org id on carbon context.
+            PrivilegedCarbonContext.getThreadLocalCarbonContext()
+                    .setApplicationResidentOrganizationId("sub-org-app-resident-id");
+            try {
+                invokeResolveSharedUserDetails(user, authCode);
+            } finally {
+                PrivilegedCarbonContext.getThreadLocalCarbonContext().setApplicationResidentOrganizationId(null);
+            }
+
+            assertTrue(user.isSharedUser(), "User should be flagged as shared.");
+            // OrganizationManager should NOT have been consulted; pre-set values must remain unchanged.
+            verify(organizationManager, never()).resolveOrganizationId(anyString());
+            assertEquals(user.getAccessingOrganization(), preSetAccessingOrg);
+            assertEquals(user.getUserResidentOrganization(), preSetResidentOrg);
+        } finally {
+            OAuthComponentServiceHolder.getInstance().setOrganizationManager(originalOrgManager);
+        }
+    }
+
+    /**
+     * Verifies that resolveSharedUserDetails leaves the user untouched when the cache entry has no extension DO
+     * or when IS_SHARED_USER is not set.
+     */
+    @Test
+    public void testResolveSharedUserDetailsNoOpForNonSharedUser() throws Exception {
+
+        AuthenticatedUser user = new AuthenticatedUser();
+        user.setUserName("regularUser");
+        user.setTenantDomain("user.tenant.com");
+
+        // Cache entry without an AccessTokenExtensionDO at all.
+        AuthorizationGrantCacheEntry cacheEntry = new AuthorizationGrantCacheEntry();
+
+        try (MockedStatic<AuthorizationGrantCache> mockCacheStatic = mockStatic(AuthorizationGrantCache.class)) {
+
+            AuthorizationGrantCache mockCache = mock(AuthorizationGrantCache.class);
+            mockCacheStatic.when(AuthorizationGrantCache::getInstance).thenReturn(mockCache);
+            when(mockCache.getValueFromCacheByCode(any(AuthorizationGrantCacheKey.class))).thenReturn(cacheEntry);
+
+            invokeResolveSharedUserDetails(user, "no-shared-flag-code");
+
+            assertFalse(user.isSharedUser(), "User must remain non-shared when no IS_SHARED_USER flag is present.");
+            assertNull(user.getAccessingOrganization());
+            assertNull(user.getUserResidentOrganization());
+        }
+    }
+
+    /**
+     * Verifies that for organization SSO federated users, the accessing organization in the cache entry takes
+     * precedence over the user-resident organization claim when populating the authenticated user.
+     */
+    @Test
+    public void testResolveAccessingAndResidentOrgsUsesCachedAccessingOrganization() throws Exception {
+
+        String authzCode = "org-sso-auth-code";
+        String accessingOrgFromCache = "cached-accessing-org";
+        String residentOrgFromClaim = "claimed-resident-org";
+
+        AuthenticatedUser user = new AuthenticatedUser();
+        user.setFederatedUser(true);
+        user.setFederatedIdPName(FrameworkConstants.ORGANIZATION_LOGIN_IDP_NAME);
+
+        AuthorizationGrantCacheEntry cacheEntry = new AuthorizationGrantCacheEntry(
+                buildUserOrganizationAttributes(residentOrgFromClaim));
+        cacheEntry.setAccessingOrganization(accessingOrgFromCache);
+
+        try (MockedStatic<AuthorizationGrantCache> mockCacheStatic = mockStatic(AuthorizationGrantCache.class)) {
+
+            AuthorizationGrantCache mockCache = mock(AuthorizationGrantCache.class);
+            mockCacheStatic.when(AuthorizationGrantCache::getInstance).thenReturn(mockCache);
+            when(mockCache.getValueFromCacheByCode(any(AuthorizationGrantCacheKey.class))).thenReturn(cacheEntry);
+
+            invokeResolveAccessingAndResidentOrgs(user, authzCode);
+
+            assertEquals(user.getAccessingOrganization(), accessingOrgFromCache,
+                    "Accessing organization must come from the cache entry when set.");
+            assertEquals(user.getUserResidentOrganization(), residentOrgFromClaim);
+        }
+    }
+
+    private void invokeResolveSharedUserDetails(AuthenticatedUser user, String authCode) throws Exception {
+
+        Method method = AuthorizationCodeGrantHandler.class.getDeclaredMethod(
+                "resolveSharedUserDetails", AuthenticatedUser.class, String.class);
+        method.setAccessible(true);
+        method.invoke(new AuthorizationCodeGrantHandler(), user, authCode);
+    }
+
+    private void invokeResolveAccessingAndResidentOrgs(AuthenticatedUser user, String authzCode) throws Exception {
+
+        Method method = AuthorizationCodeGrantHandler.class.getDeclaredMethod(
+                "resolveAccessingAndResidentOrgsForOrganizationSSOUsers",
+                AuthenticatedUser.class, String.class);
+        method.setAccessible(true);
+        method.invoke(new AuthorizationCodeGrantHandler(), user, authzCode);
+    }
+
+    private Map<ClaimMapping, String> buildUserOrganizationAttributes(String organizationId) {
+
+        Map<ClaimMapping, String> attributes = new HashMap<>();
+        ClaimMapping mapping = new ClaimMapping();
+        Claim localClaim = new Claim();
+        localClaim.setClaimUri(FrameworkConstants.USER_ORGANIZATION_CLAIM);
+        Claim remoteClaim = new Claim();
+        remoteClaim.setClaimUri(FrameworkConstants.USER_ORGANIZATION_CLAIM);
+        mapping.setLocalClaim(localClaim);
+        mapping.setRemoteClaim(remoteClaim);
+        attributes.put(mapping, organizationId);
+        return attributes;
     }
 
     private void setPrivateField(Object object, String fieldName, Object value) throws Exception {

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/util/OAuth2UtilTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/util/OAuth2UtilTest.java
@@ -49,6 +49,7 @@ import org.wso2.carbon.base.CarbonBaseConstants;
 import org.wso2.carbon.base.MultitenantConstants;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
+import org.wso2.carbon.identity.application.authentication.framework.store.UserSessionStore;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
 import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
 import org.wso2.carbon.identity.application.common.model.FederatedAuthenticatorConfig;
@@ -2163,11 +2164,14 @@ public class OAuth2UtilTest {
     @DataProvider(name = "createAuthenticatedUserWithSharedUserData")
     public Object[][] createAuthenticatedUserWithSharedUserData() {
 
+        // The tenant-domain override only fires for federated users, so the org-SSO scenarios use the
+        // FEDERATED-prefixed user store domain. The NONE accessingOrganization scenarios use PRIMARY since
+        // org details are not added for them.
         return new Object[][]{
                 // {username, userStoreDomain, tenantDomain, idpName, accessingOrganization, isSharedUser,
                 //  expectTenantDomainOverride}
-                {"testuser1", "PRIMARY", "user.tenant", "LOCAL", "accessing-org-id", true, false},
-                {"testuser1", "PRIMARY", "user.tenant", "LOCAL", "accessing-org-id", false, true},
+                {"testuser1", "FEDERATED", "user.tenant", "LOCAL", "accessing-org-id", true, false},
+                {"testuser1", "FEDERATED", "user.tenant", "LOCAL", "accessing-org-id", false, true},
                 {"testuser1", "PRIMARY", "user.tenant", "LOCAL",
                         OAuthConstants.AuthorizedOrganization.NONE, false, false},
                 {"testuser1", "PRIMARY", "user.tenant", "LOCAL",
@@ -2186,31 +2190,44 @@ public class OAuth2UtilTest {
 
         OAuth2ServiceComponentHolder.getInstance().setOrganizationManager(organizationManagerMock);
         identityTenantUtil.when(() -> IdentityTenantUtil.getTenantDomain(appTenantId)).thenReturn(appTenantDomain);
+        // Federated user creation reads this flag; default false keeps the user marked as federated.
+        lenient().when(oauthServerConfigurationMock.isMapFederatedUsersToLocal()).thenReturn(false);
 
         if (!OAuthConstants.AuthorizedOrganization.NONE.equals(accessingOrganization)) {
             lenient().when(organizationManagerMock.resolveOrganizationId(tenantDomain))
                     .thenReturn("user-resident-org-id");
         }
 
-        AuthenticatedUser authenticatedUser = OAuth2Util.createAuthenticatedUser(username, userStoreDomain,
-                tenantDomain, idpName, accessingOrganization, appTenantId, isSharedUser);
+        // The federated branch of createAuthenticatedUser calls UserSessionStore which would otherwise reach
+        // the DB layer; mock it so the test can focus on the shared-user / tenant-override logic.
+        UserSessionStore userSessionStoreMock = mock(UserSessionStore.class);
+        try (MockedStatic<UserSessionStore> userSessionStoreStatic = mockStatic(UserSessionStore.class)) {
+            userSessionStoreStatic.when(UserSessionStore::getInstance).thenReturn(userSessionStoreMock);
+            lenient().when(userSessionStoreMock.getIdPId(anyString(), anyInt())).thenReturn(1);
+            lenient().when(userSessionStoreMock.getFederatedUserId(anyString(), anyInt(), anyInt()))
+                    .thenReturn("federated-user-id");
 
-        Assert.assertEquals(authenticatedUser.getUserName(), username);
-        Assert.assertEquals(authenticatedUser.isSharedUser(), isSharedUser);
+            AuthenticatedUser authenticatedUser = OAuth2Util.createAuthenticatedUser(username, userStoreDomain,
+                    tenantDomain, idpName, accessingOrganization, appTenantId, isSharedUser);
 
-        if (!OAuthConstants.AuthorizedOrganization.NONE.equals(accessingOrganization)) {
-            Assert.assertEquals(authenticatedUser.getAccessingOrganization(), accessingOrganization);
-            Assert.assertEquals(authenticatedUser.getUserResidentOrganization(), "user-resident-org-id");
-            if (expectTenantDomainOverride) {
-                Assert.assertEquals(authenticatedUser.getTenantDomain(), appTenantDomain,
-                        "For non-shared users, tenant domain should be overridden to app tenant domain.");
+            Assert.assertEquals(authenticatedUser.getUserName(), username);
+            Assert.assertEquals(authenticatedUser.isSharedUser(), isSharedUser);
+
+            if (!OAuthConstants.AuthorizedOrganization.NONE.equals(accessingOrganization)) {
+                Assert.assertEquals(authenticatedUser.getAccessingOrganization(), accessingOrganization);
+                Assert.assertEquals(authenticatedUser.getUserResidentOrganization(), "user-resident-org-id");
+                if (expectTenantDomainOverride) {
+                    Assert.assertEquals(authenticatedUser.getTenantDomain(), appTenantDomain,
+                            "For non-shared federated users, tenant domain should be overridden to app tenant " +
+                                    "domain.");
+                } else {
+                    Assert.assertEquals(authenticatedUser.getTenantDomain(), tenantDomain,
+                            "For shared users, tenant domain should remain as the user's original tenant domain.");
+                }
             } else {
-                Assert.assertEquals(authenticatedUser.getTenantDomain(), tenantDomain,
-                        "For shared users, tenant domain should remain as the user's original tenant domain.");
+                Assert.assertNull(authenticatedUser.getAccessingOrganization(),
+                        "Accessing organization should not be set when it is NONE.");
             }
-        } else {
-            Assert.assertNull(authenticatedUser.getAccessingOrganization(),
-                    "Accessing organization should not be set when it is NONE.");
         }
     }
 

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/util/OAuth2UtilTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/util/OAuth2UtilTest.java
@@ -2160,6 +2160,60 @@ public class OAuth2UtilTest {
                         "of the user should be in {username}@{tenant-domain} format.");
     }
 
+    @DataProvider(name = "createAuthenticatedUserWithSharedUserData")
+    public Object[][] createAuthenticatedUserWithSharedUserData() {
+
+        return new Object[][]{
+                // {username, userStoreDomain, tenantDomain, idpName, accessingOrganization, isSharedUser,
+                //  expectTenantDomainOverride}
+                {"testuser1", "PRIMARY", "user.tenant", "LOCAL", "accessing-org-id", true, false},
+                {"testuser1", "PRIMARY", "user.tenant", "LOCAL", "accessing-org-id", false, true},
+                {"testuser1", "PRIMARY", "user.tenant", "LOCAL",
+                        OAuthConstants.AuthorizedOrganization.NONE, false, false},
+                {"testuser1", "PRIMARY", "user.tenant", "LOCAL",
+                        OAuthConstants.AuthorizedOrganization.NONE, true, false},
+        };
+    }
+
+    @Test(dataProvider = "createAuthenticatedUserWithSharedUserData")
+    public void testCreateAuthenticatedUserWithSharedUserFlag(String username, String userStoreDomain,
+                                                              String tenantDomain, String idpName,
+                                                              String accessingOrganization, boolean isSharedUser,
+                                                              boolean expectTenantDomainOverride) throws Exception {
+
+        String appTenantDomain = "app.tenant";
+        int appTenantId = 5678;
+
+        OAuth2ServiceComponentHolder.getInstance().setOrganizationManager(organizationManagerMock);
+        identityTenantUtil.when(() -> IdentityTenantUtil.getTenantDomain(appTenantId)).thenReturn(appTenantDomain);
+
+        if (!OAuthConstants.AuthorizedOrganization.NONE.equals(accessingOrganization)) {
+            lenient().when(organizationManagerMock.resolveOrganizationId(tenantDomain))
+                    .thenReturn("user-resident-org-id");
+        }
+
+        AuthenticatedUser authenticatedUser = OAuth2Util.createAuthenticatedUser(username, userStoreDomain,
+                tenantDomain, idpName, accessingOrganization, appTenantId, isSharedUser);
+
+        Assert.assertEquals(authenticatedUser.getUserName(), username);
+        Assert.assertEquals(authenticatedUser.isSharedUser(), isSharedUser);
+
+        if (!OAuthConstants.AuthorizedOrganization.NONE.equals(accessingOrganization)) {
+            Assert.assertEquals(authenticatedUser.getAccessingOrganization(), accessingOrganization);
+            Assert.assertEquals(authenticatedUser.getUserResidentOrganization(), "user-resident-org-id");
+            if (expectTenantDomainOverride) {
+                Assert.assertEquals(authenticatedUser.getTenantDomain(), appTenantDomain,
+                        "For non-shared users, tenant domain should be overridden to app tenant domain.");
+            } else {
+                Assert.assertEquals(authenticatedUser.getTenantDomain(), tenantDomain,
+                        "For shared users, tenant domain should remain as the user's original tenant domain.");
+            }
+        } else {
+            Assert.assertNull(authenticatedUser.getAccessingOrganization(),
+                    "Accessing organization should not be set when it is NONE.");
+        }
+    }
+
     @DataProvider(name = "oidcAudienceDataProvider")
     public Object[][] getOIDCAudience() {
 

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/validators/DefaultOAuth2ScopeValidatorTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/validators/DefaultOAuth2ScopeValidatorTest.java
@@ -21,6 +21,7 @@ package org.wso2.carbon.identity.oauth2.validators;
 import org.mockito.MockedStatic;
 import org.testng.annotations.Test;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
+import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.common.testng.WithCarbonHome;
 import org.wso2.carbon.identity.common.testng.WithRealmService;
 import org.wso2.carbon.identity.oauth.internal.OAuthComponentServiceHolder;
@@ -28,11 +29,14 @@ import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.authz.OAuthAuthzReqMessageContext;
 import org.wso2.carbon.identity.oauth2.dao.SharedAppResolveDAO;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2AuthorizeReqDTO;
+import org.wso2.carbon.identity.oauth2.internal.OAuth2ServiceComponentHolder;
 import org.wso2.carbon.identity.oauth2.util.AuthzUtil;
 
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.when;
 
 /**
  * Unit tests for {@link DefaultOAuth2ScopeValidator}.
@@ -43,6 +47,12 @@ public class DefaultOAuth2ScopeValidatorTest {
 
     @Test
     public void testValidateScopeSharedUserBypassesSharedAppResolution() throws Exception {
+
+        ApplicationManagementService originalAppMgtService = OAuth2ServiceComponentHolder.getApplicationMgtService();
+        ApplicationManagementService applicationMgtService = mock(ApplicationManagementService.class);
+        when(applicationMgtService.getApplicationResourceIDByInboundKey(anyString(), anyString(), anyString()))
+                .thenReturn("test-app-resource-id");
+        OAuth2ServiceComponentHolder.setApplicationMgtService(applicationMgtService);
 
         try (MockedStatic<AuthzUtil> authzUtil = mockStatic(AuthzUtil.class);
              MockedStatic<SharedAppResolveDAO> sharedAppResolveDAO = mockStatic(SharedAppResolveDAO.class)) {
@@ -74,6 +84,8 @@ public class DefaultOAuth2ScopeValidatorTest {
             sharedAppResolveDAO.verify(
                     () -> SharedAppResolveDAO.resolveSharedApplication(anyString(), anyString(), anyString()),
                     never());
+        } finally {
+            OAuth2ServiceComponentHolder.setApplicationMgtService(originalAppMgtService);
         }
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/validators/DefaultOAuth2ScopeValidatorTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/validators/DefaultOAuth2ScopeValidatorTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth2.validators;
+
+import org.mockito.MockedStatic;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
+import org.wso2.carbon.identity.common.testng.WithCarbonHome;
+import org.wso2.carbon.identity.common.testng.WithRealmService;
+import org.wso2.carbon.identity.oauth.internal.OAuthComponentServiceHolder;
+import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
+import org.wso2.carbon.identity.oauth2.authz.OAuthAuthzReqMessageContext;
+import org.wso2.carbon.identity.oauth2.dao.SharedAppResolveDAO;
+import org.wso2.carbon.identity.oauth2.dto.OAuth2AuthorizeReqDTO;
+import org.wso2.carbon.identity.oauth2.util.AuthzUtil;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+
+/**
+ * Unit tests for {@link DefaultOAuth2ScopeValidator}.
+ */
+@WithCarbonHome
+@WithRealmService(injectToSingletons = {OAuthComponentServiceHolder.class})
+public class DefaultOAuth2ScopeValidatorTest {
+
+    @Test
+    public void testValidateScopeSharedUserBypassesSharedAppResolution() throws Exception {
+
+        try (MockedStatic<AuthzUtil> authzUtil = mockStatic(AuthzUtil.class);
+             MockedStatic<SharedAppResolveDAO> sharedAppResolveDAO = mockStatic(SharedAppResolveDAO.class)) {
+
+            // Set up shared user accessing a non-resident organization.
+            AuthenticatedUser sharedUser = new AuthenticatedUser();
+            sharedUser.setSharedUser(true);
+            sharedUser.setAccessingOrganization("accessing-org-id");
+            sharedUser.setUserResidentOrganization("resident-org-id");
+
+            OAuth2AuthorizeReqDTO authzReqDTO = new OAuth2AuthorizeReqDTO();
+            authzReqDTO.setScopes(new String[]{"openid", "profile"});
+            authzReqDTO.setTenantDomain("carbon.super");
+            authzReqDTO.setConsumerKey("test-client-id");
+            authzReqDTO.setUser(sharedUser);
+            OAuthAuthzReqMessageContext authzReqMessageContext = new OAuthAuthzReqMessageContext(authzReqDTO);
+
+            // Mock AuthzUtil to return that user is NOT accessing resident org.
+            authzUtil.when(() -> AuthzUtil.isUserAccessingResidentOrganization(sharedUser)).thenReturn(false);
+
+            DefaultOAuth2ScopeValidator validator = new DefaultOAuth2ScopeValidator();
+            try {
+                validator.validateScope(authzReqMessageContext);
+            } catch (IdentityOAuth2Exception e) {
+                // Only ignore service-layer exceptions due to incomplete mocking of downstream dependencies.
+            }
+
+            // Verify SharedAppResolveDAO is never called for shared users.
+            sharedAppResolveDAO.verify(
+                    () -> SharedAppResolveDAO.resolveSharedApplication(anyString(), anyString(), anyString()),
+                    never());
+        }
+    }
+}

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/openidconnect/DefaultIDTokenBuilderTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/openidconnect/DefaultIDTokenBuilderTest.java
@@ -79,6 +79,7 @@ import org.wso2.carbon.identity.oauth2.dto.OAuth2AuthorizeRespDTO;
 import org.wso2.carbon.identity.oauth2.internal.OAuth2ServiceComponentHolder;
 import org.wso2.carbon.identity.oauth2.keyidprovider.DefaultKeyIDProviderImpl;
 import org.wso2.carbon.identity.oauth2.model.AccessTokenDO;
+import org.wso2.carbon.identity.oauth2.model.AccessTokenExtendedAttributes;
 import org.wso2.carbon.identity.oauth2.test.utils.CommonTestUtils;
 import org.wso2.carbon.identity.oauth2.token.OAuthTokenReqMessageContext;
 import org.wso2.carbon.identity.oauth2.token.handlers.grant.saml.SAML2BearerGrantHandlerTest;
@@ -356,6 +357,37 @@ public class DefaultIDTokenBuilderTest {
         Assert.assertTrue(issueTime <= (new Date()).getTime());
         Assert.assertNull(IdentityUtil.threadLocalProperties.get().get(IdentityCoreConstants.IS_SYSTEM_APPLICATION),
                 "Thread local should be cleaned up after ID token building.");
+    }
+
+    @Test
+    public void testBuildIDTokenFiltersSharedUserAttribute() throws Exception {
+
+        when(OrganizationManagementUtil.isOrganization(anyString())).thenReturn(false);
+
+        String clientId = "dabfba9390aa423f8b04332794d83614";
+        OAuth2AccessTokenRespDTO tokenRespDTO = new OAuth2AccessTokenRespDTO();
+        tokenRespDTO.setAccessToken("2sa9a678f890877856y66e75f605d456");
+        AuthenticatedUser user = getDefaultAuthenticatedUserFederatedUser();
+        OAuthTokenReqMessageContext messageContext = getTokenReqMessageContextForUser(user, clientId);
+
+        // Populate extended attributes with both IS_SHARED_USER (must be filtered) and a regular custom claim.
+        Map<String, String> extendedParams = new HashMap<>();
+        extendedParams.put(OAuthConstants.IS_SHARED_USER, "true");
+        extendedParams.put("custom_claim_key", "custom_claim_value");
+        AccessTokenExtendedAttributes extendedAttributes = new AccessTokenExtendedAttributes(extendedParams);
+        messageContext.getOauth2AccessTokenReqDTO().setAccessTokenExtendedAttributes(extendedAttributes);
+
+        OAuthAppDO entry = getOAuthAppDO(CLIENT_ID);
+        AppInfoCache.getInstance().addToCache(clientId, entry);
+
+        mockRealmService();
+        String idToken = defaultIDTokenBuilder.buildIDToken(messageContext, tokenRespDTO);
+        JWTClaimsSet claims = SignedJWT.parse(idToken).getJWTClaimsSet();
+
+        Assert.assertNull(claims.getClaim(OAuthConstants.IS_SHARED_USER),
+                "IS_SHARED_USER must not appear in the issued ID token.");
+        Assert.assertEquals(claims.getClaim("custom_claim_key"), "custom_claim_value",
+                "Other extended attribute claims should still be propagated to the ID token.");
     }
 
     @Test

--- a/components/org.wso2.carbon.identity.oauth/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.identity.oauth/src/test/resources/testng.xml
@@ -33,6 +33,7 @@
             <class name="org.wso2.carbon.identity.oauth2.validators.OIDCScopeHandlerTest"/>
             <class name="org.wso2.carbon.identity.oauth2.validators.TokenValidationHandlerTest"/>
             <class name="org.wso2.carbon.identity.oauth2.validators.DefaultOAuth2TokenValidatorTest"/>
+            <class name="org.wso2.carbon.identity.oauth2.validators.DefaultOAuth2ScopeValidatorTest"/>
             <class name="org.wso2.carbon.identity.oauth2.validators.OAuth2TokenValidationMessageContextTest"/>
             <class name="org.wso2.carbon.identity.oauth2.authz.handlers.CodeResponseTypeHandlerTest"/>
             <class name="org.wso2.carbon.identity.oauth2.authz.handlers.util.ResponseTypeHandlerUtilTest"/>


### PR DESCRIPTION
### Purpose
Improves the oauth components to support shared user direct logins to sub-organizations. Changes ensure the AuthenticatedUser's `isSharedUser`, `accessingOrganization` and `userResidentOrganization` properties are maintained consistently for shared user login flows which will make sure the correct claim values are populated in the returned tokens

### Dependent on
- https://github.com/wso2/carbon-identity-framework/pull/7964

### Related issue
- https://github.com/wso2/product-is/issues/27371 