### PR TITLE
Add FAPI 2.0 Security Profile support

### DIFF
--- a/components/org.wso2.carbon.identity.discovery/src/main/java/org/wso2/carbon/identity/discovery/DiscoveryConstants.java
+++ b/components/org.wso2.carbon.identity.discovery/src/main/java/org/wso2/carbon/identity/discovery/DiscoveryConstants.java
@@ -405,4 +405,14 @@ public class DiscoveryConstants {
      * Client Initiated Backchannel Authentication Flow - Core 1.0 specification.
      */
     public static final String BACKCHANNEL_AUTHENTICATION_ENDPOINT = "backchannel_authentication_endpoint";
+
+    /**
+     * authorization_response_iss_parameter_supported
+     * OPTIONAL. Boolean value specifying whether the OP supports the "iss" parameter in the
+     * Authorization Response. This allows RPs to securely determine the issuer of the response.
+     * If omitted, the default value is false.
+     * @see <a href="https://datatracker.ietf.org/doc/html/rfc9207#as_metadata">rfc9207</a>
+     */
+    public static final String AUTHORIZATION_RESPONSE_ISS_PARAMETER_SUPPORTED =
+            "authorization_response_iss_parameter_supported";
 }

--- a/components/org.wso2.carbon.identity.discovery/src/main/java/org/wso2/carbon/identity/discovery/OIDProviderConfigResponse.java
+++ b/components/org.wso2.carbon.identity.discovery/src/main/java/org/wso2/carbon/identity/discovery/OIDProviderConfigResponse.java
@@ -89,6 +89,7 @@ public class OIDProviderConfigResponse {
     private String mtlsPushedAuthorizationRequestEndpoint;
     private String[] authorizationDetailsTypesSupported;
     private String backchannelAuthenticationEndpoint;
+    private Boolean authorizationResponseIssParameterSupported;
 
     private static final String MUTUAL_TLS_ALIASES_ENABLED = "OAuth.MutualTLSAliases.Enabled";
 
@@ -563,6 +564,16 @@ public class OIDProviderConfigResponse {
         this.backchannelAuthenticationEndpoint = backchannelAuthenticationEndpoint;
     }
 
+    public Boolean getAuthorizationResponseIssParameterSupported() {
+
+        return authorizationResponseIssParameterSupported;
+    }
+
+    public void setAuthorizationResponseIssParameterSupported(Boolean authorizationResponseIssParameterSupported) {
+
+        this.authorizationResponseIssParameterSupported = authorizationResponseIssParameterSupported;
+    }
+
     public Map<String, Object> getConfigMap() {
         Map<String, Object> configMap = new HashMap<String, Object>();
         configMap.put(DiscoveryConstants.ISSUER.toLowerCase(), this.issuer);
@@ -644,6 +655,8 @@ public class OIDProviderConfigResponse {
                 this.authorizationDetailsTypesSupported);
         configMap.put(DiscoveryConstants.BACKCHANNEL_AUTHENTICATION_ENDPOINT,
                 this.backchannelAuthenticationEndpoint);
+        configMap.put(DiscoveryConstants.AUTHORIZATION_RESPONSE_ISS_PARAMETER_SUPPORTED,
+                this.authorizationResponseIssParameterSupported);
         return configMap;
     }
 }

--- a/components/org.wso2.carbon.identity.discovery/src/main/java/org/wso2/carbon/identity/discovery/builders/ProviderConfigBuilder.java
+++ b/components/org.wso2.carbon.identity.discovery/src/main/java/org/wso2/carbon/identity/discovery/builders/ProviderConfigBuilder.java
@@ -166,6 +166,10 @@ public class ProviderConfigBuilder {
             providerConfig
                     .setAuthorizationDetailsTypesSupported(authorizationDetailTypes.stream().toArray(String[]::new));
         }
+        // `authorization_response_iss` should be true for FAPI 2.0 compliance.
+        if (OAuth2Util.isFapi2Enabled(tenantDomain)) {
+            providerConfig.setAuthorizationResponseIssParameterSupported(Boolean.TRUE);
+        }
         return providerConfig;
     }
 }

--- a/components/org.wso2.carbon.identity.discovery/src/main/java/org/wso2/carbon/identity/discovery/servlet/OIDCDiscoveryServlet.java
+++ b/components/org.wso2.carbon.identity.discovery/src/main/java/org/wso2/carbon/identity/discovery/servlet/OIDCDiscoveryServlet.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.discovery.servlet;
+
+import com.google.gson.Gson;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.osgi.service.component.annotations.Component;
+import org.wso2.carbon.base.MultitenantConstants;
+import org.wso2.carbon.base.ServerConfigurationException;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.discovery.DefaultOIDCProcessor;
+import org.wso2.carbon.identity.discovery.OIDCDiscoveryEndPointException;
+import org.wso2.carbon.identity.discovery.OIDProviderConfigResponse;
+import org.wso2.carbon.identity.oauth.common.OAuthConstants;
+
+import java.io.IOException;
+import java.io.Serial;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.servlet.Servlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * Servlet to serve the OIDC discovery document at /.well-known/openid-configuration.
+ * <p>
+ * Handles:
+ * GET /.well-known/openid-configuration            → super-tenant discovery
+ * GET /t/{tenant}/.well-known/openid-configuration → tenant-specific discovery
+ */
+@Component(
+        service = Servlet.class,
+        immediate = true,
+        property = {
+                "osgi.http.whiteboard.servlet.pattern=/.well-known/openid-configuration/*",
+                "osgi.http.whiteboard.servlet.name=OIDCDiscovery",
+                "osgi.http.whiteboard.servlet.asyncSupported=true"
+        }
+)
+public class OIDCDiscoveryServlet extends HttpServlet {
+
+    @Serial
+    private static final long serialVersionUID = -4599438512732128049L;
+
+    private static final Log log = LogFactory.getLog(OIDCDiscoveryServlet.class);
+    private static final Pattern TENANT_PATH_PATTERN = Pattern.compile("^/t/([^/]+)$");
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+
+        String tenantDomain = resolveTenantDomain(request);
+        if (tenantDomain == null) {
+            response.setStatus(HttpServletResponse.SC_NOT_FOUND);
+            return;
+        }
+
+        DefaultOIDCProcessor oidcProcessor = DefaultOIDCProcessor.getInstance();
+        try {
+            OIDProviderConfigResponse configResponse = oidcProcessor.getResponse(request, tenantDomain);
+            response.setStatus(HttpServletResponse.SC_OK);
+            response.setContentType("application/json");
+            response.getWriter().print(new Gson().toJson(configResponse.getConfigMap()));
+        } catch (OIDCDiscoveryEndPointException e) {
+            response.setStatus(oidcProcessor.handleError(e));
+            response.setContentType("application/json");
+            response.getWriter().print(e.getMessage());
+        } catch (ServerConfigurationException e) {
+            log.error("Server Configuration error while serving OIDC discovery.", e);
+            response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+            response.setContentType("application/json");
+            response.getWriter().print("Error in reading configuration.");
+        }
+    }
+
+    /**
+     * Resolves the tenant domain from the request.
+     * <p>
+     * Returns null if the path info is not a recognised pattern (triggers a 404).
+     */
+    private String resolveTenantDomain(HttpServletRequest request) {
+
+        String pathInfo = request.getPathInfo();
+
+        // No path info → /.well-known/openid-configuration (super-tenant or tenant from thread-local)
+        if (StringUtils.isBlank(pathInfo) || "/".equals(pathInfo)) {
+            String tenantFromContext = (String) IdentityUtil.threadLocalProperties.get()
+                    .get(OAuthConstants.TENANT_NAME_FROM_CONTEXT);
+            return StringUtils.isNotEmpty(tenantFromContext)
+                    ? tenantFromContext
+                    : MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
+        }
+
+        Matcher matcher = TENANT_PATH_PATTERN.matcher(pathInfo);
+        if (matcher.matches()) {
+            return matcher.group(1);
+        }
+
+        return null;
+    }
+}

--- a/components/org.wso2.carbon.identity.discovery/src/main/java/org/wso2/carbon/identity/discovery/servlet/OIDCDiscoveryServlet.java
+++ b/components/org.wso2.carbon.identity.discovery/src/main/java/org/wso2/carbon/identity/discovery/servlet/OIDCDiscoveryServlet.java
@@ -19,22 +19,19 @@
 package org.wso2.carbon.identity.discovery.servlet;
 
 import com.google.gson.Gson;
-import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.osgi.service.component.annotations.Component;
-import org.wso2.carbon.base.MultitenantConstants;
 import org.wso2.carbon.base.ServerConfigurationException;
-import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.discovery.DefaultOIDCProcessor;
 import org.wso2.carbon.identity.discovery.OIDCDiscoveryEndPointException;
 import org.wso2.carbon.identity.discovery.OIDProviderConfigResponse;
 import org.wso2.carbon.identity.oauth.common.OAuthConstants;
+import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 
 import java.io.IOException;
 import java.io.Serial;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import java.util.Collections;
 
 import javax.servlet.Servlet;
 import javax.servlet.http.HttpServlet;
@@ -52,7 +49,7 @@ import javax.servlet.http.HttpServletResponse;
         service = Servlet.class,
         immediate = true,
         property = {
-                "osgi.http.whiteboard.servlet.pattern=/.well-known/openid-configuration/*",
+                "osgi.http.whiteboard.servlet.pattern=/.well-known/openid-configuration",
                 "osgi.http.whiteboard.servlet.name=OIDCDiscovery",
                 "osgi.http.whiteboard.servlet.asyncSupported=true"
         }
@@ -62,59 +59,28 @@ public class OIDCDiscoveryServlet extends HttpServlet {
     @Serial
     private static final long serialVersionUID = -4599438512732128049L;
 
-    private static final Log log = LogFactory.getLog(OIDCDiscoveryServlet.class);
-    private static final Pattern TENANT_PATH_PATTERN = Pattern.compile("^/t/([^/]+)$");
+    private static final Log LOG = LogFactory.getLog(OIDCDiscoveryServlet.class);
 
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
 
-        String tenantDomain = resolveTenantDomain(request);
-        if (tenantDomain == null) {
-            response.setStatus(HttpServletResponse.SC_NOT_FOUND);
-            return;
-        }
-
-        DefaultOIDCProcessor oidcProcessor = DefaultOIDCProcessor.getInstance();
+        final String tenantDomain = OAuth2Util.resolveTenantDomain(request);
+        final DefaultOIDCProcessor oidcProcessor = DefaultOIDCProcessor.getInstance();
         try {
             OIDProviderConfigResponse configResponse = oidcProcessor.getResponse(request, tenantDomain);
             response.setStatus(HttpServletResponse.SC_OK);
-            response.setContentType("application/json");
+            response.setContentType(OAuthConstants.HTTP_RESP_CONTENT_TYPE_JSON);
             response.getWriter().print(new Gson().toJson(configResponse.getConfigMap()));
         } catch (OIDCDiscoveryEndPointException e) {
             response.setStatus(oidcProcessor.handleError(e));
-            response.setContentType("application/json");
-            response.getWriter().print(e.getMessage());
+            response.setContentType(OAuthConstants.HTTP_RESP_CONTENT_TYPE_JSON);
+            response.getWriter().print(new Gson().toJson(Collections.singletonMap("error", e.getMessage())));
         } catch (ServerConfigurationException e) {
-            log.error("Server Configuration error while serving OIDC discovery.", e);
+            LOG.error("Server Configuration error while serving OIDC discovery.", e);
             response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
-            response.setContentType("application/json");
-            response.getWriter().print("Error in reading configuration.");
+            response.setContentType(OAuthConstants.HTTP_RESP_CONTENT_TYPE_JSON);
+            response.getWriter().print(new Gson()
+                    .toJson(Collections.singletonMap("error", "Error in reading configuration.")));
         }
-    }
-
-    /**
-     * Resolves the tenant domain from the request.
-     * <p>
-     * Returns null if the path info is not a recognised pattern (triggers a 404).
-     */
-    private String resolveTenantDomain(HttpServletRequest request) {
-
-        String pathInfo = request.getPathInfo();
-
-        // No path info → /.well-known/openid-configuration (super-tenant or tenant from thread-local)
-        if (StringUtils.isBlank(pathInfo) || "/".equals(pathInfo)) {
-            String tenantFromContext = (String) IdentityUtil.threadLocalProperties.get()
-                    .get(OAuthConstants.TENANT_NAME_FROM_CONTEXT);
-            return StringUtils.isNotEmpty(tenantFromContext)
-                    ? tenantFromContext
-                    : MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
-        }
-
-        Matcher matcher = TENANT_PATH_PATTERN.matcher(pathInfo);
-        if (matcher.matches()) {
-            return matcher.group(1);
-        }
-
-        return null;
     }
 }

--- a/components/org.wso2.carbon.identity.discovery/src/main/java/org/wso2/carbon/identity/discovery/servlet/OIDCDiscoveryServlet.java
+++ b/components/org.wso2.carbon.identity.discovery/src/main/java/org/wso2/carbon/identity/discovery/servlet/OIDCDiscoveryServlet.java
@@ -63,7 +63,7 @@ public class OIDCDiscoveryServlet extends HttpServlet {
     private static final long serialVersionUID = -4599438512732128049L;
 
     private static final Log log = LogFactory.getLog(OIDCDiscoveryServlet.class);
-    private static final Pattern TENANT_PATH_PATTERN = Pattern.compile("^/t/([^/]+)$");
+    private static final Pattern TENANT_PATH_PATTERN = Pattern.compile("^/(|t/[^/]+)$");
 
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {

--- a/components/org.wso2.carbon.identity.discovery/src/main/java/org/wso2/carbon/identity/discovery/servlet/OIDCDiscoveryServlet.java
+++ b/components/org.wso2.carbon.identity.discovery/src/main/java/org/wso2/carbon/identity/discovery/servlet/OIDCDiscoveryServlet.java
@@ -63,7 +63,7 @@ public class OIDCDiscoveryServlet extends HttpServlet {
     private static final long serialVersionUID = -4599438512732128049L;
 
     private static final Log log = LogFactory.getLog(OIDCDiscoveryServlet.class);
-    private static final Pattern TENANT_PATH_PATTERN = Pattern.compile("^/(|t/[^/]+)$");
+    private static final Pattern TENANT_PATH_PATTERN = Pattern.compile("^/t/([^/]+)$");
 
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {

--- a/components/org.wso2.carbon.identity.discovery/src/test/java/org/wso2/carbon/identity/discovery/builders/ProviderConfigBuilderTest.java
+++ b/components/org.wso2.carbon.identity.discovery/src/test/java/org/wso2/carbon/identity/discovery/builders/ProviderConfigBuilderTest.java
@@ -396,4 +396,51 @@ public class ProviderConfigBuilderTest {
             assertEquals(response.getConfigMap().get("frontchannel_logout_session_supported"), Boolean.TRUE);
         }
     }
+
+    @Test
+    public void testBuildOIDProviderConfig_fapi2Enabled_setsAuthorizationResponseIssParameterSupported()
+            throws Exception {
+
+        try (MockedStatic<OAuthServerConfiguration> oAuthServerConfiguration = mockStatic(
+                OAuthServerConfiguration.class);
+             MockedStatic<OIDCDiscoveryDataHolder> oidcDiscoveryDataHolder =
+                     mockStatic(OIDCDiscoveryDataHolder.class);
+             MockedStatic<OAuth2Util> oAuth2Util = mockStatic(OAuth2Util.class);
+             MockedStatic<AuthorizationDetailsProcessorFactory> factoryMockedStatic =
+                     mockStatic(AuthorizationDetailsProcessorFactory.class)) {
+            OAuthServerConfiguration mockOAuthServerConfiguration = mock(OAuthServerConfiguration.class);
+            oAuthServerConfiguration.when(
+                    OAuthServerConfiguration::getInstance).thenReturn(mockOAuthServerConfiguration);
+
+            OIDCDiscoveryDataHolder mockOidcDiscoveryDataHolder = spy(new OIDCDiscoveryDataHolder());
+            mockOidcDiscoveryDataHolder.setClaimManagementService(mockClaimMetadataManagementService);
+            oidcDiscoveryDataHolder.when(OIDCDiscoveryDataHolder::getInstance)
+                    .thenReturn(mockOidcDiscoveryDataHolder);
+
+            List<ExternalClaim> claims = new ArrayList<>();
+            ExternalClaim externalClaim = new ExternalClaim("aaa", "bbb", "ccc");
+            claims.add(externalClaim);
+
+            when(mockClaimMetadataManagementService.getExternalClaims(anyString(), anyString())).thenReturn(claims);
+            when(mockOAuthServerConfiguration.getIdTokenSignatureAlgorithm()).thenReturn(idTokenSignatureAlgorithm);
+            when(mockOAuthServerConfiguration.getUserInfoJWTSignatureAlgorithm()).thenReturn(
+                    idTokenSignatureAlgorithm);
+
+            oAuth2Util.when(() -> OAuth2Util.mapSignatureAlgorithmForJWSAlgorithm(idTokenSignatureAlgorithm))
+                    .thenReturn(JWSAlgorithm.RS256);
+            oAuth2Util.when(() -> OAuth2Util.mapSignatureAlgorithmForJWSAlgorithm(anyString()))
+                    .thenReturn(JWSAlgorithm.RS256);
+            oAuth2Util.when(() -> OAuth2Util.isFapi2Enabled(anyString())).thenReturn(true);
+            when(mockOidProviderRequest.getTenantDomain()).thenReturn(
+                    MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+
+            AuthorizationDetailsProcessorFactory factoryMock = spy(AuthorizationDetailsProcessorFactory.class);
+            doReturn(Collections.emptySet()).when(factoryMock).getSupportedAuthorizationDetailTypes();
+            factoryMockedStatic.when(AuthorizationDetailsProcessorFactory::getInstance).thenReturn(factoryMock);
+
+            OIDProviderConfigResponse response = providerConfigBuilder.buildOIDProviderConfig(mockOidProviderRequest);
+            assertNotNull(response);
+            assertEquals(response.getConfigMap().get("authorization_response_iss_parameter_supported"), Boolean.TRUE);
+        }
+    }
 }

--- a/components/org.wso2.carbon.identity.discovery/src/test/java/org/wso2/carbon/identity/discovery/servlet/OIDCDiscoveryServletTest.java
+++ b/components/org.wso2.carbon.identity.discovery/src/test/java/org/wso2/carbon/identity/discovery/servlet/OIDCDiscoveryServletTest.java
@@ -21,18 +21,15 @@ package org.wso2.carbon.identity.discovery.servlet;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.testng.MockitoTestNGListener;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.DataProvider;
 import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 import org.wso2.carbon.base.MultitenantConstants;
 import org.wso2.carbon.base.ServerConfigurationException;
 import org.wso2.carbon.identity.common.testng.WithCarbonHome;
-import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.discovery.DefaultOIDCProcessor;
 import org.wso2.carbon.identity.discovery.OIDCDiscoveryEndPointException;
 import org.wso2.carbon.identity.discovery.OIDProviderConfigResponse;
-import org.wso2.carbon.identity.oauth.common.OAuthConstants;
+import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 
 import java.io.PrintWriter;
 
@@ -43,7 +40,6 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -63,129 +59,55 @@ public class OIDCDiscoveryServletTest {
     @Mock
     private PrintWriter printWriter;
 
-    @AfterMethod
-    public void tearDown() {
-
-        IdentityUtil.threadLocalProperties.get().remove(OAuthConstants.TENANT_NAME_FROM_CONTEXT);
-    }
-
     @Test
-    public void testDoGet_nullPathInfo_returnsSuperTenantDiscovery() throws Exception {
+    public void testDoGet_resolvedTenantDomain_returnsDiscovery() throws Exception {
 
-        when(request.getPathInfo()).thenReturn(null);
         when(response.getWriter()).thenReturn(printWriter);
 
-        OIDProviderConfigResponse configResponse = buildMockConfigResponse();
-        DefaultOIDCProcessor mockProcessor = mock(DefaultOIDCProcessor.class);
-        when(mockProcessor.getResponse(eq(request), eq(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME)))
-                .thenReturn(configResponse);
-
-        try (MockedStatic<DefaultOIDCProcessor> processorStatic = mockStatic(DefaultOIDCProcessor.class)) {
-            processorStatic.when(DefaultOIDCProcessor::getInstance).thenReturn(mockProcessor);
-
-            new OIDCDiscoveryServlet().doGet(request, response);
-
-            verify(response).setStatus(HttpServletResponse.SC_OK);
-            verify(response).setContentType("application/json");
-            verify(mockProcessor).getResponse(request, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
-        }
-    }
-
-    @Test
-    public void testDoGet_rootPathInfo_returnsSuperTenantDiscovery() throws Exception {
-
-        when(request.getPathInfo()).thenReturn("/");
-        when(response.getWriter()).thenReturn(printWriter);
-
-        OIDProviderConfigResponse configResponse = buildMockConfigResponse();
-        DefaultOIDCProcessor mockProcessor = mock(DefaultOIDCProcessor.class);
-        when(mockProcessor.getResponse(eq(request), eq(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME)))
-                .thenReturn(configResponse);
-
-        try (MockedStatic<DefaultOIDCProcessor> processorStatic = mockStatic(DefaultOIDCProcessor.class)) {
-            processorStatic.when(DefaultOIDCProcessor::getInstance).thenReturn(mockProcessor);
-
-            new OIDCDiscoveryServlet().doGet(request, response);
-
-            verify(response).setStatus(HttpServletResponse.SC_OK);
-            verify(response).setContentType("application/json");
-            verify(mockProcessor).getResponse(request, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
-        }
-    }
-
-    @Test
-    public void testDoGet_tenantInThreadLocal_usesThatTenant() throws Exception {
-
-        IdentityUtil.threadLocalProperties.get().put(OAuthConstants.TENANT_NAME_FROM_CONTEXT, "test.com");
-        when(request.getPathInfo()).thenReturn(null);
-        when(response.getWriter()).thenReturn(printWriter);
-
-        OIDProviderConfigResponse configResponse = buildMockConfigResponse();
+        OIDProviderConfigResponse configResponse = new OIDProviderConfigResponse();
         DefaultOIDCProcessor mockProcessor = mock(DefaultOIDCProcessor.class);
         when(mockProcessor.getResponse(eq(request), eq("test.com"))).thenReturn(configResponse);
 
-        try (MockedStatic<DefaultOIDCProcessor> processorStatic = mockStatic(DefaultOIDCProcessor.class)) {
+        try (MockedStatic<DefaultOIDCProcessor> processorStatic = mockStatic(DefaultOIDCProcessor.class);
+             MockedStatic<OAuth2Util> oauth2UtilStatic = mockStatic(OAuth2Util.class)) {
             processorStatic.when(DefaultOIDCProcessor::getInstance).thenReturn(mockProcessor);
+            oauth2UtilStatic.when(() -> OAuth2Util.resolveTenantDomain(request)).thenReturn("test.com");
 
             new OIDCDiscoveryServlet().doGet(request, response);
 
             verify(response).setStatus(HttpServletResponse.SC_OK);
+            verify(response).setContentType("application/json");
             verify(mockProcessor).getResponse(request, "test.com");
         }
     }
 
     @Test
-    public void testDoGet_tenantFromPathInfo_usesTenantName() throws Exception {
+    public void testDoGet_superTenantDomain_returnsDiscovery() throws Exception {
 
-        when(request.getPathInfo()).thenReturn("/t/xyz.com");
         when(response.getWriter()).thenReturn(printWriter);
 
-        OIDProviderConfigResponse configResponse = buildMockConfigResponse();
+        OIDProviderConfigResponse configResponse = new OIDProviderConfigResponse();
         DefaultOIDCProcessor mockProcessor = mock(DefaultOIDCProcessor.class);
-        when(mockProcessor.getResponse(eq(request), eq("xyz.com"))).thenReturn(configResponse);
+        when(mockProcessor.getResponse(eq(request), eq(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME)))
+                .thenReturn(configResponse);
 
-        try (MockedStatic<DefaultOIDCProcessor> processorStatic = mockStatic(DefaultOIDCProcessor.class)) {
+        try (MockedStatic<DefaultOIDCProcessor> processorStatic = mockStatic(DefaultOIDCProcessor.class);
+             MockedStatic<OAuth2Util> oauth2UtilStatic = mockStatic(OAuth2Util.class)) {
             processorStatic.when(DefaultOIDCProcessor::getInstance).thenReturn(mockProcessor);
+            oauth2UtilStatic.when(() -> OAuth2Util.resolveTenantDomain(request))
+                    .thenReturn(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
 
             new OIDCDiscoveryServlet().doGet(request, response);
 
             verify(response).setStatus(HttpServletResponse.SC_OK);
-            verify(mockProcessor).getResponse(request, "xyz.com");
-        }
-    }
-
-    @DataProvider(name = "invalidPaths")
-    public Object[][] invalidPaths() {
-
-        return new Object[][]{
-                {"/bad"},
-                {"/t/a/b"},
-                {"/t/"},
-                {"/t"}
-        };
-    }
-
-    @Test(dataProvider = "invalidPaths")
-    public void testDoGet_invalidPathInfo_returns404(String pathInfo) throws Exception {
-
-        when(request.getPathInfo()).thenReturn(pathInfo);
-
-        DefaultOIDCProcessor mockProcessor = mock(DefaultOIDCProcessor.class);
-
-        try (MockedStatic<DefaultOIDCProcessor> processorStatic = mockStatic(DefaultOIDCProcessor.class)) {
-            processorStatic.when(DefaultOIDCProcessor::getInstance).thenReturn(mockProcessor);
-
-            new OIDCDiscoveryServlet().doGet(request, response);
-
-            verify(response).setStatus(HttpServletResponse.SC_NOT_FOUND);
-            verify(mockProcessor, never()).getResponse(eq(request), anyString());
+            verify(response).setContentType("application/json");
+            verify(mockProcessor).getResponse(request, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
         }
     }
 
     @Test
     public void testDoGet_oidcDiscoveryEndPointException_returnsErrorStatus() throws Exception {
 
-        when(request.getPathInfo()).thenReturn(null);
         when(response.getWriter()).thenReturn(printWriter);
 
         OIDCDiscoveryEndPointException exception = new OIDCDiscoveryEndPointException("Discovery error");
@@ -193,40 +115,40 @@ public class OIDCDiscoveryServletTest {
         when(mockProcessor.getResponse(eq(request), anyString())).thenThrow(exception);
         when(mockProcessor.handleError(exception)).thenReturn(HttpServletResponse.SC_BAD_REQUEST);
 
-        try (MockedStatic<DefaultOIDCProcessor> processorStatic = mockStatic(DefaultOIDCProcessor.class)) {
+        try (MockedStatic<DefaultOIDCProcessor> processorStatic = mockStatic(DefaultOIDCProcessor.class);
+             MockedStatic<OAuth2Util> oauth2UtilStatic = mockStatic(OAuth2Util.class)) {
             processorStatic.when(DefaultOIDCProcessor::getInstance).thenReturn(mockProcessor);
+            oauth2UtilStatic.when(() -> OAuth2Util.resolveTenantDomain(request))
+                    .thenReturn(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
 
             new OIDCDiscoveryServlet().doGet(request, response);
 
             verify(response).setStatus(HttpServletResponse.SC_BAD_REQUEST);
             verify(response).setContentType("application/json");
-            verify(printWriter).print("Discovery error");
+            verify(printWriter).print("{\"error\":\"Discovery error\"}");
         }
     }
 
     @Test
     public void testDoGet_serverConfigurationException_returns500() throws Exception {
 
-        when(request.getPathInfo()).thenReturn(null);
         when(response.getWriter()).thenReturn(printWriter);
 
         DefaultOIDCProcessor mockProcessor = mock(DefaultOIDCProcessor.class);
         when(mockProcessor.getResponse(eq(request), anyString()))
                 .thenThrow(new ServerConfigurationException("Config error"));
 
-        try (MockedStatic<DefaultOIDCProcessor> processorStatic = mockStatic(DefaultOIDCProcessor.class)) {
+        try (MockedStatic<DefaultOIDCProcessor> processorStatic = mockStatic(DefaultOIDCProcessor.class);
+             MockedStatic<OAuth2Util> oauth2UtilStatic = mockStatic(OAuth2Util.class)) {
             processorStatic.when(DefaultOIDCProcessor::getInstance).thenReturn(mockProcessor);
+            oauth2UtilStatic.when(() -> OAuth2Util.resolveTenantDomain(request))
+                    .thenReturn(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
 
             new OIDCDiscoveryServlet().doGet(request, response);
 
             verify(response).setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
             verify(response).setContentType("application/json");
-            verify(printWriter).print("Error in reading configuration.");
+            verify(printWriter).print("{\"error\":\"Error in reading configuration.\"}");
         }
-    }
-
-    private OIDProviderConfigResponse buildMockConfigResponse() {
-
-        return new OIDProviderConfigResponse();
     }
 }

--- a/components/org.wso2.carbon.identity.discovery/src/test/java/org/wso2/carbon/identity/discovery/servlet/OIDCDiscoveryServletTest.java
+++ b/components/org.wso2.carbon.identity.discovery/src/test/java/org/wso2/carbon/identity/discovery/servlet/OIDCDiscoveryServletTest.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.discovery.servlet;
+
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+import org.wso2.carbon.base.MultitenantConstants;
+import org.wso2.carbon.base.ServerConfigurationException;
+import org.wso2.carbon.identity.common.testng.WithCarbonHome;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.discovery.DefaultOIDCProcessor;
+import org.wso2.carbon.identity.discovery.OIDCDiscoveryEndPointException;
+import org.wso2.carbon.identity.discovery.OIDProviderConfigResponse;
+import org.wso2.carbon.identity.oauth.common.OAuthConstants;
+
+import java.io.PrintWriter;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link OIDCDiscoveryServlet}.
+ */
+@WithCarbonHome
+@Listeners(MockitoTestNGListener.class)
+public class OIDCDiscoveryServletTest {
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private HttpServletResponse response;
+
+    @Mock
+    private PrintWriter printWriter;
+
+    @AfterMethod
+    public void tearDown() {
+
+        IdentityUtil.threadLocalProperties.get().remove(OAuthConstants.TENANT_NAME_FROM_CONTEXT);
+    }
+
+    @Test
+    public void testDoGet_nullPathInfo_returnsSuperTenantDiscovery() throws Exception {
+
+        when(request.getPathInfo()).thenReturn(null);
+        when(response.getWriter()).thenReturn(printWriter);
+
+        OIDProviderConfigResponse configResponse = buildMockConfigResponse();
+        DefaultOIDCProcessor mockProcessor = mock(DefaultOIDCProcessor.class);
+        when(mockProcessor.getResponse(eq(request), eq(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME)))
+                .thenReturn(configResponse);
+
+        try (MockedStatic<DefaultOIDCProcessor> processorStatic = mockStatic(DefaultOIDCProcessor.class)) {
+            processorStatic.when(DefaultOIDCProcessor::getInstance).thenReturn(mockProcessor);
+
+            new OIDCDiscoveryServlet().doGet(request, response);
+
+            verify(response).setStatus(HttpServletResponse.SC_OK);
+            verify(response).setContentType("application/json");
+            verify(mockProcessor).getResponse(request, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+        }
+    }
+
+    @Test
+    public void testDoGet_rootPathInfo_returnsSuperTenantDiscovery() throws Exception {
+
+        when(request.getPathInfo()).thenReturn("/");
+        when(response.getWriter()).thenReturn(printWriter);
+
+        OIDProviderConfigResponse configResponse = buildMockConfigResponse();
+        DefaultOIDCProcessor mockProcessor = mock(DefaultOIDCProcessor.class);
+        when(mockProcessor.getResponse(eq(request), eq(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME)))
+                .thenReturn(configResponse);
+
+        try (MockedStatic<DefaultOIDCProcessor> processorStatic = mockStatic(DefaultOIDCProcessor.class)) {
+            processorStatic.when(DefaultOIDCProcessor::getInstance).thenReturn(mockProcessor);
+
+            new OIDCDiscoveryServlet().doGet(request, response);
+
+            verify(response).setStatus(HttpServletResponse.SC_OK);
+            verify(response).setContentType("application/json");
+            verify(mockProcessor).getResponse(request, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+        }
+    }
+
+    @Test
+    public void testDoGet_tenantInThreadLocal_usesThatTenant() throws Exception {
+
+        IdentityUtil.threadLocalProperties.get().put(OAuthConstants.TENANT_NAME_FROM_CONTEXT, "test.com");
+        when(request.getPathInfo()).thenReturn(null);
+        when(response.getWriter()).thenReturn(printWriter);
+
+        OIDProviderConfigResponse configResponse = buildMockConfigResponse();
+        DefaultOIDCProcessor mockProcessor = mock(DefaultOIDCProcessor.class);
+        when(mockProcessor.getResponse(eq(request), eq("test.com"))).thenReturn(configResponse);
+
+        try (MockedStatic<DefaultOIDCProcessor> processorStatic = mockStatic(DefaultOIDCProcessor.class)) {
+            processorStatic.when(DefaultOIDCProcessor::getInstance).thenReturn(mockProcessor);
+
+            new OIDCDiscoveryServlet().doGet(request, response);
+
+            verify(response).setStatus(HttpServletResponse.SC_OK);
+            verify(mockProcessor).getResponse(request, "test.com");
+        }
+    }
+
+    @Test
+    public void testDoGet_tenantFromPathInfo_usesTenantName() throws Exception {
+
+        when(request.getPathInfo()).thenReturn("/t/xyz.com");
+        when(response.getWriter()).thenReturn(printWriter);
+
+        OIDProviderConfigResponse configResponse = buildMockConfigResponse();
+        DefaultOIDCProcessor mockProcessor = mock(DefaultOIDCProcessor.class);
+        when(mockProcessor.getResponse(eq(request), eq("xyz.com"))).thenReturn(configResponse);
+
+        try (MockedStatic<DefaultOIDCProcessor> processorStatic = mockStatic(DefaultOIDCProcessor.class)) {
+            processorStatic.when(DefaultOIDCProcessor::getInstance).thenReturn(mockProcessor);
+
+            new OIDCDiscoveryServlet().doGet(request, response);
+
+            verify(response).setStatus(HttpServletResponse.SC_OK);
+            verify(mockProcessor).getResponse(request, "xyz.com");
+        }
+    }
+
+    @DataProvider(name = "invalidPaths")
+    public Object[][] invalidPaths() {
+
+        return new Object[][]{
+                {"/bad"},
+                {"/t/a/b"},
+                {"/t/"},
+                {"/t"}
+        };
+    }
+
+    @Test(dataProvider = "invalidPaths")
+    public void testDoGet_invalidPathInfo_returns404(String pathInfo) throws Exception {
+
+        when(request.getPathInfo()).thenReturn(pathInfo);
+
+        DefaultOIDCProcessor mockProcessor = mock(DefaultOIDCProcessor.class);
+
+        try (MockedStatic<DefaultOIDCProcessor> processorStatic = mockStatic(DefaultOIDCProcessor.class)) {
+            processorStatic.when(DefaultOIDCProcessor::getInstance).thenReturn(mockProcessor);
+
+            new OIDCDiscoveryServlet().doGet(request, response);
+
+            verify(response).setStatus(HttpServletResponse.SC_NOT_FOUND);
+            verify(mockProcessor, never()).getResponse(eq(request), anyString());
+        }
+    }
+
+    @Test
+    public void testDoGet_oidcDiscoveryEndPointException_returnsErrorStatus() throws Exception {
+
+        when(request.getPathInfo()).thenReturn(null);
+        when(response.getWriter()).thenReturn(printWriter);
+
+        OIDCDiscoveryEndPointException exception = new OIDCDiscoveryEndPointException("Discovery error");
+        DefaultOIDCProcessor mockProcessor = mock(DefaultOIDCProcessor.class);
+        when(mockProcessor.getResponse(eq(request), anyString())).thenThrow(exception);
+        when(mockProcessor.handleError(exception)).thenReturn(HttpServletResponse.SC_BAD_REQUEST);
+
+        try (MockedStatic<DefaultOIDCProcessor> processorStatic = mockStatic(DefaultOIDCProcessor.class)) {
+            processorStatic.when(DefaultOIDCProcessor::getInstance).thenReturn(mockProcessor);
+
+            new OIDCDiscoveryServlet().doGet(request, response);
+
+            verify(response).setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            verify(response).setContentType("application/json");
+            verify(printWriter).print("Discovery error");
+        }
+    }
+
+    @Test
+    public void testDoGet_serverConfigurationException_returns500() throws Exception {
+
+        when(request.getPathInfo()).thenReturn(null);
+        when(response.getWriter()).thenReturn(printWriter);
+
+        DefaultOIDCProcessor mockProcessor = mock(DefaultOIDCProcessor.class);
+        when(mockProcessor.getResponse(eq(request), anyString()))
+                .thenThrow(new ServerConfigurationException("Config error"));
+
+        try (MockedStatic<DefaultOIDCProcessor> processorStatic = mockStatic(DefaultOIDCProcessor.class)) {
+            processorStatic.when(DefaultOIDCProcessor::getInstance).thenReturn(mockProcessor);
+
+            new OIDCDiscoveryServlet().doGet(request, response);
+
+            verify(response).setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+            verify(response).setContentType("application/json");
+            verify(printWriter).print("Error in reading configuration.");
+        }
+    }
+
+    private OIDProviderConfigResponse buildMockConfigResponse() {
+
+        return new OIDProviderConfigResponse();
+    }
+}

--- a/components/org.wso2.carbon.identity.discovery/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.identity.discovery/src/test/resources/testng.xml
@@ -29,6 +29,7 @@
             <class name="org.wso2.carbon.identity.discovery.OIDProviderRequestTest"/>
             <class name="org.wso2.carbon.identity.discovery.OIDProviderConfigResponseTest"/>
             <class name="org.wso2.carbon.identity.discovery.DiscoveryUtilTest" />
+            <class name="org.wso2.carbon.identity.discovery.servlet.OIDCDiscoveryServletTest"/>
         </classes>
     </test>
 </suite>

--- a/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
+++ b/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
@@ -343,19 +343,6 @@ public final class OAuthConstants {
     }
 
     /**
-     * Define FAPI versions.
-     */
-    public static class FAPIVersions {
-
-        public static final String FAPI1 = "1";
-        public static final String FAPI2 = "2";
-
-        private FAPIVersions() {
-
-        }
-    }
-
-    /**
      * Define FAPI profiles.
      */
     public static class FAPIProfiles {

--- a/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
+++ b/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
@@ -343,6 +343,32 @@ public final class OAuthConstants {
     }
 
     /**
+     * Define FAPI versions.
+     */
+    public static class FAPIVersions {
+
+        public static final String FAPI1 = "1";
+        public static final String FAPI2 = "2";
+
+        private FAPIVersions() {
+
+        }
+    }
+
+    /**
+     * Define FAPI profiles.
+     */
+    public static class FAPIProfiles {
+
+        public static final String FAPI1_ADVANCED = "FAPI1_ADVANCED";
+        public static final String FAPI2_SECURITY = "FAPI2_SECURITY";
+
+        private FAPIProfiles() {
+
+        }
+    }
+
+    /**
      * Define OAuth1.0a request parameters.
      */
     public static class OAuth10AParams {
@@ -660,6 +686,8 @@ public final class OAuthConstants {
         public static final String REQUEST_OBJECT_ENCRYPTION_ALGORITHM = "requestObjectEncryptionAlgorithm";
         public static final String REQUEST_OBJECT_ENCRYPTION_METHOD = "requestObjectEncryptionMethod";
         public static final String IS_FAPI_CONFORMANT_APP = "isFAPIConformant";
+        // Stores the FAPI security profile applied to the application (e.g. "FAPI1_ADVANCED").
+        public static final String FAPI_PROFILE = "fapiProfile";
         public static final String IS_SUBJECT_TOKEN_ENABLED = "isSubjectTokenEnabled";
         public static final String SUBJECT_TOKEN_EXPIRY_TIME = "subjectTokenExpiryTime";
         public static final int SUBJECT_TOKEN_EXPIRY_TIME_VALUE = 180;

--- a/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
+++ b/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
@@ -343,19 +343,6 @@ public final class OAuthConstants {
     }
 
     /**
-     * Define FAPI profiles.
-     */
-    public static class FAPIProfiles {
-
-        public static final String FAPI1_ADVANCED = "FAPI1_ADVANCED";
-        public static final String FAPI2_SECURITY = "FAPI2_SECURITY";
-
-        private FAPIProfiles() {
-
-        }
-    }
-
-    /**
      * Define OAuth1.0a request parameters.
      */
     public static class OAuth10AParams {

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/DCRConfigurationMgtServiceImpl.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/DCRConfigurationMgtServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2024-2026, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -20,6 +20,7 @@ package org.wso2.carbon.identity.oauth.dcr;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.configuration.mgt.core.ConfigurationManager;
 import org.wso2.carbon.identity.configuration.mgt.core.exception.ConfigurationManagementException;
 import org.wso2.carbon.identity.configuration.mgt.core.model.Attribute;
@@ -31,6 +32,10 @@ import org.wso2.carbon.identity.oauth.dcr.exception.DCRMClientException;
 import org.wso2.carbon.identity.oauth.dcr.exception.DCRMServerException;
 import org.wso2.carbon.identity.oauth.dcr.internal.DCRDataHolder;
 import org.wso2.carbon.identity.oauth.dcr.model.DCRConfiguration;
+import org.wso2.carbon.identity.oauth2.fapi.exceptions.FapiConfigMgtException;
+import org.wso2.carbon.identity.oauth2.fapi.models.FapiConfig;
+import org.wso2.carbon.identity.oauth2.fapi.models.FapiProfileEnum;
+import org.wso2.carbon.identity.oauth2.fapi.services.FapiConfigMgtService;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -42,9 +47,11 @@ import static org.wso2.carbon.identity.configuration.mgt.core.constant.Configura
 import static org.wso2.carbon.identity.configuration.mgt.core.constant.ConfigurationConstants.ErrorMessages.ERROR_CODE_RESOURCE_TYPE_DOES_NOT_EXISTS;
 import static org.wso2.carbon.identity.oauth.dcr.DCRMConstants.CLIENT_AUTHENTICATION_REQUIRED;
 import static org.wso2.carbon.identity.oauth.dcr.DCRMConstants.DCRConfigErrorMessage.ERROR_CODE_DCR_CONFIGURATION_RETRIEVE;
+import static org.wso2.carbon.identity.oauth.dcr.DCRMConstants.DCRConfigErrorMessage.ERROR_CODE_UNSUPPORTED_FAPI_PROFILE;
 import static org.wso2.carbon.identity.oauth.dcr.DCRMConstants.DCR_CONFIG_RESOURCE_NAME;
 import static org.wso2.carbon.identity.oauth.dcr.DCRMConstants.DCR_CONFIG_RESOURCE_TYPE_NAME;
 import static org.wso2.carbon.identity.oauth.dcr.DCRMConstants.ENABLE_FAPI_ENFORCEMENT;
+import static org.wso2.carbon.identity.oauth.dcr.DCRMConstants.FAPI_PROFILE;
 import static org.wso2.carbon.identity.oauth.dcr.DCRMConstants.MANDATE_SSA;
 import static org.wso2.carbon.identity.oauth.dcr.DCRMConstants.SSA_JWKS;
 import static org.wso2.carbon.identity.oauth.dcr.util.DCRConfigErrorUtils.handleClientException;
@@ -84,6 +91,7 @@ public class DCRConfigurationMgtServiceImpl implements DCRConfigurationMgtServic
 
         try {
             validateMandateSSA(dcrConfiguration);
+            this.validateFapiProfile(dcrConfiguration);
             ResourceAdd resourceAdd = parseConfig(dcrConfiguration);
             getConfigurationManager().replaceResource(DCR_CONFIG_RESOURCE_TYPE_NAME, resourceAdd);
         } catch (ConfigurationManagementException e) {
@@ -174,6 +182,7 @@ public class DCRConfigurationMgtServiceImpl implements DCRConfigurationMgtServic
                     attributeMap.get(CLIENT_AUTHENTICATION_REQUIRED));
             Boolean mandateSSA = getBooleanFromString(attributeMap.get(MANDATE_SSA));
             String ssaJwks = attributeMap.get(SSA_JWKS);
+            String fapiProfile = attributeMap.get(FAPI_PROFILE);
 
             if (enableFapiEnforcement != null) {
                 dcrConfiguration.setEnableFapiEnforcement(enableFapiEnforcement);
@@ -186,6 +195,13 @@ public class DCRConfigurationMgtServiceImpl implements DCRConfigurationMgtServic
             }
             if (mandateSSA != null) {
                 dcrConfiguration.setMandateSSA(mandateSSA);
+            }
+            if (fapiProfile == null) {
+                if (Boolean.TRUE.equals(enableFapiEnforcement)) {
+                    dcrConfiguration.setFapiProfile(FapiProfileEnum.FAPI1_ADVANCED);
+                }
+            } else {
+                dcrConfiguration.setFapiProfile(FapiProfileEnum.fromValue(fapiProfile));
             }
         }
     }
@@ -209,6 +225,47 @@ public class DCRConfigurationMgtServiceImpl implements DCRConfigurationMgtServic
                 StringUtils.isBlank(dcrConfiguration.getSsaJwks())) {
             // if mandateSSA is True, ssaJwks should be provided.
             throw handleClientException(DCRMConstants.DCRConfigErrorMessage.ERROR_CODE_SSA_JWKS_REQUIRED);
+        }
+    }
+
+    /**
+     * Validates that the requested FAPI profile is supported by the organization.
+     * Skips the check if no profile is specified or if the organization has not configured any supported profiles.
+     *
+     * @param dcrConfiguration The incoming DCR configuration to validate.
+     * @throws DCRMClientException If the requested profile is not in the organization's supported profiles.
+     * @throws DCRMServerException If the organization's FAPI configuration cannot be retrieved.
+     */
+    private void validateFapiProfile(DCRConfiguration dcrConfiguration)
+            throws DCRMClientException, DCRMServerException {
+
+        FapiProfileEnum requestedProfile = dcrConfiguration.getFapiProfile();
+        if (requestedProfile == null) {
+            return;
+        }
+
+        FapiConfigMgtService fapiConfigMgtService = DCRDataHolder.getInstance().getFapiConfigMgtService();
+        if (fapiConfigMgtService == null) {
+            return;
+        }
+
+        String tenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
+        try {
+            FapiConfig fapiConfig = fapiConfigMgtService.getFapiConfig(tenantDomain);
+            List<FapiProfileEnum> supportedProfiles = fapiConfig.getSupportedProfiles();
+            if (CollectionUtils.isEmpty(supportedProfiles)) {
+                return;
+            }
+            if (!supportedProfiles.contains(requestedProfile)) {
+                String supportedProfileValues = supportedProfiles.stream()
+                        .map(FapiProfileEnum::value)
+                        .collect(Collectors.joining(", "));
+                throw handleClientException(ERROR_CODE_UNSUPPORTED_FAPI_PROFILE,
+                        requestedProfile.value(), supportedProfileValues);
+            }
+        } catch (FapiConfigMgtException e) {
+            throw handleServerException(ERROR_CODE_UNSUPPORTED_FAPI_PROFILE, e,
+                    requestedProfile.value(), "");
         }
     }
 
@@ -241,6 +298,8 @@ public class DCRConfigurationMgtServiceImpl implements DCRConfigurationMgtServic
         addAttribute(attributes, CLIENT_AUTHENTICATION_REQUIRED, authenticationRequired);
         addAttribute(attributes, SSA_JWKS, ssaJwks);
         addAttribute(attributes, MANDATE_SSA, mandateSSA);
+        addAttribute(attributes, FAPI_PROFILE,
+                dcrConfiguration.getFapiProfile() != null ? dcrConfiguration.getFapiProfile().value() : null);
 
         resourceAdd.setAttributes(attributes);
 

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/DCRConfigurationMgtServiceImpl.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/DCRConfigurationMgtServiceImpl.java
@@ -264,8 +264,7 @@ public class DCRConfigurationMgtServiceImpl implements DCRConfigurationMgtServic
                         requestedProfile.value(), supportedProfileValues);
             }
         } catch (FapiConfigMgtException e) {
-            throw handleServerException(ERROR_CODE_UNSUPPORTED_FAPI_PROFILE, e,
-                    requestedProfile.value(), "");
+            throw handleServerException(ERROR_CODE_DCR_CONFIGURATION_RETRIEVE, e, requestedProfile.value());
         }
     }
 

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/DCRConfigurationMgtServiceImpl.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/DCRConfigurationMgtServiceImpl.java
@@ -196,8 +196,8 @@ public class DCRConfigurationMgtServiceImpl implements DCRConfigurationMgtServic
             if (mandateSSA != null) {
                 dcrConfiguration.setMandateSSA(mandateSSA);
             }
-            if (fapiProfile == null) {
-                if (Boolean.TRUE.equals(enableFapiEnforcement)) {
+            if (StringUtils.isEmpty(fapiProfile)) {
+                if (Boolean.TRUE.equals(dcrConfiguration.getEnableFapiEnforcement())) {
                     dcrConfiguration.setFapiProfile(FapiProfileEnum.FAPI1_ADVANCED);
                 }
             } else {
@@ -253,10 +253,7 @@ public class DCRConfigurationMgtServiceImpl implements DCRConfigurationMgtServic
         try {
             FapiConfig fapiConfig = fapiConfigMgtService.getFapiConfig(tenantDomain);
             List<FapiProfileEnum> supportedProfiles = fapiConfig.getSupportedProfiles();
-            if (CollectionUtils.isEmpty(supportedProfiles)) {
-                return;
-            }
-            if (!supportedProfiles.contains(requestedProfile)) {
+            if (CollectionUtils.isNotEmpty(supportedProfiles) && !supportedProfiles.contains(requestedProfile)) {
                 String supportedProfileValues = supportedProfiles.stream()
                         .map(FapiProfileEnum::value)
                         .collect(Collectors.joining(", "));

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/DCRMConstants.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/DCRMConstants.java
@@ -110,6 +110,7 @@ public class DCRMConstants {
     public static final String CLIENT_AUTHENTICATION_REQUIRED = "clientAuthenticationRequired";
     public static final String SSA_JWKS = "ssaJwks";
     public static final String MANDATE_SSA = "mandateSSA";
+    public static final String FAPI_PROFILE = "fapiProfile";
 
     /**
      * Enum for DCR Configuration related error messages.
@@ -135,7 +136,14 @@ public class DCRMConstants {
          */
         ERROR_CODE_SSA_NOT_MANDATED("65022",
                                              "SSA not mandated.",
-                                             "Authentication is disabled but mandateSSA is not set to True.");
+                                             "Authentication is disabled but mandateSSA is not set to True."),
+
+        /**
+         * Unsupported FAPI profile error.
+         */
+        ERROR_CODE_UNSUPPORTED_FAPI_PROFILE("65025",
+                "Unsupported FAPI profile.",
+                "The FAPI profile '%s' is not supported by this organization. Supported profiles: %s.");
 
         /**
          * The error code.

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/DCRMConstants.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/DCRMConstants.java
@@ -141,7 +141,7 @@ public class DCRMConstants {
         /**
          * Unsupported FAPI profile error.
          */
-        ERROR_CODE_UNSUPPORTED_FAPI_PROFILE("65025",
+        ERROR_CODE_UNSUPPORTED_FAPI_PROFILE("65023",
                 "Unsupported FAPI profile.",
                 "The FAPI profile '%s' is not supported by this organization. Supported profiles: %s.");
 

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/internal/DCRDataHolder.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/internal/DCRDataHolder.java
@@ -23,6 +23,7 @@ import org.wso2.carbon.identity.configuration.mgt.core.ConfigurationManager;
 import org.wso2.carbon.identity.oauth.dcr.handler.AdditionalAttributeFilter;
 import org.wso2.carbon.identity.oauth.dcr.handler.RegistrationHandler;
 import org.wso2.carbon.identity.oauth.dcr.handler.UnRegistrationHandler;
+import org.wso2.carbon.identity.oauth2.fapi.services.FapiConfigMgtService;
 import org.wso2.carbon.identity.oauth2.token.bindings.TokenBinder;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
 
@@ -45,6 +46,7 @@ public class DCRDataHolder {
     private AdditionalAttributeFilter additionalAttributeFilter = null;
     private ConfigurationManager configurationManager;
     private OrganizationManager organizationManager;
+    private FapiConfigMgtService fapiConfigMgtService;
 
     private DCRDataHolder() {
 
@@ -123,6 +125,16 @@ public class DCRDataHolder {
     public void setOrganizationManager(OrganizationManager organizationManager) {
 
         this.organizationManager = organizationManager;
+    }
+
+    public FapiConfigMgtService getFapiConfigMgtService() {
+
+        return fapiConfigMgtService;
+    }
+
+    public void setFapiConfigMgtService(FapiConfigMgtService fapiConfigMgtService) {
+
+        this.fapiConfigMgtService = fapiConfigMgtService;
     }
 
     public AdditionalAttributeFilter getAdditionalAttributeFilter() {

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/internal/DCRServiceComponent.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/internal/DCRServiceComponent.java
@@ -42,6 +42,7 @@ import org.wso2.carbon.identity.oauth.dcr.handler.RegistrationHandler;
 import org.wso2.carbon.identity.oauth.dcr.handler.UnRegistrationHandler;
 import org.wso2.carbon.identity.oauth.dcr.processor.DCRProcessor;
 import org.wso2.carbon.identity.oauth.dcr.service.DCRMService;
+import org.wso2.carbon.identity.oauth2.fapi.services.FapiConfigMgtService;
 import org.wso2.carbon.identity.oauth2.token.bindings.TokenBinder;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
 
@@ -288,5 +289,34 @@ public class DCRServiceComponent {
     protected void unsetAdditionalAttributeFilter(AdditionalAttributeFilter tokenBinderInfo) {
 
         DCRDataHolder.getInstance().setAdditionalAttributeFilter(null);
+    }
+
+    /**
+     * Set the FapiConfigMgtService.
+     *
+     * @param fapiConfigMgtService The {@code FapiConfigMgtService} instance.
+     */
+    @Reference(
+            name = "identity.oauth2.fapi.config.service",
+            service = FapiConfigMgtService.class,
+            cardinality = ReferenceCardinality.OPTIONAL,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetFapiConfigMgtService"
+    )
+    protected void setFapiConfigMgtService(FapiConfigMgtService fapiConfigMgtService) {
+
+        log.debug("Setting FapiConfigMgtService in DCR Service Component.");
+        DCRDataHolder.getInstance().setFapiConfigMgtService(fapiConfigMgtService);
+    }
+
+    /**
+     * Unset the FapiConfigMgtService.
+     *
+     * @param fapiConfigMgtService The {@code FapiConfigMgtService} instance.
+     */
+    protected void unsetFapiConfigMgtService(FapiConfigMgtService fapiConfigMgtService) {
+
+        log.debug("Unsetting FapiConfigMgtService in DCR Service Component.");
+        DCRDataHolder.getInstance().setFapiConfigMgtService(null);
     }
 }

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/model/DCRConfiguration.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/model/DCRConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2024-2026, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -18,6 +18,8 @@
 
 package org.wso2.carbon.identity.oauth.dcr.model;
 
+import org.wso2.carbon.identity.oauth2.fapi.models.FapiProfileEnum;
+
 /**
  * DCR Configuration model.
  */
@@ -27,6 +29,7 @@ public class DCRConfiguration {
     private Boolean authenticationRequired;
     private Boolean mandateSSA;
     private String ssaJwks;
+    private FapiProfileEnum fapiProfile;
 
     /**
      * Get the value of enableFapiEnforcement.
@@ -106,5 +109,25 @@ public class DCRConfiguration {
     public void setSsaJwks(String ssaJwks) {
 
         this.ssaJwks = ssaJwks;
+    }
+
+    /**
+     * Get the value of fapiProfile.
+     *
+     * @return FapiProfileEnum instance.
+     */
+    public FapiProfileEnum getFapiProfile() {
+
+        return this.fapiProfile;
+    }
+
+    /**
+     * Set the value of fapiProfile.
+     *
+     * @param fapiProfile The value to set.
+     */
+    public void setFapiProfile(FapiProfileEnum fapiProfile) {
+
+        this.fapiProfile = fapiProfile;
     }
 }

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/service/DCRMService.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/service/DCRMService.java
@@ -61,6 +61,7 @@ import org.wso2.carbon.identity.oauth.dcr.util.ErrorCodes;
 import org.wso2.carbon.identity.oauth.dto.OAuthConsumerAppDTO;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.OAuth2Constants;
+import org.wso2.carbon.identity.oauth2.fapi.models.FapiProfileEnum;
 import org.wso2.carbon.identity.oauth2.util.JWTSignatureValidationUtils;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
@@ -838,6 +839,11 @@ public class DCRMService {
             DCRConfiguration dcrConfiguration = dcrConfigurationMgtService.getDCRConfiguration();
             boolean enableFAPIDCR = dcrConfiguration.getEnableFapiEnforcement();
             oAuthConsumerApp.setFapiConformanceEnabled(enableFAPIDCR);
+            oAuthConsumerApp.setFapiProfile(
+                    StringUtils.isNotEmpty(dcrConfiguration.getFapiProfile().value())
+                            ? dcrConfiguration.getFapiProfile().value()
+                            : FapiProfileEnum.FAPI1_ADVANCED.value()
+            );
         }
 
         if (log.isDebugEnabled()) {

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/service/DCRMService.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/service/DCRMService.java
@@ -839,10 +839,9 @@ public class DCRMService {
             DCRConfiguration dcrConfiguration = dcrConfigurationMgtService.getDCRConfiguration();
             boolean enableFAPIDCR = dcrConfiguration.getEnableFapiEnforcement();
             oAuthConsumerApp.setFapiConformanceEnabled(enableFAPIDCR);
-            oAuthConsumerApp.setFapiProfile(
-                    StringUtils.isNotEmpty(dcrConfiguration.getFapiProfile().value())
-                            ? dcrConfiguration.getFapiProfile().value()
-                            : FapiProfileEnum.FAPI1_ADVANCED.value()
+            oAuthConsumerApp.setFapiProfile(dcrConfiguration.getFapiProfile() != null
+                    ? dcrConfiguration.getFapiProfile().value()
+                    : FapiProfileEnum.FAPI1_ADVANCED.value()
             );
         }
 

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/DCRConfigurationMgtServiceImplTest.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/DCRConfigurationMgtServiceImplTest.java
@@ -23,19 +23,28 @@ import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.configuration.mgt.core.ConfigurationManager;
 import org.wso2.carbon.identity.configuration.mgt.core.model.Attribute;
 import org.wso2.carbon.identity.configuration.mgt.core.model.Resource;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.oauth.common.OAuthConstants;
+import org.wso2.carbon.identity.oauth.dcr.exception.DCRMClientException;
 import org.wso2.carbon.identity.oauth.dcr.exception.DCRMException;
 import org.wso2.carbon.identity.oauth.dcr.internal.DCRDataHolder;
 import org.wso2.carbon.identity.oauth.dcr.model.DCRConfiguration;
+import org.wso2.carbon.identity.oauth2.fapi.models.FapiConfig;
+import org.wso2.carbon.identity.oauth2.fapi.models.FapiProfileEnum;
+import org.wso2.carbon.identity.oauth2.fapi.services.FapiConfigMgtService;
 
 import java.util.Arrays;
+import java.util.Collections;
 
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
 import static org.wso2.carbon.identity.oauth.dcr.DCRMConstants.DCR_CONFIG_RESOURCE_NAME;
 import static org.wso2.carbon.identity.oauth.dcr.DCRMConstants.DCR_CONFIG_RESOURCE_TYPE_NAME;
 import static org.wso2.carbon.identity.oauth.dcr.DCRMConstants.ENABLE_FAPI_ENFORCEMENT;
@@ -117,5 +126,90 @@ public class DCRConfigurationMgtServiceImplTest {
 
         Assert.assertEquals(dcrConfiguration.getEnableFapiEnforcement(), false);
         Assert.assertEquals(dcrConfiguration.getAuthenticationRequired(), true);
+    }
+
+    @Test(priority = 4, description = "Setting an unsupported FAPI profile should throw DCRMClientException")
+    public void testSetDCRConfiguration_unsupportedFapiProfile_throws() throws Exception {
+
+        FapiConfigMgtService mockFapiService = mock(FapiConfigMgtService.class);
+        DCRDataHolder.getInstance().setFapiConfigMgtService(mockFapiService);
+
+        FapiConfig fapiConfig = new FapiConfig();
+        fapiConfig.setSupportedProfiles(Collections.singletonList(FapiProfileEnum.FAPI1_ADVANCED));
+
+        try (MockedStatic<PrivilegedCarbonContext> carbonContext = mockStatic(PrivilegedCarbonContext.class)) {
+            PrivilegedCarbonContext mockContext = mock(PrivilegedCarbonContext.class);
+            carbonContext.when(PrivilegedCarbonContext::getThreadLocalCarbonContext).thenReturn(mockContext);
+            when(mockContext.getTenantDomain()).thenReturn("carbon.super");
+            when(mockFapiService.getFapiConfig(anyString())).thenReturn(fapiConfig);
+
+            DCRConfiguration config = new DCRConfiguration();
+            config.setFapiProfile(FapiProfileEnum.FAPI2_SECURITY);
+            config.setAuthenticationRequired(true);
+            config.setMandateSSA(true);
+            config.setSsaJwks(dummySSAJwks);
+
+            try {
+                dcrConfigurationMgtService.setDCRConfiguration(config);
+                Assert.fail("Expected DCRMClientException was not thrown");
+            } catch (DCRMClientException e) {
+                assertEquals(e.getErrorCode(),
+                        DCRMConstants.DCRConfigErrorMessage.ERROR_CODE_UNSUPPORTED_FAPI_PROFILE.getCode());
+            }
+        } finally {
+            DCRDataHolder.getInstance().setFapiConfigMgtService(null);
+        }
+    }
+
+    @Test(priority = 5, description = "Setting a supported FAPI profile should not throw any exception")
+    public void testSetDCRConfiguration_supportedFapiProfile_succeeds() throws Exception {
+
+        FapiConfigMgtService mockFapiService = mock(FapiConfigMgtService.class);
+        DCRDataHolder.getInstance().setFapiConfigMgtService(mockFapiService);
+
+        FapiConfig fapiConfig = new FapiConfig();
+        fapiConfig.setSupportedProfiles(Collections.singletonList(FapiProfileEnum.FAPI1_ADVANCED));
+
+        try (MockedStatic<PrivilegedCarbonContext> carbonContext = mockStatic(PrivilegedCarbonContext.class)) {
+            PrivilegedCarbonContext mockContext = mock(PrivilegedCarbonContext.class);
+            carbonContext.when(PrivilegedCarbonContext::getThreadLocalCarbonContext).thenReturn(mockContext);
+            when(mockContext.getTenantDomain()).thenReturn("carbon.super");
+            when(mockFapiService.getFapiConfig(anyString())).thenReturn(fapiConfig);
+
+            DCRConfiguration config = new DCRConfiguration();
+            config.setFapiProfile(FapiProfileEnum.FAPI1_ADVANCED);
+            config.setAuthenticationRequired(true);
+            config.setMandateSSA(true);
+            config.setSsaJwks(dummySSAJwks);
+
+            // Should complete without throwing
+            dcrConfigurationMgtService.setDCRConfiguration(config);
+        } catch (DCRMClientException e) {
+            Assert.fail("Unexpected DCRMClientException: " + e.getMessage());
+        } finally {
+            DCRDataHolder.getInstance().setFapiConfigMgtService(null);
+        }
+    }
+
+    @Test(priority = 6, description = "Null FAPI profile in DCRConfiguration should skip profile validation")
+    public void testSetDCRConfiguration_nullFapiProfile_skipsProfileValidation() throws Exception {
+
+        FapiConfigMgtService mockFapiService = mock(FapiConfigMgtService.class);
+        DCRDataHolder.getInstance().setFapiConfigMgtService(mockFapiService);
+
+        try {
+            DCRConfiguration config = new DCRConfiguration();
+            config.setFapiProfile(null);
+            config.setAuthenticationRequired(true);
+            config.setMandateSSA(true);
+            config.setSsaJwks(dummySSAJwks);
+
+            // Should complete without consulting FapiConfigMgtService or throwing
+            dcrConfigurationMgtService.setDCRConfiguration(config);
+        } catch (DCRMClientException e) {
+            Assert.fail("Unexpected DCRMClientException: " + e.getMessage());
+        } finally {
+            DCRDataHolder.getInstance().setFapiConfigMgtService(null);
+        }
     }
 }

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/par/OAuth2ParEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/par/OAuth2ParEndpoint.java
@@ -47,6 +47,7 @@ import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.RequestObjectException;
 import org.wso2.carbon.identity.oauth2.bean.OAuthClientAuthnContext;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2ClientValidationResponseDTO;
+import org.wso2.carbon.identity.oauth2.fapi.utils.FapiUtil;
 import org.wso2.carbon.identity.oauth2.model.OAuth2Parameters;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 import org.wso2.carbon.identity.openidconnect.OIDCRequestObjectUtil;
@@ -324,7 +325,7 @@ public class OAuth2ParEndpoint {
             OAuthAuthzRequest oAuthAuthzRequest = getOAuthAuthzRequest(request);
             RequestObject requestObject = validateRequestObject(oAuthAuthzRequest);
             Map<String, String> oauthParams = overrideRequestObjectParams(request, requestObject);
-            if (isFapiConformant(oAuthAuthzRequest.getClientId())) {
+            if (FapiUtil.isFapi1AdvancedProfileCompliant(oAuthAuthzRequest.getClientId())) {
                 EndpointUtil.validateFAPIAllowedResponseTypeAndMode(oauthParams.get(RESPONSE_TYPE),
                         oauthParams.get(RESPONSE_MODE));
                 validatePKCEParameters(oauthParams);
@@ -403,8 +404,8 @@ public class OAuth2ParEndpoint {
                         throw new ParClientException(OAuth2ErrorCodes.INVALID_REQUEST,
                                 ParConstants.INVALID_REQUEST_OBJECT);
                     }
-                } else if (isFapiConformant(oAuthAuthzRequest.getClientId())) {
-                    /* Mandate request object for FAPI requests
+                } else if (FapiUtil.isFapi1AdvancedProfileCompliant(oAuthAuthzRequest.getClientId())) {
+                    /* Mandate request object for FAPI 1.0 Advanced requests
                     https://openid.net/specs/openid-financial-api-part-2-1_0.html#authorization-server (5.2.2-1) */
                     throw new ParClientException(OAuth2ErrorCodes.INVALID_REQUEST, ParConstants.REQUEST_OBJECT_MISSING);
                 }
@@ -422,7 +423,7 @@ public class OAuth2ParEndpoint {
     private boolean isFapiConformant(String clientId) throws ParCoreException {
 
         try {
-            return OAuth2Util.isFapiConformantApp(clientId);
+            return FapiUtil.isFapiConformantApp(clientId);
         } catch (InvalidOAuthClientException e) {
             throw new ParClientException(OAuth2ErrorCodes.INVALID_CLIENT, "Could not find an existing app for " +
                     "clientId: " + clientId, e);

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/par/OAuth2ParEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/par/OAuth2ParEndpoint.java
@@ -33,7 +33,6 @@ import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.oauth.client.authn.filter.OAuthClientAuthenticatorProxy;
 import org.wso2.carbon.identity.oauth.common.OAuth2ErrorCodes;
 import org.wso2.carbon.identity.oauth.common.OAuthConstants;
-import org.wso2.carbon.identity.oauth.common.exception.InvalidOAuthClientException;
 import org.wso2.carbon.identity.oauth.common.exception.InvalidOAuthRequestException;
 import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
 import org.wso2.carbon.identity.oauth.endpoint.api.auth.ApiAuthnUtils;
@@ -43,7 +42,6 @@ import org.wso2.carbon.identity.oauth.par.core.OAuthParRequestWrapper;
 import org.wso2.carbon.identity.oauth.par.exceptions.ParClientException;
 import org.wso2.carbon.identity.oauth.par.exceptions.ParCoreException;
 import org.wso2.carbon.identity.oauth.par.model.ParAuthData;
-import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.RequestObjectException;
 import org.wso2.carbon.identity.oauth2.bean.OAuthClientAuthnContext;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2ClientValidationResponseDTO;
@@ -419,20 +417,6 @@ public class OAuth2ParEndpoint {
                     e.getMessage(), e);
         }
     }
-
-    private boolean isFapiConformant(String clientId) throws ParCoreException {
-
-        try {
-            return FapiUtil.isFapiConformantApp(clientId);
-        } catch (InvalidOAuthClientException e) {
-            throw new ParClientException(OAuth2ErrorCodes.INVALID_CLIENT, "Could not find an existing app for " +
-                    "clientId: " + clientId, e);
-        } catch (IdentityOAuth2Exception e) {
-            throw new ParCoreException(OAuth2ErrorCodes.SERVER_ERROR, "Error while obtaining the service " +
-                    "provider for clientId: " + clientId, e);
-        }
-    }
-
 
     /**
      * Validate PKCE parameters for PAR requests.

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/AuthzUtil.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/AuthzUtil.java
@@ -116,6 +116,7 @@ import org.wso2.carbon.identity.oauth.endpoint.util.factory.DeviceServiceFactory
 import org.wso2.carbon.identity.oauth.endpoint.util.factory.OpenIDConnectClaimFilterFactory;
 import org.wso2.carbon.identity.oauth.extension.engine.JSEngine;
 import org.wso2.carbon.identity.oauth.extension.utils.EngineUtils;
+import org.wso2.carbon.identity.oauth.par.common.ParConstants;
 import org.wso2.carbon.identity.oauth.rar.exception.AuthorizationDetailsProcessingException;
 import org.wso2.carbon.identity.oauth.rar.model.AuthorizationDetails;
 import org.wso2.carbon.identity.oauth.rar.util.AuthorizationDetailsConstants;
@@ -135,6 +136,7 @@ import org.wso2.carbon.identity.oauth2.device.constants.Constants;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2AuthorizeReqDTO;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2AuthorizeRespDTO;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2ClientValidationResponseDTO;
+import org.wso2.carbon.identity.oauth2.fapi.utils.FapiUtil;
 import org.wso2.carbon.identity.oauth2.impersonation.models.ImpersonationContext;
 import org.wso2.carbon.identity.oauth2.impersonation.models.ImpersonationRequestDTO;
 import org.wso2.carbon.identity.oauth2.impersonation.services.ImpersonationMgtService;
@@ -2524,7 +2526,7 @@ public class AuthzUtil {
             validateNonceParameter(params.getNonce());
         }
 
-        if (isFapiConformant(params.getClientId())) {
+        if (FapiUtil.isFapi1AdvancedProfileCompliant(params.getClientId())) {
             EndpointUtil.validateFAPIAllowedResponseTypeAndMode(params.getResponseType(), params.getResponseMode());
         }
 
@@ -2877,7 +2879,18 @@ public class AuthzUtil {
             scopeSet.add("");
             params.setScopes(scopeSet);
         }
-        params.setState(oauthRequest.getState());
+
+        if (FapiUtil.isFapi2SecurityProfileCompliant(oAuthMessage.getClientId())) {
+            /* For FAPI 2.0 compliance, state parameter sent in the par request should be returned in the
+               authorization response */
+            Object parState = oAuthMessage.getRequest().getAttribute(ParConstants.PAR_STATE);
+            if (parState != null) {
+                params.setState(parState.toString());
+            }
+        } else {
+            params.setState(oauthRequest.getState());
+        }
+
         params.setApplicationName(validationResponse.getApplicationName());
 
         String spDisplayName = getSpDisplayName(clientId);
@@ -3077,9 +3090,9 @@ public class AuthzUtil {
         } else if (isRequestParameter(oauthRequest)) {
             requestObjValue = oauthRequest.getParam(REQUEST);
         }
-        /* Mandate request object for FAPI requests.
+        /* Mandate request object for FAPI 1.0 Advanced requests.
            https://openid.net/specs/openid-financial-api-part-2-1_0.html#authorization-server (5.2.2-1)  */
-        if (isFapiConformant(oAuthMessage.getClientId())) {
+        if (FapiUtil.isFapi1AdvancedProfileCompliant(oAuthMessage.getClientId())) {
             if (requestObjValue == null) {
                 throw new InvalidRequestException("Request Object is mandatory for FAPI Conformant Applications.",
                         OAuth2ErrorCodes.INVALID_REQUEST, "Request object is missing.");
@@ -5022,7 +5035,7 @@ public class AuthzUtil {
     public static boolean isFapiConformant(String clientId) throws InvalidRequestException {
 
         try {
-            return OAuth2Util.isFapiConformantApp(clientId);
+            return FapiUtil.isFapiConformantApp(clientId);
         } catch (InvalidOAuthClientException e) {
             throw new InvalidRequestException(OAuth2ErrorCodes.INVALID_CLIENT, "Could not find an existing app for " +
                     "clientId: " + clientId, e);

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
@@ -1987,7 +1987,7 @@ public class EndpointUtil {
     }
 
     /**
-     * Validate the response mode against the response type as per FAPI spec.
+     * Validate the response mode against the response type as per FAPI 1.0 Advanced spec.
      * shall require;
      * 1. the response_type value code id_token, or
      * 2. the response_type value code in conjunction with the response_mode value jwt;

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpointTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpointTest.java
@@ -117,6 +117,7 @@ import org.wso2.carbon.identity.oauth2.authz.OAuthAuthzReqMessageContext;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2AuthorizeReqDTO;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2AuthorizeRespDTO;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2ClientValidationResponseDTO;
+import org.wso2.carbon.identity.oauth2.fapi.utils.FapiUtil;
 import org.wso2.carbon.identity.oauth2.internal.OAuth2ServiceComponentHolder;
 import org.wso2.carbon.identity.oauth2.model.OAuth2Parameters;
 import org.wso2.carbon.identity.oauth2.rar.AuthorizationDetailsService;
@@ -1613,6 +1614,104 @@ public class OAuth2AuthzEndpointTest extends TestOAuthEndpointBase {
         }
     }
 
+    @Test(description = "Test redirection with error when request_uri is not sent when " +
+            "PAR is mandated in the application with FAPI 2.0 enabled")
+    public void testErrorWhenPARMandatedWithFAPI2() throws Exception {
+
+        try (MockedStatic<OAuthServerConfiguration> oAuthServerConfiguration = mockStatic(
+                OAuthServerConfiguration.class)) {
+            mockSSOConsentService(false);
+            mockOAuthServerConfiguration(oAuthServerConfiguration);
+            try (MockedStatic<FrameworkUtils> frameworkUtils = mockStatic(FrameworkUtils.class,
+                    Mockito.CALLS_REAL_METHODS);
+                 MockedStatic<IdentityTenantUtil> identityTenantUtil = mockStatic(IdentityTenantUtil.class);
+                 MockedStatic<LoggerUtils> loggerUtils = mockStatic(LoggerUtils.class);
+                 MockedStatic<CentralLogMgtServiceComponentHolder> centralLogMgtServiceComponentHolder =
+                         mockStatic(CentralLogMgtServiceComponentHolder.class);
+                 MockedStatic<OAuth2Util> oAuth2Util = mockStatic(OAuth2Util.class);
+                 MockedStatic<OAuth2Util.OAuthURL> oAuthURL = mockStatic(OAuth2Util.OAuthURL.class);
+                 MockedStatic<ServiceURLBuilder> serviceURLBuilder = mockStatic(ServiceURLBuilder.class);
+                 MockedStatic<EndpointUtil> endpointUtil = mockStatic(EndpointUtil.class, Mockito.CALLS_REAL_METHODS);
+                 MockedStatic<OAuth2ServiceFactory> oAuth2ServiceFactory = mockStatic(OAuth2ServiceFactory.class);
+                 MockedStatic<FapiUtil> fapiUtil = mockStatic(FapiUtil.class)) {
+
+                oAuth2ServiceFactory.when(OAuth2ServiceFactory::getOAuth2Service).thenReturn(oAuth2Service);
+                Map<String, String[]> requestParams = new HashMap<>();
+                Map<String, Object> requestAttributes = new HashMap<>();
+
+                requestParams.put(CLIENT_ID, new String[]{CLIENT_ID_VALUE});
+
+                // No consent data is saved in the cache yet and client doesn't send cache key
+                requestParams.put(OAuthConstants.SESSION_DATA_KEY_CONSENT, new String[]{null});
+                requestParams.put(FrameworkConstants.RequestParams.TO_COMMONAUTH, new String[]{"false"});
+                requestParams.put(REDIRECT_URI, new String[]{APP_REDIRECT_URL});
+                requestParams.put(OAuth.OAUTH_RESPONSE_TYPE, new String[]{ResponseType.TOKEN.toString()});
+
+                requestAttributes.put(FrameworkConstants.RequestParams.FLOW_STATUS, AuthenticatorFlowStatus.INCOMPLETE);
+                // No authentication data is saved in the cache yet and client doesn't send cache key
+                requestAttributes.put(FrameworkConstants.SESSION_DATA_KEY, null);
+
+                mockHttpRequest(requestParams, requestAttributes, HttpMethod.POST);
+
+                Map<String, Class<? extends OAuthValidator<HttpServletRequest>>> responseTypeValidators =
+                        new Hashtable<>();
+                responseTypeValidators.put(ResponseType.CODE.toString(), CodeValidator.class);
+                responseTypeValidators.put(ResponseType.TOKEN.toString(), TokenValidator.class);
+
+                when(mockOAuthServerConfiguration.getSupportedResponseTypeValidators()).thenReturn(
+                        responseTypeValidators);
+
+                frameworkUtils.when(() -> FrameworkUtils.startTenantFlow(anyString())).thenAnswer(invocation -> null);
+                frameworkUtils.when(FrameworkUtils::endTenantFlow).thenAnswer(invocation -> null);
+                identityTenantUtil.when(() -> IdentityTenantUtil.getTenantDomain(anyInt()))
+                        .thenReturn(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+                identityTenantUtil.when(() -> IdentityTenantUtil.getTenantId(anyString()))
+                        .thenReturn(MultitenantConstants.SUPER_TENANT_ID);
+                loggerUtils.when(LoggerUtils::isDiagnosticLogsEnabled).thenReturn(true);
+                IdentityEventService eventServiceMock = mock(IdentityEventService.class);
+
+                centralLogMgtServiceComponentHolder.when(CentralLogMgtServiceComponentHolder::getInstance)
+                        .thenReturn(centralLogMgtServiceComponentHolderMock);
+                when(centralLogMgtServiceComponentHolderMock.getIdentityEventService()).thenReturn(eventServiceMock);
+                doNothing().when(eventServiceMock).handleEvent(any());
+
+                mockEndpointUtil(false, endpointUtil);
+                when(oAuth2Service.getOauthApplicationState(CLIENT_ID_VALUE)).thenReturn("ACTIVE");
+                when(oAuth2Service.isPKCESupportEnabled()).thenReturn(false);
+
+
+                oAuth2Util.when(() -> OAuth2Util.validatePKCECodeChallenge(anyString(), anyString()))
+                        .thenCallRealMethod();
+                oAuth2Util.when(() -> OAuth2Util.validatePKCECodeVerifier(anyString())).thenCallRealMethod();
+                oAuthURL.when(OAuth2Util.OAuthURL::getOAuth2ErrorPageUrl).thenReturn(ERROR_PAGE_URL);
+                fapiUtil.when(() -> FapiUtil.isFapiConformantApp(any())).thenReturn(true);
+                oAuth2Util.when(() -> OAuth2Util.isFapi2Enabled(anyString())).thenReturn(true);
+
+
+                OAuthAppDO oAuthAppDO = new OAuthAppDO();
+                oAuthAppDO.setRequirePushedAuthorizationRequests(true);
+                oAuth2Util.when(() -> OAuth2Util.getAppInformationByClientId(any())).thenReturn(oAuthAppDO);
+
+                OAuth2ClientValidationResponseDTO validationResponseDTO = new OAuth2ClientValidationResponseDTO();
+                validationResponseDTO.setValidClient(true);
+                validationResponseDTO.setCallbackURL(APP_REDIRECT_URL);
+                when(oAuth2Service.validateClientInfo(any())).thenReturn(validationResponseDTO);
+
+                when(oAuth2Service.validateClientInfo(any())).thenReturn(validationResponseDTO);
+                oAuth2Util.when(() -> OAuth2Util.getAppInformationByClientId(any(), any())).thenReturn(oAuthAppDO);
+
+                mockServiceURLBuilder(serviceURLBuilder);
+
+                try {
+                    oAuth2AuthzEndpoint.authorize(httpServletRequest, httpServletResponse);
+                } catch (InvalidRequestParentException ire) {
+                    assertTrue(ire instanceof InvalidRequestException);
+                    assertEquals(ire.getMessage(), "PAR request is mandatory for the application.");
+                }
+            }
+        }
+    }
+
     @DataProvider(name = "provideUserConsentData")
     public Object[][] provideUserConsentData() {
 
@@ -2091,6 +2190,8 @@ public class OAuth2AuthzEndpointTest extends TestOAuthEndpointBase {
                 invocation -> invocation.getArguments()[0]);
         when(mockOAuthServerConfiguration.getOAuthAuthzRequestClassName())
                 .thenReturn("org.wso2.carbon.identity.oauth2.model.CarbonOAuthAuthzRequest");
+        when(mockOAuthServerConfiguration.getFapiVersion())
+                .thenReturn("1");
     }
 
     private void mockServiceURLBuilder(MockedStatic<ServiceURLBuilder> serviceURLBuilder) throws URLBuilderException {

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpointTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpointTest.java
@@ -2190,8 +2190,6 @@ public class OAuth2AuthzEndpointTest extends TestOAuthEndpointBase {
                 invocation -> invocation.getArguments()[0]);
         when(mockOAuthServerConfiguration.getOAuthAuthzRequestClassName())
                 .thenReturn("org.wso2.carbon.identity.oauth2.model.CarbonOAuthAuthzRequest");
-        when(mockOAuthServerConfiguration.getFapiVersion())
-                .thenReturn("1");
     }
 
     private void mockServiceURLBuilder(MockedStatic<ServiceURLBuilder> serviceURLBuilder) throws URLBuilderException {

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/par/OAuth2ParEndpointTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/par/OAuth2ParEndpointTest.java
@@ -62,6 +62,7 @@ import org.wso2.carbon.identity.oauth.par.model.ParAuthData;
 import org.wso2.carbon.identity.oauth.tokenprocessor.TokenPersistenceProcessor;
 import org.wso2.carbon.identity.oauth2.OAuth2Service;
 import org.wso2.carbon.identity.oauth2.bean.OAuthClientAuthnContext;
+import org.wso2.carbon.identity.oauth2.fapi.utils.FapiUtil;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 import org.wso2.carbon.identity.openidconnect.OIDCRequestObjectUtil;
 import org.wso2.carbon.identity.openidconnect.RequestObjectBuilder;
@@ -399,7 +400,8 @@ public class OAuth2ParEndpointTest extends TestOAuthEndpointBase {
                  MockedStatic<OIDCRequestObjectUtil> oidcRequestObjectUtil = mockStatic(OIDCRequestObjectUtil.class);
                  MockedStatic<OAuth2Util> oAuth2Util = mockStatic(OAuth2Util.class, Mockito.CALLS_REAL_METHODS);
                  MockedStatic<OAuth2ServiceFactory> oAuth2ServiceFactory = mockStatic(OAuth2ServiceFactory.class);
-                 MockedStatic<ParAuthServiceFactory> parAuthServiceFactory = mockStatic(ParAuthServiceFactory.class)) {
+                 MockedStatic<ParAuthServiceFactory> parAuthServiceFactory = mockStatic(ParAuthServiceFactory.class);
+                 MockedStatic<FapiUtil> fapiUtil = mockStatic(FapiUtil.class)) {
 
                 oAuth2ServiceFactory.when(OAuth2ServiceFactory::getOAuth2Service).thenReturn(oAuth2Service);
                 parAuthServiceFactory.when(ParAuthServiceFactory::getParAuthService).thenReturn(parAuthService);
@@ -448,7 +450,8 @@ public class OAuth2ParEndpointTest extends TestOAuthEndpointBase {
                             .thenReturn(new RequestObject());
                 }
 
-                oAuth2Util.when(() -> OAuth2Util.isFapiConformantApp(anyString())).thenReturn(isFAPITest);
+                fapiUtil.when(() -> FapiUtil.isFapi1AdvancedProfileCompliant(anyString())).thenReturn(isFAPITest);
+                fapiUtil.when(() -> FapiUtil.isFapiConformantApp(anyString())).thenReturn(isFAPITest);
 
                 Response response;
                 response = oAuth2ParEndpoint.par(request, httpServletResponse, paramMap);
@@ -539,5 +542,7 @@ public class OAuth2ParEndpointTest extends TestOAuthEndpointBase {
                 new HashMap<String, RequestObjectBuilder>() {{
                     put("request_param_value_builder", new RequestParamRequestObjectBuilder());
                 }});
+        lenient().when(mockOAuthServerConfiguration.getFapiVersion()).thenReturn("1");
+
     }
 }

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/par/OAuth2ParEndpointTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/par/OAuth2ParEndpointTest.java
@@ -542,7 +542,6 @@ public class OAuth2ParEndpointTest extends TestOAuthEndpointBase {
                 new HashMap<String, RequestObjectBuilder>() {{
                     put("request_param_value_builder", new RequestParamRequestObjectBuilder());
                 }});
-        lenient().when(mockOAuthServerConfiguration.getFapiVersion()).thenReturn("1");
 
     }
 }

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/util/AuthzUtilTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/util/AuthzUtilTest.java
@@ -131,6 +131,7 @@ import org.wso2.carbon.identity.oauth2.device.cache.DeviceAuthorizationGrantCach
 import org.wso2.carbon.identity.oauth2.dto.OAuth2AuthorizeReqDTO;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2AuthorizeRespDTO;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2ClientValidationResponseDTO;
+import org.wso2.carbon.identity.oauth2.fapi.utils.FapiUtil;
 import org.wso2.carbon.identity.oauth2.internal.OAuth2ServiceComponentHolder;
 import org.wso2.carbon.identity.oauth2.model.FederatedTokenDO;
 import org.wso2.carbon.identity.oauth2.model.OAuth2Parameters;
@@ -1429,7 +1430,8 @@ public class AuthzUtilTest extends TestOAuthEndpointBase {
             mockOAuthServerConfiguration(oAuthServerConfiguration);
             try (MockedStatic<LoggerUtils> loggerUtils = mockStatic(LoggerUtils.class);
                  MockedStatic<OAuth2Util> oAuth2Util = mockStatic(OAuth2Util.class, Mockito.CALLS_REAL_METHODS);
-                 MockedStatic<EndpointUtil> endpointUtil = mockStatic(EndpointUtil.class, Mockito.CALLS_REAL_METHODS)) {
+                 MockedStatic<EndpointUtil> endpointUtil = mockStatic(EndpointUtil.class, Mockito.CALLS_REAL_METHODS);
+                 MockedStatic<FapiUtil> fapiUtil = mockStatic(FapiUtil.class)) {
 
                 OAuth2Parameters oAuth2Parameters = (OAuth2Parameters) oAuth2ParametersObj;
                 OAuth2Parameters originalOAuth2Parameters = SerializationUtils.clone(oAuth2Parameters);
@@ -1463,7 +1465,9 @@ public class AuthzUtilTest extends TestOAuthEndpointBase {
                         .thenReturn(appDO);
                 oAuth2Util.when(() -> OAuth2Util.getAppInformationByClientId(oAuth2Parameters.getClientId(),
                         oAuth2Parameters.getTenantDomain())).thenReturn(appDO);
-                oAuth2Util.when(() -> OAuth2Util.isFapiConformantApp(any())).thenReturn(true);
+                fapiUtil.when(() -> FapiUtil.isFapi1AdvancedProfileCompliant(any())).thenReturn(true);
+                fapiUtil.when(() -> FapiUtil.isFapiConformantApp(any())).thenReturn(true);
+                fapiUtil.when(() -> FapiUtil.isFapiConformantApp(any(), any())).thenReturn(true);
 
                 mockEndpointUtil(false, endpointUtil);
                 when(oAuth2Service.isPKCESupportEnabled()).thenReturn(false);

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtilTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtilTest.java
@@ -17,6 +17,7 @@
  */
 package org.wso2.carbon.identity.oauth.endpoint.util;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.axiom.util.base64.Base64Utils;
 import org.apache.commons.collections.map.HashedMap;
 import org.apache.commons.lang.ArrayUtils;
@@ -70,6 +71,7 @@ import org.wso2.carbon.identity.oauth.common.OAuth2ErrorCodes;
 import org.wso2.carbon.identity.oauth.common.exception.OAuthClientException;
 import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
 import org.wso2.carbon.identity.oauth.endpoint.exception.InvalidApplicationClientException;
+import org.wso2.carbon.identity.oauth.endpoint.exception.TokenEndpointBadRequestException;
 import org.wso2.carbon.identity.oauth.endpoint.expmapper.InvalidRequestExceptionMapper;
 import org.wso2.carbon.identity.oauth.endpoint.message.OAuthMessage;
 import org.wso2.carbon.identity.oauth.endpoint.util.factory.OAuth2ServiceFactory;
@@ -1035,6 +1037,48 @@ public class EndpointUtilTest {
             EndpointUtil.validateFAPIAllowedResponseTypeAndMode(responseType, responseMode);
         } catch (OAuthProblemException e) {
             Assert.assertFalse(shouldPass, "Expected exception not thrown");
+        }
+    }
+
+    @Test
+    public void testParseJsonTokenRequest() throws Exception {
+
+        // Case 1: Valid JSON with simple and nested fields
+        String jsonPayload = "{\n" +
+                "  \"grant_type\": \"client_credentials\",\n" +
+                "  \"scope\": \"openid profile\",\n" +
+                "  \"client_assertion\": {\n" +
+                "    \"assertion_type\": \"jwt\",\n" +
+                "    \"value\": \"abc.def.ghi\"\n" +
+                "  },\n" +
+                "  \"extra\": [\"val1\", \"val2\"]\n" +
+                "}";
+
+        Map<String, List<String>> result = EndpointUtil.parseJsonTokenRequest(jsonPayload);
+
+        // Validate scalar fields
+        assertEquals(result.get("grant_type").get(0), "client_credentials");
+        assertEquals(result.get("scope").get(0), "openid profile");
+
+        // Validate nested JSON object (flattened as JSON string)
+        String clientAssertion = result.get("client_assertion").get(0);
+        ObjectMapper mapper = new ObjectMapper();
+        assertTrue(mapper.readTree(clientAssertion).has("assertion_type"));
+        assertEquals(mapper.readTree(clientAssertion).get("value").asText(), "abc.def.ghi");
+
+        // Validate array flattening
+        String extraArray = result.get("extra").get(0);
+        assertTrue(extraArray.startsWith("["));
+        assertTrue(extraArray.contains("val1"));
+        assertTrue(extraArray.contains("val2"));
+
+        // Case 2: Malformed JSON should throw TokenEndpointBadRequestException
+        String invalidJson = "{ \"key\": \"value\" "; // missing closing brace
+        try {
+            EndpointUtil.parseJsonTokenRequest(invalidJson);
+            Assert.fail("Expected TokenEndpointBadRequestException was not thrown");
+        } catch (TokenEndpointBadRequestException e) {
+            assertTrue(e.getMessage().contains("Malformed or unsupported request payload"));
         }
     }
 

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtilTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtilTest.java
@@ -17,7 +17,6 @@
  */
 package org.wso2.carbon.identity.oauth.endpoint.util;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.axiom.util.base64.Base64Utils;
 import org.apache.commons.collections.map.HashedMap;
 import org.apache.commons.lang.ArrayUtils;
@@ -71,7 +70,6 @@ import org.wso2.carbon.identity.oauth.common.OAuth2ErrorCodes;
 import org.wso2.carbon.identity.oauth.common.exception.OAuthClientException;
 import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
 import org.wso2.carbon.identity.oauth.endpoint.exception.InvalidApplicationClientException;
-import org.wso2.carbon.identity.oauth.endpoint.exception.TokenEndpointBadRequestException;
 import org.wso2.carbon.identity.oauth.endpoint.expmapper.InvalidRequestExceptionMapper;
 import org.wso2.carbon.identity.oauth.endpoint.message.OAuthMessage;
 import org.wso2.carbon.identity.oauth.endpoint.util.factory.OAuth2ServiceFactory;
@@ -1037,48 +1035,6 @@ public class EndpointUtilTest {
             EndpointUtil.validateFAPIAllowedResponseTypeAndMode(responseType, responseMode);
         } catch (OAuthProblemException e) {
             Assert.assertFalse(shouldPass, "Expected exception not thrown");
-        }
-    }
-
-    @Test
-    public void testParseJsonTokenRequest() throws Exception {
-
-        // Case 1: Valid JSON with simple and nested fields
-        String jsonPayload = "{\n" +
-                "  \"grant_type\": \"client_credentials\",\n" +
-                "  \"scope\": \"openid profile\",\n" +
-                "  \"client_assertion\": {\n" +
-                "    \"assertion_type\": \"jwt\",\n" +
-                "    \"value\": \"abc.def.ghi\"\n" +
-                "  },\n" +
-                "  \"extra\": [\"val1\", \"val2\"]\n" +
-                "}";
-
-        Map<String, List<String>> result = EndpointUtil.parseJsonTokenRequest(jsonPayload);
-
-        // Validate scalar fields
-        assertEquals(result.get("grant_type").get(0), "client_credentials");
-        assertEquals(result.get("scope").get(0), "openid profile");
-
-        // Validate nested JSON object (flattened as JSON string)
-        String clientAssertion = result.get("client_assertion").get(0);
-        ObjectMapper mapper = new ObjectMapper();
-        assertTrue(mapper.readTree(clientAssertion).has("assertion_type"));
-        assertEquals(mapper.readTree(clientAssertion).get("value").asText(), "abc.def.ghi");
-
-        // Validate array flattening
-        String extraArray = result.get("extra").get(0);
-        assertTrue(extraArray.startsWith("["));
-        assertTrue(extraArray.contains("val1"));
-        assertTrue(extraArray.contains("val2"));
-
-        // Case 2: Malformed JSON should throw TokenEndpointBadRequestException
-        String invalidJson = "{ \"key\": \"value\" "; // missing closing brace
-        try {
-            EndpointUtil.parseJsonTokenRequest(invalidJson);
-            Assert.fail("Expected TokenEndpointBadRequestException was not thrown");
-        } catch (TokenEndpointBadRequestException e) {
-            assertTrue(e.getMessage().contains("Malformed or unsupported request payload"));
         }
     }
 

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/resources/repository/conf/identity/identity.xml
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/resources/repository/conf/identity/identity.xml
@@ -324,6 +324,9 @@
             <SkipUserConsent>false</SkipUserConsent>
             <!-- Sign the ID Token with Service Provider Tenant Private Key-->
             <SignJWTWithSPKey>false</SignJWTWithSPKey>
+            <FAPI>
+                <FAPIVersion>1</FAPIVersion>
+            </FAPI>
 
         </OpenIDConnect>
 

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/resources/repository/conf/identity/identity.xml
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/resources/repository/conf/identity/identity.xml
@@ -324,9 +324,6 @@
             <SkipUserConsent>false</SkipUserConsent>
             <!-- Sign the ID Token with Service Provider Tenant Private Key-->
             <SignJWTWithSPKey>false</SignJWTWithSPKey>
-            <FAPI>
-                <FAPIVersion>1</FAPIVersion>
-            </FAPI>
 
         </OpenIDConnect>
 

--- a/components/org.wso2.carbon.identity.oauth.par/src/main/java/org/wso2/carbon/identity/oauth/par/common/ParConstants.java
+++ b/components/org.wso2.carbon.identity.oauth.par/src/main/java/org/wso2/carbon/identity/oauth/par/common/ParConstants.java
@@ -47,6 +47,7 @@ public class ParConstants {
     public static final String INVALID_REQUEST_OBJECT = "Unable to build a valid Request Object from the" +
             " pushed authorization request.";
     public static final String REQUEST_OBJECT_MISSING = "Request object is missing.";
+    public static final String PAR_STATE = "parRequestState";
 
     private ParConstants() {
 

--- a/components/org.wso2.carbon.identity.oauth.par/src/main/java/org/wso2/carbon/identity/oauth/par/core/ParRequestBuilder.java
+++ b/components/org.wso2.carbon.identity.oauth.par/src/main/java/org/wso2/carbon/identity/oauth/par/core/ParRequestBuilder.java
@@ -54,6 +54,9 @@ public class ParRequestBuilder implements OAuthAuthorizationRequestBuilder {
         try {
             params = ParAuthServiceComponentDataHolder.getInstance().getParAuthService()
                     .retrieveParams(uuid, request.getParameter(OAuthConstants.OAuth20Params.CLIENT_ID));
+            if (params.containsKey(OAuthConstants.OAuth20Params.STATE)) {
+                request.setAttribute(ParConstants.PAR_STATE, params.get(OAuthConstants.OAuth20Params.STATE));
+            }
         } catch (ParClientException e) {
             throw new ParAuthFailureException(e.getErrorCode(), e.getMessage(), e);
         } catch (ParCoreException e) {

--- a/components/org.wso2.carbon.identity.oauth.par/src/main/java/org/wso2/carbon/identity/oauth/par/core/ParRequestBuilder.java
+++ b/components/org.wso2.carbon.identity.oauth.par/src/main/java/org/wso2/carbon/identity/oauth/par/core/ParRequestBuilder.java
@@ -54,7 +54,7 @@ public class ParRequestBuilder implements OAuthAuthorizationRequestBuilder {
         try {
             params = ParAuthServiceComponentDataHolder.getInstance().getParAuthService()
                     .retrieveParams(uuid, request.getParameter(OAuthConstants.OAuth20Params.CLIENT_ID));
-            if (params.containsKey(OAuthConstants.OAuth20Params.STATE)) {
+            if (params != null && params.containsKey(OAuthConstants.OAuth20Params.STATE)) {
                 request.setAttribute(ParConstants.PAR_STATE, params.get(OAuthConstants.OAuth20Params.STATE));
             }
         } catch (ParClientException e) {

--- a/components/org.wso2.carbon.identity.oauth.stub/src/main/resources/OAuthAdminService.wsdl
+++ b/components/org.wso2.carbon.identity.oauth.stub/src/main/resources/OAuthAdminService.wsdl
@@ -408,6 +408,7 @@
                     <xs:element minOccurs="0" name="cibaSkipUserValidation" type="xs:boolean"/>
                     <xs:element minOccurs="0" name="extendRenewedRefreshTokenExpiryTime" type="xs:boolean"/>
                     <xs:element minOccurs="0" name="fapiConformanceEnabled" type="xs:boolean"/>
+                    <xs:element minOccurs="0" name="fapiProfile" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="frontchannelLogoutUrl" nillable="true" type="xs:string"/>
                     <xs:element minOccurs="0" name="gracefulRefreshTokenReuseLimit" type="xs:int"/>
                     <xs:element minOccurs="0" name="gracefulRefreshTokenRotationEnabled" type="xs:boolean"/>

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImpl.java
@@ -593,6 +593,9 @@ public class OAuthAdminServiceImpl {
                         }
                         app.setRequirePushedAuthorizationRequests(application.getRequirePushedAuthorizationRequests());
                         app.setFapiConformanceEnabled(application.isFapiConformanceEnabled());
+                        if (isFAPIConformanceEnabled) {
+                            app.setFapiProfile(application.getFapiProfile());
+                        }
                         app.setSubjectTokenEnabled(application.isSubjectTokenEnabled());
                         app.setSubjectTokenExpiryTime(application.getSubjectTokenExpiryTime());
                         app.setGracefulRefreshTokenRotationEnabled(
@@ -1155,6 +1158,10 @@ public class OAuthAdminServiceImpl {
             if (oAuthAppDO.isCibaAllowFederatedUsers() && !oAuthAppDO.isCibaSkipUserValidation()) {
                 throw handleClientError(INVALID_REQUEST,
                         "cibaAllowFederatedUsers requires cibaSkipUserValidation to be enabled");
+            }
+
+            if (isFAPIConformanceEnabled) {
+                oAuthAppDO.setFapiProfile(consumerAppDTO.getFapiProfile());
             }
 
             try {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImpl.java
@@ -154,6 +154,7 @@ public class OAuthAdminServiceImpl {
     static final String RESPONSE_TYPE_ID_TOKEN = "id_token";
     static final String BINDING_TYPE_NONE = "None";
     private static final String INBOUND_AUTH2_TYPE = "oauth2";
+    private static final String DPOP_TOKEN_BINDER = "DPoP";
     static List<String> allowedGrants = null;
     static String[] allowedScopeValidators = null;
 
@@ -808,21 +809,64 @@ public class OAuthAdminServiceImpl {
     }
 
     /**
-     * FAPI validation to restrict the token binding type to ensure MTLS sender constrained access tokens.
-     * Link - https://openid.net/specs/openid-financial-api-part-2-1_0.html#authorization-server
-     * @param bindingType Token binding type.
-     * @throws IdentityOAuthClientException if binding type is not 'certificate'.
+     * Validates whether the configured token binding type satisfies the
+     * Financial-grade API (FAPI) security requirements.
+     *
+     * <p>FAPI mandates sender-constrained access tokens. The allowed token binding
+     * mechanisms depend on the enabled FAPI version:
+     *
+     * <ul>
+     *     <li><b>FAPI 2.0</b>: MTLS (RFC8705) or DPoP (RFC9449)</li>
+     *     <li><b>FAPI 1.0 Advanced</b>: MTLS only</li>
+     * </ul>
+     *
+     * <p>If {@code bindingType} is {@code null}, validation is skipped.
+     *
+     * @param bindingType token binding type configured for the application
+     * @throws IdentityOAuthAdminException if the configured binding type is not permitted for the active FAPI version
      */
     private void validateFAPIBindingType(String bindingType)
-            throws IdentityOAuthClientException {
+            throws IdentityOAuthAdminException {
 
-        if (OAuth2Constants.TokenBinderType.CERTIFICATE_BASED_TOKEN_BINDER.equals(bindingType) || bindingType == null) {
+        // No token binding type configured. Nothing to validate.
+        if (bindingType == null) {
             return;
-        } else {
-            String msg = String.format("Certificate bound access tokens is required. '%s' binding type is found.",
-                    bindingType);
-            throw handleClientError(INVALID_REQUEST, msg);
         }
+
+        final boolean isFapi2Enabled = OAuth2Util.isFapi2Enabled(getAppTenantDomain());
+        // Supported token binding types.
+        final boolean isMtls = OAuth2Constants.TokenBinderType.CERTIFICATE_BASED_TOKEN_BINDER.equals(bindingType);
+        final boolean isDpop = DPOP_TOKEN_BINDER.equals(bindingType);
+
+        /*
+         * FAPI 2.0 Security Profile
+         * Spec: https://openid.net/specs/fapi-security-profile-2_0.html#section-5.3.2.1-2.5.1
+         *
+         * "shall use one of the following methods for sender-constrained access tokens:
+         *  * MTLS as described in [RFC8705],
+         *  * DPoP as described in [RFC9449];"
+         */
+        if (isFapi2Enabled) {
+            if (isMtls || isDpop) {
+                return;
+            }
+            throw handleClientError(INVALID_REQUEST,
+                    String.format("Certificate bound or DPoP access tokens is required. '%s' binding type is found",
+                    bindingType));
+        }
+
+        /*
+         * FAPI 1.0 Advanced Security Profile
+         * Spec: https://openid.net/specs/openid-financial-api-part-2-1_0.html#authorization-server
+         *
+         * "shall support MTLS as mechanism for constraining the legitimate senders of access tokens;"
+         */
+        if (isMtls) {
+            return;
+        }
+
+        throw handleClientError(INVALID_REQUEST,
+                String.format("Certificate bound access tokens is required. '%s' binding type is found.", bindingType));
     }
 
     private IdentityOAuthClientException handleClientError(Error errorMessage, String msg) {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImpl.java
@@ -828,12 +828,6 @@ public class OAuthAdminServiceImpl {
     private void validateFAPIBindingType(String bindingType)
             throws IdentityOAuthAdminException {
 
-        // No token binding type configured. Nothing to validate.
-        if (bindingType == null) {
-            return;
-        }
-
-        final boolean isFapi2Enabled = OAuth2Util.isFapi2Enabled(getAppTenantDomain());
         // Supported token binding types.
         final boolean isMtls = OAuth2Constants.TokenBinderType.CERTIFICATE_BASED_TOKEN_BINDER.equals(bindingType);
         final boolean isDpop = DPOP_TOKEN_BINDER.equals(bindingType);
@@ -846,7 +840,7 @@ public class OAuthAdminServiceImpl {
          *  * MTLS as described in [RFC8705],
          *  * DPoP as described in [RFC9449];"
          */
-        if (isFapi2Enabled) {
+        if (OAuth2Util.isFapi2Enabled(getAppTenantDomain())) {
             if (isMtls || isDpop) {
                 return;
             }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthUtil.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthUtil.java
@@ -569,6 +569,7 @@ public final class OAuthUtil {
         dto.setRequestObjectEncryptionMethod(appDO.getRequestObjectEncryptionMethod());
         dto.setRequirePushedAuthorizationRequests(appDO.isRequirePushedAuthorizationRequests());
         dto.setFapiConformanceEnabled(appDO.isFapiConformanceEnabled());
+        dto.setFapiProfile(appDO.getFapiProfile());
         dto.setSubjectTokenEnabled(appDO.isSubjectTokenEnabled());
         dto.setSubjectTokenExpiryTime(appDO.getSubjectTokenExpiryTime());
         dto.setGracefulRefreshTokenRotationEnabled(appDO.isGracefulRefreshTokenRotationEnabled());

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/RequestObjectValidatorUtil.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/RequestObjectValidatorUtil.java
@@ -35,6 +35,7 @@ import org.wso2.carbon.identity.oauth.common.exception.InvalidOAuthClientExcepti
 import org.wso2.carbon.identity.oauth.dao.OAuthAppDO;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.RequestObjectException;
+import org.wso2.carbon.identity.oauth2.fapi.utils.FapiUtil;
 import org.wso2.carbon.identity.oauth2.model.OAuth2Parameters;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 import org.wso2.carbon.identity.oauth2.validators.jwt.JWKSBasedJWTValidator;
@@ -370,7 +371,7 @@ public class RequestObjectValidatorUtil {
     private static boolean isFapiConformant(String clientId) throws RequestObjectException {
 
         try {
-            return OAuth2Util.isFapiConformantApp(clientId);
+            return FapiUtil.isFapiConformantApp(clientId);
         } catch (InvalidOAuthClientException e) {
             throw new RequestObjectException(OAuth2ErrorCodes.INVALID_CLIENT, "Could not find an existing app for " +
                     "clientId: " + clientId, e);

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
@@ -227,7 +227,6 @@ public class OAuthServerConfiguration {
     private String[] supportedClaims = null;
     private boolean isFapiCiba = false;
     private boolean isFapiSecurity = false;
-    private String fapiVersion = OAuthConstants.FAPIVersions.FAPI1;
     private Map<String, Properties> supportedClientAuthHandlerData = new HashMap<>();
     private String saml2TokenCallbackHandlerName = null;
     private String saml2BearerTokenUserType;
@@ -4004,10 +4003,6 @@ public class OAuthServerConfiguration {
                             Boolean.parseBoolean(fapiElem.getFirstChildWithName(getQNameWithIdentityNS
                                     (ConfigElements.ENABLE_FAPI_SECURITY_PROFILE)).getText().trim());
                 }
-                if (fapiElem.getFirstChildWithName(getQNameWithIdentityNS(ConfigElements.FAPI_VERSION)) != null) {
-                    fapiVersion = fapiElem.getFirstChildWithName(getQNameWithIdentityNS(
-                            ConfigElements.FAPI_VERSION)).getText().trim();
-                }
             }
             if (openIDConnectConfigElem.getFirstChildWithName(getQNameWithIdentityNS(ConfigElements
                     .REQUEST_OBJECT_ENABLED)) != null) {
@@ -4487,14 +4482,6 @@ public class OAuthServerConfiguration {
         return isFapiSecurity;
     }
 
-    /**
-     * This method returns the FAPI version supported by the server configured in identity.xml.
-     */
-    public String getFapiVersion() {
-
-        return fapiVersion;
-    }
-
     public boolean isGlobalRbacScopeIssuerEnabled() {
 
         return globalRbacScopeIssuerEnabled;
@@ -4896,7 +4883,6 @@ public class OAuthServerConfiguration {
 
         // FAPI Configurations
         private static final String FAPI = "FAPI";
-        private static final String FAPI_VERSION = "FAPIVersion";
 
         private static final String SKIP_OIDC_CLAIMS_FOR_CLIENT_CREDENTIAL_GRANT =
                 "SkipOIDCClaimsForClientCredentialGrant";

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
@@ -227,6 +227,7 @@ public class OAuthServerConfiguration {
     private String[] supportedClaims = null;
     private boolean isFapiCiba = false;
     private boolean isFapiSecurity = false;
+    private String fapiVersion = OAuthConstants.FAPIVersions.FAPI1;
     private Map<String, Properties> supportedClientAuthHandlerData = new HashMap<>();
     private String saml2TokenCallbackHandlerName = null;
     private String saml2BearerTokenUserType;
@@ -4003,6 +4004,10 @@ public class OAuthServerConfiguration {
                             Boolean.parseBoolean(fapiElem.getFirstChildWithName(getQNameWithIdentityNS
                                     (ConfigElements.ENABLE_FAPI_SECURITY_PROFILE)).getText().trim());
                 }
+                if (fapiElem.getFirstChildWithName(getQNameWithIdentityNS(ConfigElements.FAPI_VERSION)) != null) {
+                    fapiVersion = fapiElem.getFirstChildWithName(getQNameWithIdentityNS(
+                            ConfigElements.FAPI_VERSION)).getText().trim();
+                }
             }
             if (openIDConnectConfigElem.getFirstChildWithName(getQNameWithIdentityNS(ConfigElements
                     .REQUEST_OBJECT_ENABLED)) != null) {
@@ -4482,6 +4487,14 @@ public class OAuthServerConfiguration {
         return isFapiSecurity;
     }
 
+    /**
+     * This method returns the FAPI version supported by the server configured in identity.xml.
+     */
+    public String getFapiVersion() {
+
+        return fapiVersion;
+    }
+
     public boolean isGlobalRbacScopeIssuerEnabled() {
 
         return globalRbacScopeIssuerEnabled;
@@ -4883,6 +4896,7 @@ public class OAuthServerConfiguration {
 
         // FAPI Configurations
         private static final String FAPI = "FAPI";
+        private static final String FAPI_VERSION = "FAPIVersion";
 
         private static final String SKIP_OIDC_CLAIMS_FOR_CLIENT_CREDENTIAL_GRANT =
                 "SkipOIDCClaimsForClientCredentialGrant";

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dao/OAuthAppDAO.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dao/OAuthAppDAO.java
@@ -79,7 +79,6 @@ import java.util.Set;
 
 import static org.wso2.carbon.identity.oauth.OAuthUtil.handleError;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.ENABLE_CLAIMS_SEPARATION_FOR_ACCESS_TOKEN;
-import static org.wso2.carbon.identity.oauth.common.OAuthConstants.FAPIProfiles.FAPI1_ADVANCED;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.GracefulRefreshTokenRotation.GRACEFUL_REFRESH_TOKEN_REUSE_LIMIT;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.GracefulRefreshTokenRotation.GRACEFUL_REFRESH_TOKEN_ROTATION_VALIDITY_PERIOD;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.GracefulRefreshTokenRotation.IS_GRACEFUL_REFRESH_TOKEN_ROTATION_ENABLED;
@@ -122,6 +121,7 @@ import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCConfigPro
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCConfigProperties.TOKEN_EP_ALLOW_REUSE_PVT_KEY_JWT;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCConfigProperties.TOKEN_REVOCATION_WITH_IDP_SESSION_TERMINATION;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCConfigProperties.TOKEN_TYPE;
+import static org.wso2.carbon.identity.oauth2.fapi.models.FapiProfileEnum.FAPI1_ADVANCED;
 import static org.wso2.carbon.identity.oauth2.util.OAuth2Util.OPENID_CONNECT_AUDIENCE;
 import static org.wso2.carbon.identity.oauth2.util.OAuth2Util.getConsoleCallbackFromServerConfig;
 import static org.wso2.carbon.identity.oauth2.util.OAuth2Util.getMyAccountCallbackFromServerConfig;
@@ -1183,7 +1183,7 @@ public class OAuthAppDAO {
 
         if (oauthAppDO.isFapiConformanceEnabled()) {
             addOrUpdateOIDCSpProperty(preprocessedClientId, spTenantId, spOIDCProperties,
-                    FAPI_PROFILE, String.valueOf(oauthAppDO.getFapiProfile()),
+                    FAPI_PROFILE, StringUtils.defaultIfBlank(oauthAppDO.getFapiProfile(), FAPI1_ADVANCED.value()),
                     prepStatementForPropertyAdd, preparedStatementForPropertyUpdate);
         }
 
@@ -1899,15 +1899,10 @@ public class OAuthAppDAO {
             addToBatchForOIDCPropertyAdd(processedClientId, spTenantId, prepStmtAddOIDCProperty,
                     IS_FAPI_CONFORMANT_APP, String.valueOf(consumerAppDO.isFapiConformanceEnabled()));
 
-            if (consumerAppDO.isFapiConformanceEnabled() && consumerAppDO.getFapiProfile() == null) {
-                LOG.debug("fapiProfile not specified with isFAPIApplication=true. Defaulting to FAPI1_ADVANCED.");
-                addToBatchForOIDCPropertyAdd(processedClientId, spTenantId, prepStmtAddOIDCProperty,
-                        FAPI_PROFILE, FAPI1_ADVANCED);
-            }
-
-            if (consumerAppDO.isFapiConformanceEnabled() && consumerAppDO.getFapiProfile() != null) {
-                addToBatchForOIDCPropertyAdd(processedClientId, spTenantId, prepStmtAddOIDCProperty,
-                        FAPI_PROFILE, consumerAppDO.getFapiProfile());
+            if (consumerAppDO.isFapiConformanceEnabled()) {
+                addToBatchForOIDCPropertyAdd(processedClientId, spTenantId, prepStmtAddOIDCProperty, FAPI_PROFILE,
+                        StringUtils.isBlank(consumerAppDO.getFapiProfile()) ?
+                                FAPI1_ADVANCED.value() : consumerAppDO.getFapiProfile());
             }
 
             if (consumerAppDO.isJwtScopeAsArrayEnabled() != null) {
@@ -2142,12 +2137,8 @@ public class OAuthAppDAO {
         // Read back the FAPI security profile. This value is non-null only for applications
         // where a profile was explicitly configured via the management API.
         String fapiProfile = getFirstPropertyValue(spOIDCProperties, FAPI_PROFILE);
-        if (Boolean.parseBoolean(isFAPI) && fapiProfile == null) {
-            LOG.debug("fapiProfile not specified with isFAPIApplication=true. Defaulting to FAPI1_ADVANCED.");
-            oauthApp.setFapiProfile(FAPI1_ADVANCED);
-        }
-        if (fapiProfile != null) {
-            oauthApp.setFapiProfile(fapiProfile);
+        if (Boolean.parseBoolean(isFAPI)) {
+            oauthApp.setFapiProfile(StringUtils.isBlank(fapiProfile) ? FAPI1_ADVANCED.value() : fapiProfile);
         }
 
         String isJwtScopeAsArray = getFirstPropertyValue(spOIDCProperties, ENABLE_JWT_SCOPE_AS_ARRAY);

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dao/OAuthAppDAO.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dao/OAuthAppDAO.java
@@ -79,10 +79,10 @@ import java.util.Set;
 
 import static org.wso2.carbon.identity.oauth.OAuthUtil.handleError;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.ENABLE_CLAIMS_SEPARATION_FOR_ACCESS_TOKEN;
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.FAPIProfiles.FAPI1_ADVANCED;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.GracefulRefreshTokenRotation.GRACEFUL_REFRESH_TOKEN_REUSE_LIMIT;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.GracefulRefreshTokenRotation.GRACEFUL_REFRESH_TOKEN_ROTATION_VALIDITY_PERIOD;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.GracefulRefreshTokenRotation.IS_GRACEFUL_REFRESH_TOKEN_ROTATION_ENABLED;
-import static org.wso2.carbon.identity.oauth.common.OAuthConstants.FAPIProfiles.FAPI1_ADVANCED;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCConfigProperties.BACK_CHANNEL_LOGOUT_URL;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCConfigProperties.BYPASS_CLIENT_CREDENTIALS;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCConfigProperties.CIBA_ALLOW_FEDERATED_USERS;
@@ -1905,7 +1905,7 @@ public class OAuthAppDAO {
                         FAPI_PROFILE, FAPI1_ADVANCED);
             }
 
-            if (consumerAppDO.getFapiProfile() != null) {
+            if (consumerAppDO.isFapiConformanceEnabled() && consumerAppDO.getFapiProfile() != null) {
                 addToBatchForOIDCPropertyAdd(processedClientId, spTenantId, prepStmtAddOIDCProperty,
                         FAPI_PROFILE, consumerAppDO.getFapiProfile());
             }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dao/OAuthAppDAO.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dao/OAuthAppDAO.java
@@ -1899,10 +1899,7 @@ public class OAuthAppDAO {
             addToBatchForOIDCPropertyAdd(processedClientId, spTenantId, prepStmtAddOIDCProperty,
                     IS_FAPI_CONFORMANT_APP, String.valueOf(consumerAppDO.isFapiConformanceEnabled()));
 
-            // Persist the FAPI security profile only when a value has been set.
-            // A null value means the profile is not configured (FAPI may still be disabled).
-            if (Boolean.parseBoolean(String.valueOf(consumerAppDO.isFapiConformanceEnabled())) &&
-                    consumerAppDO.getFapiProfile() == null) {
+            if (consumerAppDO.isFapiConformanceEnabled() && consumerAppDO.getFapiProfile() == null) {
                 LOG.debug("fapiProfile not specified with isFAPIApplication=true. Defaulting to FAPI1_ADVANCED.");
                 addToBatchForOIDCPropertyAdd(processedClientId, spTenantId, prepStmtAddOIDCProperty,
                         FAPI_PROFILE, FAPI1_ADVANCED);

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dao/OAuthAppDAO.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dao/OAuthAppDAO.java
@@ -82,6 +82,7 @@ import static org.wso2.carbon.identity.oauth.common.OAuthConstants.ENABLE_CLAIMS
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.GracefulRefreshTokenRotation.GRACEFUL_REFRESH_TOKEN_REUSE_LIMIT;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.GracefulRefreshTokenRotation.GRACEFUL_REFRESH_TOKEN_ROTATION_VALIDITY_PERIOD;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.GracefulRefreshTokenRotation.IS_GRACEFUL_REFRESH_TOKEN_ROTATION_ENABLED;
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.FAPIProfiles.FAPI1_ADVANCED;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCConfigProperties.BACK_CHANNEL_LOGOUT_URL;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCConfigProperties.BYPASS_CLIENT_CREDENTIALS;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCConfigProperties.CIBA_ALLOW_FEDERATED_USERS;
@@ -90,6 +91,7 @@ import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCConfigPro
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCConfigProperties.CIBA_SKIP_USER_VALIDATION;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCConfigProperties.ENABLE_JWT_SCOPE_AS_ARRAY;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCConfigProperties.EXTEND_RENEWED_REFRESH_TOKEN_EXPIRY_TIME;
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCConfigProperties.FAPI_PROFILE;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCConfigProperties.FRONT_CHANNEL_LOGOUT_URL;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCConfigProperties.HYBRID_FLOW_ENABLED;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCConfigProperties.HYBRID_FLOW_RESPONSE_TYPE;
@@ -1179,6 +1181,12 @@ public class OAuthAppDAO {
                     prepStatementForPropertyAdd, preparedStatementForPropertyUpdate);
         }
 
+        if (oauthAppDO.isFapiConformanceEnabled()) {
+            addOrUpdateOIDCSpProperty(preprocessedClientId, spTenantId, spOIDCProperties,
+                    FAPI_PROFILE, String.valueOf(oauthAppDO.getFapiProfile()),
+                    prepStatementForPropertyAdd, preparedStatementForPropertyUpdate);
+        }
+
         // Execute batched add/update/delete.
         prepStatementForPropertyAdd.executeBatch();
         preparedStatementForPropertyUpdate.executeBatch();
@@ -1891,6 +1899,20 @@ public class OAuthAppDAO {
             addToBatchForOIDCPropertyAdd(processedClientId, spTenantId, prepStmtAddOIDCProperty,
                     IS_FAPI_CONFORMANT_APP, String.valueOf(consumerAppDO.isFapiConformanceEnabled()));
 
+            // Persist the FAPI security profile only when a value has been set.
+            // A null value means the profile is not configured (FAPI may still be disabled).
+            if (Boolean.parseBoolean(String.valueOf(consumerAppDO.isFapiConformanceEnabled())) &&
+                    consumerAppDO.getFapiProfile() == null) {
+                LOG.debug("fapiProfile not specified with isFAPIApplication=true. Defaulting to FAPI1_ADVANCED.");
+                addToBatchForOIDCPropertyAdd(processedClientId, spTenantId, prepStmtAddOIDCProperty,
+                        FAPI_PROFILE, FAPI1_ADVANCED);
+            }
+
+            if (consumerAppDO.getFapiProfile() != null) {
+                addToBatchForOIDCPropertyAdd(processedClientId, spTenantId, prepStmtAddOIDCProperty,
+                        FAPI_PROFILE, consumerAppDO.getFapiProfile());
+            }
+
             if (consumerAppDO.isJwtScopeAsArrayEnabled() != null) {
                 addToBatchForOIDCPropertyAdd(processedClientId, spTenantId, prepStmtAddOIDCProperty,
                         ENABLE_JWT_SCOPE_AS_ARRAY, String.valueOf(consumerAppDO.isJwtScopeAsArrayEnabled()));
@@ -2119,6 +2141,16 @@ public class OAuthAppDAO {
         String isFAPI = getFirstPropertyValue(spOIDCProperties, IS_FAPI_CONFORMANT_APP);
         if (isFAPI != null) {
             oauthApp.setFapiConformanceEnabled(Boolean.parseBoolean(isFAPI));
+        }
+        // Read back the FAPI security profile. This value is non-null only for applications
+        // where a profile was explicitly configured via the management API.
+        String fapiProfile = getFirstPropertyValue(spOIDCProperties, FAPI_PROFILE);
+        if (Boolean.parseBoolean(isFAPI) && fapiProfile == null) {
+            LOG.debug("fapiProfile not specified with isFAPIApplication=true. Defaulting to FAPI1_ADVANCED.");
+            oauthApp.setFapiProfile(FAPI1_ADVANCED);
+        }
+        if (fapiProfile != null) {
+            oauthApp.setFapiProfile(fapiProfile);
         }
 
         String isJwtScopeAsArray = getFirstPropertyValue(spOIDCProperties, ENABLE_JWT_SCOPE_AS_ARRAY);

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dao/OAuthAppDO.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dao/OAuthAppDO.java
@@ -113,6 +113,7 @@ public class OAuthAppDO extends InboundConfigurationProtocol implements Serializ
     private String requestObjectEncryptionAlgorithm;
     private String requestObjectEncryptionMethod;
     private boolean fapiConformanceEnabled;
+    private String fapiProfile;
     private Boolean jwtScopeAsArrayEnabled;
     private boolean subjectTokenEnabled;
     private int subjectTokenExpiryTime;
@@ -546,6 +547,27 @@ public class OAuthAppDO extends InboundConfigurationProtocol implements Serializ
     public void setFapiConformanceEnabled(boolean fapiConformant) {
 
         fapiConformanceEnabled = fapiConformant;
+    }
+
+    /**
+     * Returns the FAPI security profile applied to this application.
+     * Meaningful only when {@link #isFapiConformanceEnabled()} is true.
+     *
+     * @return the FAPI profile string (e.g. "FAPI1_ADVANCED"), or null if not set.
+     */
+    public String getFapiProfile() {
+
+        return this.fapiProfile;
+    }
+
+    /**
+     * Sets the FAPI security profile for this application.
+     *
+     * @param fapiProfile the FAPI profile string (e.g. "FAPI1_ADVANCED").
+     */
+    public void setFapiProfile(String fapiProfile) {
+
+        this.fapiProfile = fapiProfile;
     }
 
     public Boolean isJwtScopeAsArrayEnabled() {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dto/OAuthConsumerAppDTO.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dto/OAuthConsumerAppDTO.java
@@ -80,6 +80,7 @@ public class OAuthConsumerAppDTO implements InboundProtocolConfigurationDTO {
     private String requestObjectEncryptionMethod;
     private String jwksURI;
     private boolean fapiConformanceEnabled;
+    private String fapiProfile;
     private Boolean jwtScopeAsArrayEnabled;
     private boolean subjectTokenEnabled;
     private int subjectTokenExpiryTime;
@@ -546,6 +547,27 @@ public class OAuthConsumerAppDTO implements InboundProtocolConfigurationDTO {
     public void setFapiConformanceEnabled(boolean fapiConformant) {
 
         fapiConformanceEnabled = fapiConformant;
+    }
+
+    /**
+     * Returns the FAPI security profile configured for this OAuth application.
+     * Meaningful only when {@link #isFapiConformanceEnabled()} is true.
+     *
+     * @return the FAPI profile string (e.g. "FAPI1_ADVANCED"), or null if not set.
+     */
+    public String getFapiProfile() {
+
+        return fapiProfile;
+    }
+
+    /**
+     * Sets the FAPI security profile for this OAuth application.
+     *
+     * @param fapiProfile the FAPI profile string (e.g. "FAPI1_ADVANCED").
+     */
+    public void setFapiProfile(String fapiProfile) {
+
+        this.fapiProfile = fapiProfile;
     }
 
     public Boolean isJwtScopeAsArrayEnabled() {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/AuthorizationHandlerManager.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/AuthorizationHandlerManager.java
@@ -30,6 +30,7 @@ import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.oauth.IdentityOAuthAdminException;
 import org.wso2.carbon.identity.oauth.cache.AppInfoCache;
+import org.wso2.carbon.identity.oauth.common.OAuth2ErrorCodes;
 import org.wso2.carbon.identity.oauth.common.OAuthConstants;
 import org.wso2.carbon.identity.oauth.common.exception.InvalidOAuthClientException;
 import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
@@ -41,6 +42,8 @@ import org.wso2.carbon.identity.oauth2.IdentityOAuth2UnauthorizedScopeException;
 import org.wso2.carbon.identity.oauth2.authz.handlers.ResponseTypeHandler;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2AuthorizeReqDTO;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2AuthorizeRespDTO;
+import org.wso2.carbon.identity.oauth2.fapi.models.FapiProfileEnum;
+import org.wso2.carbon.identity.oauth2.fapi.utils.FapiUtil;
 import org.wso2.carbon.identity.oauth2.model.OAuth2Parameters;
 import org.wso2.carbon.identity.oauth2.util.AuthzUtil;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
@@ -636,7 +639,18 @@ public class AuthorizationHandlerManager {
             throws IdentityOAuth2Exception {
         boolean isAuthorizedClient = authzHandler.isAuthorizedClient(authzReqMsgCtx);
         if (!isAuthorizedClient) {
-            handleErrorRequest(authorizeRespDTO, UNAUTHORIZED_CLIENT,
+            String errorCode;
+            try {
+                if (FapiUtil.isFapiConformantApp(authzReqDTO.getConsumerKey(), FapiProfileEnum.FAPI2_SECURITY)) {
+                    errorCode = OAuth2ErrorCodes.INVALID_REQUEST;
+                } else {
+                    errorCode = UNAUTHORIZED_CLIENT;
+                }
+            } catch (InvalidOAuthClientException e) {
+                throw new IdentityOAuth2Exception("Error occurred while retrieving the fapi conformance of the " +
+                        "application.", e);
+            }
+            handleErrorRequest(authorizeRespDTO, errorCode,
                     "The authenticated client is not authorized to use this authorization grant type");
             authorizeRespDTO.setCallbackURI(authzReqDTO.getCallbackUrl());
             if (log.isDebugEnabled()) {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/client/authentication/OAuthClientAuthnService.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/client/authentication/OAuthClientAuthnService.java
@@ -29,6 +29,7 @@ import org.wso2.carbon.identity.oauth.common.exception.InvalidOAuthClientExcepti
 import org.wso2.carbon.identity.oauth.dao.OAuthAppDO;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.bean.OAuthClientAuthnContext;
+import org.wso2.carbon.identity.oauth2.fapi.utils.FapiUtil;
 import org.wso2.carbon.identity.oauth2.internal.OAuth2ServiceComponentHolder;
 import org.wso2.carbon.identity.oauth2.model.ClientAuthenticationMethodModel;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
@@ -168,7 +169,7 @@ public class OAuthClientAuthnService {
             try {
                 List<OAuthClientAuthenticator> configuredClientAuthMethods = getConfiguredClientAuthMethods(clientId);
                 List<OAuthClientAuthenticator> applicableAuthenticators;
-                if (OAuth2Util.isFapiConformantApp(clientId)) {
+                if (FapiUtil.isFapiConformantApp(clientId)) {
                     applicableAuthenticators = filterClientAuthenticatorsForFapi(configuredClientAuthMethods);
                 } else {
                     if (configuredClientAuthMethods.isEmpty()) {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/fapi/cache/FapiConfigCache.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/fapi/cache/FapiConfigCache.java
@@ -34,10 +34,12 @@ public class FapiConfigCache extends AuthenticationBaseCache<String, FapiConfig>
     private static volatile FapiConfigCache instance;
 
     private FapiConfigCache() {
+
         super(FAPI_CONFIG_CACHE_NAME);
     }
 
     public static FapiConfigCache getInstance() {
+        
         CarbonUtils.checkSecurity();
         if (instance == null) {
             synchronized (FapiConfigCache.class) {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/fapi/cache/FapiConfigCache.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/fapi/cache/FapiConfigCache.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth2.fapi.cache;
+
+import org.wso2.carbon.identity.application.authentication.framework.cache.AuthenticationBaseCache;
+import org.wso2.carbon.identity.oauth2.fapi.models.FapiConfig;
+import org.wso2.carbon.utils.CarbonUtils;
+
+/**
+ * Cache for per-tenant FAPI configurations. Avoids a DB round-trip on every call to
+ * {@code FapiConfigMgtService.getFapiConfig(tenantDomain)} which is invoked in hot auth paths.
+ * TTL and capacity are configurable via identity.xml using the cache name "FapiConfigCache".
+ */
+public class FapiConfigCache extends AuthenticationBaseCache<String, FapiConfig> {
+
+    private static final String FAPI_CONFIG_CACHE_NAME = "FapiConfigCache";
+
+    private static volatile FapiConfigCache instance;
+
+    private FapiConfigCache() {
+        super(FAPI_CONFIG_CACHE_NAME);
+    }
+
+    public static FapiConfigCache getInstance() {
+        CarbonUtils.checkSecurity();
+        if (instance == null) {
+            synchronized (FapiConfigCache.class) {
+                if (instance == null) {
+                    instance = new FapiConfigCache();
+                }
+            }
+        }
+        return instance;
+    }
+}

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/fapi/exceptions/FapiConfigMgtClientException.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/fapi/exceptions/FapiConfigMgtClientException.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth2.fapi.exceptions;
+
+/**
+ * Exception class for handling FAPI configuration management client errors (HTTP 4xx).
+ */
+public class FapiConfigMgtClientException extends FapiConfigMgtException {
+
+    /**
+     * The default constructor.
+     */
+    public FapiConfigMgtClientException() {
+
+        super();
+    }
+
+    /**
+     * Constructor with {@code message}, {@code errorCode} and {@code cause} parameters.
+     *
+     * @param message   Message to be included in the exception.
+     * @param errorCode Error code of the exception.
+     * @param cause     Exception to be wrapped.
+     */
+    public FapiConfigMgtClientException(String message, String errorCode, Throwable cause) {
+
+        super(message, errorCode, cause);
+    }
+}

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/fapi/exceptions/FapiConfigMgtException.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/fapi/exceptions/FapiConfigMgtException.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth2.fapi.exceptions;
+
+/**
+ * Exception class for handling FAPI configuration management errors.
+ */
+public class FapiConfigMgtException extends Exception {
+
+    private String errorCode;
+
+    /**
+     * The default constructor.
+     */
+    public FapiConfigMgtException() {
+
+        super();
+    }
+
+    /**
+     * Constructor with {@code message}, {@code errorCode} and {@code cause} parameters.
+     *
+     * @param message   Message to be included in the exception.
+     * @param errorCode Error code of the exception.
+     * @param cause     Exception to be wrapped.
+     */
+    public FapiConfigMgtException(String message, String errorCode, Throwable cause) {
+
+        super(message, cause);
+        this.errorCode = errorCode;
+    }
+
+    /**
+     * Get the {@code errorCode}.
+     *
+     * @return Returns the {@code errorCode}.
+     */
+    public String getErrorCode() {
+
+        return errorCode;
+    }
+}

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/fapi/exceptions/FapiConfigMgtServerException.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/fapi/exceptions/FapiConfigMgtServerException.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth2.fapi.exceptions;
+
+/**
+ * Exception class for handling FAPI configuration management server errors (HTTP 5xx).
+ */
+public class FapiConfigMgtServerException extends FapiConfigMgtException {
+
+    /**
+     * The default constructor.
+     */
+    public FapiConfigMgtServerException() {
+
+        super();
+    }
+
+    /**
+     * Constructor with {@code message}, {@code errorCode} and {@code cause} parameters.
+     *
+     * @param message   Message to be included in the exception.
+     * @param errorCode Error code of the exception.
+     * @param cause     Exception to be wrapped.
+     */
+    public FapiConfigMgtServerException(String message, String errorCode, Throwable cause) {
+
+        super(message, errorCode, cause);
+    }
+}

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/fapi/models/FapiConfig.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/fapi/models/FapiConfig.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth2.fapi.models;
+
+import java.util.List;
+
+/**
+ * The FapiConfig class handles the configuration for Financial-grade API (FAPI) settings.
+ */
+public class FapiConfig {
+
+    private boolean enabled;
+    private List<FapiProfileEnum> supportedProfiles;
+
+    /**
+     * Returns whether FAPI compliance enforcement is enabled for the tenant.
+     *
+     * @return true if FAPI enforcement is enabled, false otherwise.
+     */
+    public boolean isEnabled() {
+
+        return enabled;
+    }
+
+    /**
+     * Sets whether FAPI compliance enforcement is enabled for the tenant.
+     *
+     * @param enabled true to enable FAPI enforcement, false to disable it.
+     */
+    public void setEnabled(boolean enabled) {
+
+        this.enabled = enabled;
+    }
+
+    /**
+     * Returns the list of FAPI security profiles supported by the tenant.
+     *
+     * @return list of supported FAPI profile names.
+     */
+    public List<FapiProfileEnum> getSupportedProfiles() {
+
+        return supportedProfiles;
+    }
+
+    /**
+     * Sets the list of FAPI security profiles supported by the tenant.
+     *
+     * @param supportedProfiles list of supported FAPI profile names.
+     */
+    public void setSupportedProfiles(List<FapiProfileEnum> supportedProfiles) {
+
+        this.supportedProfiles = supportedProfiles;
+    }
+}

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/fapi/models/FapiConfig.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/fapi/models/FapiConfig.java
@@ -18,12 +18,15 @@
 
 package org.wso2.carbon.identity.oauth2.fapi.models;
 
+import java.io.Serializable;
 import java.util.List;
 
 /**
  * The FapiConfig class handles the configuration for Financial-grade API (FAPI) settings.
  */
-public class FapiConfig {
+public class FapiConfig implements Serializable {
+
+    private static final long serialVersionUID = -3812947265451286734L;
 
     private boolean enabled;
     private List<FapiProfileEnum> supportedProfiles;

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/fapi/models/FapiProfileEnum.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/fapi/models/FapiProfileEnum.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth2.fapi.models;
+
+import org.wso2.carbon.identity.oauth.common.OAuthConstants;
+
+/**
+ * Enum representing supported FAPI profiles.
+ * <p>
+ * Each enum constant holds the string value used in configuration.
+ */
+public enum FapiProfileEnum {
+
+    FAPI1_ADVANCED(OAuthConstants.FAPIProfiles.FAPI1_ADVANCED),
+    FAPI2_SECURITY(OAuthConstants.FAPIProfiles.FAPI2_SECURITY);
+
+    private final String value;
+
+    /**
+     * Create a FapiProfileEnum with the given string value.
+     *
+     * @param value the string value for the enum constant
+     */
+    FapiProfileEnum(String value) {
+        this.value = value;
+    }
+
+    /**
+     * Return the string value associated with this enum constant.
+     *
+     * @return the enum string value
+     */
+    public String value() {
+        return value;
+    }
+
+    /**
+     * Return the string representation of this enum constant.
+     *
+     * @return string representation of the enum
+     */
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    /**
+     * Convert a string value to the corresponding FapiProfileEnum constant.
+     *
+     * @param value the string representation of the enum
+     * @return matching FapiProfileEnum constant, or null if no match is found
+     */
+    public static FapiProfileEnum fromValue(String value) {
+        for (FapiProfileEnum profileEnum : FapiProfileEnum.values()) {
+            if (profileEnum.value().equals(value)) {
+                return profileEnum;
+            }
+        }
+        return null;
+    }
+}

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/fapi/models/FapiProfileEnum.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/fapi/models/FapiProfileEnum.java
@@ -18,8 +18,6 @@
 
 package org.wso2.carbon.identity.oauth2.fapi.models;
 
-import org.wso2.carbon.identity.oauth.common.OAuthConstants;
-
 /**
  * Enum representing supported FAPI profiles.
  * <p>
@@ -27,8 +25,8 @@ import org.wso2.carbon.identity.oauth.common.OAuthConstants;
  */
 public enum FapiProfileEnum {
 
-    FAPI1_ADVANCED(OAuthConstants.FAPIProfiles.FAPI1_ADVANCED),
-    FAPI2_SECURITY(OAuthConstants.FAPIProfiles.FAPI2_SECURITY);
+    FAPI1_ADVANCED("FAPI1_ADVANCED"),
+    FAPI2_SECURITY("FAPI2_SECURITY");
 
     private final String value;
 
@@ -38,6 +36,7 @@ public enum FapiProfileEnum {
      * @param value the string value for the enum constant
      */
     FapiProfileEnum(String value) {
+
         this.value = value;
     }
 
@@ -47,6 +46,7 @@ public enum FapiProfileEnum {
      * @return the enum string value
      */
     public String value() {
+
         return value;
     }
 
@@ -57,6 +57,7 @@ public enum FapiProfileEnum {
      */
     @Override
     public String toString() {
+
         return String.valueOf(value);
     }
 
@@ -67,6 +68,7 @@ public enum FapiProfileEnum {
      * @return matching FapiProfileEnum constant, or null if no match is found
      */
     public static FapiProfileEnum fromValue(String value) {
+
         for (FapiProfileEnum profileEnum : FapiProfileEnum.values()) {
             if (profileEnum.value().equals(value)) {
                 return profileEnum;

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/fapi/services/FapiConfigMgtService.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/fapi/services/FapiConfigMgtService.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth2.fapi.services;
+
+import org.wso2.carbon.identity.oauth2.fapi.exceptions.FapiConfigMgtException;
+import org.wso2.carbon.identity.oauth2.fapi.models.FapiConfig;
+
+/**
+ * Service interface for managing Financial-grade API (FAPI) configurations.
+ */
+public interface FapiConfigMgtService {
+
+    /**
+     * Retrieves the FAPI configuration for a given tenant domain.
+     *
+     * @param tenantDomain The domain of the tenant whose FAPI configuration is to be retrieved.
+     * @return The FAPI configuration of the specified tenant.
+     * @throws FapiConfigMgtException If there is an error in retrieving the configuration.
+     */
+    FapiConfig getFapiConfig(String tenantDomain) throws FapiConfigMgtException;
+
+    /**
+     * Sets the FAPI configuration for a given tenant domain.
+     *
+     * @param fapiConfig   The FAPI configuration to be set.
+     * @param tenantDomain The domain of the tenant for which the configuration is to be set.
+     * @throws FapiConfigMgtException If there is an error in setting the configuration.
+     */
+    void setFapiConfig(FapiConfig fapiConfig, String tenantDomain) throws FapiConfigMgtException;
+}

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/fapi/services/FapiConfigMgtServiceImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/fapi/services/FapiConfigMgtServiceImpl.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.oauth2.fapi.services;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.identity.base.IdentityRuntimeException;
@@ -79,12 +80,26 @@ public class FapiConfigMgtServiceImpl implements FapiConfigMgtService {
     public void setFapiConfig(FapiConfig fapiConfig, String tenantDomain) throws FapiConfigMgtException {
 
         validateTenantDomain(tenantDomain);
+        validateFapiConfig(fapiConfig);
         try {
             // Parse the FAPI configuration and replace the existing resource with the updated configuration.
             ResourceAdd resourceAdd = FapiUtil.parseConfig(fapiConfig);
             getConfigurationManager().replaceResource(FAPI_RESOURCE_TYPE_NAME, resourceAdd);
         } catch (ConfigurationManagementException e) {
             throw handleServerException(ErrorMessage.ERROR_CODE_FAPI_CONFIG_UPDATE, e, tenantDomain);
+        }
+    }
+
+    /**
+     * Validates the given FAPI configuration.
+     *
+     * @param fapiConfig The FAPI configuration to validate.
+     * @throws FapiConfigMgtException If the configuration is invalid.
+     */
+    private void validateFapiConfig(FapiConfig fapiConfig) throws FapiConfigMgtException {
+
+        if (fapiConfig.isEnabled() && CollectionUtils.isEmpty(fapiConfig.getSupportedProfiles())) {
+            throw handleClientException(ErrorMessage.ERROR_CODE_FAPI_ENABLED_WITH_EMPTY_PROFILES, null);
         }
     }
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/fapi/services/FapiConfigMgtServiceImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/fapi/services/FapiConfigMgtServiceImpl.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth2.fapi.services;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.base.IdentityRuntimeException;
+import org.wso2.carbon.identity.configuration.mgt.core.ConfigurationManager;
+import org.wso2.carbon.identity.configuration.mgt.core.exception.ConfigurationManagementException;
+import org.wso2.carbon.identity.configuration.mgt.core.model.Resource;
+import org.wso2.carbon.identity.configuration.mgt.core.model.ResourceAdd;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.oauth2.fapi.exceptions.FapiConfigMgtException;
+import org.wso2.carbon.identity.oauth2.fapi.models.FapiConfig;
+import org.wso2.carbon.identity.oauth2.fapi.utils.ErrorMessage;
+import org.wso2.carbon.identity.oauth2.fapi.utils.FapiUtil;
+import org.wso2.carbon.identity.oauth2.internal.OAuth2ServiceComponentHolder;
+
+import static org.wso2.carbon.identity.configuration.mgt.core.constant.ConfigurationConstants.ErrorMessages.ERROR_CODE_RESOURCE_DOES_NOT_EXISTS;
+import static org.wso2.carbon.identity.oauth2.fapi.utils.Constants.FAPI_RESOURCE_NAME;
+import static org.wso2.carbon.identity.oauth2.fapi.utils.Constants.FAPI_RESOURCE_TYPE_NAME;
+import static org.wso2.carbon.identity.oauth2.fapi.utils.FapiUtil.handleClientException;
+import static org.wso2.carbon.identity.oauth2.fapi.utils.FapiUtil.handleServerException;
+
+/**
+ * Implementation class for managing Financial-grade API (FAPI) configurations.
+ */
+public class FapiConfigMgtServiceImpl implements FapiConfigMgtService {
+
+    private static final Log log = LogFactory.getLog(FapiConfigMgtServiceImpl.class);
+
+    /**
+     * Retrieves the FAPI configuration for a given tenant domain.
+     *
+     * @param tenantDomain The domain of the tenant whose FAPI configuration is to be retrieved.
+     * @return The FAPI configuration of the specified tenant.
+     * @throws FapiConfigMgtException If there is an error in retrieving the configuration.
+     */
+    @Override
+    public FapiConfig getFapiConfig(String tenantDomain) throws FapiConfigMgtException {
+
+        try {
+            // Attempt to retrieve the resource containing FAPI configuration.
+            final Resource resource = this.getFapiConfigResource();
+            // If the resource is null, persist and return the default configuration, otherwise parse the resource.
+            if (resource == null) {
+                return FapiUtil.getDefaultConfiguration();
+            }
+            return FapiUtil.parseResource(resource);
+        } catch (ConfigurationManagementException e) {
+            throw handleServerException(ErrorMessage.ERROR_CODE_FAPI_CONFIG_RETRIEVE, e, tenantDomain);
+        }
+    }
+
+    /**
+     * Sets the FAPI configuration for a given tenant domain.
+     *
+     * @param fapiConfig   The FAPI configuration to be set.
+     * @param tenantDomain The domain of the tenant for which the configuration is to be set.
+     * @throws FapiConfigMgtException If there is an error in setting the configuration.
+     */
+    @Override
+    public void setFapiConfig(FapiConfig fapiConfig, String tenantDomain) throws FapiConfigMgtException {
+
+        validateTenantDomain(tenantDomain);
+        try {
+            // Parse the FAPI configuration and replace the existing resource with the updated configuration.
+            ResourceAdd resourceAdd = FapiUtil.parseConfig(fapiConfig);
+            getConfigurationManager().replaceResource(FAPI_RESOURCE_TYPE_NAME, resourceAdd);
+        } catch (ConfigurationManagementException e) {
+            throw handleServerException(ErrorMessage.ERROR_CODE_FAPI_CONFIG_UPDATE, e, tenantDomain);
+        }
+    }
+
+    /**
+     * Validates the given tenant domain.
+     *
+     * @param tenantDomain The tenant domain to validate.
+     * @throws FapiConfigMgtException If the tenant domain is invalid.
+     */
+    private void validateTenantDomain(String tenantDomain) throws FapiConfigMgtException {
+
+        try {
+            IdentityTenantUtil.getTenantId(tenantDomain);
+        } catch (IdentityRuntimeException e) {
+            throw handleClientException(ErrorMessage.ERROR_CODE_INVALID_TENANT_DOMAIN, e, tenantDomain);
+        }
+    }
+
+    /**
+     * Retrieve the ConfigurationManager instance from the OAuth2ServiceComponentHolder.
+     *
+     * @return ConfigurationManager The ConfigurationManager instance.
+     */
+    private ConfigurationManager getConfigurationManager() {
+
+        return OAuth2ServiceComponentHolder.getInstance().getConfigurationManager();
+    }
+
+    /**
+     * Retrieves the fapi config resource.
+     *
+     * @return The resource if found, or null if the resource does not exist.
+     * @throws ConfigurationManagementException If there is an error in the configuration management process.
+     */
+    private Resource getFapiConfigResource() throws ConfigurationManagementException {
+
+        try {
+            return this.getConfigurationManager().getResource(FAPI_RESOURCE_TYPE_NAME, FAPI_RESOURCE_NAME, true);
+        } catch (ConfigurationManagementException e) {
+            if (isResourceNotExistsError(e)) {
+                if (log.isDebugEnabled()) {
+                    log.debug(String.format("Resource does not exist. Caused by, %s", e.getMessage()));
+                }
+                return null;
+            }
+            throw e;
+        }
+    }
+
+    private boolean isResourceNotExistsError(ConfigurationManagementException e) {
+
+        return ERROR_CODE_RESOURCE_DOES_NOT_EXISTS.getCode().equals(e.getErrorCode());
+    }
+
+}

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/fapi/services/FapiConfigMgtServiceImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/fapi/services/FapiConfigMgtServiceImpl.java
@@ -27,6 +27,7 @@ import org.wso2.carbon.identity.configuration.mgt.core.exception.ConfigurationMa
 import org.wso2.carbon.identity.configuration.mgt.core.model.Resource;
 import org.wso2.carbon.identity.configuration.mgt.core.model.ResourceAdd;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.oauth2.fapi.cache.FapiConfigCache;
 import org.wso2.carbon.identity.oauth2.fapi.exceptions.FapiConfigMgtException;
 import org.wso2.carbon.identity.oauth2.fapi.models.FapiConfig;
 import org.wso2.carbon.identity.oauth2.fapi.utils.ErrorMessage;
@@ -45,6 +46,7 @@ import static org.wso2.carbon.identity.oauth2.fapi.utils.FapiUtil.handleServerEx
 public class FapiConfigMgtServiceImpl implements FapiConfigMgtService {
 
     private static final Log log = LogFactory.getLog(FapiConfigMgtServiceImpl.class);
+    private static final String FAPI_CONFIG_CACHE_KEY = "FAPI_CONFIG";
 
     /**
      * Retrieves the FAPI configuration for a given tenant domain.
@@ -56,14 +58,18 @@ public class FapiConfigMgtServiceImpl implements FapiConfigMgtService {
     @Override
     public FapiConfig getFapiConfig(String tenantDomain) throws FapiConfigMgtException {
 
+        FapiConfig cached = FapiConfigCache.getInstance().getValueFromCache(FAPI_CONFIG_CACHE_KEY, tenantDomain);
+        if (cached != null) {
+            return cached;
+        }
+
         try {
-            // Attempt to retrieve the resource containing FAPI configuration.
             final Resource resource = this.getFapiConfigResource();
-            // If the resource is null, persist and return the default configuration, otherwise parse the resource.
-            if (resource == null) {
-                return FapiUtil.getDefaultConfiguration();
-            }
-            return FapiUtil.parseResource(resource);
+            FapiConfig fapiConfig = (resource == null)
+                    ? FapiUtil.getDefaultConfiguration()
+                    : FapiUtil.parseResource(resource);
+            FapiConfigCache.getInstance().addToCacheOnRead(FAPI_CONFIG_CACHE_KEY, fapiConfig, tenantDomain);
+            return fapiConfig;
         } catch (ConfigurationManagementException e) {
             throw handleServerException(ErrorMessage.ERROR_CODE_FAPI_CONFIG_RETRIEVE, e, tenantDomain);
         }
@@ -82,9 +88,9 @@ public class FapiConfigMgtServiceImpl implements FapiConfigMgtService {
         validateTenantDomain(tenantDomain);
         validateFapiConfig(fapiConfig);
         try {
-            // Parse the FAPI configuration and replace the existing resource with the updated configuration.
             ResourceAdd resourceAdd = FapiUtil.parseConfig(fapiConfig);
             getConfigurationManager().replaceResource(FAPI_RESOURCE_TYPE_NAME, resourceAdd);
+            FapiConfigCache.getInstance().clearCacheEntry(FAPI_CONFIG_CACHE_KEY, tenantDomain);
         } catch (ConfigurationManagementException e) {
             throw handleServerException(ErrorMessage.ERROR_CODE_FAPI_CONFIG_UPDATE, e, tenantDomain);
         }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/fapi/services/FapiConfigMgtServiceImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/fapi/services/FapiConfigMgtServiceImpl.java
@@ -45,7 +45,7 @@ import static org.wso2.carbon.identity.oauth2.fapi.utils.FapiUtil.handleServerEx
  */
 public class FapiConfigMgtServiceImpl implements FapiConfigMgtService {
 
-    private static final Log log = LogFactory.getLog(FapiConfigMgtServiceImpl.class);
+    private static final Log LOG = LogFactory.getLog(FapiConfigMgtServiceImpl.class);
     private static final String FAPI_CONFIG_CACHE_KEY = "FAPI_CONFIG";
 
     /**
@@ -104,7 +104,8 @@ public class FapiConfigMgtServiceImpl implements FapiConfigMgtService {
      */
     private void validateFapiConfig(FapiConfig fapiConfig) throws FapiConfigMgtException {
 
-        if (fapiConfig.isEnabled() && CollectionUtils.isEmpty(fapiConfig.getSupportedProfiles())) {
+        if (fapiConfig == null ||
+                (fapiConfig.isEnabled() && CollectionUtils.isEmpty(fapiConfig.getSupportedProfiles()))) {
             throw handleClientException(ErrorMessage.ERROR_CODE_FAPI_ENABLED_WITH_EMPTY_PROFILES, null);
         }
     }
@@ -146,8 +147,8 @@ public class FapiConfigMgtServiceImpl implements FapiConfigMgtService {
             return this.getConfigurationManager().getResource(FAPI_RESOURCE_TYPE_NAME, FAPI_RESOURCE_NAME, true);
         } catch (ConfigurationManagementException e) {
             if (isResourceNotExistsError(e)) {
-                if (log.isDebugEnabled()) {
-                    log.debug(String.format("Resource does not exist. Caused by, %s", e.getMessage()));
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug(String.format("Resource does not exist. Caused by, %s", e.getMessage()));
                 }
                 return null;
             }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/fapi/utils/Constants.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/fapi/utils/Constants.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth2.fapi.utils;
+
+/**
+ * Constants for FAPI configuration management.
+ */
+public class Constants {
+
+    public static final String FAPI_RESOURCE_TYPE_NAME = "FAPI_CONFIGURATION";
+    public static final String FAPI_RESOURCE_NAME = "TENANT_FAPI_CONFIGURATION";
+
+    public static final String FAPI_ENABLED = "Enabled";
+    public static final String FAPI_SUPPORTED_PROFILES = "SupportedProfiles";
+
+    private Constants() {
+
+    }
+}

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/fapi/utils/ErrorMessage.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/fapi/utils/ErrorMessage.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth2.fapi.utils;
+
+/**
+ * Error message enum for FAPI configuration management exceptions.
+ */
+public enum ErrorMessage {
+
+    ERROR_CODE_INVALID_TENANT_DOMAIN("60004",
+            "Invalid input.",
+            "%s is not a valid tenant domain."),
+
+    ERROR_CODE_FAPI_CONFIG_RETRIEVE("65023",
+            "Unable to retrieve FAPI configuration.",
+            "Server encountered an error while retrieving the FAPI configuration of %s."),
+
+    ERROR_CODE_FAPI_CONFIG_UPDATE("65024",
+            "Unable to update FAPI configuration.",
+            "Server encountered an error while updating the FAPI configuration of %s.");
+
+    private final String code;
+    private final String message;
+    private final String description;
+
+    ErrorMessage(String code, String message, String description) {
+
+        this.code = code;
+        this.message = message;
+        this.description = description;
+    }
+
+    /**
+     * Get the {@code code}.
+     *
+     * @return Returns the {@code code} to be set.
+     */
+    public String getCode() {
+
+        return code;
+    }
+
+    /**
+     * Get the {@code message}.
+     *
+     * @return Returns the {@code message} to be set.
+     */
+    public String getMessage() {
+
+        return message;
+    }
+
+    /**
+     * Get the {@code description}.
+     *
+     * @return Returns the {@code description} to be set.
+     */
+    public String getDescription() {
+
+        return description;
+    }
+
+    @Override
+    public String toString() {
+
+        return code + ":" + message;
+    }
+}

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/fapi/utils/ErrorMessage.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/fapi/utils/ErrorMessage.java
@@ -27,6 +27,10 @@ public enum ErrorMessage {
             "Invalid input.",
             "%s is not a valid tenant domain."),
 
+    ERROR_CODE_FAPI_ENABLED_WITH_EMPTY_PROFILES("60005",
+            "Invalid input.",
+            "FAPI enforcement cannot be enabled without at least one supported profile."),
+
     ERROR_CODE_FAPI_CONFIG_RETRIEVE("65023",
             "Unable to retrieve FAPI configuration.",
             "Server encountered an error while retrieving the FAPI configuration of %s."),

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/fapi/utils/ErrorMessage.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/fapi/utils/ErrorMessage.java
@@ -31,11 +31,11 @@ public enum ErrorMessage {
             "Invalid input.",
             "FAPI enforcement cannot be enabled without at least one supported profile."),
 
-    ERROR_CODE_FAPI_CONFIG_RETRIEVE("65023",
+    ERROR_CODE_FAPI_CONFIG_RETRIEVE("65024",
             "Unable to retrieve FAPI configuration.",
             "Server encountered an error while retrieving the FAPI configuration of %s."),
 
-    ERROR_CODE_FAPI_CONFIG_UPDATE("65024",
+    ERROR_CODE_FAPI_CONFIG_UPDATE("65025",
             "Unable to update FAPI configuration.",
             "Server encountered an error while updating the FAPI configuration of %s.");
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/fapi/utils/FapiUtil.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/fapi/utils/FapiUtil.java
@@ -1,0 +1,253 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth2.fapi.utils;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.identity.configuration.mgt.core.model.Attribute;
+import org.wso2.carbon.identity.configuration.mgt.core.model.Resource;
+import org.wso2.carbon.identity.configuration.mgt.core.model.ResourceAdd;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.oauth.common.OAuthConstants;
+import org.wso2.carbon.identity.oauth.common.exception.InvalidOAuthClientException;
+import org.wso2.carbon.identity.oauth.dao.OAuthAppDO;
+import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
+import org.wso2.carbon.identity.oauth2.fapi.exceptions.FapiConfigMgtClientException;
+import org.wso2.carbon.identity.oauth2.fapi.exceptions.FapiConfigMgtException;
+import org.wso2.carbon.identity.oauth2.fapi.exceptions.FapiConfigMgtServerException;
+import org.wso2.carbon.identity.oauth2.fapi.models.FapiConfig;
+import org.wso2.carbon.identity.oauth2.fapi.models.FapiProfileEnum;
+import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static org.wso2.carbon.identity.oauth2.fapi.utils.Constants.FAPI_ENABLED;
+import static org.wso2.carbon.identity.oauth2.fapi.utils.Constants.FAPI_RESOURCE_NAME;
+import static org.wso2.carbon.identity.oauth2.fapi.utils.Constants.FAPI_SUPPORTED_PROFILES;
+
+/**
+ * Utility class providing helper methods for managing FAPI configurations.
+ */
+public class FapiUtil {
+
+    public static final String COMMA_SEPARATOR = ",";
+    private static final Log log = LogFactory.getLog(FapiUtil.class);
+
+    private FapiUtil() {
+
+    }
+
+    private static Optional<OAuthAppDO> getFapiConformantApp(String clientId)
+            throws IdentityOAuth2Exception, InvalidOAuthClientException {
+
+        String tenantDomain = IdentityTenantUtil.resolveTenantDomain();
+        String accessingOrgId = PrivilegedCarbonContext.getThreadLocalCarbonContext().getAccessingOrganizationId();
+        if (StringUtils.isNotBlank(accessingOrgId)) {
+            return Optional.of(OAuth2Util.getAppInformationFromOrgHierarchy(clientId, accessingOrgId));
+        } else {
+            return Optional.of(OAuth2Util.getAppInformationByClientId(clientId, tenantDomain));
+        }
+    }
+
+    /**
+     * Check whether the application should be FAPI conformant.
+     *
+     * @param clientId Client ID of the application.
+     * @return Whether the application should be FAPI conformant.
+     * @throws IdentityOAuth2Exception InvalidOAuthClientException
+     */
+    public static boolean isFapiConformantApp(String clientId)
+            throws IdentityOAuth2Exception, InvalidOAuthClientException {
+
+        if (!Boolean.parseBoolean(IdentityUtil.getProperty(OAuthConstants.ENABLE_FAPI))) {
+            return false;
+        }
+        return FapiUtil.getFapiConformantApp(clientId)
+                .map(OAuthAppDO::isFapiConformanceEnabled)
+                .orElse(false);
+    }
+
+    public static boolean isFapiConformantApp(String clientId, FapiProfileEnum fapiProfile)
+            throws IdentityOAuth2Exception, InvalidOAuthClientException {
+
+        if (!Boolean.parseBoolean(IdentityUtil.getProperty(OAuthConstants.ENABLE_FAPI))) {
+            return false;
+        }
+        return FapiUtil.getFapiConformantApp(clientId)
+                .map(oAuthAppDo -> fapiProfile.value().equals(oAuthAppDo.getFapiProfile()))
+                .orElse(false);
+    }
+
+    public static boolean isFapi1AdvancedProfileCompliant(String clientId) {
+
+        try {
+            return FapiUtil.isFapiConformantApp(clientId, FapiProfileEnum.FAPI1_ADVANCED);
+        } catch (InvalidOAuthClientException | IdentityOAuth2Exception e) {
+            if (log.isDebugEnabled()) {
+                log.debug("Error while checking FAPI conformance for clientId: " + clientId, e);
+            }
+        }
+        return false;
+    }
+
+    public static boolean isFapi2SecurityProfileCompliant(String clientId) {
+
+        try {
+            return FapiUtil.isFapiConformantApp(clientId, FapiProfileEnum.FAPI2_SECURITY);
+        } catch (InvalidOAuthClientException | IdentityOAuth2Exception e) {
+            if (log.isDebugEnabled()) {
+                log.debug("Error while checking FAPI conformance for clientId: " + clientId, e);
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Handles exceptions by wrapping them in a FapiConfigMgtException.
+     *
+     * @param error The error message and code associated with the exception.
+     * @param e     The underlying cause of the exception.
+     * @param data  Additional data to be included in the error message.
+     * @return An instance of FapiConfigMgtException.
+     */
+    public static FapiConfigMgtException handleException(ErrorMessage error, Throwable e, String... data) {
+
+        return new FapiConfigMgtException(String.format(error.getDescription(), (Object[]) data), error.getCode(), e);
+    }
+
+    /**
+     * Wraps a client-side error in a {@link FapiConfigMgtClientException}.
+     *
+     * @param error The error message and code.
+     * @param e     The underlying cause.
+     * @param data  Additional context data for the error description.
+     * @return A {@link FapiConfigMgtClientException} (HTTP 4xx).
+     */
+    public static FapiConfigMgtClientException handleClientException(ErrorMessage error, Throwable e,
+                                                                     String... data) {
+
+        return new FapiConfigMgtClientException(
+                String.format(error.getDescription(), (Object[]) data), error.getCode(), e);
+    }
+
+    /**
+     * Wraps a server-side error in a {@link FapiConfigMgtServerException}.
+     *
+     * @param error The error message and code.
+     * @param e     The underlying cause.
+     * @param data  Additional context data for the error description.
+     * @return A {@link FapiConfigMgtServerException} (HTTP 5xx).
+     */
+    public static FapiConfigMgtServerException handleServerException(ErrorMessage error, Throwable e,
+                                                                     String... data) {
+
+        return new FapiConfigMgtServerException(
+                String.format(error.getDescription(), (Object[]) data), error.getCode(), e);
+    }
+
+    /**
+     * Parses a FapiConfig object into a ResourceAdd object for persistence.
+     *
+     * @param fapiConfig The FAPI configuration to be parsed.
+     * @return A ResourceAdd object representing the parsed configuration.
+     */
+    public static ResourceAdd parseConfig(FapiConfig fapiConfig) {
+
+        ResourceAdd resourceAdd = new ResourceAdd();
+        resourceAdd.setName(FAPI_RESOURCE_NAME);
+        List<Attribute> attributes = new ArrayList<>();
+        addAttribute(attributes, FAPI_ENABLED, String.valueOf(fapiConfig.isEnabled()));
+        addAttribute(attributes, FAPI_SUPPORTED_PROFILES, toCommaSeparated(fapiConfig.getSupportedProfiles()));
+        resourceAdd.setAttributes(attributes);
+        return resourceAdd;
+    }
+
+    /**
+     * Parses a Resource object into a FapiConfig object.
+     *
+     * @param resource The resource to be parsed.
+     * @return A FapiConfig object representing the parsed resource.
+     */
+    public static FapiConfig parseResource(Resource resource) {
+
+        FapiConfig fapiConfig = new FapiConfig();
+        if (resource.isHasAttribute()) {
+            Map<String, String> attributeMap = getAttributeMap(resource.getAttributes());
+            fapiConfig.setEnabled(Boolean.parseBoolean(attributeMap.get(FAPI_ENABLED)));
+            fapiConfig.setSupportedProfiles(fromCommaSeparated(attributeMap.get(FAPI_SUPPORTED_PROFILES))
+                    .stream().map(FapiProfileEnum::fromValue).collect(Collectors.toList()));
+        }
+        return fapiConfig;
+    }
+
+    /**
+     * Retrieves the default FAPI configuration.
+     *
+     * @return The default FapiConfig object with enforcement disabled and empty profile lists.
+     */
+    public static FapiConfig getDefaultConfiguration() {
+
+        FapiConfig fapiConfig = new FapiConfig();
+        fapiConfig.setEnabled(true);
+        fapiConfig.setSupportedProfiles(Collections.singletonList(FapiProfileEnum.FAPI1_ADVANCED));
+        return fapiConfig;
+    }
+
+    private static void addAttribute(List<Attribute> attributeList, String key, String value) {
+
+        Attribute attribute = new Attribute();
+        attribute.setKey(key);
+        attribute.setValue(value != null ? value : StringUtils.EMPTY);
+        attributeList.add(attribute);
+    }
+
+    private static String toCommaSeparated(List<FapiProfileEnum> fapiProfiles) {
+
+        if (CollectionUtils.isEmpty(fapiProfiles)) {
+            return StringUtils.EMPTY;
+        }
+        return fapiProfiles.stream().map(FapiProfileEnum::value).collect(Collectors.joining(COMMA_SEPARATOR));
+    }
+
+    private static List<String> fromCommaSeparated(String value) {
+
+        if (StringUtils.isBlank(value)) {
+            return Collections.emptyList();
+        }
+        return new ArrayList<>(Arrays.asList(value.split(COMMA_SEPARATOR)));
+    }
+
+    private static Map<String, String> getAttributeMap(List<Attribute> attributes) {
+
+        if (CollectionUtils.isNotEmpty(attributes)) {
+            return attributes.stream().collect(Collectors.toMap(Attribute::getKey, Attribute::getValue));
+        }
+        return Collections.emptyMap();
+    }
+}

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/fapi/utils/FapiUtil.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/fapi/utils/FapiUtil.java
@@ -57,8 +57,8 @@ import static org.wso2.carbon.identity.oauth2.fapi.utils.Constants.FAPI_SUPPORTE
  */
 public class FapiUtil {
 
-    public static final String COMMA_SEPARATOR = ",";
-    private static final Log log = LogFactory.getLog(FapiUtil.class);
+    private static final String COMMA_SEPARATOR = ",";
+    private static final Log LOG = LogFactory.getLog(FapiUtil.class);
 
     private FapiUtil() {
 
@@ -111,8 +111,8 @@ public class FapiUtil {
         try {
             return FapiUtil.isFapiConformantApp(clientId, FapiProfileEnum.FAPI1_ADVANCED);
         } catch (InvalidOAuthClientException | IdentityOAuth2Exception e) {
-            if (log.isDebugEnabled()) {
-                log.debug("Error while checking FAPI conformance for clientId: " + clientId, e);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Error while checking FAPI conformance for clientId: " + clientId, e);
             }
         }
         return false;
@@ -123,8 +123,8 @@ public class FapiUtil {
         try {
             return FapiUtil.isFapiConformantApp(clientId, FapiProfileEnum.FAPI2_SECURITY);
         } catch (InvalidOAuthClientException | IdentityOAuth2Exception e) {
-            if (log.isDebugEnabled()) {
-                log.debug("Error while checking FAPI conformance for clientId: " + clientId, e);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Error while checking FAPI conformance for clientId: " + clientId, e);
             }
         }
         return false;

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/fapi/utils/FapiUtil.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/fapi/utils/FapiUtil.java
@@ -44,6 +44,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -100,7 +101,8 @@ public class FapiUtil {
             return false;
         }
         return FapiUtil.getFapiConformantApp(clientId)
-                .map(oAuthAppDo -> fapiProfile.value().equals(oAuthAppDo.getFapiProfile()))
+                .map(oAuthAppDo -> oAuthAppDo.isFapiConformanceEnabled()
+                        && fapiProfile.value().equals(oAuthAppDo.getFapiProfile()))
                 .orElse(false);
     }
 
@@ -201,15 +203,19 @@ public class FapiUtil {
             Map<String, String> attributeMap = getAttributeMap(resource.getAttributes());
             fapiConfig.setEnabled(Boolean.parseBoolean(attributeMap.get(FAPI_ENABLED)));
             fapiConfig.setSupportedProfiles(fromCommaSeparated(attributeMap.get(FAPI_SUPPORTED_PROFILES))
-                    .stream().map(FapiProfileEnum::fromValue).collect(Collectors.toList()));
+                    .stream().map(FapiProfileEnum::fromValue)
+                    .filter(Objects::nonNull)
+                    .collect(Collectors.toList()));
         }
         return fapiConfig;
     }
 
     /**
-     * Retrieves the default FAPI configuration.
+     * Returns the default FAPI configuration used when no tenant-specific configuration has been stored.
+     * FAPI enforcement is enabled by default with FAPI 1.0 Advanced as the sole supported profile,
+     * preserving backwards compatibility for tenants that already have FAPI applications.
      *
-     * @return The default FapiConfig object with enforcement disabled and empty profile lists.
+     * @return a FapiConfig with enabled=true and [FAPI1_ADVANCED] as supported profiles.
      */
     public static FapiConfig getDefaultConfiguration() {
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuth2ServiceComponent.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuth2ServiceComponent.java
@@ -84,6 +84,8 @@ import org.wso2.carbon.identity.oauth2.dao.TokenManagementDAO;
 import org.wso2.carbon.identity.oauth2.device.api.DeviceAuthService;
 import org.wso2.carbon.identity.oauth2.device.api.DeviceAuthServiceImpl;
 import org.wso2.carbon.identity.oauth2.device.response.DeviceFlowResponseTypeRequestValidator;
+import org.wso2.carbon.identity.oauth2.fapi.services.FapiConfigMgtService;
+import org.wso2.carbon.identity.oauth2.fapi.services.FapiConfigMgtServiceImpl;
 import org.wso2.carbon.identity.oauth2.impersonation.services.ImpersonationConfigMgtService;
 import org.wso2.carbon.identity.oauth2.impersonation.services.ImpersonationConfigMgtServiceImpl;
 import org.wso2.carbon.identity.oauth2.impersonation.services.ImpersonationMgtServiceImpl;
@@ -436,6 +438,9 @@ public class OAuth2ServiceComponent {
                     null);
             bundleContext.registerService(ImpersonationNotificationMgtService.class,
                     new ImpersonationNotificationMgtServiceImpl(), null);
+            final FapiConfigMgtService fapiConfigMgtService = new FapiConfigMgtServiceImpl();
+            OAuth2ServiceComponentHolder.getInstance().setFapiConfigMgtService(fapiConfigMgtService);
+            bundleContext.registerService(FapiConfigMgtService.class, fapiConfigMgtService, null);
 
             bundleContext.registerService(AccessTokenResponseHandler.class, new AccessTokenResponseRARHandler(), null);
             bundleContext.registerService(JWTAccessTokenClaimProvider.class,

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuth2ServiceComponentHolder.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/internal/OAuth2ServiceComponentHolder.java
@@ -49,6 +49,7 @@ import org.wso2.carbon.identity.oauth2.authz.validators.ResponseTypeRequestValid
 import org.wso2.carbon.identity.oauth2.bean.Scope;
 import org.wso2.carbon.identity.oauth2.client.authentication.OAuthClientAuthenticator;
 import org.wso2.carbon.identity.oauth2.config.services.OAuth2OIDCConfigOrgUsageScopeMgtService;
+import org.wso2.carbon.identity.oauth2.fapi.services.FapiConfigMgtService;
 import org.wso2.carbon.identity.oauth2.impersonation.services.ImpersonationMgtService;
 import org.wso2.carbon.identity.oauth2.impersonation.validators.ImpersonationValidator;
 import org.wso2.carbon.identity.oauth2.keyidprovider.KeyIDProvider;
@@ -147,6 +148,7 @@ public class OAuth2ServiceComponentHolder {
     private AuthorizationDetailsSchemaValidator authorizationDetailsSchemaValidator;
     private OAuth2OIDCConfigOrgUsageScopeMgtService oAuth2OIDCConfigOrgUsageScopeMgtService;
     private OrganizationDiscoveryHandler organizationDiscoveryHandler;
+    private FapiConfigMgtService fapiConfigMgtService;
 
     private OAuth2ServiceComponentHolder() {
 
@@ -1163,6 +1165,26 @@ public class OAuth2ServiceComponentHolder {
     public void setOrganizationDiscoveryHandler(OrganizationDiscoveryHandler organizationDiscoveryHandler) {
 
         this.organizationDiscoveryHandler = organizationDiscoveryHandler;
+    }
+
+    /**
+     * Get the FapiConfigMgtService instance.
+     *
+     * @return FapiConfigMgtService instance.
+     */
+    public FapiConfigMgtService getFapiConfigMgtService() {
+
+        return fapiConfigMgtService;
+    }
+
+    /**
+     * Set the FapiConfigMgtService instance.
+     *
+     * @param fapiConfigMgtService FapiConfigMgtService instance.
+     */
+    public void setFapiConfigMgtService(FapiConfigMgtService fapiConfigMgtService) {
+
+        this.fapiConfigMgtService = fapiConfigMgtService;
     }
 }
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/responsemode/provider/impl/QueryResponseModeProvider.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/responsemode/provider/impl/QueryResponseModeProvider.java
@@ -21,12 +21,18 @@ package org.wso2.carbon.identity.oauth2.responsemode.provider.impl;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.oltu.oauth2.common.exception.OAuthRuntimeException;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
 import org.wso2.carbon.identity.oauth.common.OAuthConstants;
+import org.wso2.carbon.identity.oauth.common.exception.InvalidOAuthClientException;
+import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
+import org.wso2.carbon.identity.oauth2.fapi.models.FapiProfileEnum;
+import org.wso2.carbon.identity.oauth2.fapi.utils.FapiUtil;
 import org.wso2.carbon.identity.oauth2.internal.OAuth2ServiceComponentHolder;
 import org.wso2.carbon.identity.oauth2.responsemode.provider.AbstractResponseModeProvider;
 import org.wso2.carbon.identity.oauth2.responsemode.provider.AuthorizationResponseDTO;
 import org.wso2.carbon.identity.oauth2.responsemode.provider.ResponseModeProvider;
+import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
@@ -127,10 +133,22 @@ public class QueryResponseModeProvider extends AbstractResponseModeProvider {
                 appendQueryParam(queryParams, OAuthConstants.SUBJECT_TOKEN, subjectToken);
             }
 
+            try {
+                if (FapiUtil.isFapiConformantApp(authorizationResponseDTO.getClientId(),
+                        FapiProfileEnum.FAPI2_SECURITY)) {
+                    // For FAPI 2.0 compliance, issuer should be included in the authorization response
+                    appendQueryParam(queryParams, OAuth2Util.ISS, OAuth2Util.getIdTokenIssuer(
+                            authorizationResponseDTO.getSigningTenantDomain()));
+                }
+            } catch (IdentityOAuth2Exception | InvalidOAuthClientException e) {
+                throw new OAuthRuntimeException("Error occurred while retrieving application details. ", e);
+            }
+
             redirectUrl = FrameworkUtils.appendQueryParamsStringToUrl(redirectUrl,
                     String.join("&", queryParams));
         } else {
-            redirectUrl += "?" +
+            String paramSeparator = redirectUrl.contains("?") ? "&" : "?";
+            redirectUrl += paramSeparator +
                     OAuthConstants.OAUTH_ERROR + "=" + authorizationResponseDTO.getErrorResponseDTO().getError() +
                     "&" + OAuthConstants.OAUTH_ERROR_DESCRIPTION + "=" +
                     authorizationResponseDTO.getErrorResponseDTO().getErrorDescription()

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/JWTUtils.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/JWTUtils.java
@@ -198,6 +198,10 @@ public class JWTUtils {
                     OIDC_IDP_ENTITY_ID).getValue();
         }
 
+        if (OAuth2Util.isFapi2Enabled(tenantDomain)) {
+            resourceIssuer = OAuth2Util.getIdTokenIssuer(tenantDomain);
+        }
+
         // Compare JWT issuer with the resource issuer.
         if (!jwtIssuer.equals(resourceIssuer)) {
             // Check the mutual TLS aliases enablement if the token is issued from mTLS endpoint.
@@ -267,6 +271,10 @@ public class JWTUtils {
         if (oauthAuthenticatorConfig != null) {
             resourceIssuer = IdentityApplicationManagementUtil.getProperty(oauthAuthenticatorConfig.getProperties(),
                     OIDC_IDP_ENTITY_ID).getValue();
+        }
+
+        if (OAuth2Util.isFapi2Enabled(tenantDomain)) {
+            resourceIssuer = OAuth2Util.getIdTokenIssuer(tenantDomain);
         }
 
         // Compare JWT issuer with the resource issuer.

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -1577,6 +1577,25 @@ public class OAuth2Util {
         throw new IllegalArgumentException("Cannot create user from empty user name");
     }
 
+    /**
+     * Builds the server base URL for use as the OIDC issuer identifier. The URL is
+     * {@code https://host:port} for the super-tenant, or {@code https://host:port/t/{tenant}} for
+     * other tenants.
+     *
+     * @param tenantDomain tenant domain for which the issuer URL is required.
+     * @return absolute public base URL for the given tenant.
+     * @throws IdentityOAuth2Exception if the URL cannot be constructed.
+     */
+    public static String buildBaseIssuerUrl(String tenantDomain) throws IdentityOAuth2Exception {
+
+        try {
+            return ServiceURLBuilder.create().setTenant(tenantDomain).build().getAbsolutePublicURL();
+        } catch (URLBuilderException e) {
+            throw new IdentityOAuth2Exception(
+                    "Error while building base issuer URL for tenant: " + tenantDomain, e);
+        }
+    }
+
     public static String getIDTokenIssuer() {
 
         String issuer = OAuthServerConfiguration.getInstance().getOpenIDConnectIDTokenIssuerIdentifier();
@@ -5084,9 +5103,9 @@ public class OAuth2Util {
 
         if (OAuth2Util.isFapi2Enabled(tenantDomain)) {
 
-            final String oidcDiscoveryEpUrl =  getResidentIdpOidcDiscoveryEpUrl(tenantDomain);
-            if (StringUtils.isNotBlank(oidcDiscoveryEpUrl)) {
-                return oidcDiscoveryEpUrl;
+            final String oidcIssuerEpUrl =  buildBaseIssuerUrl(tenantDomain);
+            if (StringUtils.isNotBlank(oidcIssuerEpUrl)) {
+                return oidcIssuerEpUrl;
             }
         }
 
@@ -5130,9 +5149,9 @@ public class OAuth2Util {
 
         if (OAuth2Util.isFapi2Enabled(tenantDomain)) {
 
-            final String oidcDiscoveryEpUrl =  getResidentIdpOidcDiscoveryEpUrl(tenantDomain);
-            if (StringUtils.isNotBlank(oidcDiscoveryEpUrl)) {
-                return oidcDiscoveryEpUrl;
+            final String oidcIssuerEpUrl =  buildBaseIssuerUrl(tenantDomain);
+            if (StringUtils.isNotBlank(oidcIssuerEpUrl)) {
+                return oidcIssuerEpUrl;
             }
         }
 
@@ -5238,18 +5257,6 @@ public class OAuth2Util {
                         IdentityApplicationConstants.Authenticator.OIDC.NAME);
         return IdentityApplicationManagementUtil.getProperty(oidcAuthenticatorConfig.getProperties(),
                 IDP_ENTITY_ID).getValue();
-    }
-
-    public static String getResidentIdpOidcDiscoveryEpUrl(String tenantDomain) throws IdentityOAuth2Exception {
-
-        IdentityProvider identityProvider = getResidentIdp(tenantDomain);
-        FederatedAuthenticatorConfig[] fedAuthnConfigs = identityProvider.getFederatedAuthenticatorConfigs();
-        // Get OIDC authenticator
-        FederatedAuthenticatorConfig oidcAuthenticatorConfig =
-                IdentityApplicationManagementUtil.getFederatedAuthenticator(fedAuthnConfigs,
-                        IdentityApplicationConstants.Authenticator.OIDC.NAME);
-        return IdentityApplicationManagementUtil.getProperty(oidcAuthenticatorConfig.getProperties(),
-                "OIDCDiscoveryEPUrl").getValue();
     }
 
     /**

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -148,11 +148,11 @@ import org.wso2.carbon.identity.oauth2.dto.OAuth2IntrospectionResponseDTO;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2TokenValidationRequestDTO;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2TokenValidationResponseDTO;
 import org.wso2.carbon.identity.oauth2.dto.OAuthRevocationRequestDTO;
-import org.wso2.carbon.identity.oauth2.internal.OAuth2ServiceComponentHolder;
 import org.wso2.carbon.identity.oauth2.fapi.exceptions.FapiConfigMgtException;
 import org.wso2.carbon.identity.oauth2.fapi.models.FapiConfig;
 import org.wso2.carbon.identity.oauth2.fapi.models.FapiProfileEnum;
 import org.wso2.carbon.identity.oauth2.fapi.services.FapiConfigMgtService;
+import org.wso2.carbon.identity.oauth2.internal.OAuth2ServiceComponentHolder;
 import org.wso2.carbon.identity.oauth2.model.AccessTokenDO;
 import org.wso2.carbon.identity.oauth2.model.ClientAuthenticationMethodModel;
 import org.wso2.carbon.identity.oauth2.model.ClientCredentialDO;
@@ -264,7 +264,6 @@ import static org.wso2.carbon.identity.oauth.common.OAuthConstants.SignatureAlgo
 import static org.wso2.carbon.identity.oauth2.Oauth2ScopeConstants.PERMISSIONS_BINDING_TYPE;
 import static org.wso2.carbon.identity.oauth2.device.constants.Constants.DEVICE_SUCCESS_ENDPOINT_PATH;
 import static org.wso2.carbon.identity.oauth2.device.constants.Constants.RESPONSE_TYPE_DEVICE;
-import static org.wso2.carbon.identity.oauth2.util.OAuth2Util.validateRequestTenantDomain;
 
 /**
  * Utility methods for OAuth 2.0 implementation.
@@ -5089,7 +5088,7 @@ public class OAuth2Util {
         it will be used as the issuer.
          */
         if (OAuthServerConfiguration.getInstance().getIsUseEntityIDAsIssuerEnabled()
-                        || OAuth2Util.isFapi2Enabled(tenantDomain)) {
+                || OAuth2Util.isFapi2Enabled(tenantDomain)) {
 
             String residentIdp =  getResidentIdpEntityId(tenantDomain);
             if (StringUtils.isNotBlank(residentIdp)) {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -5082,13 +5082,20 @@ public class OAuth2Util {
 
     public static String getIdTokenIssuer(String tenantDomain, boolean isMtlsRequest) throws IdentityOAuth2Exception {
 
+        if (OAuth2Util.isFapi2Enabled(tenantDomain)) {
+
+            final String oidcDiscoveryEpUrl =  getResidentIdpOidcDiscoveryEpUrl(tenantDomain);
+            if (StringUtils.isNotBlank(oidcDiscoveryEpUrl)) {
+                return oidcDiscoveryEpUrl;
+            }
+        }
+
         /*
         If the useEntityIDAsIssuerEnabled config is enabled, then the issuer will be the resident IdP entity id.
         Regardless of the request type (mtls or non-mtls), if the resident IdP entity id is available,
         it will be used as the issuer.
          */
-        if (OAuthServerConfiguration.getInstance().getIsUseEntityIDAsIssuerEnabled()
-                || OAuth2Util.isFapi2Enabled(tenantDomain)) {
+        if (OAuthServerConfiguration.getInstance().getIsUseEntityIDAsIssuerEnabled()) {
 
             String residentIdp =  getResidentIdpEntityId(tenantDomain);
             if (StringUtils.isNotBlank(residentIdp)) {
@@ -5121,14 +5128,21 @@ public class OAuth2Util {
     public static String getIdTokenIssuer(String tenantDomain, String clientId, boolean isMtlsRequest)
             throws IdentityOAuth2Exception {
 
+        if (OAuth2Util.isFapi2Enabled(tenantDomain)) {
+
+            final String oidcDiscoveryEpUrl =  getResidentIdpOidcDiscoveryEpUrl(tenantDomain);
+            if (StringUtils.isNotBlank(oidcDiscoveryEpUrl)) {
+                return oidcDiscoveryEpUrl;
+            }
+        }
+
         /*
         If the useEntityIDAsIssuerEnabled config is enabled, then the issuer will be the resident IdP entity id.
         Regardless of the request type (mtls or non-mtls), if the resident IdP entity id is available,
         it will be used as the issuer. When resident idp is used as the issuer, application level config to select
         issuer to be root or sub-org will not be applied as well.
          */
-        if (OAuthServerConfiguration.getInstance().getIsUseEntityIDAsIssuerEnabled()
-                || OAuth2Util.isFapi2Enabled(tenantDomain)) {
+        if (OAuthServerConfiguration.getInstance().getIsUseEntityIDAsIssuerEnabled()) {
 
             String residentIdp =  getResidentIdpEntityId(tenantDomain);
             if (StringUtils.isNotBlank(residentIdp)) {
@@ -5224,6 +5238,18 @@ public class OAuth2Util {
                         IdentityApplicationConstants.Authenticator.OIDC.NAME);
         return IdentityApplicationManagementUtil.getProperty(oidcAuthenticatorConfig.getProperties(),
                 IDP_ENTITY_ID).getValue();
+    }
+
+    public static String getResidentIdpOidcDiscoveryEpUrl(String tenantDomain) throws IdentityOAuth2Exception {
+
+        IdentityProvider identityProvider = getResidentIdp(tenantDomain);
+        FederatedAuthenticatorConfig[] fedAuthnConfigs = identityProvider.getFederatedAuthenticatorConfigs();
+        // Get OIDC authenticator
+        FederatedAuthenticatorConfig oidcAuthenticatorConfig =
+                IdentityApplicationManagementUtil.getFederatedAuthenticator(fedAuthnConfigs,
+                        IdentityApplicationConstants.Authenticator.OIDC.NAME);
+        return IdentityApplicationManagementUtil.getProperty(oidcAuthenticatorConfig.getProperties(),
+                "OIDCDiscoveryEPUrl").getValue();
     }
 
     /**

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -149,6 +149,10 @@ import org.wso2.carbon.identity.oauth2.dto.OAuth2TokenValidationRequestDTO;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2TokenValidationResponseDTO;
 import org.wso2.carbon.identity.oauth2.dto.OAuthRevocationRequestDTO;
 import org.wso2.carbon.identity.oauth2.internal.OAuth2ServiceComponentHolder;
+import org.wso2.carbon.identity.oauth2.fapi.exceptions.FapiConfigMgtException;
+import org.wso2.carbon.identity.oauth2.fapi.models.FapiConfig;
+import org.wso2.carbon.identity.oauth2.fapi.models.FapiProfileEnum;
+import org.wso2.carbon.identity.oauth2.fapi.services.FapiConfigMgtService;
 import org.wso2.carbon.identity.oauth2.model.AccessTokenDO;
 import org.wso2.carbon.identity.oauth2.model.ClientAuthenticationMethodModel;
 import org.wso2.carbon.identity.oauth2.model.ClientCredentialDO;
@@ -5084,7 +5088,8 @@ public class OAuth2Util {
         Regardless of the request type (mtls or non-mtls), if the resident IdP entity id is available,
         it will be used as the issuer.
          */
-        if (OAuthServerConfiguration.getInstance().getIsUseEntityIDAsIssuerEnabled()) {
+        if (OAuthServerConfiguration.getInstance().getIsUseEntityIDAsIssuerEnabled()
+                        || OAuth2Util.isFapi2Enabled(tenantDomain)) {
 
             String residentIdp =  getResidentIdpEntityId(tenantDomain);
             if (StringUtils.isNotBlank(residentIdp)) {
@@ -5123,7 +5128,8 @@ public class OAuth2Util {
         it will be used as the issuer. When resident idp is used as the issuer, application level config to select
         issuer to be root or sub-org will not be applied as well.
          */
-        if (OAuthServerConfiguration.getInstance().getIsUseEntityIDAsIssuerEnabled()) {
+        if (OAuthServerConfiguration.getInstance().getIsUseEntityIDAsIssuerEnabled()
+                || OAuth2Util.isFapi2Enabled(tenantDomain)) {
 
             String residentIdp =  getResidentIdpEntityId(tenantDomain);
             if (StringUtils.isNotBlank(residentIdp)) {
@@ -6263,27 +6269,33 @@ public class OAuth2Util {
     }
 
     /**
-     * Check whether the application should be FAPI conformant.
+     * Check whether FAPI 2.0 is enabled in the organization.
      *
-     * @param clientId Client ID of the application.
-     * @return Whether the application should be FAPI conformant.
-     * @throws IdentityOAuth2Exception InvalidOAuthClientException
+     * @param tenantDomain The tenant domain of the organization.
+     * @return Whether FAPI 2.0 is enabled for the given tenant.
      */
-    public static boolean isFapiConformantApp(String clientId)
-            throws IdentityOAuth2Exception, InvalidOAuthClientException {
+    public static boolean isFapi2Enabled(String tenantDomain) {
 
-        if (!Boolean.parseBoolean(IdentityUtil.getProperty(OAuthConstants.ENABLE_FAPI))) {
+        FapiConfigMgtService fapiConfigMgtService =
+                OAuth2ServiceComponentHolder.getInstance().getFapiConfigMgtService();
+        if (fapiConfigMgtService == null) {
+            if (log.isDebugEnabled()) {
+                log.debug("FapiConfigMgtService is not available. Treating FAPI 2.0 as disabled for tenant: "
+                        + tenantDomain);
+            }
             return false;
         }
-        String tenantDomain = IdentityTenantUtil.resolveTenantDomain();
-        String accessingOrgId = PrivilegedCarbonContext.getThreadLocalCarbonContext().getAccessingOrganizationId();
-        OAuthAppDO oAuthAppDO;
-        if (StringUtils.isNotBlank(accessingOrgId)) {
-            oAuthAppDO = OAuth2Util.getAppInformationFromOrgHierarchy(clientId, accessingOrgId);
-        } else {
-            oAuthAppDO = OAuth2Util.getAppInformationByClientId(clientId, tenantDomain);
+        try {
+            FapiConfig fapiConfig = fapiConfigMgtService.getFapiConfig(tenantDomain);
+            return fapiConfig.isEnabled() && CollectionUtils.isNotEmpty(fapiConfig.getSupportedProfiles())
+                    && fapiConfig.getSupportedProfiles().contains(FapiProfileEnum.FAPI2_SECURITY);
+        } catch (FapiConfigMgtException e) {
+            if (log.isDebugEnabled()) {
+                log.debug("Error retrieving FAPI configuration for tenant: " + tenantDomain
+                        + ". Treating FAPI 2.0 as disabled.", e);
+            }
+            return false;
         }
-        return oAuthAppDO.isFapiConformanceEnabled();
     }
 
     /**

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -152,6 +152,7 @@ import org.wso2.carbon.identity.oauth2.fapi.exceptions.FapiConfigMgtException;
 import org.wso2.carbon.identity.oauth2.fapi.models.FapiConfig;
 import org.wso2.carbon.identity.oauth2.fapi.models.FapiProfileEnum;
 import org.wso2.carbon.identity.oauth2.fapi.services.FapiConfigMgtService;
+import org.wso2.carbon.identity.oauth2.fapi.utils.FapiUtil;
 import org.wso2.carbon.identity.oauth2.internal.OAuth2ServiceComponentHolder;
 import org.wso2.carbon.identity.oauth2.model.AccessTokenDO;
 import org.wso2.carbon.identity.oauth2.model.ClientAuthenticationMethodModel;
@@ -5103,7 +5104,7 @@ public class OAuth2Util {
 
         if (OAuth2Util.isFapi2Enabled(tenantDomain)) {
 
-            final String oidcIssuerEpUrl =  buildBaseIssuerUrl(tenantDomain);
+            final String oidcIssuerEpUrl = buildBaseIssuerUrl(tenantDomain);
             if (StringUtils.isNotBlank(oidcIssuerEpUrl)) {
                 return oidcIssuerEpUrl;
             }
@@ -5149,7 +5150,7 @@ public class OAuth2Util {
 
         if (OAuth2Util.isFapi2Enabled(tenantDomain)) {
 
-            final String oidcIssuerEpUrl =  buildBaseIssuerUrl(tenantDomain);
+            final String oidcIssuerEpUrl = buildBaseIssuerUrl(tenantDomain);
             if (StringUtils.isNotBlank(oidcIssuerEpUrl)) {
                 return oidcIssuerEpUrl;
             }
@@ -6328,6 +6329,21 @@ public class OAuth2Util {
             }
             return false;
         }
+    }
+
+    /**
+     * Check whether the application should be FAPI conformant.
+     *
+     * @param clientId Client ID of the application.
+     * @return Whether the application should be FAPI conformant.
+     * @throws IdentityOAuth2Exception InvalidOAuthClientException
+     * @deprecated Use {@link org.wso2.carbon.identity.oauth2.fapi.utils.FapiUtil#isFapiConformantApp(String)} instead.
+     */
+    @Deprecated(forRemoval = true)
+    public static boolean isFapiConformantApp(String clientId)
+            throws IdentityOAuth2Exception, InvalidOAuthClientException {
+
+        return FapiUtil.isFapiConformantApp(clientId);
     }
 
     /**

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/RequestObjectValidatorImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/RequestObjectValidatorImpl.java
@@ -36,6 +36,7 @@ import org.wso2.carbon.identity.oauth.common.exception.InvalidOAuthClientExcepti
 import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.RequestObjectException;
+import org.wso2.carbon.identity.oauth2.fapi.utils.FapiUtil;
 import org.wso2.carbon.identity.oauth2.model.OAuth2Parameters;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 import org.wso2.carbon.identity.openidconnect.model.Constants;
@@ -490,7 +491,7 @@ public class RequestObjectValidatorImpl implements RequestObjectValidator {
     private boolean isFapiConformant(String clientId) throws RequestObjectException {
 
         try {
-            return OAuth2Util.isFapiConformantApp(clientId);
+            return FapiUtil.isFapiConformantApp(clientId);
         } catch (InvalidOAuthClientException e) {
             throw new RequestObjectException(OAuth2ErrorCodes.INVALID_CLIENT, "Could not find an existing app for " +
                     "clientId: " + clientId, e);

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/dao/OAuthAppDAOTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/dao/OAuthAppDAOTest.java
@@ -1156,6 +1156,98 @@ public class OAuthAppDAOTest extends TestOAuthDAOBase {
         }
     }
 
+    @DataProvider(name = "testGetAppInformationWithFapiProfileData")
+    public Object[][] testGetAppInformationWithFapiProfileData() {
+
+        return new Object[][]{
+                {"FAPI1_ADVANCED"},
+                {"FAPI2_SECURITY"},
+        };
+    }
+
+    /**
+     * Verifies that the fapiProfile OIDC property is correctly persisted when an OAuth
+     * application is added, returned on retrieval, and updated via updateConsumerApplication.
+     */
+    @Test(dataProvider = "testGetAppInformationWithFapiProfileData")
+    public void testGetAppInformationWithFapiProfileTest(String fapiProfile) throws Exception {
+
+        try (MockedStatic<OAuthServerConfiguration> oAuthServerConfiguration = mockStatic(
+                OAuthServerConfiguration.class);
+             MockedStatic<IdentityTenantUtil> identityTenantUtil = mockStatic(IdentityTenantUtil.class);
+             MockedStatic<IdentityUtil> identityUtil = mockStatic(IdentityUtil.class);
+             MockedStatic<IdentityDatabaseUtil> identityDatabaseUtil = mockStatic(IdentityDatabaseUtil.class);
+             MockedStatic<OAuthComponentServiceHolder> oAuthComponentServiceHolder =
+                     mockStatic(OAuthComponentServiceHolder.class);
+             MockedStatic<OrganizationManagementUtil> organizationManagementUtil =
+                     mockStatic(OrganizationManagementUtil.class)) {
+            setupMocksForTest(oAuthServerConfiguration, identityTenantUtil, identityUtil, organizationManagementUtil);
+            mockUserstore(oAuthComponentServiceHolder);
+            try (Connection connection = getConnection(DB_NAME)) {
+                mockIdentityUtilDataBaseConnection(connection, identityDatabaseUtil);
+                OAuthAppDO defaultOAuthAppDO = getDefaultOAuthAppDO();
+
+                // Set both FAPI conformance flag and profile before persisting.
+                defaultOAuthAppDO.setFapiConformanceEnabled(true);
+                defaultOAuthAppDO.setFapiProfile(fapiProfile);
+                addOAuthApplication(defaultOAuthAppDO, TENANT_ID);
+
+                OAuthAppDAO appDAO = new OAuthAppDAO();
+                OAuthAppDO retrievedAppDO = appDAO.getAppInformation(CONSUMER_KEY);
+                assertNotNull(retrievedAppDO);
+                // Verify the profile was persisted and loaded correctly.
+                assertEquals(retrievedAppDO.isFapiConformanceEnabled(), true);
+                assertEquals(retrievedAppDO.getFapiProfile(), fapiProfile);
+
+                // Update the profile to the other known value and verify the change is persisted.
+                String updatedProfile = "FAPI1_ADVANCED".equals(fapiProfile) ? "FAPI2_SECURITY" : "FAPI1_ADVANCED";
+                retrievedAppDO.setFapiProfile(updatedProfile);
+                appDAO.updateConsumerApplication(retrievedAppDO);
+
+                OAuthAppDO updatedAppDO = appDAO.getAppInformation(CONSUMER_KEY);
+                assertNotNull(updatedAppDO);
+                assertEquals(updatedAppDO.getFapiProfile(), updatedProfile);
+            }
+        } finally {
+            resetPrivilegedCarbonContext();
+        }
+    }
+
+    /**
+     * Verifies that fapiProfile is null when an OAuth application is persisted without
+     * a FAPI profile — i.e. the field is correctly absent and does not leak a default value.
+     */
+    @Test
+    public void testGetAppInformationWithNullFapiProfile() throws Exception {
+
+        try (MockedStatic<OAuthServerConfiguration> oAuthServerConfiguration = mockStatic(
+                OAuthServerConfiguration.class);
+             MockedStatic<IdentityTenantUtil> identityTenantUtil = mockStatic(IdentityTenantUtil.class);
+             MockedStatic<IdentityUtil> identityUtil = mockStatic(IdentityUtil.class);
+             MockedStatic<IdentityDatabaseUtil> identityDatabaseUtil = mockStatic(IdentityDatabaseUtil.class);
+             MockedStatic<OAuthComponentServiceHolder> oAuthComponentServiceHolder =
+                     mockStatic(OAuthComponentServiceHolder.class);
+             MockedStatic<OrganizationManagementUtil> organizationManagementUtil =
+                     mockStatic(OrganizationManagementUtil.class)) {
+            setupMocksForTest(oAuthServerConfiguration, identityTenantUtil, identityUtil, organizationManagementUtil);
+            mockUserstore(oAuthComponentServiceHolder);
+            try (Connection connection = getConnection(DB_NAME)) {
+                mockIdentityUtilDataBaseConnection(connection, identityDatabaseUtil);
+                // Default app has fapiProfile = null (not set).
+                OAuthAppDO defaultOAuthAppDO = getDefaultOAuthAppDO();
+                addOAuthApplication(defaultOAuthAppDO, TENANT_ID);
+
+                OAuthAppDAO appDAO = new OAuthAppDAO();
+                OAuthAppDO retrievedAppDO = appDAO.getAppInformation(CONSUMER_KEY);
+                assertNotNull(retrievedAppDO);
+                // fapiProfile should be absent when not explicitly set.
+                assertNull(retrievedAppDO.getFapiProfile());
+            }
+        } finally {
+            resetPrivilegedCarbonContext();
+        }
+    }
+
     @Test(expectedExceptions = IdentityOAuth2Exception.class)
     public void testGetAppInformationWithExceptions() throws Exception {
 

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/client/authentication/OAuthClientAuthnServiceTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/client/authentication/OAuthClientAuthnServiceTest.java
@@ -32,6 +32,7 @@ import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.oauth.common.exception.InvalidOAuthClientException;
 import org.wso2.carbon.identity.oauth.dao.OAuthAppDO;
 import org.wso2.carbon.identity.oauth2.bean.OAuthClientAuthnContext;
+import org.wso2.carbon.identity.oauth2.fapi.utils.FapiUtil;
 import org.wso2.carbon.identity.oauth2.internal.OAuth2ServiceComponentHolder;
 import org.wso2.carbon.identity.oauth2.model.ClientAuthenticationMethodModel;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
@@ -158,7 +159,8 @@ public class OAuthClientAuthnServiceTest {
                                        String clientId, boolean disableSampleAuthenticator, boolean hasAuthAppDO,
                                        String errorMsg) throws Exception {
 
-        try (MockedStatic<OAuth2Util> oAuth2Util = mockStatic(OAuth2Util.class)) {
+        try (MockedStatic<OAuth2Util> oAuth2Util = mockStatic(OAuth2Util.class);
+             MockedStatic<FapiUtil> fapiUtil = mockStatic(FapiUtil.class)) {
             if (disableSampleAuthenticator) {
                 sampleClientAuthenticator.enabled = false;
             }
@@ -166,7 +168,7 @@ public class OAuthClientAuthnServiceTest {
                     (isBasicAuthenticated);
             HttpServletRequest httpServletRequest = mock(HttpServletRequest.class);
             setHeaders(httpServletRequest, headers);
-            oAuth2Util.when(() -> OAuth2Util.isFapiConformantApp(anyString())).thenReturn(false);
+            fapiUtil.when(() -> FapiUtil.isFapiConformantApp(anyString())).thenReturn(false);
             ServiceProvider serviceProvider = new ServiceProvider();
             oAuth2Util.when(() -> OAuth2Util.getServiceProvider(anyString())).thenReturn(serviceProvider);
             if (hasAuthAppDO) {
@@ -198,7 +200,8 @@ public class OAuthClientAuthnServiceTest {
     @Test
     public void testAuthenticateForFapiApplicationsWithInvalidAuthenticatorsRegistered() throws Exception {
 
-        try (MockedStatic<OAuth2Util> oAuth2Util = mockStatic(OAuth2Util.class)) {
+        try (MockedStatic<OAuth2Util> oAuth2Util = mockStatic(OAuth2Util.class);
+             MockedStatic<FapiUtil> fapiUtil = mockStatic(FapiUtil.class)) {
             HashMap<String, List> bodyParams = new HashMap<>();
             bodyParams.put(OAuth.OAUTH_CLIENT_ID, Arrays.asList(CLIENT_ID));
             HttpServletRequest httpServletRequest = mock(HttpServletRequest.class);
@@ -207,7 +210,7 @@ public class OAuthClientAuthnServiceTest {
             oAuthAppDO.setFapiConformanceEnabled(true);
             oAuth2Util.when(() -> OAuth2Util.getAppInformationByClientId(anyString(), anyString()))
                     .thenReturn(oAuthAppDO);
-            oAuth2Util.when(() -> OAuth2Util.isFapiConformantApp(anyString())).thenReturn(true);
+            fapiUtil.when(() -> FapiUtil.isFapiConformantApp(anyString())).thenReturn(true);
             PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain("carbon.super");
             OAuthClientAuthnContext oAuthClientAuthnContext = oAuthClientAuthnService.authenticateClient
                     (httpServletRequest, bodyParams);
@@ -231,7 +234,8 @@ public class OAuthClientAuthnServiceTest {
     @Test(dataProvider = "testDataForAuthMethodConfiguredInApp")
     public void testAuthenticateWhenAuthMethodConfiguredInApp(boolean isFapiApp) throws Exception {
 
-        try (MockedStatic<OAuth2Util> oAuth2Util = mockStatic(OAuth2Util.class)) {
+        try (MockedStatic<OAuth2Util> oAuth2Util = mockStatic(OAuth2Util.class);
+             MockedStatic<FapiUtil> fapiUtil = mockStatic(FapiUtil.class)) {
             HashMap<String, List> bodyParams = new HashMap<>();
             bodyParams.put(OAuth.OAUTH_CLIENT_ID, Arrays.asList(CLIENT_ID));
             HttpServletRequest httpServletRequest = mock(HttpServletRequest.class);
@@ -240,7 +244,7 @@ public class OAuthClientAuthnServiceTest {
             oAuthAppDO.setFapiConformanceEnabled(isFapiApp);
             oAuth2Util.when(() -> OAuth2Util.getAppInformationByClientId(anyString(), anyString()))
                     .thenReturn(oAuthAppDO);
-            oAuth2Util.when(() -> OAuth2Util.isFapiConformantApp(anyString())).thenReturn(true);
+            fapiUtil.when(() -> FapiUtil.isFapiConformantApp(anyString())).thenReturn(true);
             PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain("carbon.super");
             OAuthClientAuthenticator oAuthClientAuthenticator = mock(OAuthClientAuthenticator.class);
             when(oAuthClientAuthenticator.getName()).thenReturn("PrivateKeyJWTClientAuthenticator");

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/fapi/FapiConfigMgtServiceImplTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/fapi/FapiConfigMgtServiceImplTest.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth2.fapi;
+
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.base.IdentityRuntimeException;
+import org.wso2.carbon.identity.configuration.mgt.core.ConfigurationManager;
+import org.wso2.carbon.identity.configuration.mgt.core.exception.ConfigurationManagementException;
+import org.wso2.carbon.identity.configuration.mgt.core.model.Attribute;
+import org.wso2.carbon.identity.configuration.mgt.core.model.Resource;
+import org.wso2.carbon.identity.configuration.mgt.core.model.ResourceAdd;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.oauth2.fapi.exceptions.FapiConfigMgtClientException;
+import org.wso2.carbon.identity.oauth2.fapi.exceptions.FapiConfigMgtException;
+import org.wso2.carbon.identity.oauth2.fapi.exceptions.FapiConfigMgtServerException;
+import org.wso2.carbon.identity.oauth2.fapi.models.FapiConfig;
+import org.wso2.carbon.identity.oauth2.fapi.models.FapiProfileEnum;
+import org.wso2.carbon.identity.oauth2.fapi.services.FapiConfigMgtServiceImpl;
+import org.wso2.carbon.identity.oauth2.internal.OAuth2ServiceComponentHolder;
+
+import java.util.Collections;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertFalse;
+import static org.testng.AssertJUnit.assertNotNull;
+import static org.testng.AssertJUnit.assertTrue;
+import static org.testng.FileAssert.fail;
+import static org.wso2.carbon.identity.configuration.mgt.core.constant.ConfigurationConstants.ErrorMessages.ERROR_CODE_RESOURCE_DOES_NOT_EXISTS;
+import static org.wso2.carbon.identity.configuration.mgt.core.constant.ConfigurationConstants.ErrorMessages.ERROR_CODE_RETRIEVE_RESOURCE_TYPE;
+import static org.wso2.carbon.identity.oauth2.fapi.utils.Constants.FAPI_ENABLED;
+import static org.wso2.carbon.identity.oauth2.fapi.utils.Constants.FAPI_RESOURCE_NAME;
+import static org.wso2.carbon.identity.oauth2.fapi.utils.Constants.FAPI_RESOURCE_TYPE_NAME;
+import static org.wso2.carbon.identity.oauth2.fapi.utils.ErrorMessage.ERROR_CODE_FAPI_CONFIG_RETRIEVE;
+import static org.wso2.carbon.identity.oauth2.fapi.utils.ErrorMessage.ERROR_CODE_FAPI_CONFIG_UPDATE;
+import static org.wso2.carbon.identity.oauth2.fapi.utils.ErrorMessage.ERROR_CODE_INVALID_TENANT_DOMAIN;
+
+/**
+ * Unit tests for {@link FapiConfigMgtServiceImpl}.
+ */
+@Listeners(MockitoTestNGListener.class)
+public class FapiConfigMgtServiceImplTest {
+
+    @Mock
+    private ConfigurationManager configurationManager;
+
+    private final FapiConfigMgtServiceImpl fapiConfigMgtService = new FapiConfigMgtServiceImpl();
+    private static final String TENANT_DOMAIN = "carbon.super";
+
+    @BeforeMethod
+    public void setUp() {
+
+        OAuth2ServiceComponentHolder.getInstance().setConfigurationManager(configurationManager);
+    }
+
+    @DataProvider(name = "GetFapiConfigData")
+    public Object[][] getFapiConfigData() {
+
+        Attribute enabledAttr = new Attribute(FAPI_ENABLED, "true");
+        Resource resourceEnabled = new Resource(FAPI_RESOURCE_NAME, FAPI_RESOURCE_TYPE_NAME);
+        resourceEnabled.setHasAttribute(true);
+        resourceEnabled.setAttributes(Collections.singletonList(enabledAttr));
+
+        Attribute disabledAttr = new Attribute(FAPI_ENABLED, "false");
+        Resource resourceDisabled = new Resource(FAPI_RESOURCE_NAME, FAPI_RESOURCE_TYPE_NAME);
+        resourceDisabled.setHasAttribute(true);
+        resourceDisabled.setAttributes(Collections.singletonList(disabledAttr));
+
+        return new Object[][]{
+                // resource returned by ConfigurationManager, expected isEnabled value
+                {resourceEnabled, Boolean.TRUE},
+                {resourceDisabled, Boolean.FALSE},
+                // null simulates "resource not found" — getResource() returns null → default config (enabled=true)
+                {null, Boolean.TRUE}
+        };
+    }
+
+    @Test(dataProvider = "GetFapiConfigData")
+    public void testGetFapiConfig(Object resource, boolean expectedEnabled) throws Exception {
+
+        Resource tenantResource = (Resource) resource;
+        if (tenantResource != null) {
+            when(configurationManager.getResource(FAPI_RESOURCE_TYPE_NAME, FAPI_RESOURCE_NAME, true))
+                    .thenReturn(tenantResource);
+        } else {
+            // Simulate resource not found — service's private getResource() catches this and returns null.
+            ConfigurationManagementException notFound = new ConfigurationManagementException(
+                    ERROR_CODE_RESOURCE_DOES_NOT_EXISTS.getMessage(),
+                    ERROR_CODE_RESOURCE_DOES_NOT_EXISTS.getCode());
+            when(configurationManager.getResource(FAPI_RESOURCE_TYPE_NAME, FAPI_RESOURCE_NAME, true))
+                    .thenThrow(notFound);
+        }
+
+        try {
+            FapiConfig fapiConfig = fapiConfigMgtService.getFapiConfig(TENANT_DOMAIN);
+            assertNotNull(fapiConfig);
+            assertEquals(expectedEnabled, fapiConfig.isEnabled());
+        } catch (FapiConfigMgtException e) {
+            fail("Unexpected exception: " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void testGetFapiConfigServerException() throws ConfigurationManagementException {
+
+        ConfigurationManagementException unexpectedException = new ConfigurationManagementException(
+                ERROR_CODE_RETRIEVE_RESOURCE_TYPE.getMessage(),
+                ERROR_CODE_RETRIEVE_RESOURCE_TYPE.getCode());
+        when(configurationManager.getResource(FAPI_RESOURCE_TYPE_NAME, FAPI_RESOURCE_NAME, true))
+                .thenThrow(unexpectedException);
+
+        try {
+            fapiConfigMgtService.getFapiConfig(TENANT_DOMAIN);
+            fail("Expected FapiConfigMgtServerException was not thrown");
+        } catch (FapiConfigMgtServerException e) {
+            assertEquals(ERROR_CODE_FAPI_CONFIG_RETRIEVE.getCode(), e.getErrorCode());
+            assertEquals(String.format(ERROR_CODE_FAPI_CONFIG_RETRIEVE.getDescription(), TENANT_DOMAIN),
+                    e.getMessage());
+        } catch (FapiConfigMgtException e) {
+            fail("Expected FapiConfigMgtServerException, got: " + e.getClass().getSimpleName());
+        }
+    }
+
+    @Test
+    public void testSetFapiConfig() throws ConfigurationManagementException {
+
+        try (MockedStatic<IdentityTenantUtil> identityTenantUtil = mockStatic(IdentityTenantUtil.class)) {
+            identityTenantUtil.when(() -> IdentityTenantUtil.getTenantId(TENANT_DOMAIN)).thenReturn(-1234);
+            lenient().when(configurationManager.replaceResource(eq(FAPI_RESOURCE_TYPE_NAME), any(ResourceAdd.class)))
+                    .thenReturn(new Resource());
+
+            FapiConfig fapiConfig = new FapiConfig();
+            fapiConfig.setEnabled(true);
+            fapiConfig.setSupportedProfiles(Collections.singletonList(FapiProfileEnum.FAPI1_ADVANCED));
+
+            try {
+                fapiConfigMgtService.setFapiConfig(fapiConfig, TENANT_DOMAIN);
+            } catch (FapiConfigMgtException e) {
+                fail("Unexpected exception: " + e.getMessage());
+            }
+        }
+    }
+
+    @Test
+    public void testSetFapiConfigServerException() throws ConfigurationManagementException {
+
+        try (MockedStatic<IdentityTenantUtil> identityTenantUtil = mockStatic(IdentityTenantUtil.class)) {
+            identityTenantUtil.when(() -> IdentityTenantUtil.getTenantId(TENANT_DOMAIN)).thenReturn(-1234);
+            ConfigurationManagementException configMgtException = new ConfigurationManagementException(
+                    ERROR_CODE_RESOURCE_DOES_NOT_EXISTS.getMessage(),
+                    ERROR_CODE_RESOURCE_DOES_NOT_EXISTS.getCode());
+            lenient().when(configurationManager.replaceResource(eq(FAPI_RESOURCE_TYPE_NAME), any(ResourceAdd.class)))
+                    .thenThrow(configMgtException);
+
+            FapiConfig fapiConfig = new FapiConfig();
+            fapiConfig.setEnabled(false);
+
+            try {
+                fapiConfigMgtService.setFapiConfig(fapiConfig, TENANT_DOMAIN);
+                fail("Expected FapiConfigMgtServerException was not thrown");
+            } catch (FapiConfigMgtServerException e) {
+                assertEquals(ERROR_CODE_FAPI_CONFIG_UPDATE.getCode(), e.getErrorCode());
+                assertEquals(String.format(ERROR_CODE_FAPI_CONFIG_UPDATE.getDescription(), TENANT_DOMAIN),
+                        e.getMessage());
+            } catch (FapiConfigMgtException e) {
+                fail("Expected FapiConfigMgtServerException, got: " + e.getClass().getSimpleName());
+            }
+        }
+    }
+
+    @Test
+    public void testSetFapiConfigInvalidTenantDomain() {
+
+        try (MockedStatic<IdentityTenantUtil> identityTenantUtil = mockStatic(IdentityTenantUtil.class)) {
+            identityTenantUtil.when(() -> IdentityTenantUtil.getTenantId(TENANT_DOMAIN))
+                    .thenThrow(new IdentityRuntimeException("Invalid tenant: " + TENANT_DOMAIN));
+
+            FapiConfig fapiConfig = new FapiConfig();
+            fapiConfig.setEnabled(true);
+
+            try {
+                fapiConfigMgtService.setFapiConfig(fapiConfig, TENANT_DOMAIN);
+                fail("Expected FapiConfigMgtClientException was not thrown");
+            } catch (FapiConfigMgtClientException e) {
+                assertEquals(ERROR_CODE_INVALID_TENANT_DOMAIN.getCode(), e.getErrorCode());
+            } catch (FapiConfigMgtException e) {
+                fail("Expected FapiConfigMgtClientException, got: " + e.getClass().getSimpleName());
+            }
+        }
+    }
+
+    @Test
+    public void testGetFapiConfigDefaultHasExpectedValues() throws Exception {
+
+        // When resource not found, default config has enabled=true and FAPI1_ADVANCED profile.
+        ConfigurationManagementException notFound = new ConfigurationManagementException(
+                ERROR_CODE_RESOURCE_DOES_NOT_EXISTS.getMessage(),
+                ERROR_CODE_RESOURCE_DOES_NOT_EXISTS.getCode());
+        when(configurationManager.getResource(FAPI_RESOURCE_TYPE_NAME, FAPI_RESOURCE_NAME, true))
+                .thenThrow(notFound);
+
+        FapiConfig fapiConfig = fapiConfigMgtService.getFapiConfig(TENANT_DOMAIN);
+        assertTrue(fapiConfig.isEnabled());
+        assertNotNull(fapiConfig.getSupportedProfiles());
+        assertFalse(fapiConfig.getSupportedProfiles().isEmpty());
+        assertEquals(FapiProfileEnum.FAPI1_ADVANCED, fapiConfig.getSupportedProfiles().get(0));
+    }
+}

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/fapi/FapiConfigMgtServiceImplTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/fapi/FapiConfigMgtServiceImplTest.java
@@ -21,6 +21,7 @@ package org.wso2.carbon.identity.oauth2.fapi;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Listeners;
@@ -32,6 +33,7 @@ import org.wso2.carbon.identity.configuration.mgt.core.model.Attribute;
 import org.wso2.carbon.identity.configuration.mgt.core.model.Resource;
 import org.wso2.carbon.identity.configuration.mgt.core.model.ResourceAdd;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.oauth2.fapi.cache.FapiConfigCache;
 import org.wso2.carbon.identity.oauth2.fapi.exceptions.FapiConfigMgtClientException;
 import org.wso2.carbon.identity.oauth2.fapi.exceptions.FapiConfigMgtException;
 import org.wso2.carbon.identity.oauth2.fapi.exceptions.FapiConfigMgtServerException;
@@ -45,6 +47,7 @@ import java.util.Collections;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 import static org.testng.AssertJUnit.assertEquals;
@@ -73,10 +76,22 @@ public class FapiConfigMgtServiceImplTest {
     private final FapiConfigMgtServiceImpl fapiConfigMgtService = new FapiConfigMgtServiceImpl();
     private static final String TENANT_DOMAIN = "carbon.super";
 
+    private MockedStatic<FapiConfigCache> mockedFapiConfigCache;
+
     @BeforeMethod
     public void setUp() {
 
         OAuth2ServiceComponentHolder.getInstance().setConfigurationManager(configurationManager);
+        FapiConfigCache mockCache = mock(FapiConfigCache.class);
+        mockedFapiConfigCache = mockStatic(FapiConfigCache.class);
+        mockedFapiConfigCache.when(FapiConfigCache::getInstance).thenReturn(mockCache);
+        lenient().when(mockCache.getValueFromCache(any(), any())).thenReturn(null);
+    }
+
+    @AfterMethod
+    public void tearDown() {
+
+        mockedFapiConfigCache.close();
     }
 
     @DataProvider(name = "GetFapiConfigData")

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuerTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuerTest.java
@@ -457,7 +457,10 @@ public class JWTTokenIssuerTest {
             mockCustomClaimsCallbackHandler();
             oAuth2Util.when(() -> OAuth2Util.getAppInformationByClientId(anyString(), anyString())).thenReturn(appDO);
             oAuth2Util.when(OAuth2Util::getIDTokenIssuer).thenReturn(ID_TOKEN_ISSUER);
+            oAuth2Util.when(() -> OAuth2Util.getIssuerLocation(anyString())).thenReturn(ID_TOKEN_ISSUER);
             oAuth2Util.when(() -> OAuth2Util.getIdTokenIssuer(anyString(), anyBoolean())).thenReturn(ID_TOKEN_ISSUER);
+            oAuth2Util.when(() -> OAuth2Util.getIdTokenIssuer(anyString(), anyString(), anyBoolean())).
+                    thenReturn(ID_TOKEN_ISSUER);
             oAuth2Util.when(() -> OAuth2Util.getOIDCAudience(anyString(), any())).thenReturn(Collections.singletonList
                     (DUMMY_CLIENT_ID));
             oAuth2Util.when(OAuth2Util::isTokenPersistenceEnabled).thenReturn(true);
@@ -569,6 +572,8 @@ public class JWTTokenIssuerTest {
             oAuth2Util.when(() -> OAuth2Util.getCertificate(anyString(), anyInt())).thenReturn(cert);
             oAuth2Util.when(() -> OAuth2Util.getThumbPrintWithPrevAlgorithm(any(), anyBoolean())).thenCallRealMethod();
             oAuth2Util.when(() -> OAuth2Util.getIdTokenIssuer(any(), anyBoolean()))
+                    .thenAnswer((Answer<Void>) invocation -> null);
+            oAuth2Util.when(() -> OAuth2Util.getIdTokenIssuer(any(), any(), anyBoolean()))
                     .thenAnswer((Answer<Void>) invocation -> null);
             oAuth2Util.when(() -> OAuth2Util.getKID(any(Certificate.class), any(JWSAlgorithm.class), anyString()))
                     .thenAnswer((Answer<Void>) invocation -> null);

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/util/OAuth2UtilTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/util/OAuth2UtilTest.java
@@ -104,6 +104,7 @@ import org.wso2.carbon.identity.oauth2.dao.AccessTokenDAO;
 import org.wso2.carbon.identity.oauth2.dao.OAuthTokenPersistenceFactory;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2AccessTokenReqDTO;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2TokenValidationResponseDTO;
+import org.wso2.carbon.identity.oauth2.fapi.utils.FapiUtil;
 import org.wso2.carbon.identity.oauth2.internal.OAuth2ServiceComponentHolder;
 import org.wso2.carbon.identity.oauth2.model.AccessTokenDO;
 import org.wso2.carbon.identity.oauth2.model.ClientAuthenticationMethodModel;
@@ -2872,7 +2873,7 @@ public class OAuth2UtilTest {
 
             identityTenantUtil.when(IdentityTenantUtil::resolveTenantDomain).thenReturn("carbon.super");
             identityUtil.when(() -> IdentityUtil.getProperty(OAuthConstants.ENABLE_FAPI)).thenReturn("true");
-            Assert.assertEquals(OAuth2Util.isFapiConformantApp(clientId), isFapiConformant);
+            Assert.assertEquals(FapiUtil.isFapiConformantApp(clientId), isFapiConformant);
         }
     }
 

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/openidconnect/OIDCRequestObjectUtilTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/openidconnect/OIDCRequestObjectUtilTest.java
@@ -45,6 +45,7 @@ import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
 import org.wso2.carbon.identity.oauth.dao.OAuthAppDO;
 import org.wso2.carbon.identity.oauth2.RequestObjectException;
 import org.wso2.carbon.identity.oauth2.TestConstants;
+import org.wso2.carbon.identity.oauth2.fapi.utils.FapiUtil;
 import org.wso2.carbon.identity.oauth2.model.OAuth2Parameters;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 import org.wso2.carbon.identity.openidconnect.model.Constants;
@@ -143,7 +144,8 @@ public class OIDCRequestObjectUtilTest {
                  MockedStatic<IdentityUtil> identityUtilMockedStatic = mockStatic(IdentityUtil.class,
                          CALLS_REAL_METHODS);
                  MockedStatic<OAuth2Util> oAuth2Util = mockStatic(OAuth2Util.class);
-                 MockedStatic<IdentityTenantUtil> identityTenantUtil = mockStatic(IdentityTenantUtil.class)) {
+                 MockedStatic<IdentityTenantUtil> identityTenantUtil = mockStatic(IdentityTenantUtil.class);
+                 MockedStatic<FapiUtil> fapiUtil = mockStatic(FapiUtil.class)) {
 
                 OAuth2Parameters oAuth2Parameters = new OAuth2Parameters();
                 oAuth2Parameters.setTenantDomain("carbon.super");
@@ -170,7 +172,7 @@ public class OIDCRequestObjectUtilTest {
                 oAuth2Util.when(() -> OAuth2Util.getX509CertOfOAuthApp(TEST_CLIENT_ID_1,
                                 MultitenantConstants.SUPER_TENANT_DOMAIN_NAME))
                         .thenReturn(clientKeyStore.getCertificate("wso2carbon"));
-                oAuth2Util.when(() -> OAuth2Util.isFapiConformantApp(anyString())).thenReturn(isFAPITest);
+                fapiUtil.when(() -> FapiUtil.isFapiConformantApp(anyString())).thenReturn(isFAPITest);
                 oAuth2Util.when(() -> OAuth2Util.getServiceProvider(anyString())).thenReturn(new ServiceProvider());
 
                 OAuthAppDO oAuthAppDO = new OAuthAppDO();

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/openidconnect/RequestObjectValidatorImplTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/openidconnect/RequestObjectValidatorImplTest.java
@@ -48,6 +48,7 @@ import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
 import org.wso2.carbon.identity.oauth.dao.OAuthAppDO;
 import org.wso2.carbon.identity.oauth2.RequestObjectException;
 import org.wso2.carbon.identity.oauth2.TestConstants;
+import org.wso2.carbon.identity.oauth2.fapi.utils.FapiUtil;
 import org.wso2.carbon.identity.oauth2.model.OAuth2Parameters;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 import org.wso2.carbon.identity.openidconnect.model.Constants;
@@ -234,7 +235,8 @@ public class RequestObjectValidatorImplTest {
             RequestParamRequestObjectBuilder requestParamRequestObjectBuilder = new RequestParamRequestObjectBuilder();
             when((mockServerConfiguration.getRequestObjectValidator())).thenReturn(requestObjectValidator);
 
-            try (MockedStatic<OAuth2Util> oAuth2Util = mockStatic(OAuth2Util.class)) {
+            try (MockedStatic<OAuth2Util> oAuth2Util = mockStatic(OAuth2Util.class);
+                 MockedStatic<FapiUtil> fapiUtil = mockStatic(FapiUtil.class)) {
 
                 OAuth2Parameters oAuth2Parameters = new OAuth2Parameters();
                 oAuth2Parameters.setTenantDomain(SUPER_TENANT_DOMAIN_NAME);
@@ -265,7 +267,7 @@ public class RequestObjectValidatorImplTest {
                 // Mock OAuth2Util returning public cert of the service provider
                 oAuth2Util.when(() -> OAuth2Util.getX509CertOfOAuthApp(TEST_CLIENT_ID_1, SUPER_TENANT_DOMAIN_NAME))
                         .thenReturn(clientKeyStore.getCertificate(CLIENT_PUBLIC_CERT_ALIAS));
-                oAuth2Util.when(() -> OAuth2Util.isFapiConformantApp(anyString())).thenReturn(isFAPITest);
+                fapiUtil.when(() -> FapiUtil.isFapiConformantApp(anyString())).thenReturn(isFAPITest);
                 oAuth2Util.when(() -> OAuth2Util.getServiceProvider(anyString())).thenReturn(new ServiceProvider());
 
                 mockIdentityProviderManager(identityProviderManager);

--- a/components/org.wso2.carbon.identity.oauth/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.identity.oauth/src/test/resources/testng.xml
@@ -50,6 +50,7 @@
             <class name="org.wso2.carbon.identity.oauth2.impersonation.SubjectScopeValidatorTest"/>
             <class name="org.wso2.carbon.identity.oauth2.impersonation.UserAccountStatusValidatorTest"/>
             <class name="org.wso2.carbon.identity.oauth2.impersonation.ImpersonationConfigMgtTest"/>
+            <class name="org.wso2.carbon.identity.oauth2.fapi.FapiConfigMgtServiceImplTest"/>
             <class name="org.wso2.carbon.identity.openidconnect.RememberMeStoreTest"/>
             <class name="org.wso2.carbon.identity.openidconnect.RequestObjectValidatorImplTest"/>
             <class name="org.wso2.carbon.identity.openidconnect.RequestParamRequestObjectBuilderTest"/>


### PR DESCRIPTION
## Purpose
Identity Server supports FAPI 1.0 (Advanced) but lacks FAPI 2.0 support. This PR extends the FAPI implementation to introduce FAPI 2.0 Security Profile conformance, addressing the need for the latest financial-grade API security
standards.


## Goals
- Introduce FAPI 2.0 Security Profile support alongside the existing FAPI 1.0 Advanced Profile
- Enforce correct FAPI profile requirements during Dynamic Client Registration (DCR)
- Lay the groundwork for FAPI 2.0 OpenID Foundation conformance certification

## Approach
- Introduced `FapiProfileEnum` with `FAPI1_ADVANCED` and `FAPI2_SECURITY` constants to represent supported FAPI profiles
- Added `FapiConfig` model and `FapiConfigMgtServiceImpl` to manage per-tenant FAPI configuration (enabled state + supported profiles) via WSO2's Configuration Management API
- Added `FapiUtil` helper methods: `isFapi1AdvancedProfileCompliant()` and `isFapi2SecurityProfileCompliant()` for profile-specific conformance checks
- Updated `DCRMService` to enforce FAPI profile requirements during application registration
- Updated `OAuthConstants` to include the `FAPI2_SECURITY` profile constant
- Updated `OAuthServerConfiguration` and `OAuth2Util` to handle FAPI 2.0 and token-binding related configuration
- Added validation that prevents enabling FAPI enforcement without at least one supported profile configured (error code `60005`)

## User stories

- As a server admin of a financial-grade API deployment, I want to configure WSO2 Identity Server to enforce FAPI 2.0 Security Profile compliance, so that my deployment meets the latest industry standards for financial API authorization.
- As a developer registering OAuth applications via DCR/MCR, I want my applications to be validated against the FAPI profile configured on the server, so that only compliant apps are registered under FAPI-enforced deployments.

## Release note

Added support for FAPI 2.0 Security Profile. Administrators can now configure the server to enforce either FAPI 1.0 Advanced or FAPI 2.0 Security Profile via tenant-level configuration. Dynamic Client Registration is updated to respect the
configured FAPI profile. Validation is enforced to prevent enabling FAPI without at least one supported profile.

## Documentation

> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter "N/A" plus brief explanation of why there's no doc impact

## Training

> N/A

## Certification

> N/A

## Marketing

> N/A

## Automation tests

- Unit tests
  > Coverage for `FapiConfigMgtServiceImpl` validation logic (e.g., enabling FAPI with empty profiles, invalid tenant domain) and `FapiUtil` profile-check utilities

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? yes
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

> N/A

## Related PRs

> N/A

## Migrations (if applicable)

N/A — new functionality. Existing FAPI 1.0 behavior is preserved by default.