### PR TITLE
Improve token revocation of shared users for legacy organization authentication

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthUtil.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthUtil.java
@@ -1047,6 +1047,7 @@ public final class OAuthUtil {
         AuthenticatedUser authenticatedUser = buildAuthenticatedUser(userStoreManager, username, userStoreDomain,
                 tenantDomain);
         AuthenticatedUser authenticatedOrgUser = null;
+        AuthenticatedUser authenticatedSharedUser = null;
         if (authenticatedUser.getUserResidentOrganization() != null) {
             try {
                 String userResidentTenant = OAuthComponentServiceHolder.getInstance().getOrganizationManager()
@@ -1142,6 +1143,13 @@ public final class OAuthUtil {
                             .getAllTimeAuthorizedClientIdsWithAppTenantDomain(authenticatedOrgUser));
                 }
 
+                authenticatedSharedUser =  resolveAuthenticatedSharedUser(authenticatedUser, tenantDomain);
+                if (authenticatedSharedUser != null) {
+                    clientAppInfos.addAll(OAuthTokenPersistenceFactory.getInstance()
+                            .getTokenManagementDAO()
+                            .getAllTimeAuthorizedClientIdsWithAppTenantDomain(authenticatedSharedUser));
+                }
+
                 if (role != null && RoleConstants.ORGANIZATION.equals(role.getAudience())) {
                     clientAppInfos = filterClientIdsWithOrganizationAudience(clientAppInfos);
                 }
@@ -1159,6 +1167,11 @@ public final class OAuthUtil {
         boolean isErrorOnRevokingTokens;
         isErrorOnRevokingTokens = processTokenRevocation(clientAppInfos, authenticatedUser,
                 userStoreDomain, username);
+
+        if (authenticatedSharedUser != null) {
+            isErrorOnRevokingTokens |= processTokenRevocation(clientAppInfos, authenticatedSharedUser,
+                    authenticatedSharedUser.getUserStoreDomain(), username);
+        }
 
         if (!isErrorOnRevokingTokens && !clientAppInfos.isEmpty()) {
             // Considering the root tenant revocation in current scope, will consider the sub organizations later.
@@ -1179,6 +1192,45 @@ public final class OAuthUtil {
             throw new UserStoreException("Error occurred while revoking Access Tokens of the user " + username);
         }
         return true;
+    }
+
+    /**
+     * Resolves the authenticated shared user representation used for token revocation.
+     * The resolved user is used to revoke tokens issued by shared applications when shared users
+     * log in to them via legacy federation-based organization login.
+     *
+     * @param authenticatedUser The authenticated user whose shared user representation needs to be resolved.
+     * @param tenantDomain      The tenant domain of the organization.
+     * @return The resolved {@link AuthenticatedUser} representing the shared user, or {@code null} if no
+     *         user association exists.
+     * @throws UserStoreException If an error occurs while resolving the user association or IDP details.
+     */
+    private static AuthenticatedUser resolveAuthenticatedSharedUser(
+            AuthenticatedUser authenticatedUser, String tenantDomain) throws UserStoreException {
+
+        try {
+            String accessingOrgId = OAuthComponentServiceHolder.getInstance().getOrganizationManager()
+                    .resolveOrganizationId(tenantDomain);
+            UserAssociation userAssociation = OAuthComponentServiceHolder.getInstance()
+                    .getOrganizationUserSharingService().getUserAssociation(
+                            authenticatedUser.getSharedUserId(), accessingOrgId);
+            if (userAssociation != null) {
+                AuthenticatedUser sharedUser = new AuthenticatedUser(authenticatedUser);
+                sharedUser.setUserName(authenticatedUser.getUserId());
+                setOrganizationSSOUserDetails(sharedUser);
+                return sharedUser;
+            }
+            return null;
+        } catch (OrganizationManagementException e) {
+            throw new UserStoreException("Error while getting user associations for user: "
+                    + authenticatedUser.getLoggableMaskedUserId(), e);
+        } catch (UserIdNotFoundException e) {
+            throw new UserStoreException("Error while resolving user ID for user: "
+                    + authenticatedUser.getLoggableMaskedUserId(), e);
+        } catch (IdentityProviderManagementException e) {
+            throw new UserStoreException("Error occurred while resolving IDP name of the organization login IDP in: "
+                    + tenantDomain, e);
+        }
     }
 
     /**

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthUtil.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthUtil.java
@@ -1214,18 +1214,15 @@ public final class OAuthUtil {
             UserAssociation userAssociation = OAuthComponentServiceHolder.getInstance()
                     .getOrganizationUserSharingService().getUserAssociation(
                             authenticatedUser.getSharedUserId(), accessingOrgId);
-            if (userAssociation != null) {
+            if (OrganizationManagementUtil.isOrganization(tenantDomain) && userAssociation != null) {
                 AuthenticatedUser sharedUser = new AuthenticatedUser(authenticatedUser);
-                sharedUser.setUserName(authenticatedUser.getUserId());
+                sharedUser.setUserName(userAssociation.getAssociatedUserId());
                 setOrganizationSSOUserDetails(sharedUser);
                 return sharedUser;
             }
             return null;
         } catch (OrganizationManagementException e) {
             throw new UserStoreException("Error while getting user associations for user: "
-                    + authenticatedUser.getLoggableMaskedUserId(), e);
-        } catch (UserIdNotFoundException e) {
-            throw new UserStoreException("Error while resolving user ID for user: "
                     + authenticatedUser.getLoggableMaskedUserId(), e);
         } catch (IdentityProviderManagementException e) {
             throw new UserStoreException("Error occurred while resolving IDP name of the organization login IDP in: "

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/OAuthUtilTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/OAuthUtilTest.java
@@ -30,6 +30,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
 import org.wso2.carbon.identity.application.common.model.InboundAuthenticationConfig;
 import org.wso2.carbon.identity.application.common.model.InboundAuthenticationRequestConfig;
 import org.wso2.carbon.identity.application.common.model.ServiceProvider;
@@ -491,13 +492,28 @@ public class OAuthUtilTest {
     public void testAuthenticatedUserInSharedUserFlow(boolean isSSOLoginUser, boolean isUserAssociationFound,
                                                       boolean shouldThrowUserStoreException) throws Exception {
 
-        try (MockedStatic<UserCoreUtil> userCoreUtil = mockStatic(UserCoreUtil.class)) {
+        try (MockedStatic<UserCoreUtil> userCoreUtil = mockStatic(UserCoreUtil.class);
+             MockedStatic<FrameworkUtils> frameworkUtils = mockStatic(FrameworkUtils.class);
+             MockedStatic<IdentityTenantUtil> identityTenantUtil = mockStatic(IdentityTenantUtil.class)) {
+
+            frameworkUtils.when(() -> FrameworkUtils.resolveUserIdFromUsername(
+                    anyInt(), anyString(), anyString())).thenReturn("dummyUserId");
+
+            userCoreUtil.when(() -> UserCoreUtil.getDomainName(any())).thenReturn("dummyDomainName");
+
+            identityTenantUtil.when(() -> IdentityTenantUtil.getTenantDomain(anyInt()))
+                    .thenReturn("dummyTenantDomain");
+            identityTenantUtil.when(() -> IdentityTenantUtil.getTenantId(anyString())).thenReturn(-1234);
+            when(organizationManager.resolveOrganizationId(anyString())).thenReturn("dummyOrgId");
+            when(organizationManager.getPrimaryOrganizationId(anyString())).thenReturn("dummyPrimaryOrgId");
+            when(organizationManager.resolveTenantDomain(anyString())).thenReturn("dummyTenantDomain");
 
             UniqueIDJDBCUserStoreManager userStoreManager = Mockito.spy(
                     new UniqueIDJDBCUserStoreManager(new RealmConfiguration(), 1));
 
             org.wso2.carbon.user.core.common.User mockUser = Mockito.mock(org.wso2.carbon.user.core.common.User.class);
             doReturn(mockUser).when(userStoreManager).getUser(any(), eq(null));
+            lenient().doReturn(false).when(userStoreManager).isExistingUser(anyString());
 
             Map<String, String> claimsMap = new HashMap<>();
             claimsMap.put(MANAGED_ORG_CLAIM_URI, SAMPLE_ID);
@@ -515,7 +531,8 @@ public class OAuthUtilTest {
             if (isUserAssociationFound) {
                 UserAssociation userAssociation = new UserAssociation();
                 userAssociation.setAssociatedUserId(SAMPLE_ID);
-                when(organizationUserSharingService.getUserAssociation(null, null)).thenReturn(userAssociation);
+                when(organizationUserSharingService.getUserAssociation(isNull(), anyString()))
+                        .thenReturn(userAssociation);
             }
             if (shouldThrowUserStoreException) {
                 when(realmService.getTenantUserRealm(anyInt())).thenThrow(new UserStoreException());


### PR DESCRIPTION
### Purpose
This pr improves token revocation for shared users when they login through shared applications via legacy federation based authentication.

### Related issue
- https://github.com/wso2/product-is/issues/27371