### PR TITLE
 Add graceful refresh token rotation configuration support

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
+++ b/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
@@ -686,6 +686,25 @@ public final class OAuthConstants {
     }
 
     /**
+     * Graceful refresh token rotation constants.
+     */
+    public static class GracefulRefreshTokenRotation {
+
+        public static final String IS_GRACEFUL_REFRESH_TOKEN_ROTATION_ENABLED = "isGracefulRefreshTokenRotationEnabled";
+        public static final String GRACEFUL_REFRESH_TOKEN_ROTATION_VALIDITY_PERIOD =
+                "gracefulRefreshTokenRotationValidityPeriod";
+        public static final int GRACEFUL_REFRESH_TOKEN_ROTATION_VALIDITY_PERIOD_VALUE = 30;
+        public static final int GRACEFUL_REFRESH_TOKEN_ROTATION_VALIDITY_PERIOD_SEALING_VALUE = 60;
+        public static final String GRACEFUL_REFRESH_TOKEN_REUSE_LIMIT = "gracefulRefreshTokenReuseLimit";
+        public static final int GRACEFUL_REFRESH_TOKEN_REUSE_LIMIT_MAX_VALUE = 5;
+        public static final int GRACEFUL_REFRESH_TOKEN_REUSE_LIMIT_MIN_VALUE = 1;
+
+        private GracefulRefreshTokenRotation() {
+
+        }
+    }
+
+    /**
      * Signature algorithms constants.
      */
     public static class SignatureAlgorithms {

--- a/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
+++ b/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
@@ -693,7 +693,7 @@ public final class OAuthConstants {
         public static final String IS_GRACEFUL_REFRESH_TOKEN_ROTATION_ENABLED = "isGracefulRefreshTokenRotationEnabled";
         public static final String GRACEFUL_REFRESH_TOKEN_ROTATION_VALIDITY_PERIOD =
                 "gracefulRefreshTokenRotationValidityPeriod";
-        public static final int GRACEFUL_REFRESH_TOKEN_ROTATION_VALIDITY_PERIOD_VALUE = 30;
+        public static final int DEFAULT_GRACEFUL_REFRESH_TOKEN_ROTATION_VALIDITY_PERIOD_VALUE = 30;
         public static final int GRACEFUL_REFRESH_TOKEN_ROTATION_VALIDITY_PERIOD_SEALING_VALUE = 60;
         public static final String GRACEFUL_REFRESH_TOKEN_REUSE_LIMIT = "gracefulRefreshTokenReuseLimit";
         public static final int GRACEFUL_REFRESH_TOKEN_REUSE_LIMIT_MAX_VALUE = 5;

--- a/components/org.wso2.carbon.identity.oauth.stub/src/main/resources/OAuthAdminService.wsdl
+++ b/components/org.wso2.carbon.identity.oauth.stub/src/main/resources/OAuthAdminService.wsdl
@@ -409,6 +409,9 @@
                     <xs:element minOccurs="0" name="extendRenewedRefreshTokenExpiryTime" type="xs:boolean"/>
                     <xs:element minOccurs="0" name="fapiConformanceEnabled" type="xs:boolean"/>
                     <xs:element minOccurs="0" name="frontchannelLogoutUrl" nillable="true" type="xs:string"/>
+                    <xs:element minOccurs="0" name="gracefulRefreshTokenReuseLimit" type="xs:int"/>
+                    <xs:element minOccurs="0" name="gracefulRefreshTokenRotationEnabled" type="xs:boolean"/>
+                    <xs:element minOccurs="0" name="gracefulRefreshTokenRotationValidityPeriod" type="xs:int"/>
                     <xs:element minOccurs="0" name="grantTypes" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="hybridFlowEnabled" type="xs:boolean"/>
                     <xs:element minOccurs="0" name="hybridFlowResponseType" nillable="true" type="xs:string"/>

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImpl.java
@@ -123,8 +123,8 @@ import static org.wso2.carbon.identity.oauth.OAuthUtil.handleError;
 import static org.wso2.carbon.identity.oauth.OAuthUtil.handleErrorWithExceptionType;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.CALLBACK_URL_REGEXP_PREFIX;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.ENABLE_CLAIMS_SEPARATION_FOR_ACCESS_TOKEN;
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.GracefulRefreshTokenRotation.DEFAULT_GRACEFUL_REFRESH_TOKEN_ROTATION_VALIDITY_PERIOD_VALUE;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.GracefulRefreshTokenRotation.GRACEFUL_REFRESH_TOKEN_REUSE_LIMIT_MIN_VALUE;
-import static org.wso2.carbon.identity.oauth.common.OAuthConstants.GracefulRefreshTokenRotation.GRACEFUL_REFRESH_TOKEN_ROTATION_VALIDITY_PERIOD_VALUE;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.NonPersistenceConstants.ENTITY_ID_TYPE_CLIENT_ID;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDC_DIALECT;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OauthAppStates.APP_STATE_ACTIVE;
@@ -3312,7 +3312,7 @@ public class OAuthAdminServiceImpl {
         if (current <= 0) {
             // Clamp default to the operator-configured ceiling so we never exceed it.
             appDO.setGracefulRefreshTokenRotationValidityPeriod(
-                    Math.min(GRACEFUL_REFRESH_TOKEN_ROTATION_VALIDITY_PERIOD_VALUE, maxValidity));
+                    Math.min(DEFAULT_GRACEFUL_REFRESH_TOKEN_ROTATION_VALIDITY_PERIOD_VALUE, maxValidity));
         } else if (current > maxValidity) {
             appDO.setGracefulRefreshTokenRotationValidityPeriod(maxValidity);
             if (LOG.isDebugEnabled()) {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImpl.java
@@ -123,6 +123,8 @@ import static org.wso2.carbon.identity.oauth.OAuthUtil.handleError;
 import static org.wso2.carbon.identity.oauth.OAuthUtil.handleErrorWithExceptionType;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.CALLBACK_URL_REGEXP_PREFIX;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.ENABLE_CLAIMS_SEPARATION_FOR_ACCESS_TOKEN;
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.GracefulRefreshTokenRotation.GRACEFUL_REFRESH_TOKEN_REUSE_LIMIT_MIN_VALUE;
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.GracefulRefreshTokenRotation.GRACEFUL_REFRESH_TOKEN_ROTATION_VALIDITY_PERIOD_VALUE;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.NonPersistenceConstants.ENTITY_ID_TYPE_CLIENT_ID;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDC_DIALECT;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OauthAppStates.APP_STATE_ACTIVE;
@@ -593,6 +595,14 @@ public class OAuthAdminServiceImpl {
                         app.setFapiConformanceEnabled(application.isFapiConformanceEnabled());
                         app.setSubjectTokenEnabled(application.isSubjectTokenEnabled());
                         app.setSubjectTokenExpiryTime(application.getSubjectTokenExpiryTime());
+                        app.setGracefulRefreshTokenRotationEnabled(
+                                application.isGracefulRefreshTokenRotationEnabled());
+                        app.setGracefulRefreshTokenRotationValidityPeriod(
+                                application.getGracefulRefreshTokenRotationValidityPeriod());
+                        app.setGracefulRefreshTokenReuseLimit(
+                                application.getGracefulRefreshTokenReuseLimit());
+                        normalizeGracefulRotationValidityPeriod(app);
+                        normalizeGracefulReuseLimit(app);
                         app.setJwtScopeAsArrayEnabled(application.isJwtScopeAsArrayEnabled());
                         if (isAccessTokenClaimsSeparationFeatureEnabled()) {
                             validateAccessTokenClaims(application, tenantDomain);
@@ -1097,6 +1107,13 @@ public class OAuthAdminServiceImpl {
             oAuthAppDO.setRequirePushedAuthorizationRequests(consumerAppDTO.getRequirePushedAuthorizationRequests());
             oAuthAppDO.setSubjectTokenEnabled(consumerAppDTO.isSubjectTokenEnabled());
             oAuthAppDO.setSubjectTokenExpiryTime(consumerAppDTO.getSubjectTokenExpiryTime());
+            oAuthAppDO.setGracefulRefreshTokenRotationEnabled(
+                    consumerAppDTO.isGracefulRefreshTokenRotationEnabled());
+            oAuthAppDO.setGracefulRefreshTokenRotationValidityPeriod(
+                    consumerAppDTO.getGracefulRefreshTokenRotationValidityPeriod());
+            oAuthAppDO.setGracefulRefreshTokenReuseLimit(consumerAppDTO.getGracefulRefreshTokenReuseLimit());
+            normalizeGracefulRotationValidityPeriod(oAuthAppDO);
+            normalizeGracefulReuseLimit(oAuthAppDO);
             oAuthAppDO.setJwtScopeAsArrayEnabled(consumerAppDTO.isJwtScopeAsArrayEnabled());
 
             if (isAccessTokenClaimsSeparationFeatureEnabled()) {
@@ -3285,5 +3302,38 @@ public class OAuthAdminServiceImpl {
                                 + consumerKey, e);
             }
         }
+    }
+
+    private void normalizeGracefulRotationValidityPeriod(OAuthAppDO appDO) {
+
+        int maxValidity = OAuthServerConfiguration.getInstance()
+                .getGracefulRefreshTokenRotationValidityPeriodMax();
+        if (appDO.getGracefulRefreshTokenRotationValidityPeriod() <= 0) {
+            appDO.setGracefulRefreshTokenRotationValidityPeriod(GRACEFUL_REFRESH_TOKEN_ROTATION_VALIDITY_PERIOD_VALUE);
+        } else if (appDO.getGracefulRefreshTokenRotationValidityPeriod() > maxValidity) {
+            appDO.setGracefulRefreshTokenRotationValidityPeriod(maxValidity);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("The graceful refresh token rotation validity period configured for the application: " +
+                        appDO.getApplicationName() + " is greater than the maximum allowed value. " +
+                        "Hence, setting it to the maximum allowed value: " + maxValidity + " seconds.");
+            }
+        }
+    }
+
+    private void normalizeGracefulReuseLimit(OAuthAppDO appDO) {
+
+        int maxLimit = OAuthServerConfiguration.getInstance().getGracefulRefreshTokenReuseLimitMax();
+        int limit = appDO.getGracefulRefreshTokenReuseLimit();
+        if (limit < GRACEFUL_REFRESH_TOKEN_REUSE_LIMIT_MIN_VALUE) {
+            limit = GRACEFUL_REFRESH_TOKEN_REUSE_LIMIT_MIN_VALUE;
+        } else if (limit > maxLimit) {
+            limit = maxLimit;
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("The graceful refresh token reuse limit configured for the application: " +
+                        appDO.getApplicationName() + " exceeds the maximum allowed value. " +
+                        "Hence, setting it to the maximum allowed value: " + maxLimit + ".");
+            }
+        }
+        appDO.setGracefulRefreshTokenReuseLimit(limit);
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImpl.java
@@ -3308,9 +3308,12 @@ public class OAuthAdminServiceImpl {
 
         int maxValidity = OAuthServerConfiguration.getInstance()
                 .getGracefulRefreshTokenRotationValidityPeriodMax();
-        if (appDO.getGracefulRefreshTokenRotationValidityPeriod() <= 0) {
-            appDO.setGracefulRefreshTokenRotationValidityPeriod(GRACEFUL_REFRESH_TOKEN_ROTATION_VALIDITY_PERIOD_VALUE);
-        } else if (appDO.getGracefulRefreshTokenRotationValidityPeriod() > maxValidity) {
+        int current = appDO.getGracefulRefreshTokenRotationValidityPeriod();
+        if (current <= 0) {
+            // Clamp default to the operator-configured ceiling so we never exceed it.
+            appDO.setGracefulRefreshTokenRotationValidityPeriod(
+                    Math.min(GRACEFUL_REFRESH_TOKEN_ROTATION_VALIDITY_PERIOD_VALUE, maxValidity));
+        } else if (current > maxValidity) {
             appDO.setGracefulRefreshTokenRotationValidityPeriod(maxValidity);
             if (LOG.isDebugEnabled()) {
                 LOG.debug("The graceful refresh token rotation validity period configured for the application: " +

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthUtil.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthUtil.java
@@ -569,6 +569,9 @@ public final class OAuthUtil {
         dto.setFapiConformanceEnabled(appDO.isFapiConformanceEnabled());
         dto.setSubjectTokenEnabled(appDO.isSubjectTokenEnabled());
         dto.setSubjectTokenExpiryTime(appDO.getSubjectTokenExpiryTime());
+        dto.setGracefulRefreshTokenRotationEnabled(appDO.isGracefulRefreshTokenRotationEnabled());
+        dto.setGracefulRefreshTokenRotationValidityPeriod(appDO.getGracefulRefreshTokenRotationValidityPeriod());
+        dto.setGracefulRefreshTokenReuseLimit(appDO.getGracefulRefreshTokenReuseLimit());
         dto.setJwtScopeAsArrayEnabled(appDO.isJwtScopeAsArrayEnabled());
         dto.setAccessTokenClaims(appDO.getAccessTokenClaims());
         dto.setCibaNotificationChannels(appDO.getCibaNotificationChannels());

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
@@ -174,6 +174,10 @@ public class OAuthServerConfiguration {
     private String persistAccessTokenAlias;
     private String retainOldAccessTokens;
     private String tokenCleanupFeatureEnable;
+    private int gracefulRefreshTokenRotationValidityPeriodMax =
+            OAuthConstants.GracefulRefreshTokenRotation.GRACEFUL_REFRESH_TOKEN_ROTATION_VALIDITY_PERIOD_SEALING_VALUE;
+    private int gracefulRefreshTokenReuseLimitMax =
+            OAuthConstants.GracefulRefreshTokenRotation.GRACEFUL_REFRESH_TOKEN_REUSE_LIMIT_MAX_VALUE;
     private OauthTokenIssuer oauthIdentityTokenGenerator;
     private boolean scopeValidationConfigValue = true;
     private boolean globalRbacScopeIssuerEnabled = false;
@@ -468,6 +472,9 @@ public class OAuthServerConfiguration {
 
         // read refresh token renewal config
         parseRefreshTokenRenewalConfiguration(oauthElem);
+
+        // read graceful refresh token rotation config
+        parseGracefulRefreshTokenRotationConfig(oauthElem);
 
         // read token persistence config
         parseTokenPersistenceConfiguration(oauthElem);
@@ -1142,6 +1149,16 @@ public class OAuthServerConfiguration {
     public boolean isTokenCleanupEnabled() {
 
         return Boolean.TRUE.toString().equalsIgnoreCase(tokenCleanupFeatureEnable);
+    }
+
+    public int getGracefulRefreshTokenRotationValidityPeriodMax() {
+
+        return gracefulRefreshTokenRotationValidityPeriodMax;
+    }
+
+    public int getGracefulRefreshTokenReuseLimitMax() {
+
+        return gracefulRefreshTokenReuseLimitMax;
     }
 
     public String getOIDCConsentPageUrl() {
@@ -2990,6 +3007,39 @@ public class OAuthServerConfiguration {
         }
     }
 
+    private void parseGracefulRefreshTokenRotationConfig(OMElement oauthConfigElem) {
+
+        OMElement rootElem = oauthConfigElem.getFirstChildWithName(
+                getQNameWithIdentityNS(ConfigElements.GRACEFUL_REFRESH_TOKEN_ROTATION));
+        if (rootElem == null) {
+            return;
+        }
+        gracefulRefreshTokenRotationValidityPeriodMax = parsePositiveIntChild(rootElem,
+                ConfigElements.GRACEFUL_VALIDITY_PERIOD_MAX,
+                gracefulRefreshTokenRotationValidityPeriodMax);
+        gracefulRefreshTokenReuseLimitMax = parsePositiveIntChild(rootElem,
+                ConfigElements.GRACEFUL_REUSE_LIMIT_MAX,
+                gracefulRefreshTokenReuseLimitMax);
+    }
+
+    private int parsePositiveIntChild(OMElement parent, String childName, int fallback) {
+
+        OMElement child = parent.getFirstChildWithName(getQNameWithIdentityNS(childName));
+        if (child == null || !StringUtils.isNotBlank(child.getText())) {
+            return fallback;
+        }
+        try {
+            int value = Integer.parseInt(child.getText().trim());
+            if (value > 0) {
+                return value;
+            }
+            log.warn("Invalid value for " + childName + ": " + value + ". Using default: " + fallback);
+        } catch (NumberFormatException e) {
+            log.warn("Invalid value for " + childName + ": " + child.getText() + ". Using default: " + fallback);
+        }
+        return fallback;
+    }
+
     private void tokenCleanupFeatureConfig(OMElement oauthCleanupConfigElem) {
 
         OMElement tokenCleanElem = oauthCleanupConfigElem
@@ -4710,6 +4760,10 @@ public class OAuthServerConfiguration {
         private static final String TOKEN_CLEANUP_FEATURE = "EnableTokenCleanup";
         // Enable/Disable retain old access token
         private static final String RETAIN_OLD_ACCESS_TOKENS = "RetainOldAccessToken";
+        // Graceful refresh token rotation config
+        private static final String GRACEFUL_REFRESH_TOKEN_ROTATION = "GracefulRefreshTokenRotation";
+        private static final String GRACEFUL_VALIDITY_PERIOD_MAX = "ValidityPeriodMax";
+        private static final String GRACEFUL_REUSE_LIMIT_MAX = "ReuseLimitMax";
 
         // Supported Grant Types
         private static final String SUPPORTED_GRANT_TYPES = "SupportedGrantTypes";

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dao/OAuthAppDAO.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dao/OAuthAppDAO.java
@@ -79,6 +79,9 @@ import java.util.Set;
 
 import static org.wso2.carbon.identity.oauth.OAuthUtil.handleError;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.ENABLE_CLAIMS_SEPARATION_FOR_ACCESS_TOKEN;
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.GracefulRefreshTokenRotation.GRACEFUL_REFRESH_TOKEN_REUSE_LIMIT;
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.GracefulRefreshTokenRotation.GRACEFUL_REFRESH_TOKEN_ROTATION_VALIDITY_PERIOD;
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.GracefulRefreshTokenRotation.IS_GRACEFUL_REFRESH_TOKEN_ROTATION_ENABLED;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCConfigProperties.BACK_CHANNEL_LOGOUT_URL;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCConfigProperties.BYPASS_CLIENT_CREDENTIALS;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCConfigProperties.CIBA_ALLOW_FEDERATED_USERS;
@@ -1126,6 +1129,21 @@ public class OAuthAppDAO {
                 prepStatementForPropertyAdd, preparedStatementForPropertyUpdate);
 
         addOrUpdateOIDCSpProperty(preprocessedClientId, spTenantId, spOIDCProperties,
+                IS_GRACEFUL_REFRESH_TOKEN_ROTATION_ENABLED,
+                String.valueOf(oauthAppDO.isGracefulRefreshTokenRotationEnabled()),
+                prepStatementForPropertyAdd, preparedStatementForPropertyUpdate);
+
+        addOrUpdateOIDCSpProperty(preprocessedClientId, spTenantId, spOIDCProperties,
+                GRACEFUL_REFRESH_TOKEN_ROTATION_VALIDITY_PERIOD,
+                String.valueOf(oauthAppDO.getGracefulRefreshTokenRotationValidityPeriod()),
+                prepStatementForPropertyAdd, preparedStatementForPropertyUpdate);
+
+        addOrUpdateOIDCSpProperty(preprocessedClientId, spTenantId, spOIDCProperties,
+                GRACEFUL_REFRESH_TOKEN_REUSE_LIMIT,
+                String.valueOf(oauthAppDO.getGracefulRefreshTokenReuseLimit()),
+                prepStatementForPropertyAdd, preparedStatementForPropertyUpdate);
+
+        addOrUpdateOIDCSpProperty(preprocessedClientId, spTenantId, spOIDCProperties,
                 ENABLE_JWT_SCOPE_AS_ARRAY, String.valueOf(oauthAppDO.isJwtScopeAsArrayEnabled()),
                 prepStatementForPropertyAdd, preparedStatementForPropertyUpdate);
 
@@ -1888,6 +1906,18 @@ public class OAuthAppDAO {
                     SUBJECT_TOKEN_EXPIRY_TIME, String.valueOf(consumerAppDO.getSubjectTokenExpiryTime()));
 
             addToBatchForOIDCPropertyAdd(processedClientId, spTenantId, prepStmtAddOIDCProperty,
+                    IS_GRACEFUL_REFRESH_TOKEN_ROTATION_ENABLED,
+                    String.valueOf(consumerAppDO.isGracefulRefreshTokenRotationEnabled()));
+
+            addToBatchForOIDCPropertyAdd(processedClientId, spTenantId, prepStmtAddOIDCProperty,
+                    GRACEFUL_REFRESH_TOKEN_ROTATION_VALIDITY_PERIOD,
+                    String.valueOf(consumerAppDO.getGracefulRefreshTokenRotationValidityPeriod()));
+
+            addToBatchForOIDCPropertyAdd(processedClientId, spTenantId, prepStmtAddOIDCProperty,
+                    GRACEFUL_REFRESH_TOKEN_REUSE_LIMIT,
+                    String.valueOf(consumerAppDO.getGracefulRefreshTokenReuseLimit()));
+
+            addToBatchForOIDCPropertyAdd(processedClientId, spTenantId, prepStmtAddOIDCProperty,
                     HYBRID_FLOW_ENABLED,
                     String.valueOf(consumerAppDO.isHybridFlowEnabled()));
 
@@ -2103,6 +2133,24 @@ public class OAuthAppDAO {
         String subjectTokenExpiryTime = getFirstPropertyValue(spOIDCProperties, SUBJECT_TOKEN_EXPIRY_TIME);
         if (subjectTokenExpiryTime != null) {
             oauthApp.setSubjectTokenExpiryTime(Integer.parseInt(subjectTokenExpiryTime));
+        }
+
+        String isGracefulRefreshTokenRotationEnabled = getFirstPropertyValue(spOIDCProperties,
+                IS_GRACEFUL_REFRESH_TOKEN_ROTATION_ENABLED);
+        if (isGracefulRefreshTokenRotationEnabled != null) {
+            oauthApp.setGracefulRefreshTokenRotationEnabled(
+                    Boolean.parseBoolean(isGracefulRefreshTokenRotationEnabled));
+        }
+        String gracefulRefreshTokenRotationValidityPeriod = getFirstPropertyValue(spOIDCProperties,
+                GRACEFUL_REFRESH_TOKEN_ROTATION_VALIDITY_PERIOD);
+        if (gracefulRefreshTokenRotationValidityPeriod != null) {
+            oauthApp.setGracefulRefreshTokenRotationValidityPeriod(
+                    Integer.parseInt(gracefulRefreshTokenRotationValidityPeriod));
+        }
+        String gracefulRefreshTokenReuseLimit = getFirstPropertyValue(spOIDCProperties,
+                GRACEFUL_REFRESH_TOKEN_REUSE_LIMIT);
+        if (gracefulRefreshTokenReuseLimit != null) {
+            oauthApp.setGracefulRefreshTokenReuseLimit(Integer.parseInt(gracefulRefreshTokenReuseLimit));
         }
 
         String hybridFlowEnabledProperty = getFirstPropertyValue(spOIDCProperties, HYBRID_FLOW_ENABLED);

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dao/OAuthAppDO.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dao/OAuthAppDO.java
@@ -116,6 +116,9 @@ public class OAuthAppDO extends InboundConfigurationProtocol implements Serializ
     private Boolean jwtScopeAsArrayEnabled;
     private boolean subjectTokenEnabled;
     private int subjectTokenExpiryTime;
+    private boolean gracefulRefreshTokenRotationEnabled;
+    private int gracefulRefreshTokenRotationValidityPeriod;
+    private int gracefulRefreshTokenReuseLimit;
     private String[] accessTokenClaims;
     private String issuerOrg;
     // CIBA related properties.
@@ -573,6 +576,36 @@ public class OAuthAppDO extends InboundConfigurationProtocol implements Serializ
     public void setSubjectTokenExpiryTime(int subjectTokenExpiryTime) {
 
         this.subjectTokenExpiryTime = subjectTokenExpiryTime;
+    }
+
+    public boolean isGracefulRefreshTokenRotationEnabled() {
+
+        return gracefulRefreshTokenRotationEnabled;
+    }
+
+    public void setGracefulRefreshTokenRotationEnabled(boolean gracefulRefreshTokenRotationEnabled) {
+
+        this.gracefulRefreshTokenRotationEnabled = gracefulRefreshTokenRotationEnabled;
+    }
+
+    public int getGracefulRefreshTokenRotationValidityPeriod() {
+
+        return gracefulRefreshTokenRotationValidityPeriod;
+    }
+
+    public void setGracefulRefreshTokenRotationValidityPeriod(int gracefulRefreshTokenRotationValidityPeriod) {
+
+        this.gracefulRefreshTokenRotationValidityPeriod = gracefulRefreshTokenRotationValidityPeriod;
+    }
+
+    public int getGracefulRefreshTokenReuseLimit() {
+
+        return gracefulRefreshTokenReuseLimit;
+    }
+
+    public void setGracefulRefreshTokenReuseLimit(int gracefulRefreshTokenReuseLimit) {
+
+        this.gracefulRefreshTokenReuseLimit = gracefulRefreshTokenReuseLimit;
     }
 
     public String[] getAccessTokenClaims() {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dto/OAuthConsumerAppDTO.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dto/OAuthConsumerAppDTO.java
@@ -83,6 +83,9 @@ public class OAuthConsumerAppDTO implements InboundProtocolConfigurationDTO {
     private Boolean jwtScopeAsArrayEnabled;
     private boolean subjectTokenEnabled;
     private int subjectTokenExpiryTime;
+    private boolean gracefulRefreshTokenRotationEnabled;
+    private int gracefulRefreshTokenRotationValidityPeriod;
+    private int gracefulRefreshTokenReuseLimit;
     private String[] accessTokenClaims;
     private String cibaNotificationChannels;
 
@@ -599,6 +602,36 @@ public class OAuthConsumerAppDTO implements InboundProtocolConfigurationDTO {
     public void setSubjectTokenExpiryTime(int subjectTokenExpiryTime) {
 
         this.subjectTokenExpiryTime = subjectTokenExpiryTime;
+    }
+
+    public boolean isGracefulRefreshTokenRotationEnabled() {
+
+        return gracefulRefreshTokenRotationEnabled;
+    }
+
+    public void setGracefulRefreshTokenRotationEnabled(boolean gracefulRefreshTokenRotationEnabled) {
+
+        this.gracefulRefreshTokenRotationEnabled = gracefulRefreshTokenRotationEnabled;
+    }
+
+    public int getGracefulRefreshTokenRotationValidityPeriod() {
+
+        return gracefulRefreshTokenRotationValidityPeriod;
+    }
+
+    public void setGracefulRefreshTokenRotationValidityPeriod(int gracefulRefreshTokenRotationValidityPeriod) {
+
+        this.gracefulRefreshTokenRotationValidityPeriod = gracefulRefreshTokenRotationValidityPeriod;
+    }
+
+    public int getGracefulRefreshTokenReuseLimit() {
+
+        return gracefulRefreshTokenReuseLimit;
+    }
+
+    public void setGracefulRefreshTokenReuseLimit(int gracefulRefreshTokenReuseLimit) {
+
+        this.gracefulRefreshTokenReuseLimit = gracefulRefreshTokenReuseLimit;
     }
 
     public String[] getAccessTokenClaims() {

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImplTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImplTest.java
@@ -2343,4 +2343,66 @@ public class OAuthAdminServiceImplTest {
             }
         }
     }
+
+    @Test
+    public void testNormalizeGracefulRotationValidityPeriodWhenDefaultExceedsConfiguredMax() throws Exception {
+
+        OAuthAdminServiceImpl.allowedGrants = null;
+        String consumerKey = UUID.randomUUID().toString();
+
+        try (MockedStatic<IdentityUtil> identityUtil = mockStatic(IdentityUtil.class);
+             MockedStatic<OAuthComponentServiceHolder> oAuthComponentServiceHolder =
+                     mockStatic(OAuthComponentServiceHolder.class);
+             MockedStatic<OAuthServerConfiguration> oAuthServerConfigurationMockedStatic =
+                     mockStatic(OAuthServerConfiguration.class);
+             MockedStatic<OrganizationManagementUtil> organizationManagementUtil =
+                     mockStatic(OrganizationManagementUtil.class)) {
+
+            mockOAuthServerConfiguration = mock(OAuthServerConfiguration.class);
+            oAuthServerConfigurationMockedStatic.when(OAuthServerConfiguration::getInstance)
+                    .thenReturn(mockOAuthServerConfiguration);
+            when(mockOAuthServerConfiguration.getSupportedGrantTypes()).thenReturn(new HashMap<>());
+            // Configure a max (10) that is less than the compile-time default (30).
+            when(mockOAuthServerConfiguration.getGracefulRefreshTokenRotationValidityPeriodMax()).thenReturn(10);
+            when(mockOAuthServerConfiguration.getGracefulRefreshTokenReuseLimitMax()).thenReturn(5);
+
+            organizationManagementUtil.when(() -> OrganizationManagementUtil.isOrganization(anyString()))
+                    .thenReturn(false);
+
+            PrivilegedCarbonContext.getThreadLocalCarbonContext()
+                    .setTenantDomain(SUPER_TENANT_DOMAIN_NAME);
+            PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantId(SUPER_TENANT_ID);
+            PrivilegedCarbonContext.getThreadLocalCarbonContext().setUsername(USER_NAME);
+            PrivilegedCarbonContext.getThreadLocalCarbonContext().setUserRealm(userRealm);
+
+            OAuthAppDO existingApp = buildDummyOAuthAppDO(USER_NAME);
+            existingApp.setOauthConsumerKey(consumerKey);
+
+            ArgumentCaptor<OAuthAppDO> captor = ArgumentCaptor.forClass(OAuthAppDO.class);
+
+            try (MockedConstruction<OAuthAppDAO> mockedConstruction = Mockito.mockConstruction(OAuthAppDAO.class,
+                    (mock, context) -> {
+                        when(mock.getAppInformation(consumerKey, SUPER_TENANT_ID)).thenReturn(existingApp);
+                        doNothing().when(mock).updateConsumerApplication(captor.capture());
+                    })) {
+
+                mockUserstore(identityUtil, oAuthComponentServiceHolder);
+                identityUtil.when(() -> IdentityUtil.addDomainToName(anyString(), anyString()))
+                        .thenCallRealMethod();
+
+                OAuthConsumerAppDTO dto = getoAuthConsumerAppDTO(USER_NAME, consumerKey,
+                        "consumer-secret", OAuthConstants.OAuthVersions.VERSION_2);
+                dto.setGracefulRefreshTokenRotationEnabled(true);
+                dto.setGracefulRefreshTokenRotationValidityPeriod(0);
+                dto.setGracefulRefreshTokenReuseLimit(3);
+                dto.setOauthConsumerSecret("some-consumer-secret");
+
+                new OAuthAdminServiceImpl().updateConsumerApplication(dto);
+
+                Assert.assertEquals(captor.getValue().getGracefulRefreshTokenRotationValidityPeriod(), 10,
+                        "When the configured max (10) is less than the default (30), the default path must "
+                                + "be clamped to the max, not set to 30.");
+            }
+        }
+    }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImplTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImplTest.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import org.apache.axis2.context.ConfigurationContext;
 import org.apache.axis2.engine.AxisConfiguration;
 import org.apache.commons.lang.StringUtils;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockedConstruction;
 import org.mockito.MockedStatic;
@@ -2061,5 +2062,285 @@ public class OAuthAdminServiceImplTest {
         oAuthConsumerAppDTO.setOauthConsumerKey(consumerKey);
         oAuthConsumerAppDTO.setOauthConsumerSecret(consumerSecret);
         return oAuthConsumerAppDTO;
+    }
+
+    @DataProvider(name = "gracefulRotationValidityPeriodNormalizationData")
+    public Object[][] gracefulRotationValidityPeriodNormalizationData() {
+
+        // rotationEnabled, inputPeriod, expectedPeriod
+        // Default validity period = 30, sealing value = 60.
+        return new Object[][] {
+                // Rotation disabled + invalid (<=0): should still be set to default (30).
+                {false, 0, 30},
+                // Rotation enabled + invalid (<=0): should be set to default (30).
+                {true, 0, 30},
+                {true, -1, 30},
+                // Rotation enabled + exceeds sealing value (60): should be clamped.
+                {true, 9999, 60},
+                {true, 61, 60},
+                // Rotation enabled + valid range: should be preserved.
+                {true, 30, 30},
+                {true, 60, 60},
+        };
+    }
+
+    @Test(dataProvider = "gracefulRotationValidityPeriodNormalizationData")
+    public void testNormalizeGracefulRotationValidityPeriod(boolean rotationEnabled, int inputPeriod,
+                                                            int expectedPeriod) throws Exception {
+
+        OAuthAdminServiceImpl.allowedGrants = null;
+        String consumerKey = UUID.randomUUID().toString();
+
+        try (MockedStatic<IdentityUtil> identityUtil = mockStatic(IdentityUtil.class);
+             MockedStatic<OAuthComponentServiceHolder> oAuthComponentServiceHolder =
+                     mockStatic(OAuthComponentServiceHolder.class);
+             MockedStatic<OAuthServerConfiguration> oAuthServerConfigurationMockedStatic =
+                     mockStatic(OAuthServerConfiguration.class);
+             MockedStatic<OrganizationManagementUtil> organizationManagementUtil =
+                     mockStatic(OrganizationManagementUtil.class)) {
+
+            mockOAuthServerConfiguration = mock(OAuthServerConfiguration.class);
+            oAuthServerConfigurationMockedStatic.when(OAuthServerConfiguration::getInstance)
+                    .thenReturn(mockOAuthServerConfiguration);
+            when(mockOAuthServerConfiguration.getSupportedGrantTypes()).thenReturn(new HashMap<>());
+            when(mockOAuthServerConfiguration.getGracefulRefreshTokenRotationValidityPeriodMax()).thenReturn(60);
+            when(mockOAuthServerConfiguration.getGracefulRefreshTokenReuseLimitMax()).thenReturn(5);
+
+            organizationManagementUtil.when(() -> OrganizationManagementUtil.isOrganization(anyString()))
+                    .thenReturn(false);
+
+            PrivilegedCarbonContext.getThreadLocalCarbonContext()
+                    .setTenantDomain(SUPER_TENANT_DOMAIN_NAME);
+            PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantId(SUPER_TENANT_ID);
+            PrivilegedCarbonContext.getThreadLocalCarbonContext().setUsername(USER_NAME);
+            PrivilegedCarbonContext.getThreadLocalCarbonContext().setUserRealm(userRealm);
+
+            OAuthAppDO existingApp = buildDummyOAuthAppDO(USER_NAME);
+            existingApp.setOauthConsumerKey(consumerKey);
+
+            ArgumentCaptor<OAuthAppDO> captor = ArgumentCaptor.forClass(OAuthAppDO.class);
+
+            try (MockedConstruction<OAuthAppDAO> mockedConstruction = Mockito.mockConstruction(OAuthAppDAO.class,
+                    (mock, context) -> {
+                        when(mock.getAppInformation(consumerKey, SUPER_TENANT_ID)).thenReturn(existingApp);
+                        doNothing().when(mock).updateConsumerApplication(captor.capture());
+                    })) {
+
+                mockUserstore(identityUtil, oAuthComponentServiceHolder);
+                identityUtil.when(() -> IdentityUtil.addDomainToName(anyString(), anyString()))
+                        .thenCallRealMethod();
+
+                OAuthConsumerAppDTO dto = getoAuthConsumerAppDTO(USER_NAME, consumerKey,
+                        "consumer-secret", OAuthConstants.OAuthVersions.VERSION_2);
+                dto.setGracefulRefreshTokenRotationEnabled(rotationEnabled);
+                dto.setGracefulRefreshTokenRotationValidityPeriod(inputPeriod);
+                dto.setGracefulRefreshTokenReuseLimit(3);
+                dto.setOauthConsumerSecret("some-consumer-secret");
+
+                new OAuthAdminServiceImpl().updateConsumerApplication(dto);
+
+                Assert.assertEquals(captor.getValue().getGracefulRefreshTokenRotationValidityPeriod(),
+                        expectedPeriod,
+                        "Rotation validity period not normalized correctly for rotationEnabled=" + rotationEnabled
+                                + ", input=" + inputPeriod);
+            }
+        }
+    }
+
+    @DataProvider(name = "gracefulReuseLimitNormalizationData")
+    public Object[][] gracefulReuseLimitNormalizationData() {
+
+        // inputLimit, expectedLimit
+        // Min = 1, default = 3, max = 5.
+        return new Object[][] {
+                // Below min (1): should be clamped to min (1).
+                {0, 1},
+                {-5, 1},
+                // Above max (5): should be clamped.
+                {6, 5},
+                {99, 5},
+                // Within valid range: preserved.
+                {1, 1},
+                {3, 3},
+                {5, 5},
+        };
+    }
+
+    @Test(dataProvider = "gracefulReuseLimitNormalizationData")
+    public void testNormalizeGracefulReuseLimit(int inputLimit, int expectedLimit) throws Exception {
+
+        OAuthAdminServiceImpl.allowedGrants = null;
+        String consumerKey = UUID.randomUUID().toString();
+
+        try (MockedStatic<IdentityUtil> identityUtil = mockStatic(IdentityUtil.class);
+             MockedStatic<OAuthComponentServiceHolder> oAuthComponentServiceHolder =
+                     mockStatic(OAuthComponentServiceHolder.class);
+             MockedStatic<OAuthServerConfiguration> oAuthServerConfigurationMockedStatic =
+                     mockStatic(OAuthServerConfiguration.class);
+             MockedStatic<OrganizationManagementUtil> organizationManagementUtil =
+                     mockStatic(OrganizationManagementUtil.class)) {
+
+            mockOAuthServerConfiguration = mock(OAuthServerConfiguration.class);
+            oAuthServerConfigurationMockedStatic.when(OAuthServerConfiguration::getInstance)
+                    .thenReturn(mockOAuthServerConfiguration);
+            when(mockOAuthServerConfiguration.getSupportedGrantTypes()).thenReturn(new HashMap<>());
+            when(mockOAuthServerConfiguration.getGracefulRefreshTokenRotationValidityPeriodMax()).thenReturn(60);
+            when(mockOAuthServerConfiguration.getGracefulRefreshTokenReuseLimitMax()).thenReturn(5);
+
+            organizationManagementUtil.when(() -> OrganizationManagementUtil.isOrganization(anyString()))
+                    .thenReturn(false);
+
+            PrivilegedCarbonContext.getThreadLocalCarbonContext()
+                    .setTenantDomain(SUPER_TENANT_DOMAIN_NAME);
+            PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantId(SUPER_TENANT_ID);
+            PrivilegedCarbonContext.getThreadLocalCarbonContext().setUsername(USER_NAME);
+            PrivilegedCarbonContext.getThreadLocalCarbonContext().setUserRealm(userRealm);
+
+            OAuthAppDO existingApp = buildDummyOAuthAppDO(USER_NAME);
+            existingApp.setOauthConsumerKey(consumerKey);
+
+            ArgumentCaptor<OAuthAppDO> captor = ArgumentCaptor.forClass(OAuthAppDO.class);
+
+            try (MockedConstruction<OAuthAppDAO> mockedConstruction = Mockito.mockConstruction(OAuthAppDAO.class,
+                    (mock, context) -> {
+                        when(mock.getAppInformation(consumerKey, SUPER_TENANT_ID)).thenReturn(existingApp);
+                        doNothing().when(mock).updateConsumerApplication(captor.capture());
+                    })) {
+
+                mockUserstore(identityUtil, oAuthComponentServiceHolder);
+                identityUtil.when(() -> IdentityUtil.addDomainToName(anyString(), anyString()))
+                        .thenCallRealMethod();
+
+                OAuthConsumerAppDTO dto = getoAuthConsumerAppDTO(USER_NAME, consumerKey,
+                        "consumer-secret", OAuthConstants.OAuthVersions.VERSION_2);
+                dto.setGracefulRefreshTokenReuseLimit(inputLimit);
+                dto.setGracefulRefreshTokenRotationEnabled(false);
+                dto.setOauthConsumerSecret("some-consumer-secret");
+
+                new OAuthAdminServiceImpl().updateConsumerApplication(dto);
+
+                Assert.assertEquals(captor.getValue().getGracefulRefreshTokenReuseLimit(), expectedLimit,
+                        "Reuse limit not normalized correctly for input=" + inputLimit);
+            }
+        }
+    }
+
+    @Test
+    public void testNormalizeGracefulRotationValidityPeriodWithConfiguredMax() throws Exception {
+
+        OAuthAdminServiceImpl.allowedGrants = null;
+        String consumerKey = UUID.randomUUID().toString();
+
+        try (MockedStatic<IdentityUtil> identityUtil = mockStatic(IdentityUtil.class);
+             MockedStatic<OAuthComponentServiceHolder> oAuthComponentServiceHolder =
+                     mockStatic(OAuthComponentServiceHolder.class);
+             MockedStatic<OAuthServerConfiguration> oAuthServerConfigurationMockedStatic =
+                     mockStatic(OAuthServerConfiguration.class);
+             MockedStatic<OrganizationManagementUtil> organizationManagementUtil =
+                     mockStatic(OrganizationManagementUtil.class)) {
+
+            mockOAuthServerConfiguration = mock(OAuthServerConfiguration.class);
+            oAuthServerConfigurationMockedStatic.when(OAuthServerConfiguration::getInstance)
+                    .thenReturn(mockOAuthServerConfiguration);
+            when(mockOAuthServerConfiguration.getSupportedGrantTypes()).thenReturn(new HashMap<>());
+            when(mockOAuthServerConfiguration.getGracefulRefreshTokenRotationValidityPeriodMax()).thenReturn(90);
+            when(mockOAuthServerConfiguration.getGracefulRefreshTokenReuseLimitMax()).thenReturn(5);
+
+            organizationManagementUtil.when(() -> OrganizationManagementUtil.isOrganization(anyString()))
+                    .thenReturn(false);
+
+            PrivilegedCarbonContext.getThreadLocalCarbonContext()
+                    .setTenantDomain(SUPER_TENANT_DOMAIN_NAME);
+            PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantId(SUPER_TENANT_ID);
+            PrivilegedCarbonContext.getThreadLocalCarbonContext().setUsername(USER_NAME);
+            PrivilegedCarbonContext.getThreadLocalCarbonContext().setUserRealm(userRealm);
+
+            OAuthAppDO existingApp = buildDummyOAuthAppDO(USER_NAME);
+            existingApp.setOauthConsumerKey(consumerKey);
+
+            ArgumentCaptor<OAuthAppDO> captor = ArgumentCaptor.forClass(OAuthAppDO.class);
+
+            try (MockedConstruction<OAuthAppDAO> mockedConstruction = Mockito.mockConstruction(OAuthAppDAO.class,
+                    (mock, context) -> {
+                        when(mock.getAppInformation(consumerKey, SUPER_TENANT_ID)).thenReturn(existingApp);
+                        doNothing().when(mock).updateConsumerApplication(captor.capture());
+                    })) {
+
+                mockUserstore(identityUtil, oAuthComponentServiceHolder);
+                identityUtil.when(() -> IdentityUtil.addDomainToName(anyString(), anyString()))
+                        .thenCallRealMethod();
+
+                OAuthConsumerAppDTO dto = getoAuthConsumerAppDTO(USER_NAME, consumerKey,
+                        "consumer-secret", OAuthConstants.OAuthVersions.VERSION_2);
+                dto.setGracefulRefreshTokenRotationEnabled(true);
+                dto.setGracefulRefreshTokenRotationValidityPeriod(200);
+                dto.setGracefulRefreshTokenReuseLimit(3);
+                dto.setOauthConsumerSecret("some-consumer-secret");
+
+                new OAuthAdminServiceImpl().updateConsumerApplication(dto);
+
+                Assert.assertEquals(captor.getValue().getGracefulRefreshTokenRotationValidityPeriod(), 90,
+                        "Validity period should be clamped to the configured max (90), not the hardcoded default.");
+            }
+        }
+    }
+
+    @Test
+    public void testNormalizeGracefulReuseLimitWithConfiguredMax() throws Exception {
+
+        OAuthAdminServiceImpl.allowedGrants = null;
+        String consumerKey = UUID.randomUUID().toString();
+
+        try (MockedStatic<IdentityUtil> identityUtil = mockStatic(IdentityUtil.class);
+             MockedStatic<OAuthComponentServiceHolder> oAuthComponentServiceHolder =
+                     mockStatic(OAuthComponentServiceHolder.class);
+             MockedStatic<OAuthServerConfiguration> oAuthServerConfigurationMockedStatic =
+                     mockStatic(OAuthServerConfiguration.class);
+             MockedStatic<OrganizationManagementUtil> organizationManagementUtil =
+                     mockStatic(OrganizationManagementUtil.class)) {
+
+            mockOAuthServerConfiguration = mock(OAuthServerConfiguration.class);
+            oAuthServerConfigurationMockedStatic.when(OAuthServerConfiguration::getInstance)
+                    .thenReturn(mockOAuthServerConfiguration);
+            when(mockOAuthServerConfiguration.getSupportedGrantTypes()).thenReturn(new HashMap<>());
+            when(mockOAuthServerConfiguration.getGracefulRefreshTokenRotationValidityPeriodMax()).thenReturn(60);
+            when(mockOAuthServerConfiguration.getGracefulRefreshTokenReuseLimitMax()).thenReturn(7);
+
+            organizationManagementUtil.when(() -> OrganizationManagementUtil.isOrganization(anyString()))
+                    .thenReturn(false);
+
+            PrivilegedCarbonContext.getThreadLocalCarbonContext()
+                    .setTenantDomain(SUPER_TENANT_DOMAIN_NAME);
+            PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantId(SUPER_TENANT_ID);
+            PrivilegedCarbonContext.getThreadLocalCarbonContext().setUsername(USER_NAME);
+            PrivilegedCarbonContext.getThreadLocalCarbonContext().setUserRealm(userRealm);
+
+            OAuthAppDO existingApp = buildDummyOAuthAppDO(USER_NAME);
+            existingApp.setOauthConsumerKey(consumerKey);
+
+            ArgumentCaptor<OAuthAppDO> captor = ArgumentCaptor.forClass(OAuthAppDO.class);
+
+            try (MockedConstruction<OAuthAppDAO> mockedConstruction = Mockito.mockConstruction(OAuthAppDAO.class,
+                    (mock, context) -> {
+                        when(mock.getAppInformation(consumerKey, SUPER_TENANT_ID)).thenReturn(existingApp);
+                        doNothing().when(mock).updateConsumerApplication(captor.capture());
+                    })) {
+
+                mockUserstore(identityUtil, oAuthComponentServiceHolder);
+                identityUtil.when(() -> IdentityUtil.addDomainToName(anyString(), anyString()))
+                        .thenCallRealMethod();
+
+                OAuthConsumerAppDTO dto = getoAuthConsumerAppDTO(USER_NAME, consumerKey,
+                        "consumer-secret", OAuthConstants.OAuthVersions.VERSION_2);
+                dto.setGracefulRefreshTokenReuseLimit(99);
+                dto.setGracefulRefreshTokenRotationEnabled(false);
+                dto.setOauthConsumerSecret("some-consumer-secret");
+
+                new OAuthAdminServiceImpl().updateConsumerApplication(dto);
+
+                Assert.assertEquals(captor.getValue().getGracefulRefreshTokenReuseLimit(), 7,
+                        "Reuse limit should be clamped to the configured max (7), not the hardcoded default.");
+            }
+        }
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/dao/OAuthAppDAOTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/dao/OAuthAppDAOTest.java
@@ -1095,13 +1095,15 @@ public class OAuthAppDAOTest extends TestOAuthDAOBase {
     public Object[][] testGetAppInformationWithOIDCPropertiesForImpersonationData() {
 
         return new Object[][]{
-                {true, 3600},
-                {false, 600},
+                {true, 3600, true, 120, 3},
+                {false, 600, false, 30, 5},
         };
     }
     @Test(dataProvider = "testGetAppInformationWithOIDCPropertiesForImpersonationData")
     public void testGetAppInformationWithOIDCPropertiesForImpersonationTest
-            (boolean subjectTokenEnabled, int subjectTokenExpiryTime) throws Exception {
+            (boolean subjectTokenEnabled, int subjectTokenExpiryTime,
+             boolean gracefulRotationEnabled, int gracefulRotationValidity,
+             int gracefulReuseLimit) throws Exception {
 
         try (MockedStatic<OAuthServerConfiguration> oAuthServerConfiguration = mockStatic(
                 OAuthServerConfiguration.class);
@@ -1121,6 +1123,9 @@ public class OAuthAppDAOTest extends TestOAuthDAOBase {
                 // Add Impersonation OIDC properties.
                 defaultOAuthAppDO.setSubjectTokenEnabled(subjectTokenEnabled);
                 defaultOAuthAppDO.setSubjectTokenExpiryTime(subjectTokenExpiryTime);
+                defaultOAuthAppDO.setGracefulRefreshTokenRotationEnabled(gracefulRotationEnabled);
+                defaultOAuthAppDO.setGracefulRefreshTokenRotationValidityPeriod(gracefulRotationValidity);
+                defaultOAuthAppDO.setGracefulRefreshTokenReuseLimit(gracefulReuseLimit);
                 addOAuthApplication(defaultOAuthAppDO, TENANT_ID);
 
                 OAuthAppDAO appDAO = new OAuthAppDAO();
@@ -1128,14 +1133,23 @@ public class OAuthAppDAOTest extends TestOAuthDAOBase {
                 assertNotNull(oAuthAppDO);
                 assertEquals(oAuthAppDO.isSubjectTokenEnabled(), subjectTokenEnabled);
                 assertEquals(oAuthAppDO.getSubjectTokenExpiryTime(), subjectTokenExpiryTime);
+                assertEquals(oAuthAppDO.isGracefulRefreshTokenRotationEnabled(), gracefulRotationEnabled);
+                assertEquals(oAuthAppDO.getGracefulRefreshTokenRotationValidityPeriod(),
+                        gracefulRotationValidity);
+                assertEquals(oAuthAppDO.getGracefulRefreshTokenReuseLimit(), gracefulReuseLimit);
 
                 // Update Impersonation OIDC properties.
                 oAuthAppDO.setSubjectTokenEnabled(!subjectTokenEnabled);
+                oAuthAppDO.setGracefulRefreshTokenRotationEnabled(!gracefulRotationEnabled);
+                oAuthAppDO.setGracefulRefreshTokenReuseLimit(gracefulReuseLimit + 1 > 5 ? 1 : gracefulReuseLimit + 1);
 
                 appDAO.updateConsumerApplication(oAuthAppDO);
                 OAuthAppDO retrievedOAuthAppDO = appDAO.getAppInformation(CONSUMER_KEY);
                 assertNotNull(retrievedOAuthAppDO);
                 assertEquals(retrievedOAuthAppDO.isSubjectTokenEnabled(), !subjectTokenEnabled);
+                assertEquals(retrievedOAuthAppDO.isGracefulRefreshTokenRotationEnabled(), !gracefulRotationEnabled);
+                assertEquals(retrievedOAuthAppDO.getGracefulRefreshTokenReuseLimit(),
+                        gracefulReuseLimit + 1 > 5 ? 1 : gracefulReuseLimit + 1);
             }
         } finally {
             resetPrivilegedCarbonContext();


### PR DESCRIPTION
### Proposed changes in this pull request
Related Issue: https://github.com/wso2/product-is/issues/27820

  Introduce per-application configuration for **Graceful Refresh Token Rotation**. This adds the persistence, DTO/DAO, admin-service, and server-config plumbing that downstream token-issuance changes will consume.

  ### What is added

  - **Three new app-level properties** on `OAuthAppDO` and `OAuthConsumerAppDTO`:
    - `gracefulRefreshTokenRotationEnabled` (boolean)
    - `gracefulRefreshTokenRotationValidityPeriod` (int, seconds)
    - `gracefulRefreshTokenReuseLimit` (int)
  - **Persistence** via `OAuthAppDAO` as OIDC SP properties (add, update, read-back) — no DB schema changes required.
  - **Admin service wiring** in `registerOAuthApplicationData` and `updateConsumerApplication`, with normalization helpers:
    - `normalizeGracefulRotationValidityPeriod` — defaults to 30s when `<= 0`; clamps to configured max.
    - `normalizeGracefulReuseLimit` — clamps to `[MIN=1, configured-max]`.
  - **Server-level configuration** in `OAuthServerConfiguration`:
    - New XML element `<GracefulRefreshTokenRotation>` with `<ValidityPeriodMax>` and `<ReuseLimitMax>` children.
    - Defaults: validity-period max = 60s, reuse-limit max = 5.
  - **Constants** under `OAuthConstants.GracefulRefreshTokenRotation`.
  - **DTO ↔ DO mapping** in `OAuthUtil#buildConsumerAppDTO`.

  ### Configuration (optional override in `identity.xml`)

  ```xml
  <OAuth>
      <GracefulRefreshTokenRotation>
          <ValidityPeriodMax>60</ValidityPeriodMax>
          <ReuseLimitMax>5</ReuseLimitMax>
      </GracefulRefreshTokenRotation>
  </OAuth>

  Tests
  
  - OAuthAdminServiceImplTest: data-driven tests for both normalization helpers, including boundary, invalid-input, and clamping cases, plus configured-max variants.
  - OAuthAppDAOTest: end-to-end persistence round-trip for all three new properties.
