### PR TITLE
Address review comments on #2987.

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuer.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuer.java
@@ -1555,8 +1555,14 @@ public class AccessTokenIssuer {
                 idTokenDTO.setIdTokenClaimsSet(null);
                 authorizationGrantCacheEntry.setPreIssueIDTokenActionDTO(idTokenDTO);
                 authorizationGrantCacheEntry.setPreIssueIDTokenActionsExecuted(true);
-                log.debug("Customized audience list and ID token attributes from pre issue ID token actions are" +
-                        "persisted in the AuthorizationGrantCache against the token id: " + tokenRespDTO.getTokenId());
+                if (log.isDebugEnabled()) {
+                    log.debug("Customized audience list and ID token attributes from pre issue ID token actions are " +
+                            "persisted in the AuthorizationGrantCache against the token id: "
+                            + tokenRespDTO.getTokenId());
+                }
+            } else {
+                log.warn("Pre issue ID token actions were marked as executed but the IDTokenDTO is null. " +
+                        "ID token customizations will not be persisted for the token id: " + tokenRespDTO.getTokenId());
             }
         }
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/DefaultIDTokenBuilder.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/DefaultIDTokenBuilder.java
@@ -1082,8 +1082,13 @@ public class DefaultIDTokenBuilder implements org.wso2.carbon.identity.openidcon
 
         if (tokenReqMessageContext.isPreIssueIDTokenActionsExecuted()) {
             IDTokenDTO idTokenDTO = tokenReqMessageContext.getPreIssueIDTokenActionDTO();
-            idTokenDTO.setIdTokenClaimsSet(idTokenJwtClaimSetBuilder.build());
-            return idTokenDTO;
+            if (idTokenDTO != null) {
+                idTokenDTO.setIdTokenClaimsSet(idTokenJwtClaimSetBuilder.build());
+                return idTokenDTO;
+            }
+            log.warn("Pre issue ID token actions were marked as executed but the IDTokenDTO is null. " +
+                    "Falling back to a new IDTokenDTO; ID token customizations will be lost for client_id: " +
+                    tokenReqMessageContext.getOauth2AccessTokenReqDTO().getClientId());
         }
         IDTokenDTO idTokenDTO = new IDTokenDTO();
         idTokenDTO.setIdTokenClaimsSet(idTokenJwtClaimSetBuilder.build());


### PR DESCRIPTION
This pr addresses review comments on:

- [ ] https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2987

This pull request focuses on improving the reliability and debuggability of ID token customization logic in the OAuth2/OpenID Connect flow. The changes add clearer warnings and debug logs when pre-issue ID token actions are marked as executed, but the expected data is missing, and they fix a potential bug in list index validation.

**Logging and error handling improvements:**

* Added a warning log in `DefaultIDTokenBuilder.java` to notify when pre-issue ID token actions are marked as executed, but the `IDTokenDTO` is null; this also clarifies that a fallback will occur and customizations will be lost for the affected `client_id`.
* Added a warning log in `AccessTokenIssuer.java` to highlight when pre-issue ID token actions are marked as executed but the `IDTokenDTO` is null, indicating that customizations will not be persisted for the relevant token. Also, wrapped a debug log with a check for debug level to avoid unnecessary log output.

**Bug fix:**

* Fixed the `validateIndex` method in `PreIssueIDTokenResponseProcessor.java` to correctly return `-1` instead of `0` when the list is empty and the last element is requested, preventing invalid index access.