### PR TITLE
Introduce selective multi-valued claim handling in JWT and UserInfo based on claim metadata

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/user/impl/UserInfoUserStoreClaimRetriever.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/user/impl/UserInfoUserStoreClaimRetriever.java
@@ -26,6 +26,7 @@ import org.wso2.carbon.identity.oauth.user.UserInfoClaimRetriever;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Retrieving claims from the user store for the given claims dialect
@@ -35,8 +36,16 @@ public class UserInfoUserStoreClaimRetriever implements UserInfoClaimRetriever {
     @Override
     public Map<String, Object> getClaimsMap(Map<ClaimMapping, String> userAttributes) {
 
+        return getClaimsMap(userAttributes, null);
+    }
+
+    @Override
+    public Map<String, Object> getClaimsMap(Map<ClaimMapping, String> userAttributes,
+                                            Set<String> multiValuedLocalClaimUris) {
+
         Map<String, Object> claims = new HashMap<String, Object>();
         if (MapUtils.isNotEmpty(userAttributes)) {
+            // A null multiValuedLocalClaimUris means legacy behaviour applies.
             for (Map.Entry<ClaimMapping, String> entry : userAttributes.entrySet()) {
 
                 if (entry.getKey().getRemoteClaim() == null || IdentityCoreConstants.MULTI_ATTRIBUTE_SEPARATOR.equals(
@@ -45,10 +54,13 @@ public class UserInfoUserStoreClaimRetriever implements UserInfoClaimRetriever {
                 }
                 String claimValue = entry.getValue();
                 String claimUri = entry.getKey().getRemoteClaim().getClaimUri();
+                String localClaimUri = entry.getKey().getLocalClaim() != null ?
+                        entry.getKey().getLocalClaim().getClaimUri() : null;
                 boolean isMultiValueSupportEnabledForUserinfoResponse = OAuthServerConfiguration.getInstance()
                         .getUserInfoMultiValueSupportEnabled();
                 if (isMultiValueSupportEnabledForUserinfoResponse &&
-                        ClaimUtil.isMultiValuedAttribute(claimUri, claimValue)) {
+                        ClaimUtil.isMultiValuedAttribute(claimUri, localClaimUri, claimValue,
+                                multiValuedLocalClaimUris)) {
                     String[] attributeValues = ClaimUtil.processMultiValuedAttribute(claimValue);
                     claims.put(claimUri, attributeValues);
                 } else {

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/ClaimUtil.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/ClaimUtil.java
@@ -69,6 +69,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Pattern;
 
 import static org.apache.commons.collections.MapUtils.isEmpty;
@@ -103,7 +104,15 @@ public class ClaimUtil {
             userClaimsInOIDCDialect = getClaimsFromUserStore(tokenResponse);
         } else {
             UserInfoClaimRetriever retriever = UserInfoEndpointConfig.getInstance().getUserInfoClaimRetriever();
-            userClaimsInOIDCDialect = retriever.getClaimsMap(userAttributes);
+            // Resolve against the SP tenant domain to stay consistent with the cache-miss path.
+            Set<String> multiValuedLocalClaimUris = null;
+            if (OAuthServerConfiguration.getInstance().getHonourMultiValuedClaimMetadata()) {
+                String spTenantDomain = resolveSpTenantDomain(tokenResponse);
+                if (spTenantDomain != null) {
+                    multiValuedLocalClaimUris = OAuth2Util.getMultiValuedClaimUris(spTenantDomain);
+                }
+            }
+            userClaimsInOIDCDialect = retriever.getClaimsMap(userAttributes, multiValuedLocalClaimUris);
         }
 
         if (isEmpty(userClaimsInOIDCDialect)) {
@@ -111,6 +120,32 @@ public class ClaimUtil {
         }
 
         return userClaimsInOIDCDialect;
+    }
+
+    /**
+     * Resolve the service provider tenant domain for the given token.
+     *
+     * @param tokenResponse OAuth2TokenValidationResponseDTO containing the token information.
+     * @return Service provider tenant domain, or {@code null} if it could not be resolved.
+     */
+    private static String resolveSpTenantDomain(OAuth2TokenValidationResponseDTO tokenResponse) {
+
+        try {
+            String appResidentTenantDomain = OAuth2Util.getAppResidentTenantDomain();
+            if (StringUtils.isNotEmpty(appResidentTenantDomain)) {
+                return appResidentTenantDomain;
+            }
+            AccessTokenDO accessTokenDO = OAuth2ServiceComponentHolder.getInstance().getTokenProvider()
+                    .getVerifiedAccessToken(tokenResponse.getAuthorizationContextToken().getTokenString(), false);
+            String clientId = getClientID(accessTokenDO);
+            OAuthAppDO oAuthAppDO = OAuth2Util.getAppInformationByClientId(clientId);
+            return OAuth2Util.getTenantDomainOfOauthApp(oAuthAppDO);
+        } catch (Exception e) {
+            if (log.isDebugEnabled()) {
+                log.debug("Failed to resolve SP tenant domain for multi-valued claims; using legacy behaviour.", e);
+            }
+            return null;
+        }
     }
 
     /**
@@ -264,6 +299,11 @@ public class ClaimUtil {
                             userId, realm, claimURIList, isImpersonatedUser);
                 }
 
+                // Resolve metadata multi-valued claims once; null set -> legacy behaviour.
+                Set<String> multiValuedLocalClaimUris = null;
+                if (OAuthServerConfiguration.getInstance().getHonourMultiValuedClaimMetadata()) {
+                    multiValuedLocalClaimUris = OAuth2Util.getMultiValuedClaimUris(spTenantDomain);
+                }
                 if (isNotEmpty(userClaims)) {
                     for (Map.Entry<String, String> entry : userClaims.entrySet()) {
                         //set local2sp role mappings
@@ -289,7 +329,8 @@ public class ClaimUtil {
                             boolean isMultiValueSupportEnabledForUserinfoResponse = OAuthServerConfiguration
                                     .getInstance().getUserInfoMultiValueSupportEnabled();
                             if (isMultiValueSupportEnabledForUserinfoResponse &&
-                                    isMultiValuedAttribute(oidcClaimUri, claimValue)) {
+                                    isMultiValuedAttribute(oidcClaimUri, entry.getKey(), claimValue,
+                                            multiValuedLocalClaimUris)) {
                                 String[] attributeValues = processMultiValuedAttribute(claimValue);
                                 mappedAppClaims.put(oidcClaimUri, attributeValues);
                             } else {
@@ -571,6 +612,31 @@ public class ClaimUtil {
         group as multi value attribute. */
         if (GROUPS.equals(claimUri)) {
             return true;
+        }
+        return StringUtils.contains(claimValue, FrameworkUtils.getMultiAttributeSeparator());
+    }
+
+    /**
+     * Checks whether a user value should be emitted as a multi-valued (array) attribute. The {@code groups} claim is
+     * always an array. When {@code multiValuedLocalClaimUris} is non-null, only claims whose local URI is in the set
+     * are arrays; a null set falls back to the legacy separator-based check.
+     *
+     * @param claimUri                  OIDC dialect claim URI (short name).
+     * @param localClaimUri             Local claim URI mapped to the OIDC claim.
+     * @param claimValue                Claim value.
+     * @param multiValuedLocalClaimUris Set of multi-valued local claim URIs, or {@code null} for legacy behaviour.
+     * @return Whether the claim should be emitted as a multi-valued (array) attribute.
+     */
+    public static boolean isMultiValuedAttribute(String claimUri, String localClaimUri, String claimValue,
+                                                 Set<String> multiValuedLocalClaimUris) {
+
+        /* To format the groups claim to always return as an array, we should consider single
+        group as multi value attribute. */
+        if (GROUPS.equals(claimUri)) {
+            return true;
+        }
+        if (multiValuedLocalClaimUris != null) {
+            return multiValuedLocalClaimUris.contains(localClaimUri);
         }
         return StringUtils.contains(claimValue, FrameworkUtils.getMultiAttributeSeparator());
     }

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/util/ClaimUtilTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/util/ClaimUtilTest.java
@@ -66,8 +66,10 @@ import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
@@ -560,6 +562,56 @@ public class ClaimUtilTest {
         String returned = ClaimUtil.getServiceProviderMappedUserRoles(mockedServiceProvider,
                 locallyMappedUserRoles, claimSeparator);
         Assert.assertEquals(returned, expected, "Invalid returned value");
+    }
+
+    private static final String GROUPS_CLAIM_URI = "groups";
+    private static final String GIVEN_NAME_OIDC_URI = "given_name";
+    private static final String GIVEN_NAME_LOCAL_URI = "http://wso2.org/claims/givenname";
+    private static final String MULTI_TEST_OIDC_URI = "multi_test";
+    private static final String MULTI_TEST_LOCAL_URI = "http://wso2.org/claims/multiTest";
+
+    @DataProvider(name = "selectiveMultiValuedAttributeProvider")
+    public Object[][] selectiveMultiValuedAttributeProvider() {
+
+        Set<String> multiValuedLocalClaimUris = new HashSet<>();
+        multiValuedLocalClaimUris.add(MULTI_TEST_LOCAL_URI);
+
+        return new Object[][]{
+                // claimUri, localClaimUri, claimValue, multiValuedLocalClaimUris (null = legacy), expectedMultiValued.
+
+                // Scenario (d): groups is always treated as an array, regardless of flag/value.
+                {GROUPS_CLAIM_URI, "http://wso2.org/claims/groups", "admin", null, true},
+                {GROUPS_CLAIM_URI, "http://wso2.org/claims/groups", "admin", multiValuedLocalClaimUris, true},
+
+                // Scenario (c): flag ON + claim flagged multiValued=true -> array, even without separator.
+                {MULTI_TEST_OIDC_URI, MULTI_TEST_LOCAL_URI, "a", multiValuedLocalClaimUris, true},
+                {MULTI_TEST_OIDC_URI, MULTI_TEST_LOCAL_URI, "a,b,c,d", multiValuedLocalClaimUris, true},
+
+                // Scenario (b): flag ON + claim flagged multiValued=false with comma value -> plain string (no array).
+                {GIVEN_NAME_OIDC_URI, GIVEN_NAME_LOCAL_URI, "a,b,c,d", multiValuedLocalClaimUris, false},
+                // Flag ON + non-flagged claim, no separator -> still not an array.
+                {GIVEN_NAME_OIDC_URI, GIVEN_NAME_LOCAL_URI, "a", multiValuedLocalClaimUris, false},
+
+                // Scenario (a): flag OFF (null set) -> legacy comma-split behaviour preserved.
+                {GIVEN_NAME_OIDC_URI, GIVEN_NAME_LOCAL_URI, "a,b,c,d", null, true},
+                {GIVEN_NAME_OIDC_URI, GIVEN_NAME_LOCAL_URI, "a", null, false},
+                // Legacy fallback applies to a flagged claim's local URI when the set is null (flag off).
+                {MULTI_TEST_OIDC_URI, MULTI_TEST_LOCAL_URI, "a", null, false},
+        };
+    }
+
+    @Test(dataProvider = "selectiveMultiValuedAttributeProvider")
+    public void testIsMultiValuedAttributeSelective(String claimUri, String localClaimUri, String claimValue,
+                                                    Set<String> multiValuedLocalClaimUris, boolean expected) {
+
+        try (MockedStatic<FrameworkUtils> frameworkUtils = mockStatic(FrameworkUtils.class)) {
+            frameworkUtils.when(FrameworkUtils::getMultiAttributeSeparator).thenReturn(CLAIM_SEPARATOR);
+            boolean actual = ClaimUtil.isMultiValuedAttribute(claimUri, localClaimUri, claimValue,
+                    multiValuedLocalClaimUris);
+            Assert.assertEquals(actual, expected,
+                    "Unexpected multi-valued resolution for claim '" + claimUri + "' (local '" + localClaimUri +
+                            "') with value '" + claimValue + "' and selectiveSet=" + multiValuedLocalClaimUris);
+        }
     }
 
     @Test

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
@@ -246,6 +246,7 @@ public class OAuthServerConfiguration {
     private List<String> supportedIdTokenEncryptionMethods = new ArrayList<>();
     private String userInfoJWTSignatureAlgorithm = "SHA256withRSA";
     private boolean userInfoMultiValueSupportEnabled = true;
+    private boolean honourMultiValuedClaimMetadata = false;
     private boolean userInfoRemoveInternalPrefixFromRoles = false;
     private boolean isReturnOnlyAppAssociatedRolesInUserInfo = false;
     private boolean isReturnOnlyAppAssociatedRolesInJWTToken = false;
@@ -1824,6 +1825,17 @@ public class OAuthServerConfiguration {
     public boolean getUserInfoMultiValueSupportEnabled() {
 
         return userInfoMultiValueSupportEnabled;
+    }
+
+    /**
+     * Whether the multi-valued state defined in claim metadata is honoured when emitting claims, so that only claims
+     * flagged multiValued become JSON arrays (vs the legacy separator-based split). Disabled by default.
+     *
+     * @return True if the multi-valued claim metadata state should be honoured.
+     */
+    public boolean getHonourMultiValuedClaimMetadata() {
+
+        return honourMultiValuedClaimMetadata;
     }
 
     /**
@@ -3934,6 +3946,16 @@ public class OAuthServerConfiguration {
                         userInfoMultiValueSupportEnabledElem.getText().trim());
             }
 
+            OMElement claimMetadataElem = openIDConnectConfigElem.getFirstChildWithName(
+                    getQNameWithIdentityNS(ConfigElements.OPENID_CONNECT_CLAIM_METADATA));
+            if (claimMetadataElem != null) {
+                OMElement honourMultiValuedElem = claimMetadataElem.getFirstChildWithName(
+                        getQNameWithIdentityNS(ConfigElements.OPENID_CONNECT_HONOUR_MULTI_VALUED));
+                if (honourMultiValuedElem != null) {
+                    honourMultiValuedClaimMetadata = Boolean.parseBoolean(honourMultiValuedElem.getText().trim());
+                }
+            }
+
             OMElement userInfoResponseRemoveInternalPrefixFromRoles = openIDConnectConfigElem.getFirstChildWithName(
                     getQNameWithIdentityNS(ConfigElements.OPENID_CONNECT_USERINFO_REMOVE_INTERNAL_PREFIX_FROM_ROLES));
             if (userInfoResponseRemoveInternalPrefixFromRoles != null) {
@@ -4681,6 +4703,8 @@ public class OAuthServerConfiguration {
         public static final String OPENID_CONNECT_USERINFO_JWT_SIGNATURE_ALGORITHM = "UserInfoJWTSignatureAlgorithm";
         public static final String OPENID_CONNECT_USERINFO_MULTI_VALUE_SUPPORT_ENABLED =
                 "UserInfoMultiValueSupportEnabled";
+        public static final String OPENID_CONNECT_CLAIM_METADATA = "ClaimMetadata";
+        public static final String OPENID_CONNECT_HONOUR_MULTI_VALUED = "HonourMultiValued";
         public static final String OPENID_CONNECT_USERINFO_REMOVE_INTERNAL_PREFIX_FROM_ROLES =
                 "UserInfoRemoveInternalPrefixFromRoles";
         private static final String OPENID_CONNECT_RETURN_APP_ROLES_IN_USERINFO =

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/user/UserInfoClaimRetriever.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/user/UserInfoClaimRetriever.java
@@ -20,6 +20,7 @@ package org.wso2.carbon.identity.oauth.user;
 import org.wso2.carbon.identity.application.common.model.ClaimMapping;
 
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Retrieving claims from the user store for the given claims dialect
@@ -27,4 +28,19 @@ import java.util.Map;
 public interface UserInfoClaimRetriever {
 
     public Map<String, Object> getClaimsMap(Map<ClaimMapping, String> userAttributes);
+
+    /**
+     * Retrieve the claims map, honouring selective multi-valued claim handling. When
+     * {@code multiValuedLocalClaimUris} is non-null, only claims flagged as multi-valued are emitted as arrays;
+     * a {@code null} set falls back to legacy separator-based behaviour.
+     *
+     * @param userAttributes            User attributes keyed by claim mapping.
+     * @param multiValuedLocalClaimUris Set of multi-valued claim URIs, or {@code null} for legacy behaviour.
+     * @return Map of claims.
+     */
+    default Map<String, Object> getClaimsMap(Map<ClaimMapping, String> userAttributes,
+                                             Set<String> multiValuedLocalClaimUris) {
+
+        return getClaimsMap(userAttributes);
+    }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -93,6 +93,8 @@ import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
 import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
 import org.wso2.carbon.identity.claim.metadata.mgt.exception.ClaimMetadataException;
 import org.wso2.carbon.identity.claim.metadata.mgt.model.ExternalClaim;
+import org.wso2.carbon.identity.claim.metadata.mgt.model.LocalClaim;
+import org.wso2.carbon.identity.claim.metadata.mgt.util.ClaimConstants;
 import org.wso2.carbon.identity.consent.server.configs.mgt.exceptions.ConsentServerConfigsMgtException;
 import org.wso2.carbon.identity.consent.server.configs.mgt.services.ConsentServerConfigsManagementService;
 import org.wso2.carbon.identity.core.IdentityKeyStoreResolver;
@@ -2317,6 +2319,78 @@ public class OAuth2Util {
             }
         } catch (IdentityOAuth2Exception | ClaimMetadataException | OrganizationManagementException e) {
             log.error(e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Build the set of claim URIs that should be treated as multi-valued when the
+     * {@code ClaimMetadata.HonourMultiValued} configuration is enabled, using the claim metadata service
+     * registered with the OAuth2 service component holder.
+     *
+     * @param tenantDomain Tenant domain to resolve claim metadata for.
+     * @return Set of multi-valued claim URIs (local claim URIs plus their mapped OIDC dialect claim URIs), or
+     * {@code null} if the metadata could not be resolved (so that callers fall back to legacy separator-based
+     * multi-valued claim handling).
+     */
+    public static Set<String> getMultiValuedClaimUris(String tenantDomain) {
+
+        ClaimMetadataManagementService claimMetadataManagementService =
+                OAuth2ServiceComponentHolder.getInstance().getClaimMetadataManagementService();
+        return getMultiValuedClaimUris(claimMetadataManagementService, tenantDomain);
+    }
+
+    /**
+     * Build the set of claim URIs that should be treated as multi-valued when the
+     * {@code ClaimMetadata.HonourMultiValued} configuration is enabled. The returned set contains both the local
+     * claim URIs flagged {@code multiValued=true} and their mapped OIDC dialect claim URIs, so callers keyed on
+     * either match.
+     *
+     * @param claimMetadataManagementService Claim metadata service used to resolve claims.
+     * @param tenantDomain                   Tenant domain to resolve claim metadata for.
+     * @return Set of multi-valued claim URIs (local + mapped OIDC), or {@code null} if the metadata could not be
+     * resolved (so that callers fall back to legacy separator-based multi-valued claim handling).
+     */
+    public static Set<String> getMultiValuedClaimUris(ClaimMetadataManagementService claimMetadataManagementService,
+                                                      String tenantDomain) {
+
+        if (claimMetadataManagementService == null) {
+            if (log.isDebugEnabled()) {
+                log.debug("ClaimMetadataManagementService unavailable; legacy multi-valued handling for tenant: "
+                        + tenantDomain);
+            }
+            return null;
+        }
+        try {
+            List<LocalClaim> localClaims = claimMetadataManagementService.getLocalClaims(tenantDomain);
+            if (localClaims == null) {
+                if (log.isDebugEnabled()) {
+                    log.debug("No local claims for tenant: " + tenantDomain + "; legacy multi-valued handling.");
+                }
+                return null;
+            }
+            Set<String> multiValuedLocalClaimUris = new HashSet<>();
+            for (LocalClaim localClaim : localClaims) {
+                if (Boolean.parseBoolean(localClaim.getClaimProperty(ClaimConstants.MULTI_VALUED_PROPERTY))) {
+                    multiValuedLocalClaimUris.add(localClaim.getClaimURI());
+                }
+            }
+            // Set spans both dialects: UserInfo keys claims by local URI; token maps key them by OIDC URI (filtered)
+            // or local URI (preserved/non-OIDC). Including both lets one membership check serve every caller.
+            Set<String> multiValuedClaimUris = new HashSet<>(multiValuedLocalClaimUris);
+            List<ExternalClaim> oidcClaims =
+                    claimMetadataManagementService.getExternalClaims(OAuthConstants.OIDC_DIALECT, tenantDomain);
+            if (oidcClaims != null) {
+                for (ExternalClaim oidcClaim : oidcClaims) {
+                    if (multiValuedLocalClaimUris.contains(oidcClaim.getMappedLocalClaim())) {
+                        multiValuedClaimUris.add(oidcClaim.getClaimURI());
+                    }
+                }
+            }
+            return multiValuedClaimUris;
+        } catch (ClaimMetadataException e) {
+            log.error("Error reading claim metadata for multi-valued claims; tenant: " + tenantDomain
+                    + ". Falling back to legacy handling.", e);
+            return null;
         }
     }
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/DefaultOIDCClaimsCallbackHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/DefaultOIDCClaimsCallbackHandler.java
@@ -37,6 +37,7 @@ import org.wso2.carbon.identity.application.common.model.ServiceProvider;
 import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.base.IdentityConstants;
 import org.wso2.carbon.identity.base.IdentityException;
+import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.oauth.cache.AuthorizationGrantCache;
 import org.wso2.carbon.identity.oauth.cache.AuthorizationGrantCacheEntry;
@@ -70,7 +71,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.regex.Pattern;
+import java.util.Set;
 
 import static org.apache.commons.collections.MapUtils.isEmpty;
 import static org.apache.commons.collections.MapUtils.isNotEmpty;
@@ -78,8 +79,6 @@ import static org.wso2.carbon.identity.application.authentication.framework.util
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.ACCESS_TOKEN;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.AUTHZ_CODE;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.ID_TOKEN;
-import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCClaims.ADDRESS;
-import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCClaims.GROUPS;
 import static org.wso2.carbon.identity.oauth2.device.constants.Constants.DEVICE_CODE;
 import static org.wso2.carbon.identity.oauth2.util.OAuth2Util.handleGroupClaim;
 import static org.wso2.carbon.identity.openidconnect.OIDCConstants.ID_TOKEN_USER_CLAIMS_PROP_KEY;
@@ -99,7 +98,8 @@ public class DefaultOIDCClaimsCallbackHandler implements CustomClaimsCallbackHan
         try {
             Map<String, Object> userClaimsInOIDCDialect = getUserClaimsInOIDCDialect(tokenReqMessageContext);
             tokenReqMessageContext.addProperty(ID_TOKEN_USER_CLAIMS_PROP_KEY, userClaimsInOIDCDialect.keySet());
-            return setClaimsToJwtClaimSet(jwtClaimsSetBuilder, userClaimsInOIDCDialect);
+            return setClaimsToJwtClaimSet(jwtClaimsSetBuilder, userClaimsInOIDCDialect,
+                    getServiceProviderTenantDomain(tokenReqMessageContext));
         } catch (OAuthSystemException e) {
             if (log.isDebugEnabled()) {
                 log.debug("Error occurred while adding claims of user: " + tokenReqMessageContext.getAuthorizedUser() +
@@ -116,7 +116,8 @@ public class DefaultOIDCClaimsCallbackHandler implements CustomClaimsCallbackHan
 
         try {
             Map<String, Object> userClaimsInOIDCDialect = getUserClaimsInOIDCDialect(authzReqMessageContext);
-            return setClaimsToJwtClaimSet(jwtClaimsSet, userClaimsInOIDCDialect);
+            return setClaimsToJwtClaimSet(jwtClaimsSet, userClaimsInOIDCDialect,
+                    getServiceProviderTenantDomain(authzReqMessageContext));
         } catch (OAuthSystemException e) {
             log.error("Error occurred while adding claims of user: " +
                     authzReqMessageContext.getAuthorizationReqDTO().getUser() + " to the JWTClaimSet used to " +
@@ -870,21 +871,23 @@ public class DefaultOIDCClaimsCallbackHandler implements CustomClaimsCallbackHan
      * @param userClaimsInOIDCDialect
      */
     private JWTClaimsSet setClaimsToJwtClaimSet(JWTClaimsSet.Builder jwtClaimsSetBuilder, Map<String, Object>
-            userClaimsInOIDCDialect) {
+            userClaimsInOIDCDialect, String spTenantDomain) {
 
         JWTClaimsSet jwtClaimsSet = jwtClaimsSetBuilder.build();
         String multiAttributeSeparator = FrameworkUtils.getMultiAttributeSeparator();
+        // Resolve metadata multi-valued claims once; null set -> legacy behaviour.
+        Set<String> multiValuedClaimUris = null;
+        if (OAuthServerConfiguration.getInstance().getHonourMultiValuedClaimMetadata()) {
+            multiValuedClaimUris = getMultiValuedClaimUris(spTenantDomain);
+        }
         for (Map.Entry<String, Object> claimEntry : userClaimsInOIDCDialect.entrySet()) {
             String claimValue = claimEntry.getValue().toString();
             String claimKey = claimEntry.getKey();
-            if (isMultiValuedAttribute(claimKey, claimValue, multiAttributeSeparator)) {
+            if (OIDCClaimUtil.isMultiValuedAttribute(claimKey, claimValue, multiAttributeSeparator,
+                    multiValuedClaimUris)) {
                 JSONArray claimValues = new JSONArray();
-                String[] attributeValues = claimValue.split(Pattern.quote(multiAttributeSeparator));
-                for (String attributeValue : attributeValues) {
-                    if (StringUtils.isNotBlank(attributeValue)) {
-                        claimValues.add(attributeValue);
-                    }
-                }
+                Collections.addAll(claimValues,
+                        OIDCClaimUtil.splitMultiValuedAttribute(claimValue, multiAttributeSeparator));
                 if (jwtClaimsSet.getClaim(claimKey) == null) {
                     jwtClaimsSetBuilder.claim(claimEntry.getKey(), claimValues);
                 }
@@ -922,18 +925,18 @@ public class DefaultOIDCClaimsCallbackHandler implements CustomClaimsCallbackHan
         return !authzReqMessageContext.getAuthorizationReqDTO().getUser().isFederatedUser();
     }
 
-    private boolean isMultiValuedAttribute(String claimKey, String claimValue, String multiAttributeSeparator) {
+    /**
+     * Build the set of multi-valued claim URIs for the given tenant, delegating to the shared
+     * {@link OAuth2Util#getMultiValuedClaimUris(ClaimMetadataManagementService, String)}.
+     *
+     * @param tenantDomain Tenant domain of the service provider.
+     * @return Set of multi-valued claim URIs (local + mapped OIDC), or {@code null} for legacy handling.
+     */
+    private Set<String> getMultiValuedClaimUris(String tenantDomain) {
 
-        // Address claim contains multi attribute separator but its not a multi valued attribute.
-        if (claimKey.equals(ADDRESS)) {
-            return false;
-        }
-        // To format the groups claim to always return as an array, we should consider single group as
-        // multi value attribute.
-        if (claimKey.equals(GROUPS)) {
-            return true;
-        }
-        return StringUtils.contains(claimValue, multiAttributeSeparator);
+        ClaimMetadataManagementService claimMetadataManagementService =
+                OpenIDConnectServiceComponentHolder.getInstance().getClaimMetadataManagementService();
+        return OAuth2Util.getMultiValuedClaimUris(claimMetadataManagementService, tenantDomain);
     }
 
     private boolean isApiBasedAuthFlow(String accessToken, String authorizationCode) {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/JWTAccessTokenOIDCClaimsHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/JWTAccessTokenOIDCClaimsHandler.java
@@ -37,6 +37,7 @@ import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.base.IdentityConstants;
 import org.wso2.carbon.identity.base.IdentityException;
 import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataHandler;
+import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
 import org.wso2.carbon.identity.claim.metadata.mgt.exception.ClaimMetadataException;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
@@ -73,7 +74,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.regex.Pattern;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.apache.commons.collections.MapUtils.isEmpty;
@@ -81,8 +82,6 @@ import static org.apache.commons.collections.MapUtils.isNotEmpty;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.ORGANIZATION_LOGIN_IDP_NAME;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.ACCESS_TOKEN;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.AUTHZ_CODE;
-import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCClaims.ADDRESS;
-import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCClaims.GROUPS;
 import static org.wso2.carbon.identity.oauth2.device.constants.Constants.DEVICE_CODE;
 
 /**
@@ -100,7 +99,7 @@ public class JWTAccessTokenOIDCClaimsHandler implements CustomClaimsCallbackHand
             throws IdentityOAuth2Exception {
 
         Map<String, Object> claims = getUserClaimsInOIDCDialect(request);
-        return setClaimsToJwtClaimSet(builder, claims);
+        return setClaimsToJwtClaimSet(builder, claims, getServiceProviderTenantDomain(request));
     }
 
     @Override
@@ -112,7 +111,7 @@ public class JWTAccessTokenOIDCClaimsHandler implements CustomClaimsCallbackHand
           to manage user attributes for the access token.
          */
         Map<String, Object> claims = getUserClaimsInOIDCDialect(request);
-        return setClaimsToJwtClaimSet(builder, claims);
+        return setClaimsToJwtClaimSet(builder, claims, getServiceProviderTenantDomain(request));
     }
 
     /**
@@ -877,21 +876,23 @@ public class JWTAccessTokenOIDCClaimsHandler implements CustomClaimsCallbackHand
      * @return JWTClaimSet with claims.
      */
     private JWTClaimsSet setClaimsToJwtClaimSet(JWTClaimsSet.Builder jwtClaimsSetBuilder, Map<String, Object>
-            userClaimsInOIDCDialect) {
+            userClaimsInOIDCDialect, String spTenantDomain) {
 
         JWTClaimsSet jwtClaimsSet = jwtClaimsSetBuilder.build();
         String multiAttributeSeparator = FrameworkUtils.getMultiAttributeSeparator();
+        // Resolve metadata multi-valued claims once; null set -> legacy behaviour.
+        Set<String> multiValuedClaimUris = null;
+        if (OAuthServerConfiguration.getInstance().getHonourMultiValuedClaimMetadata()) {
+            multiValuedClaimUris = getMultiValuedClaimUris(spTenantDomain);
+        }
         for (Map.Entry<String, Object> claimEntry : userClaimsInOIDCDialect.entrySet()) {
             String claimValue = claimEntry.getValue().toString();
             String claimKey = claimEntry.getKey();
-            if (isMultiValuedAttribute(claimKey, claimValue, multiAttributeSeparator)) {
+            if (OIDCClaimUtil.isMultiValuedAttribute(claimKey, claimValue, multiAttributeSeparator,
+                    multiValuedClaimUris)) {
                 JSONArray claimValues = new JSONArray();
-                String[] attributeValues = claimValue.split(Pattern.quote(multiAttributeSeparator));
-                for (String attributeValue : attributeValues) {
-                    if (StringUtils.isNotBlank(attributeValue)) {
-                        claimValues.add(attributeValue);
-                    }
-                }
+                Collections.addAll(claimValues,
+                        OIDCClaimUtil.splitMultiValuedAttribute(claimValue, multiAttributeSeparator));
                 if (jwtClaimsSet.getClaim(claimKey) == null) {
                     jwtClaimsSetBuilder.claim(claimEntry.getKey(), claimValues);
                 }
@@ -905,25 +906,17 @@ public class JWTAccessTokenOIDCClaimsHandler implements CustomClaimsCallbackHand
     }
 
     /**
-     * Check weather claim value if multi valued or not.
+     * Build the set of multi-valued claim URIs for the given tenant, delegating to the shared
+     * {@link OAuth2Util#getMultiValuedClaimUris(ClaimMetadataManagementService, String)}.
      *
-     * @param claimKey Claim key.
-     * @param claimValue Claim value.
-     * @param multiAttributeSeparator Multi attribute separator.
-     * @return True if claim value is multi valued, false otherwise.
+     * @param tenantDomain Tenant domain of the service provider.
+     * @return Set of multi-valued claim URIs (local + mapped OIDC), or {@code null} for legacy handling.
      */
-    private boolean isMultiValuedAttribute(String claimKey, String claimValue, String multiAttributeSeparator) {
+    private Set<String> getMultiValuedClaimUris(String tenantDomain) {
 
-        // Address claim contains multi attribute separator but its not a multi valued attribute.
-        if (claimKey.equals(ADDRESS)) {
-            return false;
-        }
-        // To format the groups claim to always return as an array, we should consider single group as
-        // multi value attribute.
-        if (claimKey.equals(GROUPS)) {
-            return true;
-        }
-        return StringUtils.contains(claimValue, multiAttributeSeparator);
+        ClaimMetadataManagementService claimMetadataManagementService =
+                OpenIDConnectServiceComponentHolder.getInstance().getClaimMetadataManagementService();
+        return OAuth2Util.getMultiValuedClaimUris(claimMetadataManagementService, tenantDomain);
     }
 
     /**

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/OIDCClaimUtil.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/OIDCClaimUtil.java
@@ -65,6 +65,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.regex.Pattern;
 
@@ -756,5 +757,55 @@ public class OIDCClaimUtil {
         }
 
         return userClaimsInOidcDialect;
+    }
+
+    /**
+     * Checks whether a claim should be emitted as a multi-valued (array) attribute. The {@code address} claim is
+     * never an array; the {@code groups} claim always is. When {@code multiValuedClaimUris} is non-null, only claims
+     * present in the set are arrays; otherwise the legacy separator-based check applies.
+     *
+     * @param claimKey                OIDC dialect claim URI.
+     * @param claimValue              Claim value.
+     * @param multiAttributeSeparator Multi-attribute separator used for the legacy check.
+     * @param multiValuedClaimUris    Set of multi-valued claim URIs (local + mapped OIDC), or {@code null} for legacy
+     *                                separator-based behaviour.
+     * @return Whether the claim should be emitted as a multi-valued (array) attribute.
+     */
+    public static boolean isMultiValuedAttribute(String claimKey, String claimValue, String multiAttributeSeparator,
+                                                 Set<String> multiValuedClaimUris) {
+
+        // Address claim contains the multi attribute separator but is not a multi valued attribute.
+        if (OAuthConstants.OIDCClaims.ADDRESS.equals(claimKey)) {
+            return false;
+        }
+        // To format the groups claim to always return as an array, we should consider single group as
+        // multi value attribute.
+        if (OAuthConstants.OIDCClaims.GROUPS.equals(claimKey)) {
+            return true;
+        }
+        // Feature on: only claims flagged multi-valued in metadata are arrays. Null set -> legacy fallback.
+        if (multiValuedClaimUris != null) {
+            return multiValuedClaimUris.contains(claimKey);
+        }
+        return StringUtils.contains(claimValue, multiAttributeSeparator);
+    }
+
+    /**
+     * Split a multi-valued claim value by the given separator, dropping blank segments.
+     *
+     * @param claimValue              Claim value to split.
+     * @param multiAttributeSeparator Multi-attribute separator.
+     * @return Non-blank segments of the value (empty array if none).
+     */
+    public static String[] splitMultiValuedAttribute(String claimValue, String multiAttributeSeparator) {
+
+        String[] attributeValues = claimValue.split(Pattern.quote(multiAttributeSeparator));
+        List<String> nonBlankValues = new ArrayList<>();
+        for (String attributeValue : attributeValues) {
+            if (StringUtils.isNotBlank(attributeValue)) {
+                nonBlankValues.add(attributeValue);
+            }
+        }
+        return nonBlankValues.toArray(new String[0]);
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/util/OAuth2UtilTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/util/OAuth2UtilTest.java
@@ -65,6 +65,8 @@ import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
 import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
 import org.wso2.carbon.identity.claim.metadata.mgt.exception.ClaimMetadataException;
 import org.wso2.carbon.identity.claim.metadata.mgt.model.ExternalClaim;
+import org.wso2.carbon.identity.claim.metadata.mgt.model.LocalClaim;
+import org.wso2.carbon.identity.claim.metadata.mgt.util.ClaimConstants;
 import org.wso2.carbon.identity.common.testng.WithCarbonHome;
 import org.wso2.carbon.identity.core.IdentityKeyStoreResolver;
 import org.wso2.carbon.identity.core.ServiceURLBuilder;
@@ -3103,6 +3105,106 @@ public class OAuth2UtilTest {
             OAuth2Util.initiateOIDCScopes(SUPER_TENANT_ID);
             verify(log, times(1))
                     .error(claimMetadataException.getMessage(), claimMetadataException);
+        }
+    }
+
+    @Test(description = "Issue #7138: getMultiValuedClaimUris returns both the local claim URIs flagged "
+            + "multiValued=true and their mapped OIDC claim URIs.")
+    public void testGetMultiValuedClaimUris() throws Exception {
+
+        try (MockedStatic<OAuth2ServiceComponentHolder> mockedHolder =
+                     mockStatic(OAuth2ServiceComponentHolder.class)) {
+
+            OAuth2ServiceComponentHolder holder = mock(OAuth2ServiceComponentHolder.class);
+            ClaimMetadataManagementService claimService = mock(ClaimMetadataManagementService.class);
+            mockedHolder.when(OAuth2ServiceComponentHolder::getInstance).thenReturn(holder);
+            when(holder.getClaimMetadataManagementService()).thenReturn(claimService);
+
+            LocalClaim multiValuedClaim = new LocalClaim("http://wso2.org/claims/multiTest");
+            multiValuedClaim.setClaimProperty(ClaimConstants.MULTI_VALUED_PROPERTY, "true");
+            LocalClaim singleValuedClaim = new LocalClaim("http://wso2.org/claims/givenname");
+            singleValuedClaim.setClaimProperty(ClaimConstants.MULTI_VALUED_PROPERTY, "false");
+            LocalClaim noPropertyClaim = new LocalClaim("http://wso2.org/claims/lastname");
+
+            List<LocalClaim> localClaims = new ArrayList<>();
+            localClaims.add(multiValuedClaim);
+            localClaims.add(singleValuedClaim);
+            localClaims.add(noPropertyClaim);
+            when(claimService.getLocalClaims(SUPER_TENANT_DOMAIN_NAME)).thenReturn(localClaims);
+
+            ExternalClaim multiTestOidc =
+                    new ExternalClaim(OIDC_DIALECT, "multi_test", "http://wso2.org/claims/multiTest");
+            ExternalClaim givenNameOidc =
+                    new ExternalClaim(OIDC_DIALECT, "given_name", "http://wso2.org/claims/givenname");
+            when(claimService.getExternalClaims(OIDC_DIALECT, SUPER_TENANT_DOMAIN_NAME))
+                    .thenReturn(Arrays.asList(multiTestOidc, givenNameOidc));
+
+            Set<String> result = OAuth2Util.getMultiValuedClaimUris(SUPER_TENANT_DOMAIN_NAME);
+
+            assertNotNull(result, "Expected a non-null set when claim metadata is resolved.");
+            assertEquals(result.size(), 2, "The multiValued local claim URI and its mapped OIDC URI should be "
+                    + "returned.");
+            assertTrue(result.contains("http://wso2.org/claims/multiTest"), "Local multiValued claim URI expected.");
+            assertTrue(result.contains("multi_test"), "Mapped OIDC claim URI expected.");
+            assertFalse(result.contains("http://wso2.org/claims/givenname"));
+            assertFalse(result.contains("given_name"));
+            assertFalse(result.contains("http://wso2.org/claims/lastname"));
+        }
+    }
+
+    @Test(description = "Issue #7138: getMultiValuedClaimUris falls back to null (legacy behaviour) when the "
+            + "ClaimMetadataManagementService is unavailable.")
+    public void testGetMultiValuedClaimUrisWithNullService() {
+
+        try (MockedStatic<OAuth2ServiceComponentHolder> mockedHolder =
+                     mockStatic(OAuth2ServiceComponentHolder.class)) {
+
+            OAuth2ServiceComponentHolder holder = mock(OAuth2ServiceComponentHolder.class);
+            mockedHolder.when(OAuth2ServiceComponentHolder::getInstance).thenReturn(holder);
+            when(holder.getClaimMetadataManagementService()).thenReturn(null);
+
+            Set<String> result = OAuth2Util.getMultiValuedClaimUris(SUPER_TENANT_DOMAIN_NAME);
+
+            assertNull(result, "Expected null (legacy fallback) when the claim metadata service is unavailable.");
+        }
+    }
+
+    @Test(description = "Issue #7138: getMultiValuedClaimUris falls back to null (legacy behaviour) when the local "
+            + "claim lookup returns null.")
+    public void testGetMultiValuedClaimUrisWithNullLocalClaims() throws Exception {
+
+        try (MockedStatic<OAuth2ServiceComponentHolder> mockedHolder =
+                     mockStatic(OAuth2ServiceComponentHolder.class)) {
+
+            OAuth2ServiceComponentHolder holder = mock(OAuth2ServiceComponentHolder.class);
+            ClaimMetadataManagementService claimService = mock(ClaimMetadataManagementService.class);
+            mockedHolder.when(OAuth2ServiceComponentHolder::getInstance).thenReturn(holder);
+            when(holder.getClaimMetadataManagementService()).thenReturn(claimService);
+            when(claimService.getLocalClaims(SUPER_TENANT_DOMAIN_NAME)).thenReturn(null);
+
+            Set<String> result = OAuth2Util.getMultiValuedClaimUris(SUPER_TENANT_DOMAIN_NAME);
+
+            assertNull(result, "Expected null (graceful legacy fallback) when getLocalClaims returns null.");
+        }
+    }
+
+    @Test(description = "Issue #7138: getMultiValuedClaimUris falls back to null (legacy behaviour) and does not "
+            + "fail token issuance when claim metadata lookup throws.")
+    public void testGetMultiValuedClaimUrisWithClaimMetadataException() throws Exception {
+
+        try (MockedStatic<OAuth2ServiceComponentHolder> mockedHolder =
+                     mockStatic(OAuth2ServiceComponentHolder.class)) {
+
+            OAuth2ServiceComponentHolder holder = mock(OAuth2ServiceComponentHolder.class);
+            ClaimMetadataManagementService claimService = mock(ClaimMetadataManagementService.class);
+            mockedHolder.when(OAuth2ServiceComponentHolder::getInstance).thenReturn(holder);
+            when(holder.getClaimMetadataManagementService()).thenReturn(claimService);
+            when(claimService.getLocalClaims(SUPER_TENANT_DOMAIN_NAME))
+                    .thenThrow(new ClaimMetadataException("error while reading claim metadata"));
+
+            Set<String> result = OAuth2Util.getMultiValuedClaimUris(SUPER_TENANT_DOMAIN_NAME);
+
+            assertNull(result, "Expected null (graceful legacy fallback) on ClaimMetadataException.");
         }
     }
 

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/openidconnect/DefaultOIDCClaimsCallbackHandlerMultiValuedClaimTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/openidconnect/DefaultOIDCClaimsCallbackHandlerMultiValuedClaimTest.java
@@ -1,0 +1,321 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.identity.openidconnect;
+
+import com.nimbusds.jwt.JWTClaimsSet;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
+import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
+import org.wso2.carbon.identity.claim.metadata.mgt.exception.ClaimMetadataException;
+import org.wso2.carbon.identity.claim.metadata.mgt.model.ExternalClaim;
+import org.wso2.carbon.identity.claim.metadata.mgt.model.LocalClaim;
+import org.wso2.carbon.identity.claim.metadata.mgt.util.ClaimConstants;
+import org.wso2.carbon.identity.common.testng.WithCarbonHome;
+import org.wso2.carbon.identity.oauth.common.OAuthConstants;
+import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
+import org.wso2.carbon.identity.openidconnect.internal.OpenIDConnectServiceComponentHolder;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Tests selective multi-valued claim handling on the JWT/ID-token path
+ * ({@link DefaultOIDCClaimsCallbackHandler}), gated by {@code ClaimMetadata.HonourMultiValued}.
+ * Exercises the private {@code isMultiValuedAttribute} and {@code getMultiValuedClaimUris} methods.
+ */
+@WithCarbonHome
+@Listeners(MockitoTestNGListener.class)
+public class DefaultOIDCClaimsCallbackHandlerMultiValuedClaimTest {
+
+    private static final String SEPARATOR = ",";
+    private static final String TENANT_DOMAIN = "carbon.super";
+
+    private static final String GIVEN_NAME = "given_name";
+    private static final String MULTI_TEST = "multi_test";
+    private static final String ADDRESS = "address";
+    private static final String GROUPS = "groups";
+
+    private static final String LOCAL_GIVEN_NAME_URI = "http://wso2.org/claims/givenname";
+    private static final String LOCAL_MULTI_TEST_URI = "http://wso2.org/claims/multiTest";
+
+    @Mock
+    private ClaimMetadataManagementService claimMetadataManagementService;
+
+    private DefaultOIDCClaimsCallbackHandler handler;
+    private ClaimMetadataManagementService originalService;
+
+    @BeforeMethod
+    public void setUp() {
+
+        handler = new DefaultOIDCClaimsCallbackHandler();
+        // Preserve whatever (if anything) the holder already had so we don't pollute sibling tests.
+        originalService = OpenIDConnectServiceComponentHolder.getInstance().getClaimMetadataManagementService();
+    }
+
+    @AfterMethod
+    public void tearDown() {
+
+        OpenIDConnectServiceComponentHolder.getInstance().setClaimMetadataManagementService(originalService);
+    }
+
+    /**
+     * (a) Flag OFF: a {@code null} multi-valued set must preserve the legacy behaviour — a value
+     * containing the separator is treated as multi-valued (array), a value without it is not.
+     */
+    @Test
+    public void testLegacyBehaviourWhenFeatureDisabled() throws Exception {
+
+        assertTrue(invokeIsMultiValued(GIVEN_NAME, "a,b,c,d", null),
+                "Legacy path must split a comma-containing value into an array when the feature is off.");
+        assertFalse(invokeIsMultiValued(GIVEN_NAME, "singleValue", null),
+                "Legacy path must keep a value without the separator as a plain string.");
+    }
+
+    /**
+     * (b) Flag ON + claim NOT flagged multi-valued: even though the value contains commas it must
+     * be emitted as a plain string (not array).
+     */
+    @Test
+    public void testSingleValuedClaimWithCommaRemainsStringWhenFeatureEnabled() throws Exception {
+
+        Set<String> multiValued = new HashSet<>();
+        multiValued.add(MULTI_TEST); // given_name is intentionally absent.
+        assertFalse(invokeIsMultiValued(GIVEN_NAME, "a,b,c,d", multiValued),
+                "A non-multi-valued claim with a comma value must stay a string when the feature is on.");
+    }
+
+    /**
+     * (c) Flag ON + claim flagged multi-valued: emitted as an array.
+     */
+    @Test
+    public void testMultiValuedClaimBecomesArrayWhenFeatureEnabled() throws Exception {
+
+        Set<String> multiValued = new HashSet<>();
+        multiValued.add(MULTI_TEST);
+        assertTrue(invokeIsMultiValued(MULTI_TEST, "a,b,c,d", multiValued),
+                "A claim flagged multi-valued must be emitted as an array when the feature is on.");
+    }
+
+    /**
+     * (d) Special cases must be preserved regardless of the feature flag: {@code address} is never
+     * an array (even with a separator) and {@code groups} is always an array.
+     */
+    @Test(dataProvider = "specialCaseProvider")
+    public void testSpecialCaseClaimsPreserved(Set<String> multiValuedSet) throws Exception {
+
+        assertFalse(invokeIsMultiValued(ADDRESS, "country,street,province", multiValuedSet),
+                "address must never be treated as a multi-valued (array) attribute.");
+        assertTrue(invokeIsMultiValued(GROUPS, "admin", multiValuedSet),
+                "groups must always be treated as a multi-valued (array) attribute.");
+    }
+
+    @DataProvider(name = "specialCaseProvider")
+    public Object[][] specialCaseProvider() {
+
+        Set<String> enabledEmpty = new HashSet<>();           // feature on, nothing flagged.
+        Set<String> enabledWithGroups = new HashSet<>();
+        enabledWithGroups.add(GROUPS);
+        return new Object[][]{
+                {null},               // feature off (legacy).
+                {enabledEmpty},       // feature on, groups/address not in set.
+                {enabledWithGroups}
+        };
+    }
+
+    /**
+     * Resolving the metadata-derived set must return both the local claim URIs flagged {@code multiValued=true}
+     * and their mapped OIDC claim URIs, so that preserved (non-OIDC) and OIDC-keyed claims both match.
+     */
+    @Test
+    public void testGetMultiValuedClaimUrisResolvesFlaggedClaims() throws Exception {
+
+        LocalClaim multiValuedLocal = new LocalClaim(LOCAL_MULTI_TEST_URI);
+        multiValuedLocal.setClaimProperty(ClaimConstants.MULTI_VALUED_PROPERTY, "true");
+        LocalClaim singleValuedLocal = new LocalClaim(LOCAL_GIVEN_NAME_URI);
+        singleValuedLocal.setClaimProperty(ClaimConstants.MULTI_VALUED_PROPERTY, "false");
+
+        ExternalClaim multiTestOidc =
+                new ExternalClaim(OAuthConstants.OIDC_DIALECT, MULTI_TEST, LOCAL_MULTI_TEST_URI);
+        ExternalClaim givenNameOidc =
+                new ExternalClaim(OAuthConstants.OIDC_DIALECT, GIVEN_NAME, LOCAL_GIVEN_NAME_URI);
+
+        when(claimMetadataManagementService.getLocalClaims(TENANT_DOMAIN))
+                .thenReturn(Arrays.asList(multiValuedLocal, singleValuedLocal));
+        when(claimMetadataManagementService.getExternalClaims(OAuthConstants.OIDC_DIALECT, TENANT_DOMAIN))
+                .thenReturn(Arrays.asList(multiTestOidc, givenNameOidc));
+        OpenIDConnectServiceComponentHolder.getInstance()
+                .setClaimMetadataManagementService(claimMetadataManagementService);
+
+        Set<String> resolved = invokeGetMultiValuedClaimUris(TENANT_DOMAIN);
+        assertEquals(resolved, new HashSet<>(Arrays.asList(LOCAL_MULTI_TEST_URI, MULTI_TEST)),
+                "Both the multiValued=true local claim URI and its mapped OIDC claim URI must be returned.");
+    }
+
+    /**
+     * (e) Graceful fallback: when the claim metadata service is unavailable the method must return
+     * {@code null} (legacy fallback) rather than fail token issuance.
+     */
+    @Test
+    public void testGetMultiValuedClaimUrisReturnsNullWhenServiceUnavailable() throws Exception {
+
+        OpenIDConnectServiceComponentHolder.getInstance().setClaimMetadataManagementService(null);
+        assertNull(invokeGetMultiValuedClaimUris(TENANT_DOMAIN),
+                "A missing claim metadata service must fall back to legacy handling (null set).");
+    }
+
+    /**
+     * (e) Graceful fallback: a {@link ClaimMetadataException} during lookup must be swallowed and
+     * mapped to {@code null} (legacy fallback), so token issuance never fails on metadata errors.
+     */
+    @Test
+    public void testGetMultiValuedClaimUrisReturnsNullOnClaimMetadataException() throws Exception {
+
+        when(claimMetadataManagementService.getLocalClaims(TENANT_DOMAIN))
+                .thenThrow(new ClaimMetadataException("Simulated claim metadata failure."));
+        OpenIDConnectServiceComponentHolder.getInstance()
+                .setClaimMetadataManagementService(claimMetadataManagementService);
+
+        assertNull(invokeGetMultiValuedClaimUris(TENANT_DOMAIN),
+                "A ClaimMetadataException must be handled gracefully and fall back to legacy handling.");
+    }
+
+    /**
+     * Exercises the handler wiring end to end: {@code setClaimsToJwtClaimSet} must read the feature flag, thread the
+     * SP tenant domain into the metadata resolver and emit each claim with the correct type. With the flag ON a
+     * multiValued-flagged claim is an array even for a single value, while a non-multiValued comma value stays a
+     * string.
+     */
+    @Test
+    public void testSetClaimsToJwtClaimSetEmitsArrayOnlyForMultiValuedWhenFeatureEnabled() throws Exception {
+
+        stubClaimMetadata();
+        Map<String, Object> claims = new LinkedHashMap<>();
+        claims.put(MULTI_TEST, "solo");   // single value, flagged multiValued -> must be an array.
+        claims.put(GIVEN_NAME, "a,b");    // not multiValued, has separator -> must stay a string.
+
+        JWTClaimsSet result = invokeSetClaimsToJwtClaimSet(claims, TENANT_DOMAIN, true);
+
+        assertTrue(result.getClaim(MULTI_TEST) instanceof List,
+                "A multiValued-flagged claim must be an array even for a single value.");
+        assertEquals(result.getClaim(MULTI_TEST), Collections.singletonList("solo"));
+        assertTrue(result.getClaim(GIVEN_NAME) instanceof String,
+                "A non-multiValued claim with a separator value must stay a string.");
+        assertEquals(result.getClaim(GIVEN_NAME), "a,b");
+    }
+
+    /**
+     * With the flag OFF the handler must keep the legacy separator-based behaviour: a value with the separator
+     * becomes an array, a value without it stays a string.
+     */
+    @Test
+    public void testSetClaimsToJwtClaimSetLegacyBehaviourWhenFeatureDisabled() throws Exception {
+
+        Map<String, Object> claims = new LinkedHashMap<>();
+        claims.put(MULTI_TEST, "solo");   // no separator -> legacy keeps it a string.
+        claims.put(GIVEN_NAME, "a,b");    // has separator -> legacy splits into an array.
+
+        JWTClaimsSet result = invokeSetClaimsToJwtClaimSet(claims, TENANT_DOMAIN, false);
+
+        assertTrue(result.getClaim(MULTI_TEST) instanceof String,
+                "Legacy: a single value without the separator stays a string.");
+        assertTrue(result.getClaim(GIVEN_NAME) instanceof List,
+                "Legacy: a value containing the separator is split into an array.");
+    }
+
+    private void stubClaimMetadata() throws Exception {
+
+        LocalClaim multiValuedLocal = new LocalClaim(LOCAL_MULTI_TEST_URI);
+        multiValuedLocal.setClaimProperty(ClaimConstants.MULTI_VALUED_PROPERTY, "true");
+        LocalClaim singleValuedLocal = new LocalClaim(LOCAL_GIVEN_NAME_URI);
+        singleValuedLocal.setClaimProperty(ClaimConstants.MULTI_VALUED_PROPERTY, "false");
+        ExternalClaim multiTestOidc =
+                new ExternalClaim(OAuthConstants.OIDC_DIALECT, MULTI_TEST, LOCAL_MULTI_TEST_URI);
+        ExternalClaim givenNameOidc =
+                new ExternalClaim(OAuthConstants.OIDC_DIALECT, GIVEN_NAME, LOCAL_GIVEN_NAME_URI);
+        when(claimMetadataManagementService.getLocalClaims(TENANT_DOMAIN))
+                .thenReturn(Arrays.asList(multiValuedLocal, singleValuedLocal));
+        when(claimMetadataManagementService.getExternalClaims(OAuthConstants.OIDC_DIALECT, TENANT_DOMAIN))
+                .thenReturn(Arrays.asList(multiTestOidc, givenNameOidc));
+        OpenIDConnectServiceComponentHolder.getInstance()
+                .setClaimMetadataManagementService(claimMetadataManagementService);
+    }
+
+    private JWTClaimsSet invokeSetClaimsToJwtClaimSet(Map<String, Object> claims, String spTenantDomain,
+                                                      boolean featureEnabled) throws Exception {
+
+        // Toggle the field on the real configuration rather than mocking OAuthServerConfiguration statically:
+        // OAuth2Util reads OAuthServerConfiguration.getInstance() in a static field initialiser, so a static mock
+        // would poison its class initialisation.
+        OAuthServerConfiguration config = OAuthServerConfiguration.getInstance();
+        boolean original = config.getHonourMultiValuedClaimMetadata();
+        setHonourMultiValuedClaimMetadata(config, featureEnabled);
+        try (MockedStatic<FrameworkUtils> frameworkUtils = mockStatic(FrameworkUtils.class)) {
+            frameworkUtils.when(FrameworkUtils::getMultiAttributeSeparator).thenReturn(SEPARATOR);
+            Method method = DefaultOIDCClaimsCallbackHandler.class.getDeclaredMethod(
+                    "setClaimsToJwtClaimSet", JWTClaimsSet.Builder.class, Map.class, String.class);
+            method.setAccessible(true);
+            return (JWTClaimsSet) method.invoke(handler, new JWTClaimsSet.Builder(), claims, spTenantDomain);
+        } finally {
+            setHonourMultiValuedClaimMetadata(config, original);
+        }
+    }
+
+    private static void setHonourMultiValuedClaimMetadata(OAuthServerConfiguration config, boolean value)
+            throws Exception {
+
+        Field field = OAuthServerConfiguration.class.getDeclaredField("honourMultiValuedClaimMetadata");
+        field.setAccessible(true);
+        field.setBoolean(config, value);
+    }
+
+    private boolean invokeIsMultiValued(String claimKey, String claimValue, Set<String> multiValuedClaimUris) {
+
+        // The predicate now lives in the shared OIDCClaimUtil; the handler delegates to it.
+        return OIDCClaimUtil.isMultiValuedAttribute(claimKey, claimValue, SEPARATOR, multiValuedClaimUris);
+    }
+
+    @SuppressWarnings("unchecked")
+    private Set<String> invokeGetMultiValuedClaimUris(String tenantDomain) throws Exception {
+
+        Method method = DefaultOIDCClaimsCallbackHandler.class.getDeclaredMethod(
+                "getMultiValuedClaimUris", String.class);
+        method.setAccessible(true);
+        return (Set<String>) method.invoke(handler, tenantDomain);
+    }
+}

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/openidconnect/JWTAccessTokenOIDCClaimsHandlerMultiValuedClaimTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/openidconnect/JWTAccessTokenOIDCClaimsHandlerMultiValuedClaimTest.java
@@ -1,0 +1,322 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.identity.openidconnect;
+
+import com.nimbusds.jwt.JWTClaimsSet;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
+import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
+import org.wso2.carbon.identity.claim.metadata.mgt.exception.ClaimMetadataException;
+import org.wso2.carbon.identity.claim.metadata.mgt.model.ExternalClaim;
+import org.wso2.carbon.identity.claim.metadata.mgt.model.LocalClaim;
+import org.wso2.carbon.identity.claim.metadata.mgt.util.ClaimConstants;
+import org.wso2.carbon.identity.common.testng.WithCarbonHome;
+import org.wso2.carbon.identity.oauth.common.OAuthConstants;
+import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
+import org.wso2.carbon.identity.openidconnect.internal.OpenIDConnectServiceComponentHolder;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Tests selective multi-valued claim handling on the JWT access token path
+ * ({@link JWTAccessTokenOIDCClaimsHandler}), gated by {@code ClaimMetadata.HonourMultiValued}.
+ * Exercises the private {@code isMultiValuedAttribute} and {@code getMultiValuedClaimUris} methods.
+ */
+@WithCarbonHome
+@Listeners(MockitoTestNGListener.class)
+public class JWTAccessTokenOIDCClaimsHandlerMultiValuedClaimTest {
+
+    private static final String SEPARATOR = ",";
+    private static final String TENANT_DOMAIN = "carbon.super";
+
+    private static final String GIVEN_NAME = "given_name";
+    private static final String MULTI_TEST = "multi_test";
+    private static final String ADDRESS = "address";
+    private static final String GROUPS = "groups";
+
+    private static final String LOCAL_GIVEN_NAME_URI = "http://wso2.org/claims/givenname";
+    private static final String LOCAL_MULTI_TEST_URI = "http://wso2.org/claims/multiTest";
+
+    @Mock
+    private ClaimMetadataManagementService claimMetadataManagementService;
+
+    private JWTAccessTokenOIDCClaimsHandler handler;
+    private ClaimMetadataManagementService originalService;
+
+    @BeforeMethod
+    public void setUp() {
+
+        handler = new JWTAccessTokenOIDCClaimsHandler();
+        // Preserve whatever (if anything) the holder already had so we don't pollute sibling tests.
+        originalService = OpenIDConnectServiceComponentHolder.getInstance().getClaimMetadataManagementService();
+    }
+
+    @AfterMethod
+    public void tearDown() {
+
+        OpenIDConnectServiceComponentHolder.getInstance().setClaimMetadataManagementService(originalService);
+    }
+
+    /**
+     * (a) Flag OFF: a {@code null} multi-valued set must preserve the legacy behaviour — a value
+     * containing the separator is treated as multi-valued (array), a value without it is not.
+     */
+    @Test
+    public void testLegacyBehaviourWhenFeatureDisabled() throws Exception {
+
+        assertTrue(invokeIsMultiValued(GIVEN_NAME, "a,b,c,d", null),
+                "Legacy path must split a comma-containing value into an array when the feature is off.");
+        assertFalse(invokeIsMultiValued(GIVEN_NAME, "singleValue", null),
+                "Legacy path must keep a value without the separator as a plain string.");
+    }
+
+    /**
+     * (b) Flag ON + claim NOT flagged multi-valued: even though the value contains commas it must be
+     * emitted as a plain string (not array) in the JWT access token.
+     */
+    @Test
+    public void testSingleValuedClaimWithCommaRemainsStringWhenFeatureEnabled() throws Exception {
+
+        Set<String> multiValued = new HashSet<>();
+        multiValued.add(MULTI_TEST); // given_name is intentionally absent.
+        assertFalse(invokeIsMultiValued(GIVEN_NAME, "a,b,c,d", multiValued),
+                "A non-multi-valued claim with a comma value must stay a string in the JWT access token "
+                        + "when the feature is on.");
+    }
+
+    /**
+     * (c) Flag ON + claim flagged multi-valued: emitted as an array.
+     */
+    @Test
+    public void testMultiValuedClaimBecomesArrayWhenFeatureEnabled() throws Exception {
+
+        Set<String> multiValued = new HashSet<>();
+        multiValued.add(MULTI_TEST);
+        assertTrue(invokeIsMultiValued(MULTI_TEST, "a,b,c,d", multiValued),
+                "A claim flagged multi-valued must be emitted as an array when the feature is on.");
+    }
+
+    /**
+     * (d) Special cases must be preserved regardless of the feature flag: {@code address} is never an
+     * array (even with a separator) and {@code groups} is always an array.
+     */
+    @Test(dataProvider = "specialCaseProvider")
+    public void testSpecialCaseClaimsPreserved(Set<String> multiValuedSet) throws Exception {
+
+        assertFalse(invokeIsMultiValued(ADDRESS, "country,street,province", multiValuedSet),
+                "address must never be treated as a multi-valued (array) attribute.");
+        assertTrue(invokeIsMultiValued(GROUPS, "admin", multiValuedSet),
+                "groups must always be treated as a multi-valued (array) attribute.");
+    }
+
+    @DataProvider(name = "specialCaseProvider")
+    public Object[][] specialCaseProvider() {
+
+        Set<String> enabledEmpty = new HashSet<>();           // feature on, nothing flagged.
+        Set<String> enabledWithGroups = new HashSet<>();
+        enabledWithGroups.add(GROUPS);
+        return new Object[][]{
+                {null},               // feature off (legacy).
+                {enabledEmpty},       // feature on, groups/address not in set.
+                {enabledWithGroups}
+        };
+    }
+
+    /**
+     * Resolving the metadata-derived set must return both the local claim URIs flagged {@code multiValued=true} and
+     * their mapped OIDC claim URIs, so that preserved (non-OIDC) and OIDC-keyed claims both match.
+     */
+    @Test
+    public void testGetMultiValuedClaimUrisResolvesFlaggedClaims() throws Exception {
+
+        LocalClaim multiValuedLocal = new LocalClaim(LOCAL_MULTI_TEST_URI);
+        multiValuedLocal.setClaimProperty(ClaimConstants.MULTI_VALUED_PROPERTY, "true");
+        LocalClaim singleValuedLocal = new LocalClaim(LOCAL_GIVEN_NAME_URI);
+        singleValuedLocal.setClaimProperty(ClaimConstants.MULTI_VALUED_PROPERTY, "false");
+
+        ExternalClaim multiTestOidc =
+                new ExternalClaim(OAuthConstants.OIDC_DIALECT, MULTI_TEST, LOCAL_MULTI_TEST_URI);
+        ExternalClaim givenNameOidc =
+                new ExternalClaim(OAuthConstants.OIDC_DIALECT, GIVEN_NAME, LOCAL_GIVEN_NAME_URI);
+
+        when(claimMetadataManagementService.getLocalClaims(TENANT_DOMAIN))
+                .thenReturn(Arrays.asList(multiValuedLocal, singleValuedLocal));
+        when(claimMetadataManagementService.getExternalClaims(OAuthConstants.OIDC_DIALECT, TENANT_DOMAIN))
+                .thenReturn(Arrays.asList(multiTestOidc, givenNameOidc));
+        OpenIDConnectServiceComponentHolder.getInstance()
+                .setClaimMetadataManagementService(claimMetadataManagementService);
+
+        Set<String> resolved = invokeGetMultiValuedClaimUris(TENANT_DOMAIN);
+        assertEquals(resolved, new HashSet<>(Arrays.asList(LOCAL_MULTI_TEST_URI, MULTI_TEST)),
+                "Both the multiValued=true local claim URI and its mapped OIDC claim URI must be returned.");
+    }
+
+    /**
+     * (e) Graceful fallback: when the claim metadata service is unavailable the method must return
+     * {@code null} (legacy fallback) rather than fail token issuance.
+     */
+    @Test
+    public void testGetMultiValuedClaimUrisReturnsNullWhenServiceUnavailable() throws Exception {
+
+        OpenIDConnectServiceComponentHolder.getInstance().setClaimMetadataManagementService(null);
+        assertNull(invokeGetMultiValuedClaimUris(TENANT_DOMAIN),
+                "A missing claim metadata service must fall back to legacy handling (null set).");
+    }
+
+    /**
+     * (e) Graceful fallback: a {@link ClaimMetadataException} during lookup must be swallowed and
+     * mapped to {@code null} (legacy fallback), so token issuance never fails on metadata errors.
+     */
+    @Test
+    public void testGetMultiValuedClaimUrisReturnsNullOnClaimMetadataException() throws Exception {
+
+        when(claimMetadataManagementService.getLocalClaims(TENANT_DOMAIN))
+                .thenThrow(new ClaimMetadataException("Simulated claim metadata failure."));
+        OpenIDConnectServiceComponentHolder.getInstance()
+                .setClaimMetadataManagementService(claimMetadataManagementService);
+
+        assertNull(invokeGetMultiValuedClaimUris(TENANT_DOMAIN),
+                "A ClaimMetadataException must be handled gracefully and fall back to legacy handling.");
+    }
+
+    /**
+     * Exercises the handler wiring end to end: {@code setClaimsToJwtClaimSet} must read the feature flag, thread the
+     * SP tenant domain into the metadata resolver and emit each claim with the correct type. With the flag ON a
+     * multiValued-flagged claim is an array even for a single value, while a non-multiValued comma value stays a
+     * string.
+     */
+    @Test
+    public void testSetClaimsToJwtClaimSetEmitsArrayOnlyForMultiValuedWhenFeatureEnabled() throws Exception {
+
+        stubClaimMetadata();
+        Map<String, Object> claims = new LinkedHashMap<>();
+        claims.put(MULTI_TEST, "solo");   // single value, flagged multiValued -> must be an array.
+        claims.put(GIVEN_NAME, "a,b");    // not multiValued, has separator -> must stay a string.
+
+        JWTClaimsSet result = invokeSetClaimsToJwtClaimSet(claims, TENANT_DOMAIN, true);
+
+        assertTrue(result.getClaim(MULTI_TEST) instanceof List,
+                "A multiValued-flagged claim must be an array even for a single value.");
+        assertEquals(result.getClaim(MULTI_TEST), Collections.singletonList("solo"));
+        assertTrue(result.getClaim(GIVEN_NAME) instanceof String,
+                "A non-multiValued claim with a separator value must stay a string.");
+        assertEquals(result.getClaim(GIVEN_NAME), "a,b");
+    }
+
+    /**
+     * With the flag OFF the handler must keep the legacy separator-based behaviour: a value with the separator
+     * becomes an array, a value without it stays a string.
+     */
+    @Test
+    public void testSetClaimsToJwtClaimSetLegacyBehaviourWhenFeatureDisabled() throws Exception {
+
+        Map<String, Object> claims = new LinkedHashMap<>();
+        claims.put(MULTI_TEST, "solo");   // no separator -> legacy keeps it a string.
+        claims.put(GIVEN_NAME, "a,b");    // has separator -> legacy splits into an array.
+
+        JWTClaimsSet result = invokeSetClaimsToJwtClaimSet(claims, TENANT_DOMAIN, false);
+
+        assertTrue(result.getClaim(MULTI_TEST) instanceof String,
+                "Legacy: a single value without the separator stays a string.");
+        assertTrue(result.getClaim(GIVEN_NAME) instanceof List,
+                "Legacy: a value containing the separator is split into an array.");
+    }
+
+    private void stubClaimMetadata() throws Exception {
+
+        LocalClaim multiValuedLocal = new LocalClaim(LOCAL_MULTI_TEST_URI);
+        multiValuedLocal.setClaimProperty(ClaimConstants.MULTI_VALUED_PROPERTY, "true");
+        LocalClaim singleValuedLocal = new LocalClaim(LOCAL_GIVEN_NAME_URI);
+        singleValuedLocal.setClaimProperty(ClaimConstants.MULTI_VALUED_PROPERTY, "false");
+        ExternalClaim multiTestOidc =
+                new ExternalClaim(OAuthConstants.OIDC_DIALECT, MULTI_TEST, LOCAL_MULTI_TEST_URI);
+        ExternalClaim givenNameOidc =
+                new ExternalClaim(OAuthConstants.OIDC_DIALECT, GIVEN_NAME, LOCAL_GIVEN_NAME_URI);
+        when(claimMetadataManagementService.getLocalClaims(TENANT_DOMAIN))
+                .thenReturn(Arrays.asList(multiValuedLocal, singleValuedLocal));
+        when(claimMetadataManagementService.getExternalClaims(OAuthConstants.OIDC_DIALECT, TENANT_DOMAIN))
+                .thenReturn(Arrays.asList(multiTestOidc, givenNameOidc));
+        OpenIDConnectServiceComponentHolder.getInstance()
+                .setClaimMetadataManagementService(claimMetadataManagementService);
+    }
+
+    private JWTClaimsSet invokeSetClaimsToJwtClaimSet(Map<String, Object> claims, String spTenantDomain,
+                                                      boolean featureEnabled) throws Exception {
+
+        // Toggle the field on the real configuration rather than mocking OAuthServerConfiguration statically:
+        // OAuth2Util reads OAuthServerConfiguration.getInstance() in a static field initialiser, so a static mock
+        // would poison its class initialisation.
+        OAuthServerConfiguration config = OAuthServerConfiguration.getInstance();
+        boolean original = config.getHonourMultiValuedClaimMetadata();
+        setHonourMultiValuedClaimMetadata(config, featureEnabled);
+        try (MockedStatic<FrameworkUtils> frameworkUtils = mockStatic(FrameworkUtils.class)) {
+            frameworkUtils.when(FrameworkUtils::getMultiAttributeSeparator).thenReturn(SEPARATOR);
+            Method method = JWTAccessTokenOIDCClaimsHandler.class.getDeclaredMethod(
+                    "setClaimsToJwtClaimSet", JWTClaimsSet.Builder.class, Map.class, String.class);
+            method.setAccessible(true);
+            return (JWTClaimsSet) method.invoke(handler, new JWTClaimsSet.Builder(), claims, spTenantDomain);
+        } finally {
+            setHonourMultiValuedClaimMetadata(config, original);
+        }
+    }
+
+    private static void setHonourMultiValuedClaimMetadata(OAuthServerConfiguration config, boolean value)
+            throws Exception {
+
+        Field field = OAuthServerConfiguration.class.getDeclaredField("honourMultiValuedClaimMetadata");
+        field.setAccessible(true);
+        field.setBoolean(config, value);
+    }
+
+    private boolean invokeIsMultiValued(String claimKey, String claimValue, Set<String> multiValuedClaimUris) {
+
+        // The predicate now lives in the shared OIDCClaimUtil; the handler delegates to it.
+        return OIDCClaimUtil.isMultiValuedAttribute(claimKey, claimValue, SEPARATOR, multiValuedClaimUris);
+    }
+
+    @SuppressWarnings("unchecked")
+    private Set<String> invokeGetMultiValuedClaimUris(String tenantDomain) throws Exception {
+
+        Method method = JWTAccessTokenOIDCClaimsHandler.class.getDeclaredMethod(
+                "getMultiValuedClaimUris", String.class);
+        method.setAccessible(true);
+        return (Set<String>) method.invoke(handler, tenantDomain);
+    }
+}

--- a/components/org.wso2.carbon.identity.oauth/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.identity.oauth/src/test/resources/testng.xml
@@ -143,6 +143,8 @@
             <class name="org.wso2.carbon.identity.oauth2.util.TokenMgtUtilTest"/>
             <!--<class name="org.wso2.carbon.identity.openidconnect.DefaultIDTokenBuilderTest"/>-->
             <class name="org.wso2.carbon.identity.openidconnect.DefaultOIDCClaimsCallbackHandlerTest"/>
+            <class name="org.wso2.carbon.identity.openidconnect.DefaultOIDCClaimsCallbackHandlerMultiValuedClaimTest"/>
+            <class name="org.wso2.carbon.identity.openidconnect.JWTAccessTokenOIDCClaimsHandlerMultiValuedClaimTest"/>
             <class name="org.wso2.carbon.identity.openidconnect.JWTAccessTokenOIDCClaimsHandler"/>
             <class name="org.wso2.carbon.identity.oauth2.validators.jwt.JWKSBasedJWTValidatorTest"/>
             <class name="org.wso2.carbon.identity.oauth2.device.codegenerator.GenerateKeysTest"/>


### PR DESCRIPTION
## Purpose
Resolves wso2/product-is#27652.

Currently any user-claim value containing the multi-attribute separator (`,`) is unconditionally split into a JSON array when building JWT access tokens, ID tokens and the UserInfo response — corrupting genuinely single-valued claims that happen to contain commas. This PR makes the split **selective** and **opt-in**.

## Approach
New config `ConvertOnlyMultiValuedClaimsToArray` (default `false`). When enabled, a claim is emitted as an array only if its local-claim metadata has `multiValued=true`. Special cases preserved: `groups` always array, `address` never. When disabled (default), legacy comma-split behaviour is retained — no change for existing deployments.

Config key wiring: wso2/carbon-identity-framework#8157.

## Changes
- `OAuthServerConfiguration` — parse the new flag + getter.
- `DefaultOIDCClaimsCallbackHandler` — JWT/ID-token path: resolve per-tenant set of multi-valued OIDC claim URIs and gate the array/string decision on it.
- `JWTAccessTokenOIDCClaimsHandler` — same selective logic on the access-token claims-separation path, so JWT access tokens honour the flag too.
- `OAuth2Util` — shared helper resolving local claim URIs flagged `multiValued`.
- `ClaimUtil` + `UserInfoUserStoreClaimRetriever` — UserInfo path (primary + cache-hit), keyed on the local claim URI.
- All paths degrade gracefully to legacy comma-split on `ClaimMetadataException` / unavailable service.

## Tests
- `DefaultOIDCClaimsCallbackHandlerMultiValuedClaimTest`, `JWTAccessTokenOIDCClaimsHandlerMultiValuedClaimTest` — JWT/ID-token + access-token decision logic.
- `OAuth2UtilTest`, `ClaimUtilTest` — UserInfo helper + path.
- Cover: flag off (legacy), flag on single→string / multi→array, `groups`/`address` special cases, graceful fallback. All green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)