### PR TITLE
Reject userinfo requests carrying multiple Authorization headers

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/user/impl/UserInforRequestDefaultValidator.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/user/impl/UserInforRequestDefaultValidator.java
@@ -29,6 +29,7 @@ import java.nio.charset.CharacterCodingException;
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.StandardCharsets;
+import java.util.Enumeration;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.HttpMethod;
@@ -50,6 +51,11 @@ public class UserInforRequestDefaultValidator implements UserInfoRequestValidato
 
     @Override
     public String validateRequest(HttpServletRequest request) throws UserInfoEndpointException {
+
+        if (hasMultipleAuthorizationHeaders(request)) {
+            throw new UserInfoEndpointException(OAuthError.ResourceResponse.INVALID_REQUEST,
+                    "Multiple Authorization headers are not allowed");
+        }
 
         String authzHeaders = request.getHeader(HttpHeaders.AUTHORIZATION);
         if (authzHeaders == null) {
@@ -124,6 +130,27 @@ public class UserInforRequestDefaultValidator implements UserInfoRequestValidato
                     OAuthError.ResourceResponse.INVALID_REQUEST, "Bearer token missing"
             );
         }
+    }
+
+    /**
+     * The Authorization header is defined as a single value by RFC 9110 (Section 11.6.1), so a
+     * request that carries it more than once is malformed. This detects that case so the caller can
+     * reject the request instead of silently honoring the first value and ignoring the rest.
+     */
+    private boolean hasMultipleAuthorizationHeaders(HttpServletRequest request) {
+
+        Enumeration<String> authorizationHeaders = request.getHeaders(HttpHeaders.AUTHORIZATION);
+        if (authorizationHeaders == null) {
+            return false;
+        }
+        int count = 0;
+        while (authorizationHeaders.hasMoreElements()) {
+            authorizationHeaders.nextElement();
+            if (++count > 1) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public static boolean isPureAscii(String requestBody) {

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/user/impl/UserInfoISAccessTokenValidatorTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/user/impl/UserInfoISAccessTokenValidatorTest.java
@@ -47,6 +47,8 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Collections;
 
 import javax.servlet.ServletInputStream;
 import javax.servlet.http.HttpServletRequest;
@@ -134,6 +136,24 @@ public class UserInfoISAccessTokenValidatorTest {
         prepareHttpServletRequest(bearerAuthHeader, null);
         assertEquals(bearerAuthHeader.split(" ")[1], userInforRequestDefaultValidator.validateRequest
                 (httpServletRequest));
+    }
+
+    @Test(expectedExceptions = UserInfoEndpointException.class)
+    public void testValidateRequestRejectsMultipleAuthorizationHeaders() throws Exception {
+
+        when(httpServletRequest.getHeaders(HttpHeaders.AUTHORIZATION)).thenReturn(
+                Collections.enumeration(Arrays.asList("Bearer " + token, "Bearer invalid_token")));
+        userInforRequestDefaultValidator.validateRequest(httpServletRequest);
+    }
+
+    @Test
+    public void testValidateRequestAllowsSingleAuthorizationHeader() throws Exception {
+
+        String bearerAuthHeader = "Bearer " + token;
+        when(httpServletRequest.getHeaders(HttpHeaders.AUTHORIZATION)).thenReturn(
+                Collections.enumeration(Collections.singletonList(bearerAuthHeader)));
+        when(httpServletRequest.getHeader(HttpHeaders.AUTHORIZATION)).thenReturn(bearerAuthHeader);
+        assertEquals(userInforRequestDefaultValidator.validateRequest(httpServletRequest), token);
     }
 
     @DataProvider


### PR DESCRIPTION
### Proposed changes in this pull request

- `UserInforRequestDefaultValidator#validateRequest` now rejects a request that carries more than one `Authorization` header with `UserInfoEndpointException(INVALID_REQUEST, ...)` → `400 Bad Request`, before reading the token. The `Authorization` field is single-valued (RFC 9110 §11.6.1); previously the first header was used and the rest silently ignored (`200`). Requests with zero or one `Authorization` header are unchanged, and the existing request-body / DPoP paths are untouched.
- Added test cases in `UserInfoISAccessTokenValidatorTest` (multiple headers → rejected; single header → accepted).

Fixes wso2/product-is#28038.

> **Behavioral change:** a request with duplicate `Authorization` headers now returns `400` instead of `200`. Flagging so the appropriate label can be applied. No migration or configuration impact.

### When should this PR be merged

No preconditions.

### Follow up actions

-

## Developer Checklist (Mandatory)

- [x] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact. *(Behavioral change noted above; no migration/configuration impact.)*

### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description.
- [ ] **Is the PR labeled correctly?**

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.

#### Tests

- [ ] **Are there sufficient test cases?**
- [ ] **If this is a bug fix, are tests for the issue in place?** There must be a test case for the bug to ensure the issue won't regress. Make sure that the tests break without the new code to fix the issue.

#### Security

- [ ] **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
- [ ] **Are all external inputs validated and sanitized appropriately?**
- [ ] **Does all branching logic have a default case?**
- [ ] **Does this solution handle outliers and edge cases gracefully?**
