### PR TITLE
add seperate config for client secret hash

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpointTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpointTest.java
@@ -2084,6 +2084,8 @@ public class OAuth2AuthzEndpointTest extends TestOAuthEndpointBase {
 
         oAuthServerConfiguration.when(OAuthServerConfiguration::getInstance).thenReturn(mockOAuthServerConfiguration);
         when(mockOAuthServerConfiguration.getPersistenceProcessor()).thenReturn(tokenPersistenceProcessor);
+        when(mockOAuthServerConfiguration.getClientSecretPersistenceProcessor())
+                .thenReturn(tokenPersistenceProcessor);
         when(mockOAuthServerConfiguration.isRedirectToRequestedRedirectUriEnabled()).thenReturn(false);
         when(tokenPersistenceProcessor.getProcessedClientId(anyString())).thenAnswer(
                 invocation -> invocation.getArguments()[0]);

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/device/DeviceEndpointTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/device/DeviceEndpointTest.java
@@ -282,6 +282,8 @@ public class DeviceEndpointTest extends TestOAuthEndpointBase {
 
         oAuthServerConfiguration.when(OAuthServerConfiguration::getInstance).thenReturn(mockOAuthServerConfiguration);
         lenient().when(mockOAuthServerConfiguration.getPersistenceProcessor()).thenReturn(tokenPersistenceProcessor);
+        lenient().when(mockOAuthServerConfiguration.getClientSecretPersistenceProcessor())
+                .thenReturn(tokenPersistenceProcessor);
         lenient().when(mockOAuthServerConfiguration.getDeviceCodeKeySet())
                 .thenReturn("abcdefghijklmnopABCDEFGHIJ123456789");
         lenient().when(mockOAuthServerConfiguration.getDeviceCodeExpiryTime()).thenReturn(60000L);

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/device/UserAuthenticationEndpointTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/device/UserAuthenticationEndpointTest.java
@@ -259,6 +259,8 @@ public class UserAuthenticationEndpointTest extends TestOAuthEndpointBase {
 
         oAuthServerConfiguration.when(OAuthServerConfiguration::getInstance).thenReturn(mockOAuthServerConfiguration);
         lenient().when(mockOAuthServerConfiguration.getPersistenceProcessor()).thenReturn(tokenPersistenceProcessor);
+        lenient().when(mockOAuthServerConfiguration.getClientSecretPersistenceProcessor())
+                .thenReturn(tokenPersistenceProcessor);
         lenient().when(mockOAuthServerConfiguration.isRedirectToRequestedRedirectUriEnabled()).thenReturn(false);
         lenient().when(tokenPersistenceProcessor.getProcessedClientId(anyString())).thenAnswer(
                 invocation -> invocation.getArguments()[0]);

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/introspection/OAuth2IntrospectionEndpointTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/introspection/OAuth2IntrospectionEndpointTest.java
@@ -185,6 +185,8 @@ public class OAuth2IntrospectionEndpointTest {
 
         oAuthServerConfiguration.when(OAuthServerConfiguration::getInstance).thenReturn(mockOAuthServerConfiguration);
         lenient().when(mockOAuthServerConfiguration.getPersistenceProcessor()).thenReturn(tokenPersistenceProcessor);
+        lenient().when(mockOAuthServerConfiguration.getClientSecretPersistenceProcessor())
+                .thenReturn(tokenPersistenceProcessor);
         lenient().when(mockOAuthServerConfiguration.isRedirectToRequestedRedirectUriEnabled()).thenReturn(false);
         lenient().when(tokenPersistenceProcessor.getProcessedClientId(anyString())).thenAnswer(
                 invocation -> invocation.getArguments()[0]);

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/jwks/JwksEndpointTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/jwks/JwksEndpointTest.java
@@ -373,6 +373,8 @@ public class JwksEndpointTest {
 
         oAuthServerConfiguration.when(OAuthServerConfiguration::getInstance).thenReturn(mockOAuthServerConfiguration);
         lenient().when(mockOAuthServerConfiguration.getPersistenceProcessor()).thenReturn(tokenPersistenceProcessor);
+        lenient().when(mockOAuthServerConfiguration.getClientSecretPersistenceProcessor())
+                .thenReturn(tokenPersistenceProcessor);
         lenient().when(mockOAuthServerConfiguration.getIdTokenSignatureAlgorithm()).thenReturn("SHA512withRSA");
         lenient().when(mockOAuthServerConfiguration.getSignatureAlgorithm()).thenReturn("SHA256withRSA");
         lenient().when(mockOAuthServerConfiguration.getUserInfoJWTSignatureAlgorithm()).thenReturn("SHA384withRSA");

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/par/OAuth2ParEndpointTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/par/OAuth2ParEndpointTest.java
@@ -529,6 +529,8 @@ public class OAuth2ParEndpointTest extends TestOAuthEndpointBase {
                 .thenReturn(responseTypeValidators);
 
         lenient().when(mockOAuthServerConfiguration.getPersistenceProcessor()).thenReturn(tokenPersistenceProcessor);
+        lenient().when(mockOAuthServerConfiguration.getClientSecretPersistenceProcessor())
+                .thenReturn(tokenPersistenceProcessor);
         lenient().when(tokenPersistenceProcessor.getProcessedClientId(anyString())).thenAnswer(
                 invocation -> invocation.getArguments()[0]);
         lenient().when(mockOAuthServerConfiguration.getOAuthAuthzRequestClassName())

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/token/OAuth2TokenEndpointTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/token/OAuth2TokenEndpointTest.java
@@ -682,6 +682,8 @@ public class OAuth2TokenEndpointTest extends TestOAuthEndpointBase {
 
         oAuthServerConfiguration.when(OAuthServerConfiguration::getInstance).thenReturn(mockOAuthServerConfiguration);
         lenient().when(mockOAuthServerConfiguration.getPersistenceProcessor()).thenReturn(tokenPersistenceProcessor);
+        lenient().when(mockOAuthServerConfiguration.getClientSecretPersistenceProcessor())
+                .thenReturn(tokenPersistenceProcessor);
         lenient().when(tokenPersistenceProcessor.getProcessedClientId(anyString())).thenAnswer(
                 invocation -> invocation.getArguments()[0]);
     }

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/util/AuthzUtilTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/util/AuthzUtilTest.java
@@ -1713,6 +1713,8 @@ public class AuthzUtilTest extends TestOAuthEndpointBase {
 
         oAuthServerConfiguration.when(OAuthServerConfiguration::getInstance).thenReturn(mockOAuthServerConfiguration);
         when(mockOAuthServerConfiguration.getPersistenceProcessor()).thenReturn(tokenPersistenceProcessor);
+        when(mockOAuthServerConfiguration.getClientSecretPersistenceProcessor())
+                .thenReturn(tokenPersistenceProcessor);
         when(mockOAuthServerConfiguration.isRedirectToRequestedRedirectUriEnabled()).thenReturn(false);
         when(tokenPersistenceProcessor.getProcessedClientId(anyString())).thenAnswer(
                 invocation -> invocation.getArguments()[0]);

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/util/OpenIDConnectUserRPStoreTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/util/OpenIDConnectUserRPStoreTest.java
@@ -138,6 +138,8 @@ public class OpenIDConnectUserRPStoreTest extends TestOAuthEndpointBase {
                     .thenReturn(this.mockOAuthServerConfiguration);
             lenient().when(mockOAuthServerConfiguration.getPersistenceProcessor())
                     .thenReturn(tokenPersistenceProcessor);
+            lenient().when(mockOAuthServerConfiguration.getClientSecretPersistenceProcessor())
+                    .thenReturn(tokenPersistenceProcessor);
             lenient().when(tokenPersistenceProcessor.getProcessedClientId(anyString()))
                     .thenAnswer(invocation -> invocation.getArguments()[0]);
 
@@ -192,6 +194,8 @@ public class OpenIDConnectUserRPStoreTest extends TestOAuthEndpointBase {
             oAuthServerConfiguration.when(OAuthServerConfiguration::getInstance)
                     .thenReturn(mockOAuthServerConfiguration);
             lenient().when(mockOAuthServerConfiguration.getPersistenceProcessor())
+                    .thenReturn(tokenPersistenceProcessor);
+            lenient().when(mockOAuthServerConfiguration.getClientSecretPersistenceProcessor())
                     .thenReturn(tokenPersistenceProcessor);
             lenient().when(tokenPersistenceProcessor.getProcessedClientId(anyString()))
                     .thenAnswer(invocation -> invocation.getArguments()[0]);

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImpl.java
@@ -71,6 +71,7 @@ import org.wso2.carbon.identity.oauth.event.OAuthEventInterceptor;
 import org.wso2.carbon.identity.oauth.internal.OAuthComponentServiceHolder;
 import org.wso2.carbon.identity.oauth.internal.util.AccessTokenEventUtil;
 import org.wso2.carbon.identity.oauth.listener.OAuthApplicationMgtListener;
+import org.wso2.carbon.identity.oauth.tokenprocessor.TokenPersistenceProcessor;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2ScopeClientException;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2ScopeException;
@@ -265,6 +266,14 @@ public class OAuthAdminServiceImpl {
                 dto = OAuthUtil.buildConsumerAppDTO(app);
                 if (LOG.isDebugEnabled()) {
                     LOG.debug("Found App :" + dto.getApplicationName() + " for consumerKey: " + consumerKey);
+                }
+                if (OAuth2Util.isClientSecretHashingEnabled()) {
+                    TokenPersistenceProcessor persistenceProcessor = OAuth2Util.getClientSecretPersistenceProcessor();
+                    if (persistenceProcessor != null) {
+                        if (!persistenceProcessor.isProcessed(app.getOauthConsumerSecret())) {
+                            AppInfoCache.getInstance().clearCacheEntry(consumerKey, tenantDomain);
+                        }
+                    }
                 }
             } else {
                 dto = new OAuthConsumerAppDTO();
@@ -622,8 +631,14 @@ public class OAuthAdminServiceImpl {
                             app.setCallbackUrl(consoleCallBackURL);
                         }
                     }
-                    if (StringUtils.isNotBlank(app.getCallbackUrl()) &&
-                            !app.getCallbackUrl().contains(BASE_URL_PLACEHOLDER)) {
+                    String callbackUrl = app.getCallbackUrl();
+                    boolean containsUnresolvedPlaceholder = StringUtils.isNotBlank(callbackUrl) &&
+                            callbackUrl.contains(BASE_URL_PLACEHOLDER);
+
+                    // For apps shared with sub-organizations, the callback URL may contain a base URL
+                    // placeholder that is resolved only after DB retrieval.
+                    // Avoid caching entries with unresolved placeholders on app creation.
+                    if (!containsUnresolvedPlaceholder) {
                         AppInfoCache.getInstance().addToCache(app.getOauthConsumerKey(), app, tenantDomain);
                     }
                     if (LOG.isDebugEnabled()) {
@@ -2665,7 +2680,7 @@ public class OAuthAdminServiceImpl {
      */
     public boolean isHashDisabled() {
 
-        return OAuth2Util.isHashDisabled();
+        return OAuth2Util.isClientSecretHashingDisabled();
     }
 
     AuthenticatedUser getAppOwner(OAuthConsumerAppDTO application,

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
@@ -164,6 +164,9 @@ public class OAuthServerConfiguration {
     private boolean enablePasswordFlowEnhancements = false;
     private String tokenPersistenceProcessorClassName =
             "org.wso2.carbon.identity.oauth.tokenprocessor.PlainTextPersistenceProcessor";
+    // Optional dedicated processor for client secret only. When unset, client-secret
+    // callers fall back to the shared token persistence processor for backward compatibility.
+    private String clientSecretPersistenceProcessorClassName = null;
     private String oauthTokenGeneratorClassName;
     private OAuthIssuer oauthTokenGenerator;
     private String oauthIdentityTokenGeneratorClassName;
@@ -193,6 +196,7 @@ public class OAuthServerConfiguration {
     private boolean useLegacyPermissionAccessForUserBasedAuth = false;
     private String accessTokenPartitioningDomains = null;
     private TokenPersistenceProcessor persistenceProcessor = null;
+    private TokenPersistenceProcessor clientSecretPersistenceProcessor = null;
     private Set<OAuthCallbackHandlerMetaData> callbackHandlerMetaData = new HashSet<>();
     private Map<String, String> supportedGrantTypeClassNames = new HashMap<>();
     private Map<String, Boolean> refreshTokenAllowedGrantTypes = new HashMap<>();
@@ -329,6 +333,7 @@ public class OAuthServerConfiguration {
     //property to define hashing algorithm when enabling hashing of tokens and authorization codes.
     private String hashAlgorithm = "SHA-256";
     private boolean isClientSecretHashEnabled = false;
+    private boolean isClientSecretHashOnlyEnabled = false;
 
 
     // Property added to determine the expiration of logout token in oidc back-channel logout.
@@ -472,6 +477,9 @@ public class OAuthServerConfiguration {
 
         // read token persistence processor config
         parseTokenPersistenceProcessorConfig(oauthElem);
+
+        // read client-secret dedicated persistence processor config (optional)
+        parseClientSecretPersistenceProcessorConfig(oauthElem);
 
         // read supported grant types
         parseSupportedGrantTypesConfig(oauthElem);
@@ -1499,6 +1507,10 @@ public class OAuthServerConfiguration {
         return isClientSecretHashEnabled;
     }
 
+    public boolean isClientSecretHashOnlyEnabled() {
+        return isClientSecretHashOnlyEnabled;
+    }
+
     private void parseRequestObjectConfig(OMElement requestObjectBuildersElem) {
         if (requestObjectBuildersElem != null) {
             Iterator<OMElement> iterator = requestObjectBuildersElem
@@ -1848,6 +1860,49 @@ public class OAuthServerConfiguration {
             }
         }
         return persistenceProcessor;
+    }
+
+    /**
+     * Return the persistence processor dedicated for client secret operations.
+     *
+     * <p>If {@code ClientSecretPersistenceProcessor} is configured in identity.xml, an instance of that class is
+     * returned (lazily created, cached). Otherwise this falls back to {@link #getPersistenceProcessor()} so existing
+     * deployments that only configure {@code TokenPersistenceProcessor} continue to behave exactly as before.
+     *
+     * @return The processor to use for client secret pre/post-processing.
+     * @throws IdentityOAuth2Exception If the fallback processor cannot be instantiated.
+     */
+    public TokenPersistenceProcessor getClientSecretPersistenceProcessor() throws IdentityOAuth2Exception {
+
+        if (StringUtils.isBlank(clientSecretPersistenceProcessorClassName)) {
+            return getPersistenceProcessor();
+        }
+        if (clientSecretPersistenceProcessor == null) {
+            synchronized (this) {
+                if (clientSecretPersistenceProcessor == null) {
+                    try {
+                        Class clazz =
+                                this.getClass().getClassLoader()
+                                        .loadClass(clientSecretPersistenceProcessorClassName);
+                        clientSecretPersistenceProcessor = (TokenPersistenceProcessor) clazz.newInstance();
+
+                        if (log.isDebugEnabled()) {
+                            log.debug("An instance of " + clientSecretPersistenceProcessorClassName +
+                                    " is created for client secret processing.");
+                        }
+
+                    } catch (Exception e) {
+                        String errorMsg =
+                                "Error when instantiating the ClientSecretPersistenceProcessor : " +
+                                        clientSecretPersistenceProcessorClassName +
+                                        ". Falling back to the shared TokenPersistenceProcessor.";
+                        log.error(errorMsg, e);
+                        return getPersistenceProcessor();
+                    }
+                }
+            }
+        }
+        return clientSecretPersistenceProcessor;
     }
 
     /**
@@ -2828,6 +2883,21 @@ public class OAuthServerConfiguration {
             log.debug("Token Persistence Processor was set to : " + tokenPersistenceProcessorClassName);
         }
 
+    }
+
+    private void parseClientSecretPersistenceProcessorConfig(OMElement oauthConfigElem) {
+
+        OMElement clientSecretProcessorElem =
+                oauthConfigElem
+                        .getFirstChildWithName(
+                                getQNameWithIdentityNS(ConfigElements.CLIENT_SECRET_PERSISTENCE_PROCESSOR));
+        if (clientSecretProcessorElem != null && StringUtils.isNotBlank(clientSecretProcessorElem.getText())) {
+            clientSecretPersistenceProcessorClassName = clientSecretProcessorElem.getText().trim();
+        }
+
+        if (log.isDebugEnabled()) {
+            log.debug("Client Secret Persistence Processor was set to : " + clientSecretPersistenceProcessorClassName);
+        }
     }
 
     /**
@@ -3984,6 +4054,24 @@ public class OAuthServerConfiguration {
                 log.debug("Is client secret hashing enabled: " + isClientSecretHashEnabled);
             }
         }
+
+        try {
+            clientSecretPersistenceProcessor = getClientSecretPersistenceProcessor();
+        } catch (IdentityOAuth2Exception e) {
+            log.error("Error while getting an instance of Client Secret Persistence Processor.");
+        }
+
+        if (clientSecretPersistenceProcessor instanceof HashingPersistenceProcessor) {
+
+            OMElement clientSecretHashOnlyElement = oauthConfigElem
+                    .getFirstChildWithName(getQNameWithIdentityNS(ConfigElements.ENABLE_CLIENT_SECRET_HASH_ONLY));
+            if (clientSecretHashOnlyElement != null) {
+                isClientSecretHashOnlyEnabled = Boolean.parseBoolean(clientSecretHashOnlyElement.getText());
+            }
+            if (log.isDebugEnabled()) {
+                log.debug("Is client secret only hashing enabled: " + isClientSecretHashOnlyEnabled);
+            }
+        }
     }
 
     private void parseRedirectToOAuthErrorPageConfig(OMElement oauthConfigElem) {
@@ -4607,6 +4695,8 @@ public class OAuthServerConfiguration {
         private static final String KEEP_REVOKED_ACCESS_TOKENS = "KeepRevokedAccessTokens";
         // TokenPersistenceProcessor
         private static final String TOKEN_PERSISTENCE_PROCESSOR = "TokenPersistenceProcessor";
+        // Dedicated processor for client secrets (optional, falls back to TokenPersistenceProcessor).
+        private static final String CLIENT_SECRET_PERSISTENCE_PROCESSOR = "ClientSecretPersistenceProcessor";
         // Token issuer generator.
         private static final String OAUTH_TOKEN_GENERATOR = "OAuthTokenGenerator";
         private static final String IDENTITY_OAUTH_TOKEN_GENERATOR = "IdentityOAuthTokenGenerator";
@@ -4691,6 +4781,7 @@ public class OAuthServerConfiguration {
         //Hash algorithm configs
         private static final String HASH_ALGORITHM = "HashAlgorithm";
         private static final String ENABLE_CLIENT_SECRET_HASH = "EnableClientSecretHash";
+        private static final String ENABLE_CLIENT_SECRET_HASH_ONLY = "HashClientSecretOnly";
 
         // Token introspection Configs
         private static final String INTROSPECTION_CONFIG = "Introspection";

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dao/OAuthAppDAO.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dao/OAuthAppDAO.java
@@ -150,12 +150,12 @@ public class OAuthAppDAO {
     private static final String BASE_URL_PLACEHOLDER = "<PROTOCOL>://<HOSTNAME>:<PORT>";
 
     private TokenPersistenceProcessor persistenceProcessor;
-    private boolean isHashDisabled = OAuth2Util.isHashDisabled();
+    private boolean isHashDisabled = OAuth2Util.isClientSecretHashingDisabled();
 
     public OAuthAppDAO() {
 
         try {
-            persistenceProcessor = OAuthServerConfiguration.getInstance().getPersistenceProcessor();
+            persistenceProcessor = OAuthServerConfiguration.getInstance().getClientSecretPersistenceProcessor();
         } catch (IdentityOAuth2Exception e) {
             LOG.error("Error retrieving TokenPersistenceProcessor. Defaulting to PlainTextPersistenceProcessor");
             persistenceProcessor = new PlainTextPersistenceProcessor();

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dao/OAuthConsumerDAO.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dao/OAuthConsumerDAO.java
@@ -48,13 +48,13 @@ public class OAuthConsumerDAO {
     public static final Log LOG = LogFactory.getLog(OAuthConsumerDAO.class);
     public static final String OUT_OF_BAND = "oob";
     private TokenPersistenceProcessor persistenceProcessor;
-    private boolean isHashDisabled = OAuth2Util.isHashDisabled();
+    private boolean isHashDisabled = OAuth2Util.isClientSecretHashingDisabled();
     private static final String BASE_URL_PLACEHOLDER = "<PROTOCOL>://<HOSTNAME>:<PORT>";
 
     public OAuthConsumerDAO() {
 
         try {
-            persistenceProcessor = OAuthServerConfiguration.getInstance().getPersistenceProcessor();
+            persistenceProcessor = OAuthServerConfiguration.getInstance().getClientSecretPersistenceProcessor();
         } catch (IdentityOAuth2Exception e) {
             LOG.error("Error retrieving TokenPersistenceProcessor. Defaulting to PlainTextProcessor", e);
             persistenceProcessor = new PlainTextPersistenceProcessor();

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/tokenprocessor/HashingPersistenceProcessor.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/tokenprocessor/HashingPersistenceProcessor.java
@@ -101,6 +101,21 @@ public class HashingPersistenceProcessor implements TokenPersistenceProcessor {
         return processedRefreshToken;
     }
 
+    @Override
+    public boolean isProcessed(String secret) throws IdentityOAuth2Exception {
+
+        if (StringUtils.isEmpty(secret)) {
+            return false;
+        }
+
+        try {
+            JSONObject obj = new JSONObject(secret);
+            return obj.has(ALGORITHM) && obj.has(HASH);
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
     /**
      * Method to generate hash value
      *

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/tokenprocessor/TokenPersistenceProcessor.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/tokenprocessor/TokenPersistenceProcessor.java
@@ -51,4 +51,8 @@ public interface TokenPersistenceProcessor {
     public String getPreprocessedRefreshToken(String processedRefreshToken)
             throws IdentityOAuth2Exception;
 
+    default boolean isProcessed(String secret) throws IdentityOAuth2Exception {
+        return true;
+    }
+
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dao/TokenManagementDAOImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dao/TokenManagementDAOImpl.java
@@ -33,6 +33,8 @@ import org.wso2.carbon.identity.core.util.IdentityDatabaseUtil;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.oauth.common.OAuthConstants;
+import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
+import org.wso2.carbon.identity.oauth.tokenprocessor.TokenPersistenceProcessor;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.Oauth2ScopeConstants;
 import org.wso2.carbon.identity.oauth2.internal.OAuth2ServiceComponentHolder;
@@ -608,6 +610,11 @@ public class TokenManagementDAOImpl extends AbstractOAuthDAO implements TokenMan
                 updateStateStatement.execute();
 
             } else if (OAuthConstants.ACTION_REGENERATE.equals(action)) {
+                TokenPersistenceProcessor tokenPersistenceProcessor = getPersistenceProcessor();
+                if (OAuthServerConfiguration.getInstance().isClientSecretHashOnlyEnabled()) {
+                    tokenPersistenceProcessor = OAuthServerConfiguration.getInstance()
+                            .getClientSecretPersistenceProcessor();
+                }
                 String newSecretKey;
                 if (properties.containsKey(OAuthConstants.OAUTH_APP_NEW_SECRET_KEY)) {
                     newSecretKey = properties.getProperty(OAuthConstants.OAUTH_APP_NEW_SECRET_KEY);
@@ -620,7 +627,7 @@ public class TokenManagementDAOImpl extends AbstractOAuthDAO implements TokenMan
                     updateStateStatement = connection.prepareStatement
                             (org.wso2.carbon.identity.oauth.dao.SQLQueries.OAuthAppDAOSQLQueries.
                                     UPDATE_OAUTH_SECRET_KEY_AND_STATE);
-                    updateStateStatement.setString(1, getPersistenceProcessor().getProcessedClientSecret(newSecretKey));
+                    updateStateStatement.setString(1, tokenPersistenceProcessor.getProcessedClientSecret(newSecretKey));
                     updateStateStatement.setString(2, properties.getProperty(OAuthConstants.OAUTH_APP_NEW_STATE));
                     updateStateStatement.setString(3, consumerKey);
                     updateStateStatement.setInt(4, appTenantId);
@@ -629,7 +636,7 @@ public class TokenManagementDAOImpl extends AbstractOAuthDAO implements TokenMan
                     updateStateStatement = connection.prepareStatement
                             (org.wso2.carbon.identity.oauth.dao.SQLQueries.OAuthAppDAOSQLQueries.
                                     UPDATE_OAUTH_SECRET_KEY);
-                    updateStateStatement.setString(1, getPersistenceProcessor().getProcessedClientSecret(newSecretKey));
+                    updateStateStatement.setString(1, tokenPersistenceProcessor.getProcessedClientSecret(newSecretKey));
                     updateStateStatement.setString(2, consumerKey);
                     updateStateStatement.setInt(3, appTenantId);
                 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuthApplicationMgtListener.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuthApplicationMgtListener.java
@@ -356,7 +356,8 @@ public class OAuthApplicationMgtListener extends AbstractApplicationMgtListener 
 
                         OAuthAppDAO dao = new OAuthAppDAO();
                         OAuthAppDO authApplication = dao.getAppInformation(authConfig.getInboundAuthKey());
-                        String tokenProcessorName = OAuthServerConfiguration.getInstance().getPersistenceProcessor()
+                        String tokenProcessorName =
+                                OAuthServerConfiguration.getInstance().getClientSecretPersistenceProcessor()
                                 .getClass().getName();
                         if (!"org.wso2.carbon.identity.oauth.tokenprocessor.PlainTextPersistenceProcessor"
                                 .equals(tokenProcessorName) || !exportSecrets) {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -604,7 +604,7 @@ public class OAuth2Util {
         }
 
         // Cache miss
-        boolean isHashDisabled = isHashDisabled();
+        boolean isHashDisabled = isClientSecretHashingDisabled();
         String appClientSecret = appDO.getOauthConsumerSecret();
         if (isHashDisabled) {
             if (!StringUtils.equals(appClientSecret, clientSecretProvided)) {
@@ -615,7 +615,7 @@ public class OAuth2Util {
                 return false;
             }
         } else {
-            TokenPersistenceProcessor persistenceProcessor = getPersistenceProcessor();
+            TokenPersistenceProcessor persistenceProcessor = getClientSecretPersistenceProcessor();
             // We convert the provided client_secret to the processed form stored in the DB.
             String processedProvidedClientSecret = persistenceProcessor.getProcessedClientSecret(clientSecretProvided);
 
@@ -661,7 +661,7 @@ public class OAuth2Util {
         }
 
         // Cache miss
-        boolean isHashDisabled = isHashDisabled();
+        boolean isHashDisabled = isClientSecretHashingDisabled();
         String appClientSecret = appDO.getOauthConsumerSecret();
         if (isHashDisabled) {
             if (!StringUtils.equals(appClientSecret, clientSecretProvided)) {
@@ -672,7 +672,7 @@ public class OAuth2Util {
                 return false;
             }
         } else {
-            TokenPersistenceProcessor persistenceProcessor = getPersistenceProcessor();
+            TokenPersistenceProcessor persistenceProcessor = getClientSecretPersistenceProcessor();
             // We convert the provided client_secret to the processed form stored in the DB.
             String processedProvidedClientSecret = persistenceProcessor.getProcessedClientSecret(clientSecretProvided);
 
@@ -772,9 +772,30 @@ public class OAuth2Util {
         return persistenceProcessor;
     }
 
+    public static TokenPersistenceProcessor getClientSecretPersistenceProcessor() {
+
+        TokenPersistenceProcessor persistenceProcessor;
+        try {
+            persistenceProcessor = OAuthServerConfiguration.getInstance().getClientSecretPersistenceProcessor();
+        } catch (IdentityOAuth2Exception e) {
+            String msg = "Error retrieving TokenPersistenceProcessor configured in " +
+                    "OAuth.ClientSecretPersistenceProcessor in identity.xml. " +
+                    "Defaulting to PlainTextPersistenceProcessor.";
+            log.warn(msg);
+            if (log.isDebugEnabled()) {
+                log.debug(msg, e);
+            }
+            persistenceProcessor = getPersistenceProcessor();
+        }
+        return persistenceProcessor;
+    }
+
     /**
      * Check whether hashing oauth keys (consumer secret, access token, refresh token and authorization code)
      * configuration is disabled or not in identity.xml file.
+     *
+     * <p>For client-secret-specific hashing decisions use {@link #isClientSecretHashingDisabled()} instead,
+     * as it also honours the newer {@code EnableClientSecretHashOnly} configuration.
      *
      * @return Whether hash feature is disabled or not.
      */
@@ -789,12 +810,41 @@ public class OAuth2Util {
      * Check whether hashing oauth keys (consumer secret, access token, refresh token and authorization code)
      * configuration is enabled or not in identity.xml file.
      *
+     * <p>For client-secret-specific hashing decisions use {@link #isClientSecretHashingEnabled()} instead,
+     * as it also honours the newer {@code EnableClientSecretHashOnly} configuration.
+     *
      * @return Whether hash feature is enable or not.
      */
     public static boolean isHashEnabled() {
 
         boolean isHashEnabled = OAuthServerConfiguration.getInstance().isClientSecretHashEnabled();
         return isHashEnabled;
+    }
+
+    /**
+     * Check whether client secret hashing is effectively enabled — i.e., either the legacy
+     * {@code EnableClientSecretHash} flag (which hashes client secret, access token, refresh token and auth code)
+     * OR the newer {@code EnableClientSecretHashOnly} flag (which hashes ONLY the client secret) is turned on.
+     *
+     * <p>Use this for any client-secret-hashing decision. For token / auth-code decisions,
+     * keep using {@link #isHashEnabled()} / {@link #isHashDisabled()}.
+     *
+     * @return Whether client secret hashing is enabled.
+     */
+    public static boolean isClientSecretHashingEnabled() {
+
+        return isHashEnabled() || OAuthServerConfiguration.getInstance().isClientSecretHashOnlyEnabled();
+    }
+
+    /**
+     * Check whether client secret hashing is disabled.
+     *
+     * @return Whether client secret hashing is disabled.
+     * @see #isClientSecretHashingEnabled()
+     */
+    public static boolean isClientSecretHashingDisabled() {
+
+        return !isClientSecretHashingEnabled();
     }
 
     /**

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImplTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImplTest.java
@@ -48,6 +48,7 @@ import org.wso2.carbon.identity.core.internal.component.IdentityCoreServiceCompo
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.event.services.IdentityEventService;
+import org.wso2.carbon.identity.oauth.cache.AppInfoCache;
 import org.wso2.carbon.identity.oauth.common.OAuth2ErrorCodes;
 import org.wso2.carbon.identity.oauth.common.OAuthConstants;
 import org.wso2.carbon.identity.oauth.common.exception.InvalidOAuthClientException;
@@ -114,6 +115,7 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
@@ -539,6 +541,76 @@ public class OAuthAdminServiceImplTest {
 
             OAuthAdminServiceImpl oAuthAdminServiceImpl = new OAuthAdminServiceImpl();
             oAuthAdminServiceImpl.getOAuthApplicationData(consumerKey, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+        }
+    }
+
+    @DataProvider(name = "clientSecretHashCacheInvalidation")
+    public Object[][] clientSecretHashCacheInvalidationData() {
+
+        return new Object[][]{
+                // hashingEnabled, secretAlreadyProcessed, expectCacheClear
+                {false, true,  false},  // hashing disabled: cache never cleared
+                {true,  true,  false},  // hashing enabled, secret already hashed: no clear
+                {true,  false, true},   // hashing enabled, plaintext secret in cache: clear triggered
+        };
+    }
+
+    @Test(dataProvider = "clientSecretHashCacheInvalidation")
+    public void testGetOAuthApplicationData_clientSecretHashCacheInvalidation(
+            boolean hashingEnabled, boolean secretAlreadyProcessed, boolean expectCacheClear) throws Exception {
+
+        String consumerKey = "test-consumer-key";
+        OAuthAppDO app = buildDummyOAuthAppDO("test-user");
+
+        // OAuthServerConfiguration must be stubbed before OAuth2Util is instrumented,
+        // because OAuth2Util's static initializer calls OAuthServerConfiguration.getInstance().
+        try (MockedStatic<OAuthServerConfiguration> oAuthServerConfigStatic =
+                     mockStatic(OAuthServerConfiguration.class)) {
+
+            mockOAuthServerConfiguration = mock(OAuthServerConfiguration.class);
+            oAuthServerConfigStatic.when(OAuthServerConfiguration::getInstance)
+                    .thenReturn(mockOAuthServerConfiguration);
+
+            try (MockedStatic<OAuth2Util> oAuth2UtilStatic = mockStatic(OAuth2Util.class);
+                 MockedStatic<IdentityUtil> identityUtilStatic = mockStatic(IdentityUtil.class);
+                 MockedStatic<AppInfoCache> appInfoCacheStatic = mockStatic(AppInfoCache.class);
+                 MockedConstruction<OAuthAppDAO> ignored = Mockito.mockConstruction(OAuthAppDAO.class,
+                         (mock, context) ->
+                                 when(mock.getAppInformation(consumerKey, MultitenantConstants.SUPER_TENANT_ID))
+                                         .thenReturn(app))) {
+
+                // Disable claim separation so the test focuses on hashing logic only.
+                identityUtilStatic.when(() -> IdentityUtil.getProperty(ENABLE_CLAIMS_SEPARATION_FOR_ACCESS_TOKEN))
+                        .thenReturn("false");
+
+                oAuth2UtilStatic.when(OAuth2Util::isClientSecretHashingEnabled).thenReturn(hashingEnabled);
+
+                if (hashingEnabled) {
+                    TokenPersistenceProcessor mockProcessor = mock(TokenPersistenceProcessor.class);
+                    // Use doReturn to safely stub a default interface method.
+                    doReturn(secretAlreadyProcessed).when(mockProcessor).isProcessed(anyString());
+                    oAuth2UtilStatic.when(OAuth2Util::getClientSecretPersistenceProcessor)
+                            .thenReturn(mockProcessor);
+                }
+
+                AppInfoCache mockCache = mock(AppInfoCache.class);
+                appInfoCacheStatic.when(AppInfoCache::getInstance).thenReturn(mockCache);
+                // Simulate cache miss so the app is loaded from DAO.
+                lenient().when(mockCache.getValueFromCache(consumerKey, SUPER_TENANT_DOMAIN_NAME)).thenReturn(null);
+
+                OAuthAdminServiceImpl service = new OAuthAdminServiceImpl();
+                OAuthConsumerAppDTO result = service.getOAuthApplicationData(consumerKey, SUPER_TENANT_DOMAIN_NAME);
+
+                Assert.assertNotNull(result, "DTO should not be null");
+                Assert.assertEquals(result.getOauthConsumerKey(), app.getOauthConsumerKey(),
+                        "Consumer key in DTO should match the app");
+
+                if (expectCacheClear) {
+                    verify(mockCache, times(1)).clearCacheEntry(consumerKey, SUPER_TENANT_DOMAIN_NAME);
+                } else {
+                    verify(mockCache, never()).clearCacheEntry(consumerKey, SUPER_TENANT_DOMAIN_NAME);
+                }
+            }
         }
     }
 

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/dao/OAuthAppDAOTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/dao/OAuthAppDAOTest.java
@@ -46,7 +46,9 @@ import org.wso2.carbon.identity.oauth.IdentityOAuthClientException;
 import org.wso2.carbon.identity.oauth.common.OAuthConstants;
 import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
 import org.wso2.carbon.identity.oauth.internal.OAuthComponentServiceHolder;
+import org.wso2.carbon.identity.oauth.tokenprocessor.HashingPersistenceProcessor;
 import org.wso2.carbon.identity.oauth.tokenprocessor.PlainTextPersistenceProcessor;
+import org.wso2.carbon.identity.oauth.tokenprocessor.TokenPersistenceProcessor;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.internal.OAuth2ServiceComponentHolder;
 import org.wso2.carbon.identity.oauth2.model.AccessTokenDO;
@@ -60,6 +62,7 @@ import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
 import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.carbon.user.core.tenant.TenantManager;
 
+import java.lang.reflect.Field;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -73,6 +76,7 @@ import java.util.UUID;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
@@ -1579,7 +1583,7 @@ public class OAuthAppDAOTest extends TestOAuthDAOBase {
         oAuthServerConfiguration.when(OAuthServerConfiguration::getInstance).thenReturn(mockedServerConfig);
 
         PlainTextPersistenceProcessor processor = new PlainTextPersistenceProcessor();
-        when(mockedServerConfig.getPersistenceProcessor()).thenReturn(processor);
+        when(mockedServerConfig.getClientSecretPersistenceProcessor()).thenReturn(processor);
 
         identityTenantUtil.when(() -> IdentityTenantUtil.getTenantDomain(TENANT_ID)).thenReturn(TENANT_DOMAIN);
         identityTenantUtil.when(() -> IdentityTenantUtil.getTenantId(TENANT_DOMAIN)).thenReturn(TENANT_ID);
@@ -1719,5 +1723,83 @@ public class OAuthAppDAOTest extends TestOAuthDAOBase {
     public static void resetPrivilegedCarbonContext() throws Exception {
         System.clearProperty(CarbonBaseConstants.CARBON_HOME);
         PrivilegedCarbonContext.endTenantFlow();
+    }
+
+    // ---------- Constructor persistenceProcessor selection tests ----------
+
+    @DataProvider(name = "persistenceProcessorConfigs")
+    public Object[][] persistenceProcessorConfigs() {
+        String hashingClass = HashingPersistenceProcessor.class.getName();
+        String plainTextClass = PlainTextPersistenceProcessor.class.getName();
+        return new Object[][]{
+                // clientSecretClass, tokenClass, expectedType
+                // Case 1: ClientSecretPersistenceProcessor explicitly configured as Hashing.
+                {hashingClass, plainTextClass, HashingPersistenceProcessor.class},
+                // Case 2: ClientSecretPersistenceProcessor explicitly configured as PlainText.
+                {plainTextClass, hashingClass, PlainTextPersistenceProcessor.class},
+                // Case 3: ClientSecretPersistenceProcessor not configured; token processor = Hashing (fallback).
+                {null, hashingClass, HashingPersistenceProcessor.class},
+                // Case 4: ClientSecretPersistenceProcessor not configured; token processor = PlainText (fallback).
+                {null, plainTextClass, PlainTextPersistenceProcessor.class},
+                // Case 5: Neither configured; ultimate default resolves to PlainText.
+                {null, null, PlainTextPersistenceProcessor.class},
+                // Case 6: ClientSecretPersistenceProcessor configured with an uninstantiable class;
+                //         falls back to token processor = Hashing.
+                {"com.nonexistent.Processor", hashingClass, HashingPersistenceProcessor.class},
+        };
+    }
+
+    @Test(dataProvider = "persistenceProcessorConfigs")
+    public void testConstructorPicksCorrectPersistenceProcessor(
+            String clientSecretClass,
+            String tokenClass,
+            Class<? extends TokenPersistenceProcessor> expectedType) throws Exception {
+
+        OAuthServerConfiguration configInstance = mock(OAuthServerConfiguration.class);
+        setOAuthServerConfigField(configInstance, "clientSecretPersistenceProcessorClassName", clientSecretClass);
+        setOAuthServerConfigField(configInstance, "tokenPersistenceProcessorClassName", tokenClass);
+        setOAuthServerConfigField(configInstance, "persistenceProcessor", null);
+        setOAuthServerConfigField(configInstance, "clientSecretPersistenceProcessor", null);
+        doCallRealMethod().when(configInstance).getClientSecretPersistenceProcessor();
+        doCallRealMethod().when(configInstance).getPersistenceProcessor();
+
+        try (MockedStatic<OAuthServerConfiguration> mockedConfig = mockStatic(OAuthServerConfiguration.class)) {
+            mockedConfig.when(OAuthServerConfiguration::getInstance).thenReturn(configInstance);
+            OAuthAppDAO dao = new OAuthAppDAO();
+            TokenPersistenceProcessor actual = extractPersistenceProcessorFromDAO(dao);
+            assertNotNull(actual, "persistenceProcessor field should not be null");
+            assertTrue(expectedType.isInstance(actual),
+                    "Expected " + expectedType.getSimpleName() + " but got " + actual.getClass().getSimpleName());
+        }
+    }
+
+    @Test
+    public void testConstructorFallsBackToPlainTextWhenGetClientSecretProcessorThrows() throws Exception {
+
+        OAuthServerConfiguration configInstance = mock(OAuthServerConfiguration.class);
+        when(configInstance.getClientSecretPersistenceProcessor())
+                .thenThrow(new IdentityOAuth2Exception("Simulated config error"));
+
+        try (MockedStatic<OAuthServerConfiguration> mockedConfig = mockStatic(OAuthServerConfiguration.class)) {
+            mockedConfig.when(OAuthServerConfiguration::getInstance).thenReturn(configInstance);
+            OAuthAppDAO dao = new OAuthAppDAO();
+            TokenPersistenceProcessor actual = extractPersistenceProcessorFromDAO(dao);
+            assertNotNull(actual, "persistenceProcessor field should not be null");
+            assertTrue(actual instanceof PlainTextPersistenceProcessor,
+                    "Expected PlainTextPersistenceProcessor as fallback but got "
+                            + actual.getClass().getSimpleName());
+        }
+    }
+
+    private void setOAuthServerConfigField(Object target, String fieldName, Object value) throws Exception {
+        Field field = OAuthServerConfiguration.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+
+    private TokenPersistenceProcessor extractPersistenceProcessorFromDAO(OAuthAppDAO dao) throws Exception {
+        Field field = OAuthAppDAO.class.getDeclaredField("persistenceProcessor");
+        field.setAccessible(true);
+        return (TokenPersistenceProcessor) field.get(dao);
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/dao/OAuthConsumerDAOTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/dao/OAuthConsumerDAOTest.java
@@ -36,21 +36,28 @@ import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.oauth.IdentityOAuthAdminException;
 import org.wso2.carbon.identity.oauth.Parameters;
 import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
+import org.wso2.carbon.identity.oauth.tokenprocessor.HashingPersistenceProcessor;
 import org.wso2.carbon.identity.oauth.tokenprocessor.PlainTextPersistenceProcessor;
+import org.wso2.carbon.identity.oauth.tokenprocessor.TokenPersistenceProcessor;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 
+import java.lang.reflect.Field;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
 /*
@@ -124,7 +131,7 @@ public class OAuthConsumerDAOTest extends TestOAuthDAOBase {
              MockedStatic<IdentityDatabaseUtil> identityDatabaseUtil = mockStatic(IdentityDatabaseUtil.class)) {
             oAuthServerConfiguration.when(OAuthServerConfiguration::getInstance).thenReturn(mockedServerConfig);
             PlainTextPersistenceProcessor processor = new PlainTextPersistenceProcessor();
-            when(mockedServerConfig.getPersistenceProcessor()).thenReturn(processor);
+            when(mockedServerConfig.getClientSecretPersistenceProcessor()).thenReturn(processor);
 
             try (Connection connection1 = getConnection(DB_NAME)) {
                 identityDatabaseUtil.when(() -> IdentityDatabaseUtil.getDBConnection(false)).thenReturn(connection1);
@@ -143,7 +150,7 @@ public class OAuthConsumerDAOTest extends TestOAuthDAOBase {
              MockedStatic<IdentityDatabaseUtil> identityDatabaseUtil = mockStatic(IdentityDatabaseUtil.class)) {
             oAuthServerConfiguration.when(OAuthServerConfiguration::getInstance).thenReturn(mockedServerConfig);
             PlainTextPersistenceProcessor processor = new PlainTextPersistenceProcessor();
-            when(mockedServerConfig.getPersistenceProcessor()).thenReturn(processor);
+            when(mockedServerConfig.getClientSecretPersistenceProcessor()).thenReturn(processor);
 
             try (Connection connection1 = getConnection(DB_NAME)) {
                 Connection connection2 = spy(connection1);
@@ -165,7 +172,7 @@ public class OAuthConsumerDAOTest extends TestOAuthDAOBase {
              MockedStatic<IdentityDatabaseUtil> identityDatabaseUtil = mockStatic(IdentityDatabaseUtil.class)) {
             oAuthServerConfiguration.when(OAuthServerConfiguration::getInstance).thenReturn(mockedServerConfig);
             PlainTextPersistenceProcessor processor = new PlainTextPersistenceProcessor();
-            when(mockedServerConfig.getPersistenceProcessor()).thenReturn(processor);
+            when(mockedServerConfig.getClientSecretPersistenceProcessor()).thenReturn(processor);
 
             try (Connection connection = getConnection(DB_NAME)) {
 
@@ -198,7 +205,7 @@ public class OAuthConsumerDAOTest extends TestOAuthDAOBase {
                 identityDatabaseUtil.when(() -> IdentityDatabaseUtil.getDBConnection(false)).thenReturn(connection2);
                 oAuthServerConfiguration.when(OAuthServerConfiguration::getInstance).thenReturn(mockedServerConfig);
                 PlainTextPersistenceProcessor processor = new PlainTextPersistenceProcessor();
-                when(mockedServerConfig.getPersistenceProcessor()).thenReturn(processor);
+                when(mockedServerConfig.getClientSecretPersistenceProcessor()).thenReturn(processor);
 
                 OAuthConsumerDAO consumerDAO = new OAuthConsumerDAO();
                 assertEquals(consumerDAO.getAuthenticatedUsername(CLIENT_ID, SECRET), USER_NAME);
@@ -220,7 +227,7 @@ public class OAuthConsumerDAOTest extends TestOAuthDAOBase {
 
                 oAuthServerConfiguration.when(OAuthServerConfiguration::getInstance).thenReturn(mockedServerConfig);
                 PlainTextPersistenceProcessor processor = new PlainTextPersistenceProcessor();
-                when(mockedServerConfig.getPersistenceProcessor()).thenReturn(processor);
+                when(mockedServerConfig.getClientSecretPersistenceProcessor()).thenReturn(processor);
 
                 OAuthConsumerDAO consumerDAO = new OAuthConsumerDAO();
                 consumerDAO.getAuthenticatedUsername(CLIENT_ID, SECRET);
@@ -244,7 +251,7 @@ public class OAuthConsumerDAOTest extends TestOAuthDAOBase {
              MockedStatic<IdentityDatabaseUtil> identityDatabaseUtil = mockStatic(IdentityDatabaseUtil.class)) {
             oAuthServerConfiguration.when(OAuthServerConfiguration::getInstance).thenReturn(mockedServerConfig);
             PlainTextPersistenceProcessor processor = new PlainTextPersistenceProcessor();
-            when(mockedServerConfig.getPersistenceProcessor()).thenReturn(processor);
+            when(mockedServerConfig.getClientSecretPersistenceProcessor()).thenReturn(processor);
 
             try (Connection connection3 = getConnection(DB_NAME)) {
                 identityDatabaseUtil.when(() -> IdentityDatabaseUtil.getDBConnection(false)).thenReturn(connection3);
@@ -264,7 +271,7 @@ public class OAuthConsumerDAOTest extends TestOAuthDAOBase {
              MockedStatic<IdentityDatabaseUtil> identityDatabaseUtil = mockStatic(IdentityDatabaseUtil.class)) {
             oAuthServerConfiguration.when(OAuthServerConfiguration::getInstance).thenReturn(mockedServerConfig);
             PlainTextPersistenceProcessor processor = new PlainTextPersistenceProcessor();
-            when(mockedServerConfig.getPersistenceProcessor()).thenReturn(processor);
+            when(mockedServerConfig.getClientSecretPersistenceProcessor()).thenReturn(processor);
 
             try (Connection connection = getConnection(DB_NAME)) {
                 Connection connection1 = spy(connection);
@@ -285,7 +292,7 @@ public class OAuthConsumerDAOTest extends TestOAuthDAOBase {
              MockedStatic<IdentityDatabaseUtil> identityDatabaseUtil = mockStatic(IdentityDatabaseUtil.class)) {
             oAuthServerConfiguration.when(OAuthServerConfiguration::getInstance).thenReturn(mockedServerConfig);
             PlainTextPersistenceProcessor processor = new PlainTextPersistenceProcessor();
-            when(mockedServerConfig.getPersistenceProcessor()).thenReturn(processor);
+            when(mockedServerConfig.getClientSecretPersistenceProcessor()).thenReturn(processor);
 
 
             try (Connection connection3 = getConnection(DB_NAME)) {
@@ -310,7 +317,7 @@ public class OAuthConsumerDAOTest extends TestOAuthDAOBase {
              MockedStatic<IdentityDatabaseUtil> identityDatabaseUtil = mockStatic(IdentityDatabaseUtil.class)) {
             oAuthServerConfiguration.when(OAuthServerConfiguration::getInstance).thenReturn(mockedServerConfig);
             PlainTextPersistenceProcessor processor = new PlainTextPersistenceProcessor();
-            when(mockedServerConfig.getPersistenceProcessor()).thenReturn(processor);
+            when(mockedServerConfig.getClientSecretPersistenceProcessor()).thenReturn(processor);
 
 //            whenNew(Parameters.class).withNoArguments().thenReturn(mockedParameters);
 
@@ -343,7 +350,7 @@ public class OAuthConsumerDAOTest extends TestOAuthDAOBase {
              MockedStatic<IdentityDatabaseUtil> identityDatabaseUtil = mockStatic(IdentityDatabaseUtil.class)) {
             oAuthServerConfiguration.when(OAuthServerConfiguration::getInstance).thenReturn(mockedServerConfig);
             PlainTextPersistenceProcessor processor = new PlainTextPersistenceProcessor();
-            when(mockedServerConfig.getPersistenceProcessor()).thenReturn(processor);
+            when(mockedServerConfig.getClientSecretPersistenceProcessor()).thenReturn(processor);
 
             try (Connection connection3 = getConnection(DB_NAME)) {
                 identityDatabaseUtil.when(IdentityDatabaseUtil::getDBConnection).thenReturn(connection3);
@@ -387,7 +394,7 @@ public class OAuthConsumerDAOTest extends TestOAuthDAOBase {
              MockedStatic<IdentityDatabaseUtil> identityDatabaseUtil = mockStatic(IdentityDatabaseUtil.class)) {
             oAuthServerConfiguration.when(OAuthServerConfiguration::getInstance).thenReturn(mockedServerConfig);
             PlainTextPersistenceProcessor processor = new PlainTextPersistenceProcessor();
-            when(mockedServerConfig.getPersistenceProcessor()).thenReturn(processor);
+            when(mockedServerConfig.getClientSecretPersistenceProcessor()).thenReturn(processor);
 
             try (Connection connection3 = getConnection(DB_NAME)) {
                 identityDatabaseUtil.when(IdentityDatabaseUtil::getDBConnection).thenReturn(connection3);
@@ -413,7 +420,7 @@ public class OAuthConsumerDAOTest extends TestOAuthDAOBase {
              MockedStatic<IdentityDatabaseUtil> identityDatabaseUtil = mockStatic(IdentityDatabaseUtil.class)) {
             oAuthServerConfiguration.when(OAuthServerConfiguration::getInstance).thenReturn(mockedServerConfig);
             PlainTextPersistenceProcessor processor = new PlainTextPersistenceProcessor();
-            when(mockedServerConfig.getPersistenceProcessor()).thenReturn(processor);
+            when(mockedServerConfig.getClientSecretPersistenceProcessor()).thenReturn(processor);
 
             try (Connection connection = getConnection(DB_NAME)) {
                 Connection connection1 = spy(connection);
@@ -435,7 +442,7 @@ public class OAuthConsumerDAOTest extends TestOAuthDAOBase {
              MockedStatic<IdentityDatabaseUtil> identityDatabaseUtil = mockStatic(IdentityDatabaseUtil.class)) {
             oAuthServerConfiguration.when(OAuthServerConfiguration::getInstance).thenReturn(mockedServerConfig);
             PlainTextPersistenceProcessor processor = new PlainTextPersistenceProcessor();
-            when(mockedServerConfig.getPersistenceProcessor()).thenReturn(processor);
+            when(mockedServerConfig.getClientSecretPersistenceProcessor()).thenReturn(processor);
 
             try (Connection connection3 = getConnection(DB_NAME)) {
                 identityDatabaseUtil.when(IdentityDatabaseUtil::getDBConnection).thenReturn(connection3);
@@ -456,7 +463,7 @@ public class OAuthConsumerDAOTest extends TestOAuthDAOBase {
              MockedStatic<IdentityDatabaseUtil> identityDatabaseUtil = mockStatic(IdentityDatabaseUtil.class)) {
             oAuthServerConfiguration.when(OAuthServerConfiguration::getInstance).thenReturn(mockedServerConfig);
             PlainTextPersistenceProcessor processor = new PlainTextPersistenceProcessor();
-            when(mockedServerConfig.getPersistenceProcessor()).thenReturn(processor);
+            when(mockedServerConfig.getClientSecretPersistenceProcessor()).thenReturn(processor);
 
 //            whenNew(Parameters.class).withNoArguments().thenReturn(mockedParameters);
 
@@ -479,7 +486,7 @@ public class OAuthConsumerDAOTest extends TestOAuthDAOBase {
              MockedStatic<IdentityDatabaseUtil> identityDatabaseUtil = mockStatic(IdentityDatabaseUtil.class)) {
             oAuthServerConfiguration.when(OAuthServerConfiguration::getInstance).thenReturn(mockedServerConfig);
             PlainTextPersistenceProcessor processor = new PlainTextPersistenceProcessor();
-            when(mockedServerConfig.getPersistenceProcessor()).thenReturn(processor);
+            when(mockedServerConfig.getClientSecretPersistenceProcessor()).thenReturn(processor);
 
             try (Connection connection = getConnection(DB_NAME)) {
                 identityDatabaseUtil.when(() -> IdentityDatabaseUtil.getDBConnection(false)).thenReturn(connection);
@@ -498,7 +505,7 @@ public class OAuthConsumerDAOTest extends TestOAuthDAOBase {
              MockedStatic<IdentityDatabaseUtil> identityDatabaseUtil = mockStatic(IdentityDatabaseUtil.class)) {
             oAuthServerConfiguration.when(OAuthServerConfiguration::getInstance).thenReturn(mockedServerConfig);
             PlainTextPersistenceProcessor processor = new PlainTextPersistenceProcessor();
-            when(mockedServerConfig.getPersistenceProcessor()).thenReturn(processor);
+            when(mockedServerConfig.getClientSecretPersistenceProcessor()).thenReturn(processor);
 
             try (Connection connection = getConnection(DB_NAME)) {
                 Connection connection1 = spy(connection);
@@ -519,7 +526,7 @@ public class OAuthConsumerDAOTest extends TestOAuthDAOBase {
              MockedStatic<IdentityDatabaseUtil> identityDatabaseUtil = mockStatic(IdentityDatabaseUtil.class)) {
             oAuthServerConfiguration.when(OAuthServerConfiguration::getInstance).thenReturn(mockedServerConfig);
             PlainTextPersistenceProcessor processor = new PlainTextPersistenceProcessor();
-            when(mockedServerConfig.getPersistenceProcessor()).thenReturn(processor);
+            when(mockedServerConfig.getClientSecretPersistenceProcessor()).thenReturn(processor);
 
             try (Connection connection1 = getConnection(DB_NAME)) {
                 identityDatabaseUtil.when(() -> IdentityDatabaseUtil.getDBConnection(false)).thenReturn(connection1);
@@ -538,7 +545,7 @@ public class OAuthConsumerDAOTest extends TestOAuthDAOBase {
              MockedStatic<IdentityDatabaseUtil> identityDatabaseUtil = mockStatic(IdentityDatabaseUtil.class)) {
             oAuthServerConfiguration.when(OAuthServerConfiguration::getInstance).thenReturn(mockedServerConfig);
             PlainTextPersistenceProcessor processor = new PlainTextPersistenceProcessor();
-            when(mockedServerConfig.getPersistenceProcessor()).thenReturn(processor);
+            when(mockedServerConfig.getClientSecretPersistenceProcessor()).thenReturn(processor);
 
             try (Connection connection1 = getConnection(DB_NAME)) {
                 identityDatabaseUtil.when(() -> IdentityDatabaseUtil.getDBConnection(false)).thenReturn(connection1);
@@ -556,7 +563,7 @@ public class OAuthConsumerDAOTest extends TestOAuthDAOBase {
                 OAuthServerConfiguration.class);
              MockedStatic<IdentityDatabaseUtil> identityDatabaseUtil = mockStatic(IdentityDatabaseUtil.class)) {
             oAuthServerConfiguration.when(OAuthServerConfiguration::getInstance).thenReturn(mockedServerConfig);
-            when(mockedServerConfig.getPersistenceProcessor()).thenReturn(persistenceProcessor);
+            when(mockedServerConfig.getClientSecretPersistenceProcessor()).thenReturn(persistenceProcessor);
             doThrow(new IdentityOAuth2Exception("Test")).when(persistenceProcessor).getProcessedClientId(CLIENT_ID);
 
             try (Connection connection1 = getConnection(DB_NAME)) {
@@ -576,7 +583,7 @@ public class OAuthConsumerDAOTest extends TestOAuthDAOBase {
                 OAuthServerConfiguration.class);
              MockedStatic<IdentityDatabaseUtil> identityDatabaseUtil = mockStatic(IdentityDatabaseUtil.class)) {
             oAuthServerConfiguration.when(OAuthServerConfiguration::getInstance).thenReturn(mockedServerConfig);
-            when(mockedServerConfig.getPersistenceProcessor()).thenReturn(persistenceProcessor);
+            when(mockedServerConfig.getClientSecretPersistenceProcessor()).thenReturn(persistenceProcessor);
 
             try (Connection connection1 = getConnection(DB_NAME)) {
                 Connection connection2 = spy(connection1);
@@ -587,6 +594,84 @@ public class OAuthConsumerDAOTest extends TestOAuthDAOBase {
                 consumerDAO.isConsumerSecretExist(CLIENT_ID, SECRET);
             }
         }
+    }
+
+    // ---------- Constructor persistenceProcessor selection tests ----------
+
+    @DataProvider(name = "consumerDaoPersistenceProcessorConfigs")
+    public Object[][] consumerDaoPersistenceProcessorConfigs() {
+        String hashingClass = HashingPersistenceProcessor.class.getName();
+        String plainTextClass = PlainTextPersistenceProcessor.class.getName();
+        return new Object[][]{
+                // clientSecretClass, tokenClass, expectedType
+                // Case 1: ClientSecretPersistenceProcessor explicitly configured as Hashing.
+                {hashingClass, plainTextClass, HashingPersistenceProcessor.class},
+                // Case 2: ClientSecretPersistenceProcessor explicitly configured as PlainText.
+                {plainTextClass, hashingClass, PlainTextPersistenceProcessor.class},
+                // Case 3: ClientSecretPersistenceProcessor not configured; token processor = Hashing (fallback).
+                {null, hashingClass, HashingPersistenceProcessor.class},
+                // Case 4: ClientSecretPersistenceProcessor not configured; token processor = PlainText (fallback).
+                {null, plainTextClass, PlainTextPersistenceProcessor.class},
+                // Case 5: Neither configured; ultimate default resolves to PlainText.
+                {null, null, PlainTextPersistenceProcessor.class},
+                // Case 6: ClientSecretPersistenceProcessor configured with an uninstantiable class;
+                //         falls back to token processor = Hashing.
+                {"com.nonexistent.Processor", hashingClass, HashingPersistenceProcessor.class},
+        };
+    }
+
+    @Test(dataProvider = "consumerDaoPersistenceProcessorConfigs")
+    public void testConstructorPicksCorrectPersistenceProcessor(
+            String clientSecretClass,
+            String tokenClass,
+            Class<? extends TokenPersistenceProcessor> expectedType) throws Exception {
+
+        OAuthServerConfiguration configInstance = mock(OAuthServerConfiguration.class);
+        setOAuthServerConfigField(configInstance, "clientSecretPersistenceProcessorClassName", clientSecretClass);
+        setOAuthServerConfigField(configInstance, "tokenPersistenceProcessorClassName", tokenClass);
+        setOAuthServerConfigField(configInstance, "persistenceProcessor", null);
+        setOAuthServerConfigField(configInstance, "clientSecretPersistenceProcessor", null);
+        doCallRealMethod().when(configInstance).getClientSecretPersistenceProcessor();
+        lenient().doCallRealMethod().when(configInstance).getPersistenceProcessor();
+
+        try (MockedStatic<OAuthServerConfiguration> mockedConfig = mockStatic(OAuthServerConfiguration.class)) {
+            mockedConfig.when(OAuthServerConfiguration::getInstance).thenReturn(configInstance);
+            OAuthConsumerDAO dao = new OAuthConsumerDAO();
+            TokenPersistenceProcessor actual = extractPersistenceProcessorFromDAO(dao);
+            assertNotNull(actual, "persistenceProcessor field should not be null");
+            assertTrue(expectedType.isInstance(actual),
+                    "Expected " + expectedType.getSimpleName() + " but got " + actual.getClass().getSimpleName());
+        }
+    }
+
+    @Test
+    public void testConstructorFallsBackToPlainTextWhenGetClientSecretProcessorThrows() throws Exception {
+
+        OAuthServerConfiguration configInstance = mock(OAuthServerConfiguration.class);
+        when(configInstance.getClientSecretPersistenceProcessor())
+                .thenThrow(new IdentityOAuth2Exception("Simulated config error"));
+
+        try (MockedStatic<OAuthServerConfiguration> mockedConfig = mockStatic(OAuthServerConfiguration.class)) {
+            mockedConfig.when(OAuthServerConfiguration::getInstance).thenReturn(configInstance);
+            OAuthConsumerDAO dao = new OAuthConsumerDAO();
+            TokenPersistenceProcessor actual = extractPersistenceProcessorFromDAO(dao);
+            assertNotNull(actual, "persistenceProcessor field should not be null");
+            assertTrue(actual instanceof PlainTextPersistenceProcessor,
+                    "Expected PlainTextPersistenceProcessor as fallback but got "
+                            + actual.getClass().getSimpleName());
+        }
+    }
+
+    private void setOAuthServerConfigField(Object target, String fieldName, Object value) throws Exception {
+        Field field = OAuthServerConfiguration.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+
+    private TokenPersistenceProcessor extractPersistenceProcessorFromDAO(OAuthConsumerDAO dao) throws Exception {
+        Field field = OAuthConsumerDAO.class.getDeclaredField("persistenceProcessor");
+        field.setAccessible(true);
+        return (TokenPersistenceProcessor) field.get(dao);
     }
 
 }

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/dao/AccessTokenDAOImplTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/dao/AccessTokenDAOImplTest.java
@@ -174,6 +174,8 @@ public class AccessTokenDAOImplTest {
 
         TokenPersistenceProcessor mockTokenPersistenceProcessor = mock(TokenPersistenceProcessor.class);
         when(mockOAuthServerConfiguration.getPersistenceProcessor()).thenReturn(mockTokenPersistenceProcessor);
+        lenient().when(mockOAuthServerConfiguration.getClientSecretPersistenceProcessor())
+                .thenReturn(mockTokenPersistenceProcessor);
         accessTokenDAO = new AccessTokenDAOImpl();
     }
 

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/internal/OAuthApplicationMgtListenerTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/internal/OAuthApplicationMgtListenerTest.java
@@ -52,6 +52,7 @@ import java.sql.Connection;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
@@ -126,6 +127,7 @@ public class OAuthApplicationMgtListenerTest extends TestOAuthDAOBase {
         oAuthServerConfiguration.when(OAuthServerConfiguration::getInstance).thenReturn(mockOauthServicerConfig);
         PlainTextPersistenceProcessor processor = new PlainTextPersistenceProcessor();
         when(mockOauthServicerConfig.getPersistenceProcessor()).thenReturn(processor);
+        lenient().when(mockOauthServicerConfig.getClientSecretPersistenceProcessor()).thenReturn(processor);
 
         authorizationGrantCache = mockStatic(AuthorizationGrantCache.class);
         authorizationGrantCache.when(AuthorizationGrantCache::getInstance).thenReturn(mockAuthorizationGrantCache);

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/saml/SAML2BearerGrantHandlerTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/saml/SAML2BearerGrantHandlerTest.java
@@ -176,6 +176,8 @@ public class SAML2BearerGrantHandlerTest {
         oAuthServerConfiguration.when(OAuthServerConfiguration::getInstance).thenReturn(mockOAuthServerConfiguration);
         when(mockOAuthServerConfiguration.getIdentityOauthTokenIssuer()).thenReturn(oauthIssuer);
         lenient().when(mockOAuthServerConfiguration.getPersistenceProcessor()).thenReturn(persistenceProcessor);
+        lenient().when(mockOAuthServerConfiguration.getClientSecretPersistenceProcessor())
+                .thenReturn(persistenceProcessor);
         federatedAuthenticatorConfig = new FederatedAuthenticatorConfig();
         saml2BearerGrantHandler = new SAML2BearerGrantHandler();
         saml2BearerGrantHandler.init();

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/util/OAuth2UtilTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/util/OAuth2UtilTest.java
@@ -576,7 +576,7 @@ public class OAuth2UtilTest {
 
                 when(oauthServerConfigurationMock.isClientSecretHashEnabled()).thenReturn(true);
 
-                when(oauthServerConfigurationMock.getPersistenceProcessor()).thenReturn(hashingProcessor);
+                when(oauthServerConfigurationMock.getClientSecretPersistenceProcessor()).thenReturn(hashingProcessor);
                 assertEquals(OAuth2Util.authenticateClient(clientId, clientSecret), expectedResult);
             }
         }
@@ -629,6 +629,37 @@ public class OAuth2UtilTest {
 
         when(OAuthServerConfiguration.getInstance().isClientSecretHashEnabled()).thenReturn(true);
         assertTrue(OAuth2Util.isHashEnabled());
+    }
+
+    @DataProvider(name = "clientSecretHashingFlagCombinations")
+    public Object[][] clientSecretHashingFlagCombinations() {
+        // {oldConfig (EnableClientSecretHash), newConfig (EnableClientSecretHashOnly), expectedHashingEnabled}
+        return new Object[][]{
+                {true,  false, true},   // old config alone enables hashing
+                {false, true,  true},   // new config alone enables hashing
+                {true,  true,  true},   // both on — still enabled
+                {false, false, false},  // both off — no hashing
+        };
+    }
+
+    @Test(dataProvider = "clientSecretHashingFlagCombinations")
+    public void testIsClientSecretHashingEnabled(boolean oldConfig, boolean newConfig,
+                                                 boolean expectedHashingEnabled) {
+
+        // lenient() required because || short-circuits when oldConfig is true,
+        // leaving the newConfig stub unused under strict stubbing.
+        lenient().when(oauthServerConfigurationMock.isClientSecretHashEnabled()).thenReturn(oldConfig);
+        lenient().when(oauthServerConfigurationMock.isClientSecretHashOnlyEnabled()).thenReturn(newConfig);
+        assertEquals(OAuth2Util.isClientSecretHashingEnabled(), expectedHashingEnabled);
+    }
+
+    @Test(dataProvider = "clientSecretHashingFlagCombinations")
+    public void testIsClientSecretHashingDisabled(boolean oldConfig, boolean newConfig,
+                                                  boolean expectedHashingEnabled) {
+
+        lenient().when(oauthServerConfigurationMock.isClientSecretHashEnabled()).thenReturn(oldConfig);
+        lenient().when(oauthServerConfigurationMock.isClientSecretHashOnlyEnabled()).thenReturn(newConfig);
+        assertEquals(OAuth2Util.isClientSecretHashingDisabled(), !expectedHashingEnabled);
     }
 
     @DataProvider(name = "AuthenticateUsername")

--- a/components/org.wso2.carbon.identity.oidc.session/src/test/java/org/wso2/carbon/identity/oidc/session/servlet/OIDCLogoutServletTest.java
+++ b/components/org.wso2.carbon.identity.oidc.session/src/test/java/org/wso2/carbon/identity/oidc/session/servlet/OIDCLogoutServletTest.java
@@ -461,6 +461,8 @@ public class OIDCLogoutServletTest extends TestOIDCSessionBase {
 
             lenient().when(mockOAuthServerConfiguration.getPersistenceProcessor())
                     .thenReturn(tokenPersistenceProcessor);
+            lenient().when(mockOAuthServerConfiguration.getClientSecretPersistenceProcessor())
+                    .thenReturn(tokenPersistenceProcessor);
             lenient().when(tokenPersistenceProcessor.getProcessedClientId(anyString()))
                     .thenAnswer(invocation -> invocation.getArguments()[0]);
             lenient().when(request.getParameter("post_logout_redirect_uri")).thenReturn(postLogoutUrl);
@@ -576,6 +578,8 @@ public class OIDCLogoutServletTest extends TestOIDCSessionBase {
 
             lenient().when(mockOAuthServerConfiguration.isJWTSignedWithSPKey()).thenReturn(isJWTSignedWithSPKey);
             lenient().when(mockOAuthServerConfiguration.getPersistenceProcessor())
+                    .thenReturn(tokenPersistenceProcessor);
+            lenient().when(mockOAuthServerConfiguration.getClientSecretPersistenceProcessor())
                     .thenReturn(tokenPersistenceProcessor);
             lenient().when(tokenPersistenceProcessor.getProcessedClientId(anyString())).thenAnswer(
                     invocation -> invocation.getArguments()[0]);

--- a/components/org.wso2.carbon.identity.oidc.session/src/test/java/org/wso2/carbon/identity/oidc/session/servlet/OIDCSessionIFrameServletTest.java
+++ b/components/org.wso2.carbon.identity.oidc.session/src/test/java/org/wso2/carbon/identity/oidc/session/servlet/OIDCSessionIFrameServletTest.java
@@ -147,6 +147,8 @@ public class OIDCSessionIFrameServletTest extends TestOIDCSessionBase {
                     .thenReturn(mockOAuthServerConfiguration);
             lenient().when(mockOAuthServerConfiguration.getPersistenceProcessor())
                     .thenReturn(tokenPersistenceProcessor);
+            lenient().when(mockOAuthServerConfiguration.getClientSecretPersistenceProcessor())
+                    .thenReturn(tokenPersistenceProcessor);
             lenient().when(tokenPersistenceProcessor.getProcessedClientId(anyString()))
                     .thenAnswer(invocation -> invocation.getArguments()[0]);
 


### PR DESCRIPTION
Public Issue: https://github.com/wso2/product-is/issues/27252

Currently, WSO2 Identity Server provides the capability to hash OAuth tokens [1]. When this feature is enabled, it applies to access tokens, refresh tokens, authorization codes, and client secrets.

However, there is no configuration available to selectively enable hashing for client secrets alone.

It would be beneficial to introduce a separate configuration that allows hashing of client secrets independently, without impacting other token types. Additionally, providing migration support (e.g., scripts) to hash existing client secrets in the database would help ensure a smooth transition.

| <EnableClientSecretHash> | <EnableClientSecretHashOnly> | Old isHashDisabled()                 | New isClientSecretHashingDisabled() |
|--------------------------|------------------------------|--------------------------------------|-------------------------------------|
| false                    | unset                        | true                                 | true ✓ same                         |
| true                     | unset                        | false                                | false ✓ same                        |
| false                    | false                        | true                                 | true ✓ same                         |
| true                     | false                        | false                                | false ✓ same                        |
| false                    | true                         | (not relevant — flag didn't exist)   | false (new behavior, intended)      |
| true                     | true                         | (not relevant)                       | false ✓                             |


| <EnableClientSecretHash> | <EnableClientSecretHashOnly> | Old isHashEnabled()       | New isClientSecretHashingEnabled() |
|--------------------------|------------------------------|---------------------------|------------------------------------|
| false                    | unset                        | false                     | false ✓ same                       |
| true                     | unset                        | true                      | true ✓ same                        |
| false                    | false                        | false                     | false ✓ same                       |
| true                     | false                        | true                      | true ✓ same                        |
| false                    | true                         | (flag didn't exist)       | true (new behavior, intended)      |
| true                     | true                         | (not relevant)            | true ✓                             |



```toml

[oauth]
hash_client_secret=true

[oauth.extensions]
client_secret_persistence_processor = "org.wso2.carbon.identity.oauth.tokenprocessor.HashingPersistenceProcessor"

```

So for any deployment that doesn't touch the new flag, the new method returns identical results to the old one. For deployments that opt into the new flag, hashing turns on as expected.                