### PR TITLE
Implement cache clearance for original token scopes during revocation

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthUtil.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthUtil.java
@@ -52,6 +52,7 @@ import org.wso2.carbon.identity.oauth.cache.OAuthCacheKey;
 import org.wso2.carbon.identity.oauth.cache.RefreshTokenCache;
 import org.wso2.carbon.identity.oauth.cache.RefreshTokenCacheKey;
 import org.wso2.carbon.identity.oauth.common.OAuthConstants;
+import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
 import org.wso2.carbon.identity.oauth.dao.OAuthAppDO;
 import org.wso2.carbon.identity.oauth.dto.OAuthConsumerAppDTO;
 import org.wso2.carbon.identity.oauth.event.OAuthEventInterceptor;
@@ -64,6 +65,7 @@ import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2ServerException;
 import org.wso2.carbon.identity.oauth2.dao.OAuthTokenPersistenceFactory;
 import org.wso2.carbon.identity.oauth2.dao.SharedAppResolveDAO;
+import org.wso2.carbon.identity.oauth2.dto.OAuthRevocationRequestDTO;
 import org.wso2.carbon.identity.oauth2.model.AccessTokenDO;
 import org.wso2.carbon.identity.oauth2.model.AuthzCodeDO;
 import org.wso2.carbon.identity.oauth2.model.OAuthAppInfo;
@@ -1697,6 +1699,60 @@ public final class OAuthUtil {
         } catch (org.wso2.carbon.user.api.UserStoreException e) {
             throw new UserStoreException("Failed to retrieve the user store domain for the parent user with ID: "
                     + parentUserId + " in tenant domain: " + tenantDomain, e);
+        }
+    }
+
+    /**
+     * Triggers a cache clearance for the original scopes associated with a token.
+     * This is necessary because the scopes in the provided {@code accessTokenDO} might have been
+     * filtered or mutated during the request lifecycle. Fetch the original scopes from the
+     * database to ensure the cache is cleared using the correct keys.
+     *
+     * @param tokenBindingReference The token binding identifier.
+     * @param accessTokenDO        The current (potentially mutated) access token object.
+     * @param revokeRequestDTO     The revocation request details containing the consumer key.
+     */
+    public static void clearOAuthCacheUsingPersistedScopes(String tokenBindingReference, AccessTokenDO accessTokenDO,
+                                                           OAuthRevocationRequestDTO revokeRequestDTO) {
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Clearing OAuth cache for persisted scopes. Consumer key: " + revokeRequestDTO.getConsumerKey());
+        }
+
+        if (OAuthServerConfiguration.getInstance().getAllowedScopes().isEmpty()) {
+            return;
+        }
+
+        String accessToken = accessTokenDO.getAccessToken();
+        if (StringUtils.isBlank(accessToken)) {
+            return;
+        }
+
+        try {
+            // The in-memory scopes may be mutated during validation. To avoid cache-key
+            // mismatches, retrieve the original scopes from the database before clearing
+            // the OAuth cache.
+            AccessTokenDO dbTokenDO = OAuthTokenPersistenceFactory.getInstance()
+                    .getAccessTokenDAO()
+                    .getAccessToken(accessToken, true);
+            if (dbTokenDO == null || dbTokenDO.getScope() == null || dbTokenDO.getScope().length == 0) {
+                return;
+            }
+
+            String dbTokenScopeString = OAuth2Util.buildScopeString(dbTokenDO.getScope());
+            OAuthUtil.clearOAuthCache(revokeRequestDTO.getConsumerKey(),
+                    accessTokenDO.getAuthzUser(), dbTokenScopeString, tokenBindingReference);
+            OAuthUtil.clearOAuthCache(revokeRequestDTO.getConsumerKey(),
+                    accessTokenDO.getAuthzUser(), dbTokenScopeString);
+
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Successfully cleared OAuth cache entries for consumer key: " +
+                        revokeRequestDTO.getConsumerKey());
+            }
+
+        } catch (IdentityOAuth2Exception e) {
+            LOG.error("Error while clearing cache entries for extended scopes. Consumer key: "
+                    + revokeRequestDTO.getConsumerKey(), e);
         }
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/OAuth2Service.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/OAuth2Service.java
@@ -743,6 +743,8 @@ public class OAuth2Service extends AbstractAdmin {
                                 OAuth2Util.buildScopeString(accessTokenDO.getScope()));
                         OAuthUtil.clearOAuthCache(revokeRequestDTO.getConsumerKey(), accessTokenDO.getAuthzUser());
                         OAuthUtil.clearOAuthCache(accessTokenDO);
+                        OAuthUtil.clearOAuthCacheUsingPersistedScopes(tokenBindingReference,
+                                accessTokenDO, revokeRequestDTO);
                         String scope = OAuth2Util.buildScopeString(accessTokenDO.getScope());
                         synchronized ((revokeRequestDTO.getConsumerKey() + ":" + userId + ":" + scope + ":"
                                 + tokenBindingReference).intern()) {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/OAuth2Service.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/OAuth2Service.java
@@ -743,6 +743,9 @@ public class OAuth2Service extends AbstractAdmin {
                                 OAuth2Util.buildScopeString(accessTokenDO.getScope()));
                         OAuthUtil.clearOAuthCache(revokeRequestDTO.getConsumerKey(), accessTokenDO.getAuthzUser());
                         OAuthUtil.clearOAuthCache(accessTokenDO);
+                        if (log.isDebugEnabled()) {
+                            log.debug("Clearing OAuth cache for token binding reference: " + tokenBindingReference);
+                        }
                         OAuthUtil.clearOAuthCacheUsingPersistedScopes(tokenBindingReference,
                                 accessTokenDO, revokeRequestDTO);
                         String scope = OAuth2Util.buildScopeString(accessTokenDO.getScope());


### PR DESCRIPTION
## Purpose

During token revocation, the in-memory scopes on the `AccessTokenDO` may have been filtered or mutated during the request lifecycle. As a result, the OAuth cache entries keyed on the original (persisted) scopes are not cleared, leaving stale cache entries after revocation.

This change fetches the persisted scopes from the database and clears the OAuth cache using the correct keys.

## Changes
- `OAuthUtil#clearOAuthCacheUsingPersistedScopes(...)` — new util that reads original scopes from DB and clears cache (skips when no allowed/extended scopes are configured).
- `OAuth2Service#revokeTokenByOAuthClient(...)` — invokes the new util during revocation.

## Related
- Port of wso2-support/identity-inbound-auth-oauth#2399