### PR TITLE
Handle user mismatch in ciba authentication

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.ciba/src/main/java/org/wso2/carbon/identity/oauth/ciba/common/CibaConstants.java
+++ b/components/org.wso2.carbon.identity.oauth.ciba/src/main/java/org/wso2/carbon/identity/oauth/ciba/common/CibaConstants.java
@@ -53,6 +53,12 @@ public class CibaConstants {
     public static final String CIBA_USER_AUTH_ENDPOINT = "/oauth2/ciba_authorize";
     public static final String CIBA_SUCCESS_ENDPOINT_PATH = "/authenticationendpoint/device_success.do";
 
+    // CIBA error constants.
+    public static final String CIBA_AUTH_FAILED_ERROR_CODE = "authentication.attempt.failed";
+    public static final String CIBA_USER_MISMATCH_ERROR_DESCRIPTION = "ciba.user.mismatch";
+    public static final String STATUS_PARAM = "status";
+    public static final String STATUS_MSG_PARAM = "statusMsg";
+
     private CibaConstants() {
 
     }

--- a/components/org.wso2.carbon.identity.oauth.ciba/src/main/java/org/wso2/carbon/identity/oauth/ciba/handlers/CibaResponseTypeHandler.java
+++ b/components/org.wso2.carbon.identity.oauth.ciba/src/main/java/org/wso2/carbon/identity/oauth/ciba/handlers/CibaResponseTypeHandler.java
@@ -86,6 +86,11 @@ public class CibaResponseTypeHandler extends AbstractResponseTypeHandler {
                                 CibaConstants.CIBA_AUTH_FAILED_ERROR_CODE);
                         uriBuilder.addParameter(CibaConstants.STATUS_MSG_PARAM,
                                 CibaConstants.CIBA_USER_MISMATCH_ERROR_DESCRIPTION);
+                        String tenantDomain = authorizationReqDTO.getTenantDomain();
+                        if (!IdentityTenantUtil.isTenantQualifiedUrlsEnabled()
+                                && isNotSuperTenant(tenantDomain)) {
+                            uriBuilder.addParameter(FrameworkUtils.TENANT_DOMAIN, tenantDomain);
+                        }
                         respDTO.setCallbackURI(uriBuilder.build().toString());
                     } catch (URISyntaxException | URLBuilderException e) {
                         throw new IdentityOAuth2Exception("Error building CIBA retry page URL.", e);

--- a/components/org.wso2.carbon.identity.oauth.ciba/src/main/java/org/wso2/carbon/identity/oauth/ciba/handlers/CibaResponseTypeHandler.java
+++ b/components/org.wso2.carbon.identity.oauth.ciba/src/main/java/org/wso2/carbon/identity/oauth/ciba/handlers/CibaResponseTypeHandler.java
@@ -25,6 +25,7 @@ import org.apache.http.client.utils.URIBuilder;
 import org.wso2.carbon.base.MultitenantConstants;
 import org.wso2.carbon.identity.application.authentication.framework.exception.UserIdNotFoundException;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
 import org.wso2.carbon.identity.core.ServiceURLBuilder;
 import org.wso2.carbon.identity.core.URLBuilderException;
@@ -35,7 +36,6 @@ import org.wso2.carbon.identity.oauth.ciba.dao.CibaDAOFactory;
 import org.wso2.carbon.identity.oauth.ciba.exceptions.CibaCoreException;
 import org.wso2.carbon.identity.oauth.dao.OAuthAppDO;
 import org.wso2.carbon.identity.oauth.dto.OAuthErrorDTO;
-import org.wso2.carbon.identity.oauth2.IdentityOAuth2ClientException;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.authz.OAuthAuthzReqMessageContext;
 import org.wso2.carbon.identity.oauth2.authz.handlers.AbstractResponseTypeHandler;
@@ -75,8 +75,22 @@ public class CibaResponseTypeHandler extends AbstractResponseTypeHandler {
                 String authenticatedUserId = cibaAuthenticatedUser.getUserId();
                 boolean isValidUser = validateResolvedUser(authCodeKey, authenticatedUserId);
                 if (!isValidUser) {
-                    throw new IdentityOAuth2ClientException("The authenticated user: " + authenticatedUserId
-                            + " is not the same as the resolved user for the auth_req_id: " + authRequestId);
+                    log.warn("CIBA user validation failed for auth_req_id: " + authRequestId
+                            + ". The authenticated user does not match the user specified in the login_hint.");
+                    try {
+                        String retryPageUrl = ServiceURLBuilder.create()
+                                .addPath(FrameworkConstants.DefaultUrlContexts.AUTHENTICATION_ENDPOINT_RETRY)
+                                .build().getAbsolutePublicURL();
+                        URIBuilder uriBuilder = new URIBuilder(retryPageUrl);
+                        uriBuilder.addParameter(CibaConstants.STATUS_PARAM,
+                                CibaConstants.CIBA_AUTH_FAILED_ERROR_CODE);
+                        uriBuilder.addParameter(CibaConstants.STATUS_MSG_PARAM,
+                                CibaConstants.CIBA_USER_MISMATCH_ERROR_DESCRIPTION);
+                        respDTO.setCallbackURI(uriBuilder.build().toString());
+                    } catch (URISyntaxException | URLBuilderException e) {
+                        throw new IdentityOAuth2Exception("Error building CIBA retry page URL.", e);
+                    }
+                    return respDTO;
                 }
             }
 

--- a/components/org.wso2.carbon.identity.oauth.ciba/src/test/java/org/wso2/carbon/identity/oauth/ciba/handlers/CibaResponseTypeHandlerTest.java
+++ b/components/org.wso2.carbon.identity.oauth.ciba/src/test/java/org/wso2/carbon/identity/oauth/ciba/handlers/CibaResponseTypeHandlerTest.java
@@ -32,14 +32,15 @@ import org.wso2.carbon.identity.common.testng.WithH2Database;
 import org.wso2.carbon.identity.core.ServiceURL;
 import org.wso2.carbon.identity.core.ServiceURLBuilder;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.oauth.ciba.common.CibaConstants;
 import org.wso2.carbon.identity.oauth.ciba.dao.CibaDAOFactory;
 import org.wso2.carbon.identity.oauth.ciba.dao.CibaMgtDAOImpl;
 import org.wso2.carbon.identity.oauth.common.OAuthConstants;
 import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
 import org.wso2.carbon.identity.oauth.dao.OAuthAppDO;
-import org.wso2.carbon.identity.oauth2.IdentityOAuth2ClientException;
 import org.wso2.carbon.identity.oauth2.authz.OAuthAuthzReqMessageContext;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2AuthorizeReqDTO;
+import org.wso2.carbon.identity.oauth2.dto.OAuth2AuthorizeRespDTO;
 import org.wso2.carbon.identity.oauth2.model.OAuth2Parameters;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 
@@ -198,14 +199,16 @@ public class CibaResponseTypeHandlerTest {
         }
     }
 
-    @Test(expectedExceptions = IdentityOAuth2ClientException.class)
-    public void testIssueFailsWhenUserMismatchAndValidationEnabled()
+    @Test
+    public void testIssueReturnsAccessDeniedWhenUserMismatchAndValidationEnabled()
             throws Exception {
 
         try (MockedStatic<IdentityTenantUtil> identityTenantUtil =
                      mockStatic(IdentityTenantUtil.class);
                 MockedStatic<FrameworkUtils> frameworkUtils =
-                        mockStatic(FrameworkUtils.class)) {
+                        mockStatic(FrameworkUtils.class);
+                MockedStatic<ServiceURLBuilder> serviceURLBuilderMockedStatic =
+                        mockStatic(ServiceURLBuilder.class)) {
             CibaResponseTypeHandler cibaResponseTypeHandler =
                     new CibaResponseTypeHandler();
 
@@ -225,13 +228,28 @@ public class CibaResponseTypeHandlerTest {
                             anyInt(), anyString(), anyString()))
                     .thenReturn("testUser");
 
+            ServiceURLBuilder serviceURLBuilder = mock(ServiceURLBuilder.class);
+            ServiceURL serviceURL = mock(ServiceURL.class);
+            serviceURLBuilderMockedStatic.when(ServiceURLBuilder::create)
+                    .thenReturn(serviceURLBuilder);
+            when(serviceURLBuilder.addPath(anyString())).thenReturn(serviceURLBuilder);
+            when(serviceURLBuilder.build()).thenReturn(serviceURL);
+            when(serviceURL.getAbsolutePublicURL()).thenReturn(TEST_CALLBACK_URL);
+
             OAuthAppDO oAuthAppDO = new OAuthAppDO();
             oAuthAppDO.setApplicationName("testApp");
             oAuthAppDO.setCibaSkipUserValidation(false);
             authAuthzReqMessageContext.addProperty("OAuthAppDO", oAuthAppDO);
 
-            // Should throw because users don't match.
-            cibaResponseTypeHandler.issue(authAuthzReqMessageContext);
+            // Should redirect to retry page with CIBA user mismatch error when users don't match.
+            OAuth2AuthorizeRespDTO respDTO =
+                    cibaResponseTypeHandler.issue(authAuthzReqMessageContext);
+            Assert.assertNull(respDTO.getErrorCode());
+            Assert.assertNotNull(respDTO.getCallbackURI());
+            Assert.assertTrue(respDTO.getCallbackURI()
+                    .contains("status=" + CibaConstants.CIBA_AUTH_FAILED_ERROR_CODE));
+            Assert.assertTrue(respDTO.getCallbackURI()
+                    .contains("statusMsg=" + CibaConstants.CIBA_USER_MISMATCH_ERROR_DESCRIPTION));
         }
     }
 

--- a/components/org.wso2.carbon.identity.oauth.ciba/src/test/java/org/wso2/carbon/identity/oauth/ciba/handlers/CibaResponseTypeHandlerTest.java
+++ b/components/org.wso2.carbon.identity.oauth.ciba/src/test/java/org/wso2/carbon/identity/oauth/ciba/handlers/CibaResponseTypeHandlerTest.java
@@ -254,6 +254,133 @@ public class CibaResponseTypeHandlerTest {
     }
 
     @Test
+    public void testIssueAppendsRetryTenantDomainForNonSuperTenantWhenTenantQualifiedUrlsDisabled()
+            throws Exception {
+
+        try (MockedStatic<IdentityTenantUtil> identityTenantUtil = mockStatic(IdentityTenantUtil.class);
+                MockedStatic<FrameworkUtils> frameworkUtils = mockStatic(FrameworkUtils.class);
+                MockedStatic<ServiceURLBuilder> serviceURLBuilderMockedStatic =
+                        mockStatic(ServiceURLBuilder.class)) {
+            CibaResponseTypeHandler cibaResponseTypeHandler = new CibaResponseTypeHandler();
+
+            when(CibaDAOFactory.getInstance().getCibaAuthMgtDAO()).thenReturn(cibaAuthMgtDAO);
+            when(cibaAuthMgtDAO.getCibaAuthCodeKey(anyString())).thenReturn("authCodeKey");
+            when(cibaAuthMgtDAO.getResolvedUserId(anyString())).thenReturn("differentUser");
+
+            identityTenantUtil.when(() -> IdentityTenantUtil.getTenantId(anyString())).thenReturn(1234);
+            identityTenantUtil.when(IdentityTenantUtil::isTenantQualifiedUrlsEnabled).thenReturn(false);
+            frameworkUtils.when(() -> FrameworkUtils.resolveUserIdFromUsername(
+                    anyInt(), anyString(), anyString())).thenReturn("testUser");
+
+            ServiceURLBuilder serviceURLBuilder = mock(ServiceURLBuilder.class);
+            ServiceURL serviceURL = mock(ServiceURL.class);
+            serviceURLBuilderMockedStatic.when(ServiceURLBuilder::create).thenReturn(serviceURLBuilder);
+            when(serviceURLBuilder.addPath(anyString())).thenReturn(serviceURLBuilder);
+            when(serviceURLBuilder.build()).thenReturn(serviceURL);
+            when(serviceURL.getAbsolutePublicURL()).thenReturn(TEST_CALLBACK_URL);
+
+            OAuthAppDO oAuthAppDO = new OAuthAppDO();
+            oAuthAppDO.setApplicationName("testApp");
+            oAuthAppDO.setCibaSkipUserValidation(false);
+            authAuthzReqMessageContext.addProperty("OAuthAppDO", oAuthAppDO);
+            authorizationReqDTO.setTenantDomain("test.com");
+
+            OAuth2AuthorizeRespDTO respDTO =
+                    cibaResponseTypeHandler.issue(authAuthzReqMessageContext);
+            Assert.assertNull(respDTO.getErrorCode());
+            Assert.assertNotNull(respDTO.getCallbackURI());
+            Assert.assertTrue(respDTO.getCallbackURI()
+                    .contains("status=" + CibaConstants.CIBA_AUTH_FAILED_ERROR_CODE));
+            Assert.assertTrue(respDTO.getCallbackURI()
+                    .contains("statusMsg=" + CibaConstants.CIBA_USER_MISMATCH_ERROR_DESCRIPTION));
+            Assert.assertTrue(respDTO.getCallbackURI().contains("tenantDomain=test.com"));
+        }
+    }
+
+    @Test
+    public void testIssueOmitsRetryTenantDomainWhenTenantQualifiedUrlsEnabled() throws Exception {
+
+        try (MockedStatic<IdentityTenantUtil> identityTenantUtil = mockStatic(IdentityTenantUtil.class);
+                MockedStatic<FrameworkUtils> frameworkUtils = mockStatic(FrameworkUtils.class);
+                MockedStatic<ServiceURLBuilder> serviceURLBuilderMockedStatic =
+                        mockStatic(ServiceURLBuilder.class)) {
+            CibaResponseTypeHandler cibaResponseTypeHandler = new CibaResponseTypeHandler();
+
+            when(CibaDAOFactory.getInstance().getCibaAuthMgtDAO()).thenReturn(cibaAuthMgtDAO);
+            when(cibaAuthMgtDAO.getCibaAuthCodeKey(anyString())).thenReturn("authCodeKey");
+            when(cibaAuthMgtDAO.getResolvedUserId(anyString())).thenReturn("differentUser");
+
+            identityTenantUtil.when(() -> IdentityTenantUtil.getTenantId(anyString())).thenReturn(1234);
+            identityTenantUtil.when(IdentityTenantUtil::isTenantQualifiedUrlsEnabled).thenReturn(true);
+            frameworkUtils.when(() -> FrameworkUtils.resolveUserIdFromUsername(
+                    anyInt(), anyString(), anyString())).thenReturn("testUser");
+
+            ServiceURLBuilder serviceURLBuilder = mock(ServiceURLBuilder.class);
+            ServiceURL serviceURL = mock(ServiceURL.class);
+            serviceURLBuilderMockedStatic.when(ServiceURLBuilder::create).thenReturn(serviceURLBuilder);
+            when(serviceURLBuilder.addPath(anyString())).thenReturn(serviceURLBuilder);
+            when(serviceURLBuilder.build()).thenReturn(serviceURL);
+            when(serviceURL.getAbsolutePublicURL()).thenReturn(TEST_CALLBACK_URL);
+
+            OAuthAppDO oAuthAppDO = new OAuthAppDO();
+            oAuthAppDO.setApplicationName("testApp");
+            oAuthAppDO.setCibaSkipUserValidation(false);
+            authAuthzReqMessageContext.addProperty("OAuthAppDO", oAuthAppDO);
+            authorizationReqDTO.setTenantDomain("test.com");
+
+            OAuth2AuthorizeRespDTO respDTO =
+                    cibaResponseTypeHandler.issue(authAuthzReqMessageContext);
+            Assert.assertNull(respDTO.getErrorCode());
+            Assert.assertNotNull(respDTO.getCallbackURI());
+            Assert.assertTrue(respDTO.getCallbackURI()
+                    .contains("status=" + CibaConstants.CIBA_AUTH_FAILED_ERROR_CODE));
+            Assert.assertFalse(respDTO.getCallbackURI().contains("tenantDomain="));
+        }
+    }
+
+    @Test
+    public void testIssueOmitsRetryTenantDomainForSuperTenantWhenTenantQualifiedUrlsDisabled()
+            throws Exception {
+
+        try (MockedStatic<IdentityTenantUtil> identityTenantUtil = mockStatic(IdentityTenantUtil.class);
+                MockedStatic<FrameworkUtils> frameworkUtils = mockStatic(FrameworkUtils.class);
+                MockedStatic<ServiceURLBuilder> serviceURLBuilderMockedStatic =
+                        mockStatic(ServiceURLBuilder.class)) {
+            CibaResponseTypeHandler cibaResponseTypeHandler = new CibaResponseTypeHandler();
+
+            when(CibaDAOFactory.getInstance().getCibaAuthMgtDAO()).thenReturn(cibaAuthMgtDAO);
+            when(cibaAuthMgtDAO.getCibaAuthCodeKey(anyString())).thenReturn("authCodeKey");
+            when(cibaAuthMgtDAO.getResolvedUserId(anyString())).thenReturn("differentUser");
+
+            identityTenantUtil.when(() -> IdentityTenantUtil.getTenantId(anyString())).thenReturn(1234);
+            identityTenantUtil.when(IdentityTenantUtil::isTenantQualifiedUrlsEnabled).thenReturn(false);
+            frameworkUtils.when(() -> FrameworkUtils.resolveUserIdFromUsername(
+                    anyInt(), anyString(), anyString())).thenReturn("testUser");
+
+            ServiceURLBuilder serviceURLBuilder = mock(ServiceURLBuilder.class);
+            ServiceURL serviceURL = mock(ServiceURL.class);
+            serviceURLBuilderMockedStatic.when(ServiceURLBuilder::create).thenReturn(serviceURLBuilder);
+            when(serviceURLBuilder.addPath(anyString())).thenReturn(serviceURLBuilder);
+            when(serviceURLBuilder.build()).thenReturn(serviceURL);
+            when(serviceURL.getAbsolutePublicURL()).thenReturn(TEST_CALLBACK_URL);
+
+            OAuthAppDO oAuthAppDO = new OAuthAppDO();
+            oAuthAppDO.setApplicationName("testApp");
+            oAuthAppDO.setCibaSkipUserValidation(false);
+            authAuthzReqMessageContext.addProperty("OAuthAppDO", oAuthAppDO);
+            authorizationReqDTO.setTenantDomain("carbon.super");
+
+            OAuth2AuthorizeRespDTO respDTO =
+                    cibaResponseTypeHandler.issue(authAuthzReqMessageContext);
+            Assert.assertNull(respDTO.getErrorCode());
+            Assert.assertNotNull(respDTO.getCallbackURI());
+            Assert.assertTrue(respDTO.getCallbackURI()
+                    .contains("status=" + CibaConstants.CIBA_AUTH_FAILED_ERROR_CODE));
+            Assert.assertFalse(respDTO.getCallbackURI().contains("tenantDomain="));
+        }
+    }
+
+    @Test
     public void testIssueSucceedsWhenUserMatchesAndValidationEnabled() throws Exception {
 
         try (MockedStatic<OAuth2Util> oAuth2Util = mockStatic(OAuth2Util.class);


### PR DESCRIPTION
# Problem

When a user attempting to authorize a CIBA (`/oauth2/ciba`) request did not match the `login_hint` specified in the backchannel authentication request, the server returned a generic error without providing a meaningful redirect. This resulted in a poor UX.

# Solution

When the `cibaSkipUserValidation` flag is disabled and the authenticated user's resolved ID does not match the user resolved from the `login_hint`, the flow now redirects to the authentication endpoint's `retry.do` page with a structured error payload.

# Changes

### `CibaResponseTypeHandler`

- On user mismatch, builds a redirect URL to `retry.do` using `ServiceURLBuilder`.
- Appends `status` and `statusMsg` query parameters with the CIBA-specific error code and description.
- Returns the `OAuth2AuthorizeRespDTO` with the redirect URI set instead of propagating an exception.

### `CibaConstants`

Added the following constants:

- `CIBA_AUTH_FAILED_ERROR_CODE` (`authentication.attempt.failed`)
- `CIBA_USER_MISMATCH_ERROR_DESCRIPTION` (`ciba.user.mismatch`)
- `STATUS_PARAM`
- `STATUS_MSG_PARAM`

### `CibaResponseTypeHandlerTest`

- Updated `testIssueReturnsAccessDeniedWhenUserMismatchAndValidationEnabled` to verify the new redirect behavior.
- Added assertions to confirm:
  - No `errorCode` is set on the response DTO.
  - `callbackURI` contains the expected `status` and `statusMsg` query parameters.
- Added the required `CibaConstants` import.