### PR TITLE
Extend Agent Authorization Protocol to organizations

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/pom.xml
+++ b/components/org.wso2.carbon.identity.oauth/pom.xml
@@ -263,6 +263,10 @@
         </dependency>
         <dependency>
             <groupId>org.wso2.carbon.identity.organization.management</groupId>
+            <artifactId>org.wso2.carbon.identity.organization.management.organization.agent.sharing</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.organization.management</groupId>
             <artifactId>org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service</artifactId>
         </dependency>
         <dependency>
@@ -467,6 +471,7 @@
                             org.wso2.carbon.identity.organization.management.role.management.service.models; version="${carbon.identity.organization.management.version.range}",
                             org.wso2.carbon.identity.organization.management.organization.user.sharing.util;version="${carbon.identity.organization.management.version.range}",
                             org.wso2.carbon.identity.organization.management.organization.user.sharing.models;version="${carbon.identity.organization.management.version.range}",
+                            org.wso2.carbon.identity.organization.management.organization.agent.sharing.util;version="${carbon.identity.organization.management.version.range}",
                             org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service;
                             version="${carbon.identity.organization.management.version.range}",
                             org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service.exception;
@@ -641,4 +646,3 @@
     </build>
 
 </project>
-

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/AuthzUtil.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/AuthzUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2025, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2023-2026, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -30,11 +30,13 @@ import org.wso2.carbon.identity.application.authentication.framework.util.Framew
 import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
 import org.wso2.carbon.identity.application.common.model.ClaimMapping;
 import org.wso2.carbon.identity.application.common.model.Scope;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
 import org.wso2.carbon.identity.oauth.internal.OAuthComponentServiceHolder;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2ClientException;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.internal.OAuth2ServiceComponentHolder;
+import org.wso2.carbon.identity.organization.management.organization.agent.sharing.util.OrganizationSharedAgentUtil;
 import org.wso2.carbon.identity.organization.management.organization.user.sharing.util.OrganizationSharedUserUtil;
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
 import org.wso2.carbon.identity.role.v2.mgt.core.exception.IdentityRoleManagementException;
@@ -196,6 +198,7 @@ public class AuthzUtil {
             throws IdentityOAuth2Exception {
 
         String associatedUserId;
+        String accessingOrganization = authenticatedUser.getAccessingOrganization();
         /* When user ID resolving for the organization SSO federated users, the associated user ID can be found from the
          userName of the authenticated user object. */
         if (authenticatedUser.isFederatedUser()) {
@@ -205,13 +208,31 @@ public class AuthzUtil {
         } else {
             associatedUserId = getUserId(authenticatedUser);
         }
-        try {
-            Optional<String> optionalOrganizationUserId = OrganizationSharedUserUtil
-                    .getUserIdOfAssociatedUserByOrgId(associatedUserId, authenticatedUser.getAccessingOrganization());
-            return optionalOrganizationUserId.orElseThrow(() ->
-                    new IdentityOAuth2ClientException("User is not allowed to access the organization"));
-        } catch (OrganizationManagementException e) {
-            throw new IdentityOAuth2Exception("Error while resolving shared user ID" , e);
+        // For agents, perform the agent org association lookup instead of the user sharing lookup.
+        if (IdentityUtil.getAgentIdentityUserstoreName().equalsIgnoreCase(authenticatedUser.getUserStoreDomain())) {
+            try {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Looking up shared agent ID for agent in organization: " + accessingOrganization);
+                }
+                Optional<String> sharedAgentId = OrganizationSharedAgentUtil
+                        .getAgentIdOfAssociatedAgentByOrgId(associatedUserId, accessingOrganization);
+                return sharedAgentId.orElseThrow(() ->
+                        new IdentityOAuth2ClientException("Agent is not allowed to access the organization"));
+            } catch (OrganizationManagementException e) {
+                throw new IdentityOAuth2Exception("Error while resolving shared agent ID", e);
+            }
+        } else {
+            try {
+                Optional<String> optionalOrganizationUserId = OrganizationSharedUserUtil
+                        .getUserIdOfAssociatedUserByOrgId(associatedUserId, accessingOrganization);
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Looking up shared user ID for user in organization: " + accessingOrganization);
+                }
+                return optionalOrganizationUserId.orElseThrow(() ->
+                        new IdentityOAuth2ClientException("User is not allowed to access the organization"));
+            } catch (OrganizationManagementException e) {
+                throw new IdentityOAuth2Exception("Error while resolving shared user ID" , e);
+            }
         }
     }
 

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/util/AuthzUtilTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/util/AuthzUtilTest.java
@@ -28,9 +28,12 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.internal.OAuth2ServiceComponentHolder;
+import org.wso2.carbon.identity.organization.management.organization.agent.sharing.util.OrganizationSharedAgentUtil;
+import org.wso2.carbon.identity.organization.management.organization.user.sharing.util.OrganizationSharedUserUtil;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
 import org.wso2.carbon.identity.role.v2.mgt.core.RoleManagementService;
 import org.wso2.carbon.identity.role.v2.mgt.core.exception.IdentityRoleManagementException;
@@ -40,12 +43,14 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
+import static org.wso2.carbon.user.core.UserStoreConfigConstants.PRIMARY;
 
 /**
  * Unit tests for AuthzUtil class.
@@ -68,11 +73,14 @@ public class AuthzUtilTest {
     private MockedStatic<AuthzUtil> authzUtilMockedStatic;
     private MockedStatic<OAuthServerConfiguration> oAuthServerConfigurationMockedStatic;
 
+    private static final String AGENT = "AGENT";
     private static final String USER_ID = "test-user-id";
     private static final String ACCESSING_ORGANIZATION = "accessing-org-id";
     private static final String TENANT_DOMAIN = "tenantDomain";
     private static final String USER_RESIDENT_ORG_TENANT = "resident-tenant";
     private static final String ACCESSING_ORG_TENANT = "accessing-tenant";
+    private static final String SHARED_AGENT_ID = "shared-agent-id";
+    private static final String SHARED_USER_ID = "shared-user-id";
 
     @BeforeMethod
     public void setUp() {
@@ -312,5 +320,45 @@ public class AuthzUtilTest {
         List<String> result = AuthzUtil.getSubOrgUserRoles(USER_ID, "");
         Assert.assertNotNull(result);
         Assert.assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void testAgentGetUserIdOfAssociatedUser() throws Exception {
+
+        try (MockedStatic<IdentityUtil> identityUtil = mockStatic(IdentityUtil.class);
+             MockedStatic<OrganizationSharedAgentUtil> sharedAgentUtil =
+                     mockStatic(OrganizationSharedAgentUtil.class)) {
+
+            when(authenticatedUser.isFederatedUser()).thenReturn(false);
+            when(authenticatedUser.getUserId()).thenReturn(USER_ID);
+            when(authenticatedUser.getUserStoreDomain()).thenReturn(AGENT);
+            when(authenticatedUser.getAccessingOrganization()).thenReturn(ACCESSING_ORGANIZATION);
+            identityUtil.when(IdentityUtil::getAgentIdentityUserstoreName).thenReturn(AGENT);
+            sharedAgentUtil.when(() -> OrganizationSharedAgentUtil
+                    .getAgentIdOfAssociatedAgentByOrgId(USER_ID, ACCESSING_ORGANIZATION))
+                    .thenReturn(Optional.of(SHARED_AGENT_ID));
+            String result = AuthzUtil.getUserIdOfAssociatedUser(authenticatedUser);
+            Assert.assertEquals(result, SHARED_AGENT_ID);
+        }
+    }
+
+    @Test
+    public void testGetUserIdOfAssociatedUserFallsBackToUserSharing() throws Exception {
+
+        try (MockedStatic<IdentityUtil> identityUtil = mockStatic(IdentityUtil.class);
+             MockedStatic<OrganizationSharedUserUtil> sharedUserUtil =
+                     mockStatic(OrganizationSharedUserUtil.class)) {
+
+            when(authenticatedUser.isFederatedUser()).thenReturn(false);
+            when(authenticatedUser.getUserId()).thenReturn(USER_ID);
+            when(authenticatedUser.getUserStoreDomain()).thenReturn(PRIMARY);
+            when(authenticatedUser.getAccessingOrganization()).thenReturn(ACCESSING_ORGANIZATION);
+            identityUtil.when(IdentityUtil::getAgentIdentityUserstoreName).thenReturn(AGENT);
+            sharedUserUtil.when(() -> OrganizationSharedUserUtil
+                    .getUserIdOfAssociatedUserByOrgId(USER_ID, ACCESSING_ORGANIZATION))
+                    .thenReturn(Optional.of(SHARED_USER_ID));
+            String result = AuthzUtil.getUserIdOfAssociatedUser(authenticatedUser);
+            Assert.assertEquals(result, SHARED_USER_ID);
+        }
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright (c) 2015-2024, WSO2 LLC. (http://www.wso2.com).
+  ~ Copyright (c) 2015-2026, WSO2 LLC. (http://www.wso2.com).
   ~
   ~ WSO2 LLC. licenses this file to you under the Apache License,
   ~ Version 2.0 (the "License"); you may not use this file except
@@ -265,6 +265,11 @@
             <dependency>
                 <groupId>org.wso2.carbon.identity.organization.management</groupId>
                 <artifactId>org.wso2.carbon.identity.organization.management.organization.user.sharing</artifactId>
+                <version>${carbon.identity.organization.management.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.organization.management</groupId>
+                <artifactId>org.wso2.carbon.identity.organization.management.organization.agent.sharing</artifactId>
                 <version>${carbon.identity.organization.management.version}</version>
             </dependency>
             <dependency>
@@ -993,7 +998,7 @@
         </carbon.identity.framework.imp.pkg.version.range>
         <identity.oauth.xacml.version.range>[2.0.0, 3.0.0)</identity.oauth.xacml.version.range>
 
-        <carbon.identity.organization.management.version>2.4.4
+        <carbon.identity.organization.management.version>2.5.5
         </carbon.identity.organization.management.version>
         <carbon.identity.organization.management.version.range>[1.1.14, 3.0.0)
         </carbon.identity.organization.management.version.range>


### PR DESCRIPTION
### Proposed changes in this pull request
$subject

Extends the OAuth module to support agent identity resolution in the authorization utility. 

Issue: https://github.com/wso2/product-is/issues/27526
Related: 

- https://github.com/wso2-extensions/identity-organization-management/pull/628
- https://github.com/wso2/identity-api-server/pull/1117