### PR TITLE
Resolve token generation failure using authcode with empty scopes

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
@@ -2471,7 +2471,13 @@ public class OAuth2AuthzEndpoint {
             if (ArrayUtils.isEmpty(authzReqMsgCtx.getApprovedScope())) {
                 oauth2Params.setScopes(new HashSet<>(Collections.emptyList()));
             } else {
-                oauth2Params.setScopes(new HashSet<>(Arrays.asList(authzReqMsgCtx.getApprovedScope())));
+                // Exclude default scopes mentioned in the configuration from consent flow
+                List<String> defaultRequestedScopes = OAuthServerConfiguration.getInstance()
+                        .getDefaultRequestedScopes();
+                Set<String> approvedScopes = new HashSet<>(Arrays.asList(authzReqMsgCtx.getApprovedScope()));
+                log.debug("Removing default scopes from approved scopes.");
+                approvedScopes.removeAll(defaultRequestedScopes);
+                oauth2Params.setScopes(approvedScopes);
             }
         } catch (IdentityOAuth2Exception | InvalidOAuthClientException e) {
             log.error("Error occurred while validating requested scopes.", e);

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
@@ -294,6 +294,8 @@ public class OAuthServerConfiguration {
     private boolean enableIntrospectionDataProviders = false;
     // Property to define the allowed scopes.
     private List<String> allowedScopes = new ArrayList<>();
+    // Property to define the default requested scopes.
+    private List<String> defaultRequestedScopes = new ArrayList<>();
 
     // Property to define the filtered claims.
     private List<String> filteredIntrospectionClaims = new ArrayList<>();
@@ -475,6 +477,9 @@ public class OAuthServerConfiguration {
         // Read config for allowed scopes.
         parseAllowedScopesConfiguration(oauthElem);
 
+        // Read config for default requested scopes.
+        parseDefaultRequestedScopesConfiguration(oauthElem);
+
         // Read config for filtered claims for introspection response.
         parseFilteredClaimsForIntrospectionConfiguration(oauthElem);
 
@@ -508,6 +513,35 @@ public class OAuthServerConfiguration {
                 allowedScopes.add(scopeElement.getText());
             }
         }
+    }
+
+    /**
+     * Parse default requested scopes configuration.
+     *
+     * @param oauthConfigElem oauthConfigElem.
+     */
+    private void parseDefaultRequestedScopesConfiguration(OMElement oauthConfigElem) {
+
+        OMElement defaultRequestedScopesElem = oauthConfigElem.getFirstChildWithName(
+                getQNameWithIdentityNS(ConfigElements.DEFAULT_REQUESTED_SCOPES_ELEMENT));
+        if (defaultRequestedScopesElem != null) {
+            Iterator scopeIterator = defaultRequestedScopesElem.getChildrenWithName(getQNameWithIdentityNS(
+                    ConfigElements.SCOPES_ELEMENT));
+            while (scopeIterator.hasNext()) {
+                OMElement scopeElement = (OMElement) scopeIterator.next();
+                defaultRequestedScopes.add(scopeElement.getText());
+            }
+        }
+    }
+
+    /**
+     * Get the list of default requested scopes.
+     *
+     * @return String returns a list of default requested scope string.
+     */
+    public List<String> getDefaultRequestedScopes() {
+
+        return defaultRequestedScopes;
     }
 
     /**
@@ -3636,6 +3670,8 @@ public class OAuthServerConfiguration {
         private static final String RENEW_TOKEN_PER_REQUEST = "RenewTokenPerRequest";
         // Allowed Scopes Config.
         private static final String ALLOWED_SCOPES_ELEMENT = "AllowedScopes";
+        // Allowed Default Requested Scopes Config.
+        private static final String DEFAULT_REQUESTED_SCOPES_ELEMENT = "DefaultRequestedScopes";
         private static final String SCOPES_ELEMENT = "Scope";
         // Filtered Claims For Introspection Response Config.
         private static final String FILTERED_CLAIMS = "FilteredClaims";

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/AuthorizationHandlerManager.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/AuthorizationHandlerManager.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.oauth2.authz;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
@@ -272,6 +273,22 @@ public class AuthorizationHandlerManager {
         return authorizeRespDTO;
     }
 
+    /**
+     * Adds default requested scopes to the authorization request's scope list.
+     * The default scopes are retrieved from the configuration.
+     *
+     * @param authzReqMsgCtx The OAuth authorization request message context.
+     */
+    private void addDefaultRequestedScopes(OAuthAuthzReqMessageContext authzReqMsgCtx) {
+
+        List<String> defaultRequestedScopes = OAuthServerConfiguration.getInstance().getDefaultRequestedScopes();
+        String[] requestedScopes = authzReqMsgCtx.getAuthorizationReqDTO().getScopes();
+        if (ArrayUtils.isEmpty(requestedScopes) && CollectionUtils.isNotEmpty(defaultRequestedScopes)) {
+            authzReqMsgCtx.setRequestedScopes(defaultRequestedScopes.toArray(new String[0]));
+            authzReqMsgCtx.getAuthorizationReqDTO().setScopes(defaultRequestedScopes.toArray(new String[0]));
+        }
+    }
+
 
     /**
      * validated requested scopes.
@@ -282,7 +299,8 @@ public class AuthorizationHandlerManager {
     private void validateRequestedScopes(OAuthAuthzReqMessageContext authzReqMsgCtx,
                                          ResponseTypeHandler authzHandler) throws IdentityOAuth2Exception,
             IdentityOAuth2UnauthorizedScopeException {
-
+        // Get default requested scopes that are specified in the configuration.
+        addDefaultRequestedScopes(authzReqMsgCtx);
         // Get scopes that specified in the allowed scopes list.
         List<String> requestedAllowedScopes = getAllowedScopesFromRequestedScopes(authzReqMsgCtx);
         // If it is management app, we validate internal scopes in the requested scopes.


### PR DESCRIPTION
### Purpose

Porting fixes from: https://github.com/wso2-support/identity-inbound-auth-oauth/pull/1794
Fixes: https://github.com/wso2/api-manager/issues/5051

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configurable default requested scopes in OAuth2 authorization flows. Default scopes are now applied when no specific scopes are requested and are properly filtered during the authorization approval process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->