### PR TITLE
Fix JWT test failure in staging build

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpoint.java
@@ -2470,14 +2470,16 @@ public class OAuth2AuthzEndpoint {
             oAuthMessage.getSessionDataCacheEntry().setAuthzReqMsgCtx(authzReqMsgCtx);
             if (ArrayUtils.isEmpty(authzReqMsgCtx.getApprovedScope())) {
                 oauth2Params.setScopes(new HashSet<>(Collections.emptyList()));
-            } else {
-                // Exclude default scopes mentioned in the configuration from consent flow
+            } else if (CollectionUtils.isEmpty(oauth2Params.getScopes())) {
+                // Exclude default requested scopes from the consent flow when no scopes are requested
                 List<String> defaultRequestedScopes = OAuthServerConfiguration.getInstance()
                         .getDefaultRequestedScopes();
                 Set<String> approvedScopes = new HashSet<>(Arrays.asList(authzReqMsgCtx.getApprovedScope()));
-                log.debug("Removing default scopes from approved scopes.");
+                log.debug("Removing internally added default scopes from consent flow.");
                 approvedScopes.removeAll(defaultRequestedScopes);
                 oauth2Params.setScopes(approvedScopes);
+            } else {
+                oauth2Params.setScopes(new HashSet<>(Arrays.asList(authzReqMsgCtx.getApprovedScope())));
             }
         } catch (IdentityOAuth2Exception | InvalidOAuthClientException e) {
             log.error("Error occurred while validating requested scopes.", e);


### PR DESCRIPTION
### Purpose

When an authorization request arrives with no scopes, a scope named default is injected internally by AuthorizationHandlerManager.
Since 'default' is a no-consent-required scope, it should bypass the consent page. However, the fix https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/3250 removed all configured default scopes unconditionally from the consent flow. Therefore if a user explicitly requested 'default' as a scope, consent was silently skipped for it too.

This caused a JWT related test failure in staging builds and therefore this PR is added to fix that.

Related to: https://github.com/wso2/api-manager/issues/5051

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined scope consent behavior in authorization flows. Scopes explicitly included in user authorization requests are now properly displayed during the consent approval process, enabling users to have better control over permissions. Meanwhile, only implicit default scopes continue to be excluded from the consent screen to maintain a streamlined user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->