### PR TITLE
Fix NPE during token introspection when issuer is built with hostname and tenant qualified URLs are disabled

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/JWTUtils.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/JWTUtils.java
@@ -205,6 +205,13 @@ public class JWTUtils {
                     jwtIssuer.equals(OAuth2Util.OAuthURL.getOAuth2MTLSTokenEPUrl())) {
                 return residentIdentityProvider;
             }
+            // When the issuer is built with hostname (and tenant qualified URLs disabled), compare against the
+            // recomputed hostname based issuer instead of the stale entity ID stored in the database.
+            if (Boolean.parseBoolean(IdentityUtil.getProperty(OAuthConstants.OAUTH_BUILD_ISSUER_WITH_HOSTNAME)) &&
+                    !IdentityTenantUtil.isTenantQualifiedUrlsEnabled() &&
+                    jwtIssuer.equals(OAuth2Util.getIssuerLocation(tenantDomain))) {
+                return residentIdentityProvider;
+            }
             // Check for organization management enablement.
             if (!OAuth2ServiceComponentHolder.getInstance().isOrganizationManagementEnabled()) {
                 throw new IdentityOAuth2Exception("No registered IDP found for the token with issuer name : "
@@ -221,6 +228,11 @@ public class JWTUtils {
             }
             int depthOfRootOrg = getSubOrgStartLevel() - 1;
             String resourceResidentOrgId = PrivilegedCarbonContext.getThreadLocalCarbonContext().getOrganizationId();
+            // Bail out early if the organization IDs could not be resolved to avoid a NullPointerException.
+            if (jwtIssuerOrgId == null || resourceResidentOrgId == null) {
+                throw new IdentityOAuth2Exception("No registered IDP found for the token with issuer name : "
+                        + jwtIssuer);
+            }
             if (!jwtIssuerOrgId.equals(switchedOrgOrgAncestors.get(depthOfRootOrg)) ||
                     !resourceResidentOrgId.equals(switchedOrgId)) {
                 throw new IdentityOAuth2ClientException("No registered IDP found for the token with issuer name : "
@@ -276,6 +288,13 @@ public class JWTUtils {
                     jwtIssuer.equals(OAuth2Util.OAuthURL.getOAuth2MTLSTokenEPUrl())) {
                 return residentIdentityProvider;
             }
+            // When the issuer is built with hostname (and tenant qualified URLs disabled), compare against the
+            // recomputed hostname based issuer instead of the stale entity ID stored in the database.
+            if (Boolean.parseBoolean(IdentityUtil.getProperty(OAuthConstants.OAUTH_BUILD_ISSUER_WITH_HOSTNAME)) &&
+                    !IdentityTenantUtil.isTenantQualifiedUrlsEnabled() &&
+                    jwtIssuer.equals(OAuth2Util.getIssuerLocation(tenantDomain))) {
+                return residentIdentityProvider;
+            }
             // Check for organization management enablement.
             if (!OAuth2ServiceComponentHolder.getInstance().isOrganizationManagementEnabled()) {
                 throw new IdentityOAuth2Exception("No registered IDP found for the token with issuer name : "
@@ -321,6 +340,11 @@ public class JWTUtils {
                         "Ancestor list size is insufficient for the organization ID: " + switchedOrgId);
             }
             String resourceResidentOrgId = PrivilegedCarbonContext.getThreadLocalCarbonContext().getOrganizationId();
+            // Bail out early if the organization IDs could not be resolved to avoid a NullPointerException.
+            if (jwtIssuerOrgId == null || resourceResidentOrgId == null) {
+                throw new IdentityOAuth2Exception("No registered IDP found for the token with issuer name : "
+                        + jwtIssuer);
+            }
             if (!jwtIssuerOrgId.equals(switchedOrgOrgAncestors.get(depthOfRootOrg)) ||
                     !resourceResidentOrgId.equals(switchedOrgId)) {
                 throw new IdentityOAuth2ClientException("No registered IDP found for the token with issuer name : "

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/util/JWTUtilsTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/util/JWTUtilsTest.java
@@ -26,18 +26,30 @@ import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 import org.wso2.carbon.base.CarbonBaseConstants;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.identity.application.common.model.FederatedAuthenticatorConfig;
 import org.wso2.carbon.identity.application.common.model.IdentityProvider;
+import org.wso2.carbon.identity.application.common.model.Property;
 import org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants;
 import org.wso2.carbon.identity.core.IdentityKeyStoreResolver;
 import org.wso2.carbon.identity.core.util.IdentityKeyStoreResolverConstants;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
+import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
+import org.wso2.carbon.identity.oauth2.internal.OAuth2ServiceComponentHolder;
+import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
+import org.wso2.carbon.identity.organization.management.service.util.OrganizationManagementConfigUtil;
+import org.wso2.carbon.identity.organization.management.service.util.OrganizationManagementUtil;
+import org.wso2.carbon.idp.mgt.IdentityProviderManager;
 
 import java.io.FileInputStream;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.KeyStore;
 import java.security.cert.X509Certificate;
+import java.util.Arrays;
 
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
@@ -78,6 +90,9 @@ public class JWTUtilsTest {
             "3pDI4B+vQipcfTjJqgPAWvUz903z61lRuAlJFPPD69l+IQ15z1Mfc7rgl0wmZLBU\n" +
             "HjVlGsFGQX6e10Rx/msN+NWxKJGf7Z6vxS8Qoc4nddUBnndCOvCVvgI9BThNv0cG\n" +
             "e3hB2nvCQvUJ/wfuj6i1PNfoM81nA2qEQfjY/QWuF4Ex/RYWBfASNU35TBRVc26R";
+
+    private static final String MUTUAL_TLS_ALIASES_ENABLED = "OAuth.MutualTLSAliases.Enabled";
+    private static final String OAUTH_BUILD_ISSUER_WITH_HOSTNAME = "OAuth.BuildIssuerWithHostname";
 
     private PrivilegedCarbonContext privilegedCarbonContext;
 
@@ -127,6 +142,126 @@ public class JWTUtilsTest {
         certificate = JWTUtils.resolveSignerCertificate(identityProvider);
         assertEquals(certificate.getIssuerDN().getName(),
                 "CN=Intermediate CA, OU=IAM, O=WSO2, L=Colombo, ST=Western, C=LK");
+    }
+
+    @Test(description = "getIDPForIssuer returns the resident IDP when the issuer is built with hostname")
+    public void testGetIDPForIssuerWithHostnameBuiltIssuer() throws Exception {
+
+        String hostnameIssuer = "https://localhost:9443/oauth2/token";
+        IdentityProvider residentIdP = buildResidentIdP("https://stale-entity-id");
+        try (MockedStatic<IdentityProviderManager> identityProviderManager = mockStatic(IdentityProviderManager.class);
+             MockedStatic<IdentityUtil> identityUtil = mockStatic(IdentityUtil.class);
+             MockedStatic<IdentityTenantUtil> identityTenantUtil = mockStatic(IdentityTenantUtil.class);
+             MockedStatic<OAuth2Util> oAuth2Util = mockStatic(OAuth2Util.class)) {
+            mockResidentIdP(identityProviderManager, residentIdP);
+            identityUtil.when(() -> IdentityUtil.getProperty(MUTUAL_TLS_ALIASES_ENABLED)).thenReturn("false");
+            identityUtil.when(() -> IdentityUtil.getProperty(OAUTH_BUILD_ISSUER_WITH_HOSTNAME)).thenReturn("true");
+            identityTenantUtil.when(IdentityTenantUtil::isTenantQualifiedUrlsEnabled).thenReturn(false);
+            oAuth2Util.when(() -> OAuth2Util.getIssuerLocation(SUPER_TENANT_DOMAIN_NAME)).thenReturn(hostnameIssuer);
+
+            IdentityProvider result =
+                    JWTUtils.getIDPForIssuer(hostnameIssuer, SUPER_TENANT_DOMAIN_NAME, "switched-org-id");
+            assertEquals(result, residentIdP);
+        }
+    }
+
+    @Test(description = "getResidentIDPIssuer returns the resident IDP when the issuer is built with hostname")
+    public void testGetResidentIDPIssuerWithHostnameBuiltIssuer() throws Exception {
+
+        String hostnameIssuer = "https://localhost:9443/oauth2/token";
+        IdentityProvider residentIdP = buildResidentIdP("https://stale-entity-id");
+        try (MockedStatic<IdentityProviderManager> identityProviderManager = mockStatic(IdentityProviderManager.class);
+             MockedStatic<IdentityUtil> identityUtil = mockStatic(IdentityUtil.class);
+             MockedStatic<IdentityTenantUtil> identityTenantUtil = mockStatic(IdentityTenantUtil.class);
+             MockedStatic<OAuth2Util> oAuth2Util = mockStatic(OAuth2Util.class)) {
+            mockResidentIdP(identityProviderManager, residentIdP);
+            identityUtil.when(() -> IdentityUtil.getProperty(MUTUAL_TLS_ALIASES_ENABLED)).thenReturn("false");
+            identityUtil.when(() -> IdentityUtil.getProperty(OAUTH_BUILD_ISSUER_WITH_HOSTNAME)).thenReturn("true");
+            identityTenantUtil.when(IdentityTenantUtil::isTenantQualifiedUrlsEnabled).thenReturn(false);
+            oAuth2Util.when(() -> OAuth2Util.getIssuerLocation(SUPER_TENANT_DOMAIN_NAME)).thenReturn(hostnameIssuer);
+
+            IdentityProvider result = JWTUtils.getResidentIDPIssuer(hostnameIssuer, "client-id",
+                    SUPER_TENANT_DOMAIN_NAME, "switched-org-id");
+            assertEquals(result, residentIdP);
+        }
+    }
+
+    @Test(description = "getIDPForIssuer throws when the organization IDs cannot be resolved",
+            expectedExceptions = IdentityOAuth2Exception.class)
+    public void testGetIDPForIssuerWithUnresolvableOrgIds() throws Exception {
+
+        IdentityProvider residentIdP = buildResidentIdP("https://stale-entity-id");
+        try (MockedStatic<IdentityProviderManager> identityProviderManager = mockStatic(IdentityProviderManager.class);
+             MockedStatic<IdentityUtil> identityUtil = mockStatic(IdentityUtil.class);
+             MockedStatic<OAuth2ServiceComponentHolder> holder = mockStatic(OAuth2ServiceComponentHolder.class);
+             MockedStatic<OrganizationManagementConfigUtil> configUtil =
+                     mockStatic(OrganizationManagementConfigUtil.class)) {
+            mockResidentIdP(identityProviderManager, residentIdP);
+            identityUtil.when(() -> IdentityUtil.getProperty(MUTUAL_TLS_ALIASES_ENABLED)).thenReturn("false");
+            identityUtil.when(() -> IdentityUtil.getProperty(OAUTH_BUILD_ISSUER_WITH_HOSTNAME)).thenReturn("false");
+            mockOrganizationManager(holder, configUtil);
+
+            JWTUtils.getIDPForIssuer("https://some-issuer", SUPER_TENANT_DOMAIN_NAME, "switched-org-id");
+        }
+    }
+
+    @Test(description = "getResidentIDPIssuer throws when the organization IDs cannot be resolved",
+            expectedExceptions = IdentityOAuth2Exception.class)
+    public void testGetResidentIDPIssuerWithUnresolvableOrgIds() throws Exception {
+
+        IdentityProvider residentIdP = buildResidentIdP("https://stale-entity-id");
+        try (MockedStatic<IdentityProviderManager> identityProviderManager = mockStatic(IdentityProviderManager.class);
+             MockedStatic<IdentityUtil> identityUtil = mockStatic(IdentityUtil.class);
+             MockedStatic<OAuth2ServiceComponentHolder> holder = mockStatic(OAuth2ServiceComponentHolder.class);
+             MockedStatic<OrganizationManagementUtil> organizationManagementUtil =
+                     mockStatic(OrganizationManagementUtil.class);
+             MockedStatic<OrganizationManagementConfigUtil> configUtil =
+                     mockStatic(OrganizationManagementConfigUtil.class)) {
+            mockResidentIdP(identityProviderManager, residentIdP);
+            identityUtil.when(() -> IdentityUtil.getProperty(MUTUAL_TLS_ALIASES_ENABLED)).thenReturn("false");
+            identityUtil.when(() -> IdentityUtil.getProperty(OAUTH_BUILD_ISSUER_WITH_HOSTNAME)).thenReturn("false");
+            organizationManagementUtil.when(() -> OrganizationManagementUtil.isOrganization(SUPER_TENANT_DOMAIN_NAME))
+                    .thenReturn(false);
+            mockOrganizationManager(holder, configUtil);
+
+            JWTUtils.getResidentIDPIssuer("https://some-issuer", "client-id", SUPER_TENANT_DOMAIN_NAME,
+                    "switched-org-id");
+        }
+    }
+
+    private void mockResidentIdP(MockedStatic<IdentityProviderManager> identityProviderManager,
+                                 IdentityProvider residentIdP) throws Exception {
+
+        IdentityProviderManager identityProviderManagerInstance = mock(IdentityProviderManager.class);
+        identityProviderManager.when(IdentityProviderManager::getInstance).thenReturn(identityProviderManagerInstance);
+        when(identityProviderManagerInstance.getResidentIdP(SUPER_TENANT_DOMAIN_NAME)).thenReturn(residentIdP);
+    }
+
+    private void mockOrganizationManager(MockedStatic<OAuth2ServiceComponentHolder> holder,
+                                         MockedStatic<OrganizationManagementConfigUtil> configUtil) throws Exception {
+
+        OAuth2ServiceComponentHolder holderInstance = mock(OAuth2ServiceComponentHolder.class);
+        holder.when(OAuth2ServiceComponentHolder::getInstance).thenReturn(holderInstance);
+        when(holderInstance.isOrganizationManagementEnabled()).thenReturn(true);
+        OrganizationManager organizationManager = mock(OrganizationManager.class);
+        when(holderInstance.getOrganizationManager()).thenReturn(organizationManager);
+        when(organizationManager.resolveOrganizationId(SUPER_TENANT_DOMAIN_NAME)).thenReturn("jwt-issuer-org-id");
+        when(organizationManager.getAncestorOrganizationIds(anyString()))
+                .thenReturn(Arrays.asList("root-org-id", "child-org-id"));
+        configUtil.when(() -> OrganizationManagementConfigUtil.getProperty(anyString())).thenReturn("2");
+    }
+
+    private IdentityProvider buildResidentIdP(String entityId) {
+
+        Property entityIdProperty = new Property();
+        entityIdProperty.setName("IdPEntityId");
+        entityIdProperty.setValue(entityId);
+        FederatedAuthenticatorConfig oidcConfig = new FederatedAuthenticatorConfig();
+        oidcConfig.setName(IdentityApplicationConstants.Authenticator.OIDC.NAME);
+        oidcConfig.setProperties(new Property[]{entityIdProperty});
+        IdentityProvider residentIdP = new IdentityProvider();
+        residentIdP.setFederatedAuthenticatorConfigs(new FederatedAuthenticatorConfig[]{oidcConfig});
+        return residentIdP;
     }
 
     private void mockKeystores() throws Exception {


### PR DESCRIPTION
### Proposed changes in this pull request

#### Purpose

  Fixes https://github.com/wso2/product-is/issues/27999

 When the OAuth issuer is configured to be built with the hostname (`build_issuer_with_hostname = true`) and tenant qualified URLs are disabled, token introspection failed to resolve the resident IdP. The issuer in the token is built using the hostname, but the lookup compared it against the entity ID stored in the database, so no matching IdP was found. The flow then fell through to the organization management resolution path, where unresolved organization IDs (`jwtIssuerOrgId` / `resourceResidentOrgId`) caused a `NullPointerException`.

  #### Changes

  - In `JWTUtils.getIDPForIssuer`, when issuer-with-hostname is enabled and tenant qualified URLs are disabled, compare the JWT issuer against the recomputed hostname-based issuer (`OAuth2Util.getIssuerLocation(tenantDomain)`) instead of the stale DB entity ID, so the resident IdP is correctly returned.
  - Added a guard that throws a meaningful `IdentityOAuth2Exception` ("No registered IDP found...") when the organization IDs cannot be resolved, preventing the `NullPointerException`.

  #### Related Issue

  - https://github.com/wso2/product-is/issues/27999


### When should this PR be merged

[Please describe any preconditions that need to be addressed before we
can merge this pull request.]


### Follow up actions

[List any possible follow-up actions here; for instance, testing data
migrations, software that we need to install on staging and production
environments.]

-

## Developer Checklist (Mandatory)

- [ ] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact.



### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description.
- [ ] **Is the PR labeled correctly?**

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled.

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests.
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/).

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components.
- [ ] **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

#### Security

- [ ] **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
- [ ] **Are all UI and API inputs run through forms or serializers?**
- [ ] **Are all external inputs validated and sanitized appropriately?**
- [ ] **Does all branching logic have a default case?**
- [ ] **Does this solution handle outliers and edge cases gracefully?**
- [ ] **Are all external communications secured and restricted to SSL?**

#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes should be documented.
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented.
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki.
