### PR TITLE
Fix at+jwt typ rejection in JWKSBasedJWTValidator

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/jwt/JWKSBasedJWTValidator.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/jwt/JWKSBasedJWTValidator.java
@@ -72,6 +72,10 @@ public class JWKSBasedJWTValidator implements JWTValidator {
         /* Set up a JWT processor to parse the tokens and then check their signature and validity time window
         (bounded by the "iat", "nbf" and "exp" claims). */
         this.jwtProcessor = new DefaultJWTProcessor<>();
+        jwtProcessor.setJWSTypeVerifier((type, context) -> {
+            // Do nothing.
+            // This effectively says "All types are valid" to keep backward compatibility.
+        });
     }
 
     @Override

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/validators/jwt/JWKSBasedJWTValidatorTypeVerifierTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/validators/jwt/JWKSBasedJWTValidatorTypeVerifierTest.java
@@ -1,0 +1,253 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth2.validators.jwt;
+
+import com.nimbusds.jose.JOSEObjectType;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.JWSSigner;
+import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
+import com.nimbusds.jose.jwk.source.RemoteJWKSet;
+import com.nimbusds.jose.proc.JOSEObjectTypeVerifier;
+import com.nimbusds.jose.proc.SecurityContext;
+import com.nimbusds.jose.proc.SimpleSecurityContext;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import com.nimbusds.jwt.proc.ConfigurableJWTProcessor;
+import org.mockito.Mock;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.common.testng.WithCarbonHome;
+import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
+import org.wso2.carbon.identity.testutil.powermock.PowerMockIdentityBaseTest;
+
+import java.lang.reflect.Field;
+import java.util.Collections;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.MockitoAnnotations.initMocks;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.when;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+/**
+ * Regression tests for issue #4989: signature verification failing when JWKS is provided
+ * for tokens with {@code typ: at+jwt} (RFC 9068 access-token JWT type).
+ *
+ * Before the fix, {@link JWKSBasedJWTValidator}'s no-arg constructor instantiated a
+ * Nimbus {@code DefaultJWTProcessor} without overriding its default {@code JWSTypeVerifier},
+ * which from Nimbus 8.x onwards only accepts {@code typ=JWT} (or absent). Tokens with
+ * {@code typ=at+jwt} were rejected with {@code BadJOSEException}.
+ *
+ * The fix registers a permissive {@code JWSTypeVerifier} that accepts any {@code typ} value,
+ * preserving backward compatibility while fixing the regression for RFC 9068 tokens.
+ */
+@WithCarbonHome
+@PrepareForTest({JWKSourceDataProvider.class, JWKSBasedJWTValidator.class})
+public class JWKSBasedJWTValidatorTypeVerifierTest extends PowerMockIdentityBaseTest {
+
+    private static final String TEST_KID = "test-kid-4989";
+    private static final String TEST_JWKS_URI = "https://localhost:9444/oauth2/jwks";
+
+    @Mock
+    private JWKSourceDataProvider dataProvider;
+    @Mock
+    private RemoteJWKSet<SecurityContext> remoteJWKSet;
+
+    @BeforeMethod
+    public void setUp() {
+
+        initMocks(this);
+    }
+
+    /**
+     * Direct unit test on the {@code JWSTypeVerifier} configured by the constructor.
+     * Verifies that a JWT with {@code typ=at+jwt} (RFC 9068) is accepted by the type verifier.
+     * Without the fix, the verifier rejects {@code at+jwt} with
+     * {@code BadJOSEException: JOSE header typ (type) at+jwt not allowed}.
+     */
+    @Test
+    public void testJWSTypeVerifierAcceptsAtJwtType() throws Exception {
+
+        JOSEObjectTypeVerifier<SecurityContext> typeVerifier = getJWSTypeVerifier(new JWKSBasedJWTValidator());
+        assertNotNull(typeVerifier, "JWSTypeVerifier should be configured by the constructor.");
+        try {
+            typeVerifier.verify(new JOSEObjectType("at+jwt"), new SimpleSecurityContext());
+        } catch (Exception e) {
+            fail("typ=at+jwt should be accepted after the fix, but was rejected: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Control: a JWT with the standard {@code typ=JWT} must continue to be accepted by the
+     * type verifier. Asserts the fix did not break the pre-existing happy path.
+     */
+    @Test
+    public void testJWSTypeVerifierAcceptsStandardJwtType() throws Exception {
+
+        JOSEObjectTypeVerifier<SecurityContext> typeVerifier = getJWSTypeVerifier(new JWKSBasedJWTValidator());
+        try {
+            typeVerifier.verify(JOSEObjectType.JWT, new SimpleSecurityContext());
+        } catch (Exception e) {
+            fail("typ=JWT should remain accepted after the fix, but was rejected: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Verifies the permissive nature of the fix: any other custom {@code typ} value is also
+     * accepted (e.g., {@code foo+jwt}). This pins the actual fix behaviour — the verifier was
+     * deliberately written to be permissive ("All types are valid" per the inline comment) for
+     * backward compatibility — so future refactors that tighten it would fail this test and
+     * require an intentional change.
+     */
+    @Test
+    public void testJWSTypeVerifierAcceptsCustomType() throws Exception {
+
+        JOSEObjectTypeVerifier<SecurityContext> typeVerifier = getJWSTypeVerifier(new JWKSBasedJWTValidator());
+        try {
+            typeVerifier.verify(new JOSEObjectType("foo+jwt"), new SimpleSecurityContext());
+        } catch (Exception e) {
+            fail("Custom typ=foo+jwt should be accepted by the permissive fix, but was rejected: "
+                    + e.getMessage());
+        }
+    }
+
+    /**
+     * Verifies that the type verifier accepts a {@code null} type (i.e., absent {@code typ}
+     * header). This is the same behavior Nimbus's {@code DefaultJOSEObjectTypeVerifier}
+     * provided pre-8.x for unsigned/legacy tokens.
+     */
+    @Test
+    public void testJWSTypeVerifierAcceptsNullType() throws Exception {
+
+        JOSEObjectTypeVerifier<SecurityContext> typeVerifier = getJWSTypeVerifier(new JWKSBasedJWTValidator());
+        try {
+            typeVerifier.verify(null, new SimpleSecurityContext());
+        } catch (Exception e) {
+            fail("typ=<null> should be accepted, but was rejected: " + e.getMessage());
+        }
+    }
+
+    /**
+     * End-to-end regression test: signs a real RS256 JWT with {@code typ=at+jwt}, exposes the
+     * matching public key via a mocked {@code RemoteJWKSet}, and asserts that
+     * {@code validateSignature} returns {@code true}. Without the fix this throws
+     * {@code IdentityOAuth2Exception("Signature validation failed for the provided JWT")}
+     * because Nimbus's default type verifier rejects {@code at+jwt} before signature checking.
+     */
+    @Test
+    public void testValidateSignatureWithAtJwtType() throws Exception {
+
+        RSAKey rsaKey = new RSAKeyGenerator(2048).keyID(TEST_KID).generate();
+        SignedJWT signedJWT = signJwt(rsaKey, new JOSEObjectType("at+jwt"));
+
+        mockStatic(JWKSourceDataProvider.class);
+        when(JWKSourceDataProvider.getInstance()).thenReturn(dataProvider);
+        when(dataProvider.getJWKSource(TEST_JWKS_URI)).thenReturn(remoteJWKSet);
+        when(remoteJWKSet.get(any(), any()))
+                .thenReturn(Collections.<JWK>singletonList(rsaKey.toPublicJWK()));
+
+        JWKSBasedJWTValidator validator = new JWKSBasedJWTValidator();
+        boolean valid = validator.validateSignature(signedJWT, TEST_JWKS_URI, "RS256",
+                Collections.<String, Object>emptyMap());
+        assertTrue(valid, "JWT with typ=at+jwt must validate successfully after the fix.");
+    }
+
+    /**
+     * Control: the same end-to-end flow with the standard {@code typ=JWT} also succeeds.
+     */
+    @Test
+    public void testValidateSignatureWithStandardJwtType() throws Exception {
+
+        RSAKey rsaKey = new RSAKeyGenerator(2048).keyID(TEST_KID).generate();
+        SignedJWT signedJWT = signJwt(rsaKey, JOSEObjectType.JWT);
+
+        mockStatic(JWKSourceDataProvider.class);
+        when(JWKSourceDataProvider.getInstance()).thenReturn(dataProvider);
+        when(dataProvider.getJWKSource(TEST_JWKS_URI)).thenReturn(remoteJWKSet);
+        when(remoteJWKSet.get(any(), any()))
+                .thenReturn(Collections.<JWK>singletonList(rsaKey.toPublicJWK()));
+
+        JWKSBasedJWTValidator validator = new JWKSBasedJWTValidator();
+        boolean valid = validator.validateSignature(signedJWT, TEST_JWKS_URI, "RS256",
+                Collections.<String, Object>emptyMap());
+        assertTrue(valid, "JWT with typ=JWT must continue to validate successfully.");
+    }
+
+    /**
+     * Negative regression test: a JWT signed with one key but verified against a different
+     * public key must still fail signature validation, even when {@code typ=at+jwt}. This
+     * guards against the permissive type verifier accidentally weakening signature checks.
+     */
+    @Test
+    public void testValidateSignatureFailsForTamperedSignatureWithAtJwtType() throws Exception {
+
+        RSAKey signingKey = new RSAKeyGenerator(2048).keyID(TEST_KID).generate();
+        RSAKey unrelatedKey = new RSAKeyGenerator(2048).keyID(TEST_KID).generate();
+        SignedJWT signedJWT = signJwt(signingKey, new JOSEObjectType("at+jwt"));
+
+        mockStatic(JWKSourceDataProvider.class);
+        when(JWKSourceDataProvider.getInstance()).thenReturn(dataProvider);
+        when(dataProvider.getJWKSource(TEST_JWKS_URI)).thenReturn(remoteJWKSet);
+        when(remoteJWKSet.get(any(), any()))
+                .thenReturn(Collections.<JWK>singletonList(unrelatedKey.toPublicJWK()));
+
+        JWKSBasedJWTValidator validator = new JWKSBasedJWTValidator();
+        try {
+            validator.validateSignature(signedJWT, TEST_JWKS_URI, "RS256",
+                    Collections.<String, Object>emptyMap());
+            fail("Tampered signature should be rejected even with typ=at+jwt.");
+        } catch (IdentityOAuth2Exception expected) {
+            // Expected — signature must still be enforced.
+        }
+    }
+
+    private SignedJWT signJwt(RSAKey rsaKey, JOSEObjectType type) throws Exception {
+
+        JWSSigner signer = new RSASSASigner(rsaKey);
+        JWSHeader header = new JWSHeader.Builder(JWSAlgorithm.RS256)
+                .type(type)
+                .keyID(rsaKey.getKeyID())
+                .build();
+        JWTClaimsSet claims = new JWTClaimsSet.Builder()
+                .subject("alice")
+                .issuer("https://test-idp.example.com")
+                .build();
+        SignedJWT signedJWT = new SignedJWT(header, claims);
+        signedJWT.sign(signer);
+        return signedJWT;
+    }
+
+    @SuppressWarnings("unchecked")
+    private JOSEObjectTypeVerifier<SecurityContext> getJWSTypeVerifier(JWKSBasedJWTValidator validator)
+            throws Exception {
+
+        Field processorField = JWKSBasedJWTValidator.class.getDeclaredField("jwtProcessor");
+        processorField.setAccessible(true);
+        ConfigurableJWTProcessor<SecurityContext> processor =
+                (ConfigurableJWTProcessor<SecurityContext>) processorField.get(validator);
+        return (JOSEObjectTypeVerifier<SecurityContext>) processor.getJWSTypeVerifier();
+    }
+}

--- a/components/org.wso2.carbon.identity.oauth/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.identity.oauth/src/test/resources/testng.xml
@@ -113,6 +113,7 @@
             <!--<class name="org.wso2.carbon.identity.openidconnect.DefaultIDTokenBuilderTest"/>-->
             <class name="org.wso2.carbon.identity.openidconnect.DefaultOIDCClaimsCallbackHandlerTest"/>
             <class name="org.wso2.carbon.identity.oauth2.validators.jwt.JWKSBasedJWTValidatorTest"/>
+            <class name="org.wso2.carbon.identity.oauth2.validators.jwt.JWKSBasedJWTValidatorTypeVerifierTest"/>
             <class name="org.wso2.carbon.identity.oauth2.device.codegenerator.GenerateKeysTest"/>
         </classes>
     </test>


### PR DESCRIPTION
Issue: https://github.com/wso2/api-manager/issues/4989

JWKSBasedJWTValidator's no-arg constructor instantiates DefaultJWTProcessor without registering a JWSTypeVerifier. From Nimbus 8.x onward DefaultJWTProcessor ships a DefaultJOSEObjectTypeVerifier that only accepts typ=JWT (or absent), so JWTs carrying RFC 9068's typ=at+jwt are rejected with "BadJOSEException: JOSE header typ (type) at+jwt not allowed" before signature checking. This breaks the OAuth2 token-exchange grant for any federated IdP that emits at+jwt access-token JWTs (Keycloak, Auth0, IS 7.x, etc.).

Register a permissive JWSTypeVerifier on the processor so any typ value is accepted at the type-verification gate. Signature and claim validation still run unchanged.

Also adds JWKSBasedJWTValidatorTypeVerifierTest covering:
- typ=at+jwt accepted (direct bug regression)
- typ=JWT accepted (control)
- typ=foo+jwt accepted (pins permissive contract)
- typ=null accepted
- end-to-end validateSignature with at+jwt over a mocked JWKS source
- tampered-signature negative case (signature failure still surfaces)

### Proposed changes in this pull request

[List all changes you want to add here. If you fixed an issue, please
add a reference to that issue as well.]

-

### When should this PR be merged

[Please describe any preconditions that need to be addressed before we
can merge this pull request.]


### Follow up actions

[List any possible follow-up actions here; for instance, testing data
migrations, software that we need to install on staging and production
environments.]

-

## Developer Checklist (Mandatory)

- [ ] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact.



### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description.
- [ ] **Is the PR labeled correctly?**

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled.

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests.
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/).

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components.
- [ ] **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

#### Security

- [ ] **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
- [ ] **Are all UI and API inputs run through forms or serializers?**
- [ ] **Are all external inputs validated and sanitized appropriately?**
- [ ] **Does all branching logic have a default case?**
- [ ] **Does this solution handle outliers and edge cases gracefully?**
- [ ] **Are all external communications secured and restricted to SSL?**

#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes should be documented.
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented.
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki.
