### PR TITLE
Allow special characters in scope names and manage scope handling usi…

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.oauth.scope/src/gen/java/org/wso2/carbon/identity/oauth/scope/endpoint/ScopesApi.java
+++ b/components/org.wso2.carbon.identity.api.server.oauth.scope/src/gen/java/org/wso2/carbon/identity/oauth/scope/endpoint/ScopesApi.java
@@ -37,9 +37,9 @@ public class ScopesApi  {
         
         @io.swagger.annotations.ApiResponse(code = 500, message = "Server Error") })
 
-    public Response deleteScope(@ApiParam(value = "Name of the scope that is to be deleted",required=true ) @PathParam("name")  String name)
+    public Response deleteScope(@ApiParam(value = "Name of the scope that is to be deleted",required=true ) @PathParam("name")  String name, @QueryParam("encoded")  Boolean encoded)
     {
-    return delegate.deleteScope(name);
+    return delegate.deleteScope(name, encoded);
     }
     @GET
     @Path("/name/{name}")
@@ -53,9 +53,9 @@ public class ScopesApi  {
         
         @io.swagger.annotations.ApiResponse(code = 500, message = "Server Error") })
 
-    public Response getScope(@ApiParam(value = "Name of the scope that is to be retrieved",required=true ) @PathParam("name")  String name)
+    public Response getScope(@ApiParam(value = "Name of the scope that is to be retrieved",required=true ) @PathParam("name")  String name, @QueryParam("encoded")  Boolean encoded)
     {
-    return delegate.getScope(name);
+    return delegate.getScope(name, encoded);
     }
     @GET
     
@@ -89,9 +89,9 @@ public class ScopesApi  {
         @io.swagger.annotations.ApiResponse(code = 500, message = "Server Error") })
 
     public Response isScopeExists(@ApiParam(value = "Name of the scope that is to be checked",required=true ) @PathParam("name")  String name,
-                                  @ApiParam(value = "Consider OIDC scopes as well when check isScopeExists") @QueryParam("includeOIDCScopes")  Boolean includeOIDCScopes)
+                                  @ApiParam(value = "Consider OIDC scopes as well when check isScopeExists") @QueryParam("includeOIDCScopes")  Boolean includeOIDCScopes, @QueryParam("encoded")  Boolean encoded)
     {
-    return delegate.isScopeExists(name, includeOIDCScopes);
+    return delegate.isScopeExists(name, includeOIDCScopes, encoded);
     }
     @POST
     
@@ -124,9 +124,10 @@ public class ScopesApi  {
         @io.swagger.annotations.ApiResponse(code = 500, message = "Server Error") })
 
     public Response updateScope(@ApiParam(value = "updated scope" ,required=true ) ScopeToUpdateDTO scope,
-    @ApiParam(value = "Name of the scope that is to be updated",required=true ) @PathParam("name")  String name)
+    @ApiParam(value = "Name of the scope that is to be updated",required=true ) @PathParam("name")  String name,
+            @QueryParam("encoded")  Boolean encoded)
     {
-    return delegate.updateScope(scope,name);
+    return delegate.updateScope(scope,name, encoded);
     }
 }
 

--- a/components/org.wso2.carbon.identity.api.server.oauth.scope/src/gen/java/org/wso2/carbon/identity/oauth/scope/endpoint/ScopesApiService.java
+++ b/components/org.wso2.carbon.identity.api.server.oauth.scope/src/gen/java/org/wso2/carbon/identity/oauth/scope/endpoint/ScopesApiService.java
@@ -15,11 +15,11 @@ import org.apache.cxf.jaxrs.ext.multipart.Attachment;
 import javax.ws.rs.core.Response;
 
 public abstract class ScopesApiService {
-    public abstract Response deleteScope(String name);
-    public abstract Response getScope(String name);
+    public abstract Response deleteScope(String name, Boolean encoded);
+    public abstract Response getScope(String name, Boolean encoded);
     public abstract Response getScopes(Integer startIndex,Integer count,Boolean includeOIDCScopes,String requestedScopes);
-    public abstract Response isScopeExists(String name, Boolean includeOIDCScopes);
+    public abstract Response isScopeExists(String name, Boolean includeOIDCScopes, Boolean encoded);
     public abstract Response registerScope(ScopeDTO scope);
-    public abstract Response updateScope(ScopeToUpdateDTO scope,String name);
+    public abstract Response updateScope(ScopeToUpdateDTO scope,String name, Boolean encoded);
 }
 

--- a/components/org.wso2.carbon.identity.api.server.oauth.scope/src/main/java/org/wso2/carbon/identity/oauth/scope/endpoint/impl/ScopesApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.server.oauth.scope/src/main/java/org/wso2/carbon/identity/oauth/scope/endpoint/impl/ScopesApiServiceImpl.java
@@ -16,6 +16,7 @@
 
 package org.wso2.carbon.identity.oauth.scope.endpoint.impl;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.CarbonConstants;
@@ -38,6 +39,8 @@ import org.wso2.carbon.user.api.AuthorizationManager;
 import org.wso2.carbon.user.api.UserStoreException;
 
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.Set;
 
 import javax.ws.rs.core.Response;
@@ -100,11 +103,12 @@ public class ScopesApiServiceImpl extends ScopesApiService {
      * @return Response with the retrieved scope/ retrieval status.
      */
     @Override
-    public Response getScope(String name) {
+    public Response getScope(String name, Boolean encoded) {
 
         Scope scope = null;
 
         try {
+            name = decodeScopeName(name, encoded);
             scope = ScopeUtils.getOAuth2ScopeService().getScope(name);
         } catch (IdentityOAuth2ScopeClientException e) {
             if (LOG.isDebugEnabled()) {
@@ -175,11 +179,12 @@ public class ScopesApiServiceImpl extends ScopesApiService {
      * @return Response with the indication whether the scope exists or not.
      */
     @Override
-    public Response isScopeExists(String name, Boolean includeOIDCScopes) {
+    public Response isScopeExists(String name, Boolean includeOIDCScopes, Boolean encoded) {
 
         boolean isScopeExists = false;
 
         try {
+            name = decodeScopeName(name, encoded);
             isScopeExists = ScopeUtils.getOAuth2ScopeService().isScopeExists(name, includeOIDCScopes);
         } catch (IdentityOAuth2ScopeClientException e) {
             if (LOG.isDebugEnabled()) {
@@ -210,10 +215,11 @@ public class ScopesApiServiceImpl extends ScopesApiService {
      * @return
      */
     @Override
-    public Response updateScope(ScopeToUpdateDTO scope, String name) {
+    public Response updateScope(ScopeToUpdateDTO scope, String name, Boolean encoded) {
 
         ScopeDTO updatedScope = null;
         try {
+            name = decodeScopeName(name, encoded);
             validateUpdateRequest(name);
             updatedScope = ScopeUtils.getScopeDTO(ScopeUtils.getOAuth2ScopeService()
                     .updateScope(ScopeUtils.getUpdatedScope(scope, name)));
@@ -250,9 +256,10 @@ public class ScopesApiServiceImpl extends ScopesApiService {
      * @return Response with the status of scope deletion.
      */
     @Override
-    public Response deleteScope(String name) {
+    public Response deleteScope(String name, Boolean encoded) {
 
         try {
+            name = decodeScopeName(name, encoded);
             validateDeleteRequest(name);
             ScopeUtils.getOAuth2ScopeService().deleteScope(name);
         } catch (IdentityOAuth2ScopeClientException e) {
@@ -373,5 +380,33 @@ public class ScopesApiServiceImpl extends ScopesApiService {
             LOG.error("Error while validating user authorization of user: " + authenticatedUser, e);
         }
         return false;
+    }
+
+    /**
+     * Decode the scope name if it is Base64 URL-encoded.
+     *
+     * @param name    The scope name to decode
+     * @param encoded Flag indicating if the name is encoded
+     * @return Decoded scope name if encoded is true, otherwise returns the original name
+     */
+    private String decodeScopeName(String name, Boolean encoded) {
+        if (name == null || StringUtils.isBlank(name)) {
+            LOG.debug("Scope name is null, empty, or blank");
+            return name;
+        }
+        if (encoded != null && encoded) {
+            try {
+                return new String(
+                        Base64.getUrlDecoder().decode(name),
+                        StandardCharsets.UTF_8
+                );
+            } catch (IllegalArgumentException e) {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Error decoding scope name: " + name, e);
+                }
+                return name;
+            }
+        }
+        return name;
     }
 }

--- a/components/org.wso2.carbon.identity.api.server.oauth.scope/src/main/resources/api.identity.oauth2.scope.endpoint.yaml
+++ b/components/org.wso2.carbon.identity.api.server.oauth.scope/src/main/resources/api.identity.oauth2.scope.endpoint.yaml
@@ -199,9 +199,9 @@ paths:
         - name: encoded
           in: query
           description: Used to check whether the scope name is URL encoded.
-          schema:
-            type: boolean
-            default: false
+          required: false
+          type: boolean
+          default: false
 
       responses:
         200:
@@ -251,9 +251,9 @@ paths:
         - name: encoded
           in: query
           description: Used to check whether the scope name is URL encoded.
-          schema:
-            type: boolean
-            default: false
+          required: false
+          type: boolean
+          default: false
 
       responses:
         204:
@@ -311,9 +311,9 @@ paths:
         - name: encoded
           in: query
           description: Used to check whether the scope name is URL encoded.
-          schema:
-            type: boolean
-            default: false
+          required: false
+          type: boolean
+          default: false
 
       responses:
         200:
@@ -363,15 +363,15 @@ paths:
         - name: includeOIDCScopes
           in: query
           description: Used to check existence of OIDC scopes as well via OAuth2 scopes endpoint.
-          schema:
-            type: boolean
-            default: false
+          required: false
+          type: boolean
+          default: false
         - name: encoded
           in: query
           description: Used to check whether the scope name is URL encoded.
-          schema:
-            type: boolean
-            default: false
+          required: false
+          type: boolean
+          default: false
 
       responses:
         200:

--- a/components/org.wso2.carbon.identity.api.server.oauth.scope/src/main/resources/api.identity.oauth2.scope.endpoint.yaml
+++ b/components/org.wso2.carbon.identity.api.server.oauth.scope/src/main/resources/api.identity.oauth2.scope.endpoint.yaml
@@ -196,6 +196,12 @@ paths:
           description: Name of the scope that is to be retrieved
           required: true
           type: string
+        - name: encoded
+          in: query
+          description: Used to check whether the scope name is URL encoded.
+          schema:
+            type: boolean
+            default: false
 
       responses:
         200:
@@ -242,6 +248,12 @@ paths:
           description: Name of the scope that is to be deleted
           required: true
           type: string
+        - name: encoded
+          in: query
+          description: Used to check whether the scope name is URL encoded.
+          schema:
+            type: boolean
+            default: false
 
       responses:
         204:
@@ -296,6 +308,12 @@ paths:
           description: Name of the scope that is to be updated
           required: true
           type: string
+        - name: encoded
+          in: query
+          description: Used to check whether the scope name is URL encoded.
+          schema:
+            type: boolean
+            default: false
 
       responses:
         200:
@@ -348,6 +366,13 @@ paths:
           schema:
             type: boolean
             default: false
+        - name: encoded
+          in: query
+          description: Used to check whether the scope name is URL encoded.
+          schema:
+            type: boolean
+            default: false
+
       responses:
         200:
           description: Scope Exists

--- a/components/org.wso2.carbon.identity.api.server.oauth.scope/src/test/java/org/wso2/carbon/identity/oauth/scope/endpoint/impl/ScopesApiServiceImplTest.java
+++ b/components/org.wso2.carbon.identity.api.server.oauth.scope/src/test/java/org/wso2/carbon/identity/oauth/scope/endpoint/impl/ScopesApiServiceImplTest.java
@@ -102,13 +102,13 @@ public class ScopesApiServiceImplTest extends PowerMockTestCase {
 
         if (Response.Status.OK.equals(expectation)) {
             when(ScopeUtils.getScopeDTO(any(Scope.class))).thenReturn(any(ScopeDTO.class));
-            assertEquals(scopesApiService.updateScope(scopeToUpdateDTO, someScopeName).getStatus(),
+            assertEquals(scopesApiService.updateScope(scopeToUpdateDTO, someScopeName, false).getStatus(),
                     Response.Status.OK.getStatusCode(), "Error occurred while updating scopes");
         } else if (Response.Status.BAD_REQUEST.equals(expectation)) {
             when(oAuth2ScopeService.updateScope(any(Scope.class))).thenThrow(IdentityOAuth2ScopeClientException.class);
             callRealMethod();
             try {
-                scopesApiService.updateScope(scopeToUpdateDTO, someScopeName);
+                scopesApiService.updateScope(scopeToUpdateDTO, someScopeName, false);
             } catch (ScopeEndpointException e) {
                 assertEquals(e.getResponse().getStatus(), Response.Status.BAD_REQUEST.getStatusCode(),
                         "Cannot find HTTP Response, Bad Request in Case of " +
@@ -125,7 +125,7 @@ public class ScopesApiServiceImplTest extends PowerMockTestCase {
             when(oAuth2ScopeService.updateScope(any(Scope.class))).thenThrow(throwable);
             callRealMethod();
             try {
-                scopesApiService.updateScope(scopeToUpdateDTO, someScopeName);
+                scopesApiService.updateScope(scopeToUpdateDTO, someScopeName, false);
             } catch (ScopeEndpointException e) {
                 assertEquals(e.getResponse().getStatus(), Response.Status.NOT_FOUND.getStatusCode(),
                         "Cannot find HTTP Response, Not Found in Case of " +
@@ -140,7 +140,7 @@ public class ScopesApiServiceImplTest extends PowerMockTestCase {
             when(oAuth2ScopeService.updateScope(any(Scope.class))).thenThrow(IdentityOAuth2ScopeException.class);
             callRealMethod();
             try {
-                scopesApiService.updateScope(scopeToUpdateDTO, someScopeName);
+                scopesApiService.updateScope(scopeToUpdateDTO, someScopeName, false);
             } catch (ScopeEndpointException e) {
                 assertEquals(e.getResponse().getStatus(), Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(),
                         "Cannot find HTTP Response, Internal Server Error in case of " +
@@ -174,13 +174,14 @@ public class ScopesApiServiceImplTest extends PowerMockTestCase {
         if (Response.Status.OK.equals(expectation)) {
             when(oAuth2ScopeService.getScope(someScopeName))
                     .thenReturn(new Scope(someScopeName, someScopeName, someScopeDescription));
-            assertEquals(scopesApiService.getScope(someScopeName).getStatus(), Response.Status.OK.getStatusCode(),
+            assertEquals(scopesApiService.getScope(someScopeName, false).getStatus(),
+                    Response.Status.OK.getStatusCode(),
                     "Error occurred while getting a scope");
         } else if (Response.Status.BAD_REQUEST.equals(expectation)) {
             when(oAuth2ScopeService.getScope(someScopeName)).thenThrow(throwable);
             callRealMethod();
             try {
-                scopesApiService.getScope(someScopeName);
+                scopesApiService.getScope(someScopeName, false);
             } catch (ScopeEndpointException e) {
                 assertEquals(e.getResponse().getStatus(), Response.Status.BAD_REQUEST.getStatusCode(),
                         "Cannot find HTTP Response, Bad Request in Case of " +
@@ -197,7 +198,7 @@ public class ScopesApiServiceImplTest extends PowerMockTestCase {
             when(oAuth2ScopeService.getScope(someScopeName)).thenThrow(throwable);
             callRealMethod();
             try {
-                scopesApiService.getScope(someScopeName);
+                scopesApiService.getScope(someScopeName, false);
             } catch (ScopeEndpointException e) {
                 assertEquals(e.getResponse().getStatus(), Response.Status.NOT_FOUND.getStatusCode(),
                         "Cannot find HTTP Response, Not Found in Case of " +
@@ -212,7 +213,7 @@ public class ScopesApiServiceImplTest extends PowerMockTestCase {
             when(oAuth2ScopeService.getScope(someScopeName)).thenThrow(throwable);
             callRealMethod();
             try {
-                scopesApiService.getScope(someScopeName);
+                scopesApiService.getScope(someScopeName, false);
             } catch (ScopeEndpointException e) {
                 assertEquals(e.getResponse().getStatus(), Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(),
                         "Cannot find HTTP Response, Internal Server Error in case of " +
@@ -284,13 +285,13 @@ public class ScopesApiServiceImplTest extends PowerMockTestCase {
 
         if (Response.Status.OK.equals(expectation)) {
             doNothing().when(oAuth2ScopeService).deleteScope(any(String.class));
-            assertEquals(scopesApiService.deleteScope(any(String.class)).getStatus(),
+            assertEquals(scopesApiService.deleteScope(any(String.class), false).getStatus(),
                     Response.Status.OK.getStatusCode());
         } else if (Response.Status.BAD_REQUEST.equals(expectation)) {
             doThrow(throwable).when(oAuth2ScopeService).deleteScope(any(String.class));
             callRealMethod();
             try {
-                scopesApiService.deleteScope(someScopeName);
+                scopesApiService.deleteScope(someScopeName, false);
             } catch (ScopeEndpointException e) {
                 assertEquals(e.getResponse().getStatus(), Response.Status.BAD_REQUEST.getStatusCode(),
                         "Cannot find HTTP Response, Bad Request in Case of " +
@@ -307,7 +308,7 @@ public class ScopesApiServiceImplTest extends PowerMockTestCase {
             doThrow(throwable).when(oAuth2ScopeService).deleteScope(any(String.class));
             callRealMethod();
             try {
-                scopesApiService.deleteScope(someScopeName);
+                scopesApiService.deleteScope(someScopeName, false);
             } catch (ScopeEndpointException e) {
                 assertEquals(e.getResponse().getStatus(), Response.Status.NOT_FOUND.getStatusCode(),
                         "Cannot find HTTP Response, Not Found in Case of " +
@@ -417,19 +418,19 @@ public class ScopesApiServiceImplTest extends PowerMockTestCase {
 
         if (Response.Status.OK.equals(expectation)) {
             when(oAuth2ScopeService.isScopeExists(someScopeName, false)).thenReturn(Boolean.TRUE);
-            assertEquals(scopesApiService.isScopeExists(someScopeName,
-                            false).getStatus(), Response.Status.OK.getStatusCode(),
+            assertEquals(scopesApiService.isScopeExists(someScopeName, false, false).getStatus(),
+                    Response.Status.OK.getStatusCode(),
                     "Error occurred while checking is scope exist");
         } else if (Response.Status.NOT_FOUND.equals(expectation)) {
             when(oAuth2ScopeService.isScopeExists(someScopeName, false)).thenReturn(Boolean.FALSE);
-            assertEquals(scopesApiService.isScopeExists(someScopeName, false).getStatus(),
+            assertEquals(scopesApiService.isScopeExists(someScopeName, false, false).getStatus(),
                     Response.Status.NOT_FOUND.getStatusCode(),
                     "Given scope does not exist but error while checking isExist");
         } else if (Response.Status.BAD_REQUEST.equals(expectation)) {
             when(oAuth2ScopeService.isScopeExists(someScopeName, false)).thenThrow(throwable);
             callRealMethod();
             try {
-                scopesApiService.isScopeExists(someScopeName, false);
+                scopesApiService.isScopeExists(someScopeName, false, false);
             } catch (ScopeEndpointException e) {
                 assertEquals(e.getResponse().getStatus(), Response.Status.BAD_REQUEST.getStatusCode(),
                         "Cannot find HTTP Response, Bad Request in Case of " +
@@ -444,7 +445,7 @@ public class ScopesApiServiceImplTest extends PowerMockTestCase {
             when(oAuth2ScopeService.isScopeExists("scope", false)).thenThrow(throwable);
             callRealMethod();
             try {
-                scopesApiService.isScopeExists(someScopeName, false);
+                scopesApiService.isScopeExists(someScopeName, false, false);
             } catch (ScopeEndpointException e) {
                 assertEquals(e.getResponse().getStatus(), Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(),
                         "Cannot find HTTP Response, Internal Server Error in case of " +
@@ -455,6 +456,56 @@ public class ScopesApiServiceImplTest extends PowerMockTestCase {
                 reset(oAuth2ScopeService);
             }
         }
+    }
+
+    @Test
+    public void testGetScopeWithEncodedName() throws Exception {
+
+        String encodedScopeName = "dGVzdC9zY29wZQ";
+        String decodedScopeName = "test/scope";
+
+        when(oAuth2ScopeService.getScope(decodedScopeName)).thenReturn(
+                new Scope(decodedScopeName, decodedScopeName, someScopeDescription));
+
+        assertEquals(scopesApiService.getScope(encodedScopeName, true).getStatus(), Response.Status.OK.getStatusCode(),
+                "Error occurred while getting a scope with encoded name");
+    }
+
+    @Test
+    public void testUpdateScopeWithEncodedName() throws Exception {
+
+        String encodedScopeName = "dGVzdC9zY29wZQ";
+        String decodedScopeName = "test/scope";
+
+        ScopeToUpdateDTO scopeToUpdateDTO = new ScopeToUpdateDTO();
+        scopeToUpdateDTO.setDescription("updated description");
+        scopeToUpdateDTO.setBindings(Collections.emptyList());
+
+        when(ScopeUtils.getScopeDTO(any(Scope.class))).thenReturn(any(ScopeDTO.class));
+        assertEquals(scopesApiService.updateScope(scopeToUpdateDTO, encodedScopeName, true).getStatus(),
+                Response.Status.OK.getStatusCode(), "Error occurred while updating scope with encoded name");
+    }
+
+    @Test
+    public void testDeleteScopeWithEncodedName() throws Exception {
+
+        String encodedScopeName = "dGVzdC9zY29wZQ";
+        String decodedScopeName = "test/scope";
+
+        doNothing().when(oAuth2ScopeService).deleteScope(decodedScopeName);
+        assertEquals(scopesApiService.deleteScope(encodedScopeName, true).getStatus(),
+                Response.Status.OK.getStatusCode(), "Error occurred while deleting scope with encoded name");
+    }
+
+    @Test
+    public void testIsScopeExistsWithEncodedName() throws Exception {
+
+        String encodedScopeName = "dGVzdC9zY29wZQ";
+        String decodedScopeName = "test/scope";
+
+        when(oAuth2ScopeService.isScopeExists(decodedScopeName, false)).thenReturn(Boolean.TRUE);
+        assertEquals(scopesApiService.isScopeExists(encodedScopeName, false, true).getStatus(),
+                Response.Status.OK.getStatusCode(), "Error occurred while checking scope existence with encoded name");
     }
 
     private void callRealMethod() throws Exception {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/OAuth2ScopeService.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/OAuth2ScopeService.java
@@ -42,8 +42,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import static org.wso2.carbon.identity.oauth2.Oauth2ScopeConstants.ErrorMessages.
-        ERROR_CODE_BAD_REQUEST_SCOPE_NAME_NOT_SATIFIED_THE_REGEX;
 
 /**
  * OAuth2ScopeService use for scope handling
@@ -57,8 +55,6 @@ import static org.wso2.carbon.identity.oauth2.Oauth2ScopeConstants.ErrorMessages
 )
 public class OAuth2ScopeService {
     private static final Log log = LogFactory.getLog(OAuth2ScopeService.class);
-    private static final String SCOPE_VALIDATION_REGEX = "^[^?#/()]*$";
-
     /**
      * Register a scope with the bindings
      *
@@ -706,7 +702,6 @@ public class OAuth2ScopeService {
     private void addScopePreValidation(Scope scope) throws IdentityOAuth2ScopeClientException {
 
         validateScopeName(scope.getName());
-        validateRegex(scope.getName());
         validateDisplayName(scope.getDisplayName());
     }
 
@@ -736,15 +731,6 @@ public class OAuth2ScopeService {
                     ERROR_CODE_BAD_REQUEST_SCOPE_NAME_NOT_SPECIFIED, null);
         }
         validateWhiteSpaces(scopeName);
-    }
-
-    private void validateRegex(String scopeName) throws IdentityOAuth2ScopeClientException {
-
-        Pattern regexPattern = Pattern.compile(SCOPE_VALIDATION_REGEX);
-        if (!regexPattern.matcher(scopeName).matches()) {
-            throw Oauth2ScopeUtils.generateClientException
-                    (ERROR_CODE_BAD_REQUEST_SCOPE_NAME_NOT_SATIFIED_THE_REGEX, scopeName);
-        }
     }
 
     /**

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/OAuth2ScopeServiceTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/OAuth2ScopeServiceTest.java
@@ -129,9 +129,7 @@ public class OAuth2ScopeServiceTest extends PowerMockTestCase {
 
         return new Object[][]{
                 {"invalid Scope Name", Oauth2ScopeConstants.ErrorMessages.
-                        ERROR_CODE_BAD_REQUEST_SCOPE_NAME_CONTAINS_WHITESPACES.getMessage()},
-                {"invalid?scopeName", Oauth2ScopeConstants.ErrorMessages.
-                        ERROR_CODE_BAD_REQUEST_SCOPE_NAME_NOT_SATIFIED_THE_REGEX.getMessage()}
+                        ERROR_CODE_BAD_REQUEST_SCOPE_NAME_CONTAINS_WHITESPACES.getMessage()}
         };
     }
 


### PR DESCRIPTION
This PR introduces support for handling URL-encoded scope names in the OAuth2 Scope API. The main change is the addition of an encoded query parameter to relevant endpoints, allowing clients to specify whether the scope name is URL-encoded. The implementation includes decoding logic and updates to the API contract and tests.

- Fix for: https://github.com/wso2/api-manager/issues/4659

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * OAuth scope management endpoints now support optional Base64 URL-decoding of scope names through a new `encoded` parameter in scope retrieval, update, deletion, and existence check operations.
  * Simplified scope name validation to enforce whitespace restrictions.

* **Tests**
  * Expanded test coverage for Base64-encoded scope name handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->