### PR TITLE
Fix SQLException and incorrect tenant resolution in getLatestAccessTokens

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dao/AccessTokenDAOImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dao/AccessTokenDAOImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2025, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2017-2026, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -2976,14 +2976,19 @@ public class AccessTokenDAOImpl extends AbstractOAuthDAO implements AccessTokenD
         if (authzUser == null) {
             throw new IdentityOAuth2Exception("Invalid user information for given consumerKey: " + consumerKey);
         }
-        String tenantDomain = authzUser.getTenantDomain();
+        String tenantDomain = getUserResidentTenantDomain(authzUser);
         int tenantId = OAuth2Util.getTenantId(tenantDomain);
+        int appTenantId = OAuth2Util.getTenantId(getAppTenantDomain(consumerKey));
         boolean isUsernameCaseSensitive =
                 IdentityUtil.isUserStoreCaseSensitive(authzUser.getUserStoreDomain(), tenantId);
         String tenantAwareUsernameWithNoUserDomain = authzUser.getUserName();
         userStoreDomain = OAuth2Util.getSanitizedUserStoreDomain(userStoreDomain);
         String userDomain = OAuth2Util.getUserStoreDomain(authzUser);
         String authenticatedIDP = OAuth2Util.getAuthenticatedIDP(authzUser);
+        String authorizedOrganization = authzUser.getAccessingOrganization();
+        if (StringUtils.isBlank(authorizedOrganization)) {
+            authorizedOrganization = OAuthConstants.AuthorizedOrganization.NONE;
+        }
 
         Connection connection = IdentityDatabaseUtil.getDBConnection(false);
         PreparedStatement prepStmt = null;
@@ -3037,7 +3042,7 @@ public class AccessTokenDAOImpl extends AbstractOAuthDAO implements AccessTokenD
 
             prepStmt = connection.prepareStatement(sql);
             prepStmt.setString(1, getPersistenceProcessor().getProcessedClientId(consumerKey));
-            prepStmt.setInt(2, IdentityTenantUtil.getLoginTenantId());
+            prepStmt.setInt(2, appTenantId);
             if (isUsernameCaseSensitive) {
                 prepStmt.setString(3, tenantAwareUsernameWithNoUserDomain);
             } else {
@@ -3051,8 +3056,12 @@ public class AccessTokenDAOImpl extends AbstractOAuthDAO implements AccessTokenD
             }
 
             prepStmt.setString(7, tokenBindingReference);
-            prepStmt.setString(8, authenticatedIDP);
+            prepStmt.setString(8, authorizedOrganization);
 
+            prepStmt.setString(9, authenticatedIDP);
+
+            int idpTenantId = OAuth2Util.getIdpTenantId(authenticatedIDP, appTenantId, authzUser);
+            prepStmt.setInt(10, idpTenantId);
 
             resultSet = prepStmt.executeQuery();
             long latestIssuedTime = new Date().getTime();


### PR DESCRIPTION
### Purpose

Resolves https://github.com/wso2/product-is/issues/26992.

---
### Trigger Conditions

  - Old expired refresh token is presented after a new refresh token is issued for the same client/user/scope.
  - The internal token cleanup task is disabled, or the expired token has not yet been cleaned up by the scheduled task at the time of the request 

>  Note : To disable the token clean up task add the following to the `deployment.toml`
> ```
> [oauth.token_cleanup]
> enable = false
> ```

  
The response after the fix provided with this pr : 

```
400 - Bad Request
{
    "error_description": "Invalid refresh token value in the request",
    "error": "invalid_grant"
}
```

---
This PR contains two fixes to `getLatestAccessTokens()` in `AccessTokenDAOImpl.java`.

- **Fix 1: Missing prepared statement parameter bindings**

    - The SQL queries used in `getLatestAccessTokens()` contain `AUTHORIZED_ORGANIZATION = ? `(param 8) and IDP subquery parameters (params 9, 10). However, the prepared statement only bound params 1–7, with `authenticatedIDP` incorrectly set at index 8, causing:
    
           `java.sql.SQLException: No value specified for parameter 8/9`

   - This was introduced when `AUTHORIZED_ORGANIZATION` was added to the SQL queries but the parameter bindings in this method were not updated, unlike the singular `getLatestAccessToken()` which was correctly updated at the time. (Related PR: https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2187)
   - Provided Fix: 
        - Bind `AUTHORIZED_ORGANIZATION` as param 8 (defaulting to "NONE" for non-B2B flows), shift `authenticatedIDP` to the correct index 9 within the `isIDPIdColumnEnabled` block, and bind IDP tenant ID as param 10 — consistent with the singular `getLatestAccessToken()` implementation and applicable across all supported DB variants.


- **Fix 2: Incorrect tenant domain resolution for B2B flows**

  - The `TENANT_ID` filter (param 4) in `getLatestAccessTokens()` was derived from `authzUser.getTenantDomain()`. In B2B scenarios, `addOrganizationUserDetails` explicitly overrides `authzUser.setTenantDomain(appTenantDomain)` — meaning `authzUser.getTenantDomain()` holds the application's tenant, not the user's home tenant. The INSERT path stores `TENANT_ID` using `getUserResidentTenantDomain(authzUser)` (the user's home org tenant):


    ```
    // Token INSERT path
    String userTenantDomain = getUserResidentTenantDomain(accessTokenDO.getAuthzUser());
    int tenantId = OAuth2Util.getTenantId(userTenantDomain);
    prepStmt.setInt(4, tenantId);  // stores user's HOME tenant
    ```
- 
    - The singular `getLatestAccessToken()` correctly matches this by also using `getUserResidentTenantDomain`:


      ```
      String tenantDomain = getUserResidentTenantDomain(authzUser);          // user's HOME tenant → param 4
      String appTenantDomain = getAppTenantDomain(consumerKey);              // app tenant → params 2, 10
      int appTenantId = OAuth2Util.getTenantId(appTenantDomain);
      ```

- 
    - However, the plural method was using `authzUser.getTenantDomain()` (app's tenant in B2B) for the `TENANT_ID` filter — causing a mismatch with the stored value and returning zero rows for B2B users. Additionally, param 2 (`CONSUMER_APP_TENANT_ID`) was sourced from `IdentityTenantUtil.getLoginTenantId()` — a thread-local that can be stale in internal or async flows — rather than being derived directly from the authorized user.

    - Provided Fix: 
         - Align `getLatestAccessTokens()` with both the `INSERT` path and the singular method — use `getUserResidentTenantDomain(authzUser)` for `TENANT_ID` (param 4), and derive appTenantId from getAppTenantDomain(consumerKey) for the app-context lookups (params 2 and 10).