### PR TITLE
Use application's authorized scopes as default requested scopes

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
@@ -356,6 +356,7 @@ public class OAuthServerConfiguration {
     private List<String> defaultRequestedScopes = new ArrayList<>();
     // Property to define whether the default scope for back-channel grant is enabled or not.
     private boolean isDefaultScopeForBackChannelGrantEnabled = false;
+    private boolean useAppAuthorizedScopesAsDefault = false;
 
     // Property to define the filtered claims.
     private List<String> filteredIntrospectionClaims = new ArrayList<>();
@@ -581,6 +582,9 @@ public class OAuthServerConfiguration {
         // Read default requested scopes for back-channel grant from config.
         parseDefaultScopeForBackChannelConfig(oauthElem);
 
+        // Read config for using the application's authorized scopes as the default requested scopes.
+        parseUseAppAuthorizedScopesAsDefaultConfig(oauthElem);
+
         // Read config for filtered claims for introspection response.
         parseFilteredClaimsForIntrospectionConfiguration(oauthElem);
 
@@ -772,6 +776,17 @@ public class OAuthServerConfiguration {
         }
     }
 
+    private void parseUseAppAuthorizedScopesAsDefaultConfig(OMElement oauthElem) {
+
+        OMElement useAppAuthorizedScopesAsDefaultElem = oauthElem
+                .getFirstChildWithName(getQNameWithIdentityNS(ConfigElements.
+                        USE_APP_AUTHORIZED_SCOPES_AS_DEFAULT));
+        if (useAppAuthorizedScopesAsDefaultElem != null) {
+            useAppAuthorizedScopesAsDefault = Boolean.parseBoolean(
+                    useAppAuthorizedScopesAsDefaultElem.getText().trim());
+        }
+    }
+
     private void parseShowDisplayNameInConsentPage(OMElement oauthElem) {
         OMElement showApplicationNameInConsentPageElement = oauthElem
                 .getFirstChildWithName(getQNameWithIdentityNS(ConfigElements
@@ -853,6 +868,17 @@ public class OAuthServerConfiguration {
     public boolean isDefaultScopeForBackChannelGrantEnabled() {
 
         return isDefaultScopeForBackChannelGrantEnabled;
+    }
+
+    /**
+     * Returns whether the application's authorized scopes should be used as the default requested
+     * scopes when a request carries no scope.
+     *
+     * @return boolean value of the UseAppAuthorizedScopesAsDefault configuration.
+     */
+    public boolean isUseAppAuthorizedScopesAsDefault() {
+
+        return useAppAuthorizedScopesAsDefault;
     }
 
     public String getOAuth1RequestTokenUrl() {
@@ -4850,6 +4876,9 @@ public class OAuthServerConfiguration {
         // Enable Default Requested Scopes For Back Channel Grant Config.
         private static final String ENABLE_DEFAULT_REQUESTED_SCOPES_FOR_BACK_CHANNEL_GRANT =
                 "EnableDefaultRequestedScopesForBackChannelGrant";
+        // Use the application's authorized scopes as the default requested scopes when no scope is requested.
+        private static final String USE_APP_AUTHORIZED_SCOPES_AS_DEFAULT =
+                "UseAppAuthorizedScopesAsDefault";
         private static final String SCOPES_ELEMENT = "Scope";
         // Filtered Claims For Introspection Response Config.
         private static final String FILTERED_CLAIMS = "FilteredClaims";

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/AuthorizationHandlerManager.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authz/AuthorizationHandlerManager.java
@@ -432,14 +432,29 @@ public class AuthorizationHandlerManager {
      *
      * @param authzReqMsgCtx The OAuth authorization request message context.
      */
-    private void addDefaultRequestedScopes(OAuthAuthzReqMessageContext authzReqMsgCtx) {
+    private void addDefaultRequestedScopes(OAuthAuthzReqMessageContext authzReqMsgCtx)
+            throws IdentityOAuth2Exception {
 
-        List<String> defaultRequestedScopes = OAuthServerConfiguration.getInstance().getDefaultRequestedScopes();
         String[] requestedScopes = authzReqMsgCtx.getAuthorizationReqDTO().getScopes();
-        if (ArrayUtils.isEmpty(requestedScopes) && CollectionUtils.isNotEmpty(defaultRequestedScopes)) {
-            authzReqMsgCtx.setRequestedScopes(defaultRequestedScopes.toArray(new String[0]));
-            authzReqMsgCtx.getAuthorizationReqDTO().setScopes(defaultRequestedScopes.toArray(new String[0]));
+        if (ArrayUtils.isNotEmpty(requestedScopes)) {
+            return;
         }
+
+        OAuthServerConfiguration oAuthServerConfiguration = OAuthServerConfiguration.getInstance();
+        List<String> defaultRequestedScopes;
+        if (oAuthServerConfiguration.isUseAppAuthorizedScopesAsDefault()) {
+            defaultRequestedScopes = AuthzUtil.getAppAuthorizedScopes(
+                    authzReqMsgCtx.getAuthorizationReqDTO().getConsumerKey(),
+                    authzReqMsgCtx.getAuthorizationReqDTO().getTenantDomain());
+        } else {
+            defaultRequestedScopes = oAuthServerConfiguration.getDefaultRequestedScopes();
+        }
+
+        if (CollectionUtils.isEmpty(defaultRequestedScopes)) {
+            return;
+        }
+        authzReqMsgCtx.setRequestedScopes(defaultRequestedScopes.toArray(new String[0]));
+        authzReqMsgCtx.getAuthorizationReqDTO().setScopes(defaultRequestedScopes.toArray(new String[0]));
     }
 
     /**

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuer.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuer.java
@@ -1057,17 +1057,29 @@ public class AccessTokenIssuer {
         return isValidScope;
     }
 
-    private String[] getRequestedScopes(OAuthTokenReqMessageContext tokenReqMessageContext) {
+    private String[] getRequestedScopes(OAuthTokenReqMessageContext tokenReqMessageContext)
+            throws IdentityOAuth2Exception {
 
         String[] requestedScopes = tokenReqMessageContext.getScope();
         if (ArrayUtils.isNotEmpty(requestedScopes)) {
             return requestedScopes;
         }
 
-        boolean isDefaultScopeForBackChannelGrantEnabled =
-                OAuthServerConfiguration.getInstance().isDefaultScopeForBackChannelGrantEnabled();
-        List<String> defaultScopes = OAuthServerConfiguration.getInstance().getDefaultRequestedScopes();
-        if (!isDefaultScopeForBackChannelGrantEnabled || CollectionUtils.isEmpty(defaultScopes)) {
+        OAuthServerConfiguration oAuthServerConfiguration = OAuthServerConfiguration.getInstance();
+        List<String> defaultScopes;
+        if (oAuthServerConfiguration.isDefaultScopeForBackChannelGrantEnabled()) {
+            if (oAuthServerConfiguration.isUseAppAuthorizedScopesAsDefault()) {
+                defaultScopes = AuthzUtil.getAppAuthorizedScopes(
+                        tokenReqMessageContext.getOauth2AccessTokenReqDTO().getClientId(),
+                        tokenReqMessageContext.getOauth2AccessTokenReqDTO().getTenantDomain());
+            } else {
+                defaultScopes = oAuthServerConfiguration.getDefaultRequestedScopes();
+            }
+        } else {
+            return requestedScopes;
+        }
+
+        if (CollectionUtils.isEmpty(defaultScopes)) {
             return requestedScopes;
         }
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/AuthzUtil.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/AuthzUtil.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.oauth2.util;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -28,9 +29,12 @@ import org.wso2.carbon.identity.application.authentication.framework.model.Authe
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
 import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
+import org.wso2.carbon.identity.application.common.model.AuthorizedScopes;
 import org.wso2.carbon.identity.application.common.model.ClaimMapping;
 import org.wso2.carbon.identity.application.common.model.Scope;
+import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.oauth.common.OAuthConstants;
 import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
 import org.wso2.carbon.identity.oauth.internal.OAuthComponentServiceHolder;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2ClientException;
@@ -51,6 +55,7 @@ import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -603,5 +608,41 @@ public class AuthzUtil {
             throw new IdentityOAuth2Exception("Error occurred while getting tenant domain from org ids.");
         }
         return new ArrayList<>(mainAppUserRolesMappings.values());
+    }
+
+    /**
+     * Resolve the authorized scopes of the OAuth application identified by the given client id.
+     *
+     * @param clientId     OAuth2 client id (consumer key) of the application.
+     * @param tenantDomain Tenant domain the application belongs to.
+     * @return Distinct list of the application's authorized scopes, or an empty list if none.
+     * @throws IdentityOAuth2Exception If resolving the application or its authorized scopes fails.
+     */
+    public static List<String> getAppAuthorizedScopes(String clientId, String tenantDomain)
+            throws IdentityOAuth2Exception {
+
+        try {
+            ApplicationManagementService applicationMgtService =
+                    OAuth2ServiceComponentHolder.getApplicationMgtService();
+            String appId = applicationMgtService.getApplicationResourceIDByInboundKey(clientId,
+                    OAuthConstants.Scope.OAUTH2, tenantDomain);
+            if (StringUtils.isBlank(appId)) {
+                return Collections.emptyList();
+            }
+            List<AuthorizedScopes> authorizedScopesList = OAuth2ServiceComponentHolder.getInstance()
+                    .getAuthorizedAPIManagementService()
+                    .getAuthorizedScopes(appId, tenantDomain);
+            if (CollectionUtils.isEmpty(authorizedScopesList)) {
+                return Collections.emptyList();
+            }
+            return authorizedScopesList.stream()
+                    .filter(authorizedScopes -> authorizedScopes.getScopes() != null)
+                    .flatMap(authorizedScopes -> authorizedScopes.getScopes().stream())
+                    .distinct()
+                    .collect(Collectors.toList());
+        } catch (IdentityApplicationManagementException e) {
+            throw new IdentityOAuth2Exception(
+                    "Error resolving authorized scopes for clientId: " + clientId, e);
+        }
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/AuthzUtil.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/AuthzUtil.java
@@ -627,7 +627,7 @@ public class AuthzUtil {
             String appId = applicationMgtService.getApplicationResourceIDByInboundKey(clientId,
                     OAuthConstants.Scope.OAUTH2, tenantDomain);
             if (StringUtils.isBlank(appId)) {
-                return Collections.emptyList();
+                throw new IdentityOAuth2ClientException("No OAuth application found for clientId: " + clientId);
             }
             List<AuthorizedScopes> authorizedScopesList = OAuth2ServiceComponentHolder.getInstance()
                     .getAuthorizedAPIManagementService()

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/util/AuthzUtilTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/util/AuthzUtilTest.java
@@ -28,6 +28,9 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
+import org.wso2.carbon.identity.application.common.model.AuthorizedScopes;
+import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
+import org.wso2.carbon.identity.application.mgt.AuthorizedAPIManagementService;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
@@ -47,6 +50,7 @@ import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
@@ -81,6 +85,8 @@ public class AuthzUtilTest {
     private static final String ACCESSING_ORG_TENANT = "accessing-tenant";
     private static final String SHARED_AGENT_ID = "shared-agent-id";
     private static final String SHARED_USER_ID = "shared-user-id";
+    private static final String CLIENT_ID = "test-client-id";
+    private static final String APP_ID = "test-app-id";
 
     @BeforeMethod
     public void setUp() {
@@ -105,6 +111,31 @@ public class AuthzUtilTest {
         if (oAuthServerConfigurationMockedStatic != null) {
             oAuthServerConfigurationMockedStatic.close();
         }
+    }
+
+    @Test
+    public void testGetAppAuthorizedScopes() throws Exception {
+
+        ApplicationManagementService applicationManagementService =
+                Mockito.mock(ApplicationManagementService.class);
+        AuthorizedAPIManagementService authorizedAPIManagementService =
+                Mockito.mock(AuthorizedAPIManagementService.class);
+
+        oAuth2ServiceComponentHolderMockedStatic.when(OAuth2ServiceComponentHolder::getApplicationMgtService)
+                .thenReturn(applicationManagementService);
+        when(applicationManagementService.getApplicationResourceIDByInboundKey(eq(CLIENT_ID), anyString(),
+                eq(TENANT_DOMAIN))).thenReturn(APP_ID);
+        when(oAuth2ServiceComponentHolder.getAuthorizedAPIManagementService())
+                .thenReturn(authorizedAPIManagementService);
+        when(authorizedAPIManagementService.getAuthorizedScopes(APP_ID, TENANT_DOMAIN)).thenReturn(
+                Arrays.asList(new AuthorizedScopes("policy1", Arrays.asList("scope1", "scope2")),
+                        new AuthorizedScopes("policy2", Arrays.asList("scope2", "scope3"))));
+
+        List<String> scopes = AuthzUtil.getAppAuthorizedScopes(CLIENT_ID, TENANT_DOMAIN);
+
+        // Scopes from all authorized scope policies are flattened and de-duplicated.
+        Assert.assertEquals(scopes.size(), 3);
+        Assert.assertTrue(scopes.containsAll(Arrays.asList("scope1", "scope2", "scope3")));
     }
 
     @Test


### PR DESCRIPTION
## Purpose

Adds a new OAuth server configuration `UseAppAuthorizedScopesAsDefault`. When enabled and a token / authorization request carries **no scope**, the application's authorized scopes are used as the default requested scopes instead of the static `DefaultRequestedScopes` list.

## Changes

- **`OAuthServerConfiguration`** — parse and expose the new `UseAppAuthorizedScopesAsDefault` config.
- **`AuthzUtil.getAppAuthorizedScopes(clientId, tenantDomain)`** — resolve the application's authorized scopes from the client id (consumer key).
- **`AuthorizationHandlerManager.addDefaultRequestedScopes`** — when the config is enabled, use the app's authorized scopes as defaults on the authorization path.
- **`AccessTokenIssuer.getRequestedScopes`** — when `EnableDefaultRequestedScopesForBackChannelGrant` is enabled, pick app authorized scopes (if `UseAppAuthorizedScopesAsDefault` is on) or the static default list otherwise.

The config defaults to `false`, so existing behavior is unchanged unless explicitly enabled.

> [!NOTE]
> The corresponding `identity.xml.j2` config entry change in `carbon-identity-framework` will be submitted separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)