### PR TITLE
Restrict federated assertion claims to configured access token attributes

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
@@ -303,6 +303,9 @@ public class OAuthServerConfiguration {
 
     // Property added to preserve the backward compatibility to send the original claim uris comes in the assertion.
     private boolean convertOriginalClaimsFromAssertionsToOIDCDialect = false;
+    // When enabled, claims taken from the assertion for a federated user are restricted to the application's
+    // configured access token attributes. Default false to preserve backward compatibility.
+    private boolean restrictAssertionClaimsToConfiguredAttributes = false;
     // This property will decide whether to send only mapped roles received from the federated IdP
     private boolean returnOnlyMappedLocalRoles = false;
 
@@ -2173,6 +2176,10 @@ public class OAuthServerConfiguration {
         return convertOriginalClaimsFromAssertionsToOIDCDialect;
     }
 
+    public boolean isRestrictAssertionClaimsToConfiguredAttributes() {
+        return restrictAssertionClaimsToConfiguredAttributes;
+    }
+
     public boolean isReturnOnlyMappedLocalRoles() {
         return returnOnlyMappedLocalRoles;
     }
@@ -3990,6 +3997,14 @@ public class OAuthServerConfiguration {
                 convertOriginalClaimsFromAssertionsToOIDCDialect = Boolean
                         .parseBoolean(convertOriginalClaimsFromAssertionsToOIDCDialectElement.getText().trim());
             }
+
+            OMElement restrictAssertionClaimsToConfiguredAttributesElement = openIDConnectConfigElem
+                    .getFirstChildWithName(getQNameWithIdentityNS(
+                            ConfigElements.OPENID_CONNECT_RESTRICT_ASSERTION_CLAIMS_TO_CONFIGURED_ATTRIBUTES));
+            if (restrictAssertionClaimsToConfiguredAttributesElement != null) {
+                restrictAssertionClaimsToConfiguredAttributes = Boolean
+                        .parseBoolean(restrictAssertionClaimsToConfiguredAttributesElement.getText().trim());
+            }
             OMElement addUnmappedUserAttributesElement = openIDConnectConfigElem.getFirstChildWithName(
                     getQNameWithIdentityNS(ConfigElements.OPENID_CONNECT_ADD_UN_MAPPED_USER_ATTRIBUTES));
             if (addUnmappedUserAttributesElement != null) {
@@ -4692,6 +4707,8 @@ public class OAuthServerConfiguration {
                 "IDTokenCustomClaimsCallBackHandler";
         public static final String OPENID_CONNECT_CONVERT_ORIGINAL_CLAIMS_FROM_ASSERTIONS_TO_OIDCDIALECT =
                 "ConvertOriginalClaimsFromAssertionsToOIDCDialect";
+        public static final String OPENID_CONNECT_RESTRICT_ASSERTION_CLAIMS_TO_CONFIGURED_ATTRIBUTES =
+                "RestrictAssertionClaimsToConfiguredAttributes";
         // Property to decide whether to add tenant domain to id_token.
         private static final String OPENID_CONNECT_ADD_TENANT_DOMAIN_TO_ID_TOKEN = "AddTenantDomainToIdToken";
         // Property to decide whether to add userstore domain to id_token.

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/JWTAccessTokenOIDCClaimsHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/JWTAccessTokenOIDCClaimsHandler.java
@@ -177,10 +177,28 @@ public class JWTAccessTokenOIDCClaimsHandler implements CustomClaimsCallbackHand
         Object hasNonOIDCClaimsProperty = requestMsgCtx.getProperty(OIDCConstants.HAS_NON_OIDC_CLAIMS);
         if (isPreserverClaimUrisInAssertion(requestMsgCtx) || (hasNonOIDCClaimsProperty != null
                 && (Boolean) hasNonOIDCClaimsProperty)) {
+            if (OAuthServerConfiguration.getInstance().isRestrictAssertionClaimsToConfiguredAttributes()) {
+                return filterRequestedClaims(userClaimsInOIDCDialect, allowedClaims);
+            }
             return userClaimsInOIDCDialect;
         } else {
             return filterClaims(userClaimsInOIDCDialect, requestMsgCtx);
         }
+    }
+
+    /**
+     * Restrict the federated user's assertion claims to the application's configured access token attributes.
+     *
+     * @param userClaimsInOIDCDialect User claims in OIDC dialect.
+     * @param allowedClaims           Configured access token attributes.
+     * @return Claims restricted to the configured access token attributes.
+     */
+    private Map<String, Object> filterRequestedClaims(Map<String, Object> userClaimsInOIDCDialect,
+                                                      List<String> allowedClaims) {
+
+        return userClaimsInOIDCDialect.entrySet().stream()
+                .filter(entry -> allowedClaims.contains(entry.getKey()))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
     private void setOrganizationSwitchAttributes(OAuthTokenReqMessageContext requestMsgCtx)

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/openidconnect/JWTAccessTokenOIDCClaimsHandlerTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/openidconnect/JWTAccessTokenOIDCClaimsHandlerTest.java
@@ -103,6 +103,7 @@ import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import static org.wso2.carbon.identity.core.util.IdentityCoreConstants.MULTI_ATTRIBUTE_SEPARATOR_DEFAULT;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.ACCESS_TOKEN;
@@ -557,6 +558,110 @@ public class JWTAccessTokenOIDCClaimsHandlerTest {
                 assertEquals(jwtClaimsSet.getClaim("email"), TestConstants.CLAIM_VALUE2,
                         "OIDC claim email is not added with the JWT token");
             }
+        }
+    }
+
+    @Test(description = "When RestrictAssertionClaimsToConfiguredAttributes is enabled, federated assertion claims " +
+            "are restricted to the application's configured access token attributes (refs wso2/product-is#27611).")
+    public void testFederatedAssertionClaimsRestrictedWhenConfigEnabled() throws Exception {
+
+        try (MockedStatic<JDBCPersistenceManager> jdbcPersistenceManager = mockStatic(JDBCPersistenceManager.class);
+             MockedStatic<OAuthServerConfiguration> oAuthServerConfiguration = mockStatic(
+                     OAuthServerConfiguration.class);
+             MockedStatic<ClaimMetadataHandler> claimMetadataHandler = mockStatic(ClaimMetadataHandler.class);
+             MockedStatic<OAuth2Util> oAuth2Util = mockStatic(OAuth2Util.class);
+             MockedStatic<AuthzUtil> authzUtil = mockStatic(AuthzUtil.class);
+             MockedStatic<IdentityTenantUtil> identityTenantUtil = mockStatic(IdentityTenantUtil.class);
+             MockedStatic<IdentityUtil> identityUtil = mockStatic(IdentityUtil.class, Mockito.CALLS_REAL_METHODS);
+             MockedStatic<AuthorizationGrantCache> authorizationGrantCache =
+                     mockStatic(AuthorizationGrantCache.class)) {
+
+            identityUtil.when(IdentityUtil::isGroupsVsRolesSeparationImprovementsEnabled).thenReturn(true);
+            authzUtil.when(() -> AuthzUtil.getUserRoles(any(), anyString())).thenReturn(new ArrayList<>());
+            // Only "email" is configured as an access token attribute; "country" is not.
+            oAuth2Util.when(() -> OAuth2Util.getAppInformationByClientId(any(), any()))
+                    .thenReturn(getoAuthAppDO(new String[]{EMAIL}));
+            claimMetadataHandler.when(ClaimMetadataHandler::getInstance).thenReturn(mockClaimMetadataHandler);
+            lenient().when(mockClaimMetadataHandler.getMappingsMapFromOtherDialectToCarbon(
+                    anyString(), isNull(), anyString(), anyBoolean())).thenReturn(getOIDCtoLocalClaimsMapping());
+
+            OAuthTokenReqMessageContext requestMsgCtx = getTokenReqMessageContextForFederatedUser(new HashMap<>());
+            requestMsgCtx.addProperty("AuthorizationCode", "dummyAuthorizationCode");
+            Map<ClaimMapping, String> federatedUserAttributes = new HashMap<>();
+            federatedUserAttributes.put(SAML2BearerGrantHandlerTest.buildClaimMapping("country"),
+                    TestConstants.CLAIM_VALUE1);
+            federatedUserAttributes.put(SAML2BearerGrantHandlerTest.buildClaimMapping("email"),
+                    TestConstants.CLAIM_VALUE2);
+            AuthorizationGrantCacheEntry authorizationGrantCacheEntry = new AuthorizationGrantCacheEntry();
+            authorizationGrantCacheEntry.setMappedRemoteClaims(federatedUserAttributes);
+            mockAuthorizationGrantCache(authorizationGrantCacheEntry, authorizationGrantCache);
+
+            UserRealm userRealm = getUserRealmWithUserClaims(USER_CLAIMS_MAP);
+            mockUserRealm(requestMsgCtx.getAuthorizedUser().toString(), userRealm, identityTenantUtil);
+
+            JWTAccessTokenOIDCClaimsHandler handler =
+                    getJwtAccessTokenOIDCClaimsHandler(jdbcPersistenceManager, oAuthServerConfiguration);
+            OAuthServerConfiguration serverConfig = mock(OAuthServerConfiguration.class);
+            lenient().when(serverConfig.isRestrictAssertionClaimsToConfiguredAttributes()).thenReturn(true);
+            oAuthServerConfiguration.when(OAuthServerConfiguration::getInstance).thenReturn(serverConfig);
+
+            JWTClaimsSet jwtClaimsSet = handler.handleCustomClaims(new JWTClaimsSet.Builder(), requestMsgCtx);
+            assertNotNull(jwtClaimsSet);
+            assertEquals(jwtClaimsSet.getClaim(EMAIL), TestConstants.CLAIM_VALUE2,
+                    "Configured access token attribute must be present.");
+            assertNull(jwtClaimsSet.getClaim("country"),
+                    "Unconfigured assertion claim must be restricted when the config is enabled.");
+        }
+    }
+
+    @Test(description = "When RestrictAssertionClaimsToConfiguredAttributes is disabled (default), federated " +
+            "assertion claims are propagated unfiltered, preserving existing behaviour (refs wso2/product-is#27611).")
+    public void testFederatedAssertionClaimsNotRestrictedWhenConfigDisabled() throws Exception {
+
+        try (MockedStatic<JDBCPersistenceManager> jdbcPersistenceManager = mockStatic(JDBCPersistenceManager.class);
+             MockedStatic<OAuthServerConfiguration> oAuthServerConfiguration = mockStatic(
+                     OAuthServerConfiguration.class);
+             MockedStatic<ClaimMetadataHandler> claimMetadataHandler = mockStatic(ClaimMetadataHandler.class);
+             MockedStatic<OAuth2Util> oAuth2Util = mockStatic(OAuth2Util.class);
+             MockedStatic<AuthzUtil> authzUtil = mockStatic(AuthzUtil.class);
+             MockedStatic<IdentityTenantUtil> identityTenantUtil = mockStatic(IdentityTenantUtil.class);
+             MockedStatic<IdentityUtil> identityUtil = mockStatic(IdentityUtil.class, Mockito.CALLS_REAL_METHODS);
+             MockedStatic<AuthorizationGrantCache> authorizationGrantCache =
+                     mockStatic(AuthorizationGrantCache.class)) {
+
+            identityUtil.when(IdentityUtil::isGroupsVsRolesSeparationImprovementsEnabled).thenReturn(true);
+            authzUtil.when(() -> AuthzUtil.getUserRoles(any(), anyString())).thenReturn(new ArrayList<>());
+            oAuth2Util.when(() -> OAuth2Util.getAppInformationByClientId(any(), any()))
+                    .thenReturn(getoAuthAppDO(new String[]{EMAIL}));
+            claimMetadataHandler.when(ClaimMetadataHandler::getInstance).thenReturn(mockClaimMetadataHandler);
+            lenient().when(mockClaimMetadataHandler.getMappingsMapFromOtherDialectToCarbon(
+                    anyString(), isNull(), anyString(), anyBoolean())).thenReturn(getOIDCtoLocalClaimsMapping());
+
+            OAuthTokenReqMessageContext requestMsgCtx = getTokenReqMessageContextForFederatedUser(new HashMap<>());
+            requestMsgCtx.addProperty("AuthorizationCode", "dummyAuthorizationCode");
+            Map<ClaimMapping, String> federatedUserAttributes = new HashMap<>();
+            federatedUserAttributes.put(SAML2BearerGrantHandlerTest.buildClaimMapping("country"),
+                    TestConstants.CLAIM_VALUE1);
+            federatedUserAttributes.put(SAML2BearerGrantHandlerTest.buildClaimMapping("email"),
+                    TestConstants.CLAIM_VALUE2);
+            AuthorizationGrantCacheEntry authorizationGrantCacheEntry = new AuthorizationGrantCacheEntry();
+            authorizationGrantCacheEntry.setMappedRemoteClaims(federatedUserAttributes);
+            mockAuthorizationGrantCache(authorizationGrantCacheEntry, authorizationGrantCache);
+
+            UserRealm userRealm = getUserRealmWithUserClaims(USER_CLAIMS_MAP);
+            mockUserRealm(requestMsgCtx.getAuthorizedUser().toString(), userRealm, identityTenantUtil);
+
+            JWTAccessTokenOIDCClaimsHandler handler =
+                    getJwtAccessTokenOIDCClaimsHandler(jdbcPersistenceManager, oAuthServerConfiguration);
+            OAuthServerConfiguration serverConfig = mock(OAuthServerConfiguration.class);
+            lenient().when(serverConfig.isRestrictAssertionClaimsToConfiguredAttributes()).thenReturn(false);
+            oAuthServerConfiguration.when(OAuthServerConfiguration::getInstance).thenReturn(serverConfig);
+
+            JWTClaimsSet jwtClaimsSet = handler.handleCustomClaims(new JWTClaimsSet.Builder(), requestMsgCtx);
+            assertNotNull(jwtClaimsSet);
+            assertEquals(jwtClaimsSet.getClaim("country"), TestConstants.CLAIM_VALUE1,
+                    "Assertion claim must be propagated unfiltered when the config is disabled.");
+            assertEquals(jwtClaimsSet.getClaim(EMAIL), TestConstants.CLAIM_VALUE2);
         }
     }
 


### PR DESCRIPTION
## Purpose
In the JWT bearer grant, all assertion claims for a federated user are added to the JWT access token **without** applying the application's configured *Access Token Attributes* — so the configured claim list behaves as an on/off switch rather than an allow-list. See wso2/product-is#27611.

## Approach
Introduce `OAuth.OpenIDConnect.RestrictAssertionClaimsToConfiguredAttributes` (default **false**). When enabled, `JWTAccessTokenOIDCClaimsHandler` restricts the federated user's assertion claims to the application's configured access token attributes (returns a filtered copy). Default false preserves existing behaviour — fully backward compatible.

**Scope: the JWT access-token handler only.** The *Access Token Attributes* list is a claims-separation concept — it governs the access token only when access-token claims separation is enabled (which is exactly what routes the access token through `JWTAccessTokenOIDCClaimsHandler`). When claims separation is disabled, the access token (like the id_token) is governed by scopes, so there is no access-token-attribute contract to enforce; neither the access token nor the id_token is changed in that mode.

## Related Issues
- Fixes wso2/product-is#27611
- Config-mapping companion PR: wso2/carbon-identity-framework#8160

## Tests
- Unit: `JWTAccessTokenOIDCClaimsHandlerTest` — config off → unfiltered passthrough; config on → restricted to the configured attributes.
- Runtime: separation on + config on → access token restricted to the configured attributes; separation off → no change (config has no effect); id_token unchanged in every case.