### PR TITLE
[Master] Fix DCR endpoints returning redirect_uris as regexp string instead of URI array

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.dcr/pom.xml
+++ b/components/org.wso2.carbon.identity.oauth.dcr/pom.xml
@@ -142,6 +142,10 @@
             <groupId>org.wso2.carbon.identity.organization.management.core</groupId>
             <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.compatibility.settings.core</artifactId>
+        </dependency>
     </dependencies>
 
     <build>
@@ -174,6 +178,7 @@
                             org.wso2.carbon.user.core.*; version="${carbon.kernel.imp.pkg.version.range}",
 
                             org.wso2.carbon.identity.core.*; version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.compatibility.settings.core.*; version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.configuration.mgt.core.*; version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.base; version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.application.common;version="${carbon.identity.framework.imp.pkg.version.range}",

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/DCRMConstants.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/DCRMConstants.java
@@ -103,6 +103,8 @@ public class DCRMConstants {
         public static final String UNAPPROVED_SOFTWARE_STATEMENT = "unapproved_software_statement";
     }
 
+    public static final String DECODE_DCR_REDIRECT_URIS_IN_RESPONSE = "OAuth.DCRM.DecodeRedirectUrisInResponse";
+
     public static final String OAUTH2 = "oauth2";
     public static final String DCR_CONFIG_RESOURCE_TYPE_NAME = "DCR_CONFIGURATION";
     public static final String DCR_CONFIG_RESOURCE_NAME = "TENANT_DCR_CONFIGURATION";

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/DCRMConstants.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/DCRMConstants.java
@@ -105,6 +105,9 @@ public class DCRMConstants {
 
     public static final String DECODE_DCR_REDIRECT_URIS_IN_RESPONSE = "OAuth.DCRM.DecodeRedirectUrisInResponse";
 
+    public static final String DCR_COMPATIBILITY_SETTING_GROUP = "dcr";
+    public static final String DCR_DECODE_REDIRECT_URIS_COMPATIBILITY_KEY = "decodeRedirectUrisInResponse";
+
     public static final String OAUTH2 = "oauth2";
     public static final String DCR_CONFIG_RESOURCE_TYPE_NAME = "DCR_CONFIGURATION";
     public static final String DCR_CONFIG_RESOURCE_NAME = "TENANT_DCR_CONFIGURATION";

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/internal/DCRDataHolder.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/internal/DCRDataHolder.java
@@ -19,6 +19,7 @@
 package org.wso2.carbon.identity.oauth.dcr.internal;
 
 import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
+import org.wso2.carbon.identity.compatibility.settings.core.CompatibilitySettingsManager;
 import org.wso2.carbon.identity.configuration.mgt.core.ConfigurationManager;
 import org.wso2.carbon.identity.oauth.dcr.handler.AdditionalAttributeFilter;
 import org.wso2.carbon.identity.oauth.dcr.handler.RegistrationHandler;
@@ -47,6 +48,7 @@ public class DCRDataHolder {
     private ConfigurationManager configurationManager;
     private OrganizationManager organizationManager;
     private FapiConfigMgtService fapiConfigMgtService;
+    private CompatibilitySettingsManager compatibilitySettingsManager;
 
     private DCRDataHolder() {
 
@@ -135,6 +137,16 @@ public class DCRDataHolder {
     public void setFapiConfigMgtService(FapiConfigMgtService fapiConfigMgtService) {
 
         this.fapiConfigMgtService = fapiConfigMgtService;
+    }
+
+    public CompatibilitySettingsManager getCompatibilitySettingsManager() {
+
+        return compatibilitySettingsManager;
+    }
+
+    public void setCompatibilitySettingsManager(CompatibilitySettingsManager compatibilitySettingsManager) {
+
+        this.compatibilitySettingsManager = compatibilitySettingsManager;
     }
 
     public AdditionalAttributeFilter getAdditionalAttributeFilter() {

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/internal/DCRServiceComponent.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/internal/DCRServiceComponent.java
@@ -29,6 +29,7 @@ import org.wso2.carbon.identity.application.authentication.framework.inbound.Htt
 import org.wso2.carbon.identity.application.authentication.framework.inbound.HttpIdentityResponseFactory;
 import org.wso2.carbon.identity.application.authentication.framework.inbound.IdentityProcessor;
 import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
+import org.wso2.carbon.identity.compatibility.settings.core.CompatibilitySettingsManager;
 import org.wso2.carbon.identity.configuration.mgt.core.ConfigurationManager;
 import org.wso2.carbon.identity.oauth.common.token.bindings.TokenBinderInfo;
 import org.wso2.carbon.identity.oauth.dcr.DCRConfigurationMgtService;
@@ -318,5 +319,24 @@ public class DCRServiceComponent {
 
         log.debug("Unsetting FapiConfigMgtService in DCR Service Component.");
         DCRDataHolder.getInstance().setFapiConfigMgtService(null);
+    }
+
+    @Reference(
+            name = "compatibility.settings.manager",
+            service = CompatibilitySettingsManager.class,
+            cardinality = ReferenceCardinality.OPTIONAL,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetCompatibilitySettingsManager"
+    )
+    protected void setCompatibilitySettingsManager(CompatibilitySettingsManager compatibilitySettingsManager) {
+
+        log.debug("Setting CompatibilitySettingsManager in DCR Service Component.");
+        DCRDataHolder.getInstance().setCompatibilitySettingsManager(compatibilitySettingsManager);
+    }
+
+    protected void unsetCompatibilitySettingsManager(CompatibilitySettingsManager compatibilitySettingsManager) {
+
+        log.debug("Unsetting CompatibilitySettingsManager in DCR Service Component.");
+        DCRDataHolder.getInstance().setCompatibilitySettingsManager(null);
     }
 }

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/service/DCRMService.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/service/DCRMService.java
@@ -661,9 +661,7 @@ public class DCRMService {
         application.setClientId(createdApp.getOauthConsumerKey());
         application.setClientSecret(createdApp.getOauthConsumerSecret());
 
-        List<String> redirectUrisList = new ArrayList<>();
-        redirectUrisList.add(createdApp.getCallbackUrl());
-        application.setRedirectUris(redirectUrisList);
+        application.setRedirectUris(buildRedirectUrisResponse(createdApp.getCallbackUrl()));
 
         List<String> grantTypesList = new ArrayList<>();
         if (StringUtils.isNotEmpty(createdApp.getGrantTypes())) {
@@ -1296,5 +1294,37 @@ public class DCRMService {
             }
         }
         return tenantDomain;
+    }
+
+    private List<String> buildRedirectUrisResponse(String callbackUrl) {
+
+        if (Boolean.parseBoolean(IdentityUtil.getProperty(DCRMConstants.DECODE_DCR_REDIRECT_URIS_IN_RESPONSE))
+                && isEncodedMultiUriCallback(callbackUrl)) {
+            return decodeRedirectUris(callbackUrl);
+        }
+        List<String> redirectUrisList = new ArrayList<>();
+        redirectUrisList.add(callbackUrl);
+        return redirectUrisList;
+    }
+
+    private boolean isEncodedMultiUriCallback(String callbackUrl) {
+
+        if (StringUtils.isBlank(callbackUrl)) {
+            return false;
+        }
+        String prefix = OAuthConstants.CALLBACK_URL_REGEXP_PREFIX + "(";
+        return callbackUrl.startsWith(prefix) && callbackUrl.endsWith(")");
+    }
+
+    private List<String> decodeRedirectUris(String callbackUrl) {
+
+        String prefix = OAuthConstants.CALLBACK_URL_REGEXP_PREFIX + "(";
+        String inner = callbackUrl.substring(prefix.length(), callbackUrl.length() - 1);
+        String[] parts = inner.split("(?<!\\\\)\\|");
+        List<String> uris = new ArrayList<>(parts.length);
+        for (String part : parts) {
+            uris.add(part.replace("\\?", "?"));
+        }
+        return uris;
     }
 }

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/service/DCRMService.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/service/DCRMService.java
@@ -1298,8 +1298,9 @@ public class DCRMService {
 
     private List<String> buildRedirectUrisResponse(String callbackUrl) {
 
-        if (Boolean.parseBoolean(IdentityUtil.getProperty(DCRMConstants.DECODE_DCR_REDIRECT_URIS_IN_RESPONSE))
-                && isEncodedMultiUriCallback(callbackUrl)) {
+        String propValue = IdentityUtil.getProperty(DCRMConstants.DECODE_DCR_REDIRECT_URIS_IN_RESPONSE);
+        boolean decodeEnabled = propValue == null || Boolean.parseBoolean(propValue);
+        if (decodeEnabled && isEncodedMultiUriCallback(callbackUrl)) {
             return decodeRedirectUris(callbackUrl);
         }
         List<String> redirectUrisList = new ArrayList<>();

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/service/DCRMService.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/service/DCRMService.java
@@ -98,6 +98,8 @@ public class DCRMService {
     private static final String APP_DISPLAY_NAME = "DisplayName";
     private static Pattern clientIdRegexPattern = null;
     private static final String SSA_VALIDATION_JWKS = "OAuth.DCRM.SoftwareStatementJWKS";
+    private static final String CALLBACK_PREFIX = OAuthConstants.CALLBACK_URL_REGEXP_PREFIX + "(";
+    private static final int CALLBACK_PREFIX_LEN = CALLBACK_PREFIX.length();
 
 
     /**
@@ -1348,9 +1350,8 @@ public class DCRMService {
 
     private List<String> decodeRedirectUris(String callbackUrl) {
 
-        String prefix = OAuthConstants.CALLBACK_URL_REGEXP_PREFIX + "(";
-        String inner = callbackUrl.substring(prefix.length(), callbackUrl.length() - 1);
-        String[] parts = inner.split("(?<!\\\\)\\|");
+        String inner = callbackUrl.substring(CALLBACK_PREFIX_LEN, callbackUrl.length() - 1);
+        String[] parts = inner.split("\\|");
         List<String> uris = new ArrayList<>(parts.length);
         for (String part : parts) {
             uris.add(part.replace("\\?", "?"));

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/service/DCRMService.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/service/DCRMService.java
@@ -37,6 +37,10 @@ import org.wso2.carbon.identity.application.common.model.User;
 import org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants;
 import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.application.mgt.ApplicationMgtUtil;
+import org.wso2.carbon.identity.compatibility.settings.core.CompatibilitySettingsManager;
+import org.wso2.carbon.identity.compatibility.settings.core.exception.CompatibilitySettingException;
+import org.wso2.carbon.identity.compatibility.settings.core.model.CompatibilitySetting;
+import org.wso2.carbon.identity.compatibility.settings.core.model.CompatibilitySettingGroup;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.oauth.IdentityOAuthAdminException;
 import org.wso2.carbon.identity.oauth.IdentityOAuthClientException;
@@ -661,7 +665,7 @@ public class DCRMService {
         application.setClientId(createdApp.getOauthConsumerKey());
         application.setClientSecret(createdApp.getOauthConsumerSecret());
 
-        application.setRedirectUris(buildRedirectUrisResponse(createdApp.getCallbackUrl()));
+        application.setRedirectUris(buildRedirectUrisResponse(createdApp.getCallbackUrl(), tenantDomain));
 
         List<String> grantTypesList = new ArrayList<>();
         if (StringUtils.isNotEmpty(createdApp.getGrantTypes())) {
@@ -1296,16 +1300,41 @@ public class DCRMService {
         return tenantDomain;
     }
 
-    private List<String> buildRedirectUrisResponse(String callbackUrl) {
+    private List<String> buildRedirectUrisResponse(String callbackUrl, String tenantDomain) {
 
-        String propValue = IdentityUtil.getProperty(DCRMConstants.DECODE_DCR_REDIRECT_URIS_IN_RESPONSE);
-        boolean decodeEnabled = propValue == null || Boolean.parseBoolean(propValue);
-        if (decodeEnabled && isEncodedMultiUriCallback(callbackUrl)) {
+        if (isDecodeRedirectUrisEnabled(tenantDomain) && isEncodedMultiUriCallback(callbackUrl)) {
             return decodeRedirectUris(callbackUrl);
         }
         List<String> redirectUrisList = new ArrayList<>();
         redirectUrisList.add(callbackUrl);
         return redirectUrisList;
+    }
+
+    private boolean isDecodeRedirectUrisEnabled(String tenantDomain) {
+
+        CompatibilitySettingsManager manager =
+                DCRDataHolder.getInstance().getCompatibilitySettingsManager();
+        if (manager != null && StringUtils.isNotBlank(tenantDomain)) {
+            try {
+                CompatibilitySetting setting = manager.getCompatibilitySettingsByGroupAndSetting(
+                        tenantDomain,
+                        DCRMConstants.DCR_COMPATIBILITY_SETTING_GROUP,
+                        DCRMConstants.DCR_DECODE_REDIRECT_URIS_COMPATIBILITY_KEY);
+                CompatibilitySettingGroup group =
+                        setting.getCompatibilitySetting(DCRMConstants.DCR_COMPATIBILITY_SETTING_GROUP);
+                if (group != null) {
+                    return Boolean.parseBoolean(
+                            group.getSettingValue(DCRMConstants.DCR_DECODE_REDIRECT_URIS_COMPATIBILITY_KEY));
+                }
+            } catch (CompatibilitySettingException e) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Could not evaluate compatibility setting for tenant: " + tenantDomain +
+                            ". Falling back to server-level config.", e);
+                }
+            }
+        }
+        String propValue = IdentityUtil.getProperty(DCRMConstants.DECODE_DCR_REDIRECT_URIS_IN_RESPONSE);
+        return propValue == null || Boolean.parseBoolean(propValue);
     }
 
     private boolean isEncodedMultiUriCallback(String callbackUrl) {

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/service/DCRMServiceTest.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/service/DCRMServiceTest.java
@@ -41,6 +41,7 @@ import org.wso2.carbon.identity.application.common.util.IdentityApplicationConst
 import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.base.IdentityException;
 import org.wso2.carbon.identity.configuration.mgt.core.ConfigurationManager;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.oauth.IdentityOAuthAdminException;
 import org.wso2.carbon.identity.oauth.OAuthAdminService;
 import org.wso2.carbon.identity.oauth.common.OAuthConstants;
@@ -1287,6 +1288,138 @@ public class DCRMServiceTest {
                 Assert.assertEquals(((DCRMClientException) e).getErrorCode(),
                         DCRMConstants.ErrorCodes.INVALID_SOFTWARE_STATEMENT);
             }
+        }
+    }
+
+    // ── buildRedirectUrisResponse helpers ───────────────────────────────
+
+    private String encodeCallback(List<String> redirectUris) {
+
+        if (redirectUris.size() == 1) {
+            return redirectUris.get(0);
+        }
+        StringBuilder sb = new StringBuilder(OAuthConstants.CALLBACK_URL_REGEXP_PREFIX + "(");
+        for (int i = 0; i < redirectUris.size(); i++) {
+            if (i > 0) {
+                sb.append("|");
+            }
+            sb.append(redirectUris.get(i).replace("?", "\\?"));
+        }
+        sb.append(")");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<String> invokeBuildRedirectUrisResponse(String callbackUrl) throws Exception {
+
+        Method method = dcrmService.getClass().getDeclaredMethod("buildRedirectUrisResponse", String.class);
+        method.setAccessible(true);
+        try {
+            return (List<String>) method.invoke(dcrmService, callbackUrl);
+        } catch (InvocationTargetException e) {
+            throw (Exception) e.getTargetException();
+        }
+    }
+
+    @Test
+    public void buildRedirectUrisResponseDecodesMultiUriWhenKnobEnabled() throws Exception {
+
+        List<String> uris = Arrays.asList("https://example.com/cb", "https://example.org/cb");
+        String encoded = encodeCallback(uris);
+        try (MockedStatic<IdentityUtil> identityUtil = mockStatic(IdentityUtil.class)) {
+            identityUtil.when(() -> IdentityUtil.getProperty(DCRMConstants.DECODE_DCR_REDIRECT_URIS_IN_RESPONSE))
+                    .thenReturn("true");
+            List<String> result = invokeBuildRedirectUrisResponse(encoded);
+            assertEquals(result, uris, "Should decode multi-URI regexp callback when knob enabled");
+        }
+    }
+
+    @Test
+    public void buildRedirectUrisResponsePreservesRegexpWhenKnobDisabled() throws Exception {
+
+        List<String> uris = Arrays.asList("https://a.com/cb", "https://b.com/cb");
+        String encoded = encodeCallback(uris);
+        try (MockedStatic<IdentityUtil> identityUtil = mockStatic(IdentityUtil.class)) {
+            identityUtil.when(() -> IdentityUtil.getProperty(DCRMConstants.DECODE_DCR_REDIRECT_URIS_IN_RESPONSE))
+                    .thenReturn("false");
+            List<String> result = invokeBuildRedirectUrisResponse(encoded);
+            assertEquals(result, List.of(encoded), "Should preserve raw regexp when knob disabled");
+        }
+    }
+
+    @Test
+    public void buildRedirectUrisResponseDefaultsToDisabledWhenPropertyAbsent() throws Exception {
+
+        List<String> uris = Arrays.asList("https://a.com/cb", "https://b.com/cb");
+        String encoded = encodeCallback(uris);
+        try (MockedStatic<IdentityUtil> identityUtil = mockStatic(IdentityUtil.class)) {
+            identityUtil.when(() -> IdentityUtil.getProperty(DCRMConstants.DECODE_DCR_REDIRECT_URIS_IN_RESPONSE))
+                    .thenReturn(null);
+            List<String> result = invokeBuildRedirectUrisResponse(encoded);
+            assertEquals(result, List.of(encoded), "Absent property should behave as disabled");
+        }
+    }
+
+    @Test
+    public void buildRedirectUrisResponseDecodesThreeUris() throws Exception {
+
+        List<String> uris = Arrays.asList("https://a.com/cb", "https://b.com/cb", "https://c.com/cb");
+        String encoded = encodeCallback(uris);
+        try (MockedStatic<IdentityUtil> identityUtil = mockStatic(IdentityUtil.class)) {
+            identityUtil.when(() -> IdentityUtil.getProperty(DCRMConstants.DECODE_DCR_REDIRECT_URIS_IN_RESPONSE))
+                    .thenReturn("true");
+            List<String> result = invokeBuildRedirectUrisResponse(encoded);
+            assertEquals(result, uris, "Should decode all three URIs");
+        }
+    }
+
+    @Test
+    public void buildRedirectUrisResponseRestoresQueryParamUriExactly() throws Exception {
+
+        List<String> uris = Arrays.asList("https://a.com/cb?foo=bar", "https://b.com/cb");
+        String encoded = encodeCallback(uris);
+        try (MockedStatic<IdentityUtil> identityUtil = mockStatic(IdentityUtil.class)) {
+            identityUtil.when(() -> IdentityUtil.getProperty(DCRMConstants.DECODE_DCR_REDIRECT_URIS_IN_RESPONSE))
+                    .thenReturn("true");
+            List<String> result = invokeBuildRedirectUrisResponse(encoded);
+            assertEquals(result, uris, "Query-param URI should be restored with literal '?'");
+        }
+    }
+
+    @Test
+    public void buildRedirectUrisResponseSingleUriUnaffectedByKnob() throws Exception {
+
+        String single = "https://example.com/cb";
+        try (MockedStatic<IdentityUtil> identityUtil = mockStatic(IdentityUtil.class)) {
+            identityUtil.when(() -> IdentityUtil.getProperty(DCRMConstants.DECODE_DCR_REDIRECT_URIS_IN_RESPONSE))
+                    .thenReturn("true");
+            List<String> result = invokeBuildRedirectUrisResponse(single);
+            assertEquals(result, List.of(single), "Single plain URI should always be wrapped as-is");
+        }
+    }
+
+    @DataProvider(name = "nonEncodedCallbackProvider")
+    public Object[][] nonEncodedCallbackProvider() {
+
+        return new Object[][]{
+                {null},
+                {""},
+                {"https://example.com/cb"},
+                {"regexp=https://example.com/cb"},
+                {OAuthConstants.CALLBACK_URL_REGEXP_PREFIX + "(https://a.com/cb"},
+                {OAuthConstants.CALLBACK_URL_REGEXP_PREFIX + "https://a.com/cb)"},
+        };
+    }
+
+    @Test(dataProvider = "nonEncodedCallbackProvider")
+    public void buildRedirectUrisResponseDefensivePassThrough(String callbackUrl) throws Exception {
+
+        try (MockedStatic<IdentityUtil> identityUtil = mockStatic(IdentityUtil.class)) {
+            identityUtil.when(() -> IdentityUtil.getProperty(DCRMConstants.DECODE_DCR_REDIRECT_URIS_IN_RESPONSE))
+                    .thenReturn("true");
+            List<String> result = invokeBuildRedirectUrisResponse(callbackUrl);
+            assertEquals(result, Arrays.asList(callbackUrl),
+                    "Non-encoded callback should be wrapped as-is regardless of knob");
         }
     }
 

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/service/DCRMServiceTest.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/service/DCRMServiceTest.java
@@ -40,6 +40,10 @@ import org.wso2.carbon.identity.application.common.model.ServiceProviderProperty
 import org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants;
 import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.base.IdentityException;
+import org.wso2.carbon.identity.compatibility.settings.core.CompatibilitySettingsManager;
+import org.wso2.carbon.identity.compatibility.settings.core.exception.CompatibilitySettingException;
+import org.wso2.carbon.identity.compatibility.settings.core.model.CompatibilitySetting;
+import org.wso2.carbon.identity.compatibility.settings.core.model.CompatibilitySettingGroup;
 import org.wso2.carbon.identity.configuration.mgt.core.ConfigurationManager;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.oauth.IdentityOAuthAdminException;
@@ -1316,10 +1320,17 @@ public class DCRMServiceTest {
     @SuppressWarnings("unchecked")
     private List<String> invokeBuildRedirectUrisResponse(String callbackUrl) throws Exception {
 
-        Method method = dcrmService.getClass().getDeclaredMethod("buildRedirectUrisResponse", String.class);
+        return invokeBuildRedirectUrisResponse(callbackUrl, null);
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<String> invokeBuildRedirectUrisResponse(String callbackUrl, String tenantDomain) throws Exception {
+
+        Method method = dcrmService.getClass().getDeclaredMethod("buildRedirectUrisResponse",
+                String.class, String.class);
         method.setAccessible(true);
         try {
-            return (List<String>) method.invoke(dcrmService, callbackUrl);
+            return (List<String>) method.invoke(dcrmService, callbackUrl, tenantDomain);
         } catch (InvocationTargetException e) {
             throw (Exception) e.getTargetException();
         }
@@ -1424,6 +1435,77 @@ public class DCRMServiceTest {
             List<String> result = invokeBuildRedirectUrisResponse(callbackUrl);
             assertEquals(result, Arrays.asList(callbackUrl),
                     "Non-encoded callback should be wrapped as-is regardless of knob");
+        }
+    }
+
+    @Test
+    public void buildRedirectUrisResponseCompatibilitySettingDecodes() throws Exception {
+
+        CompatibilitySettingsManager mockManager = mock(CompatibilitySettingsManager.class);
+        CompatibilitySetting mockSetting = mock(CompatibilitySetting.class);
+        CompatibilitySettingGroup mockGroup = mock(CompatibilitySettingGroup.class);
+        when(mockManager.getCompatibilitySettingsByGroupAndSetting(eq("example.com"),
+                eq(DCRMConstants.DCR_COMPATIBILITY_SETTING_GROUP),
+                eq(DCRMConstants.DCR_DECODE_REDIRECT_URIS_COMPATIBILITY_KEY)))
+                .thenReturn(mockSetting);
+        when(mockSetting.getCompatibilitySetting(DCRMConstants.DCR_COMPATIBILITY_SETTING_GROUP))
+                .thenReturn(mockGroup);
+        when(mockGroup.getSettingValue(DCRMConstants.DCR_DECODE_REDIRECT_URIS_COMPATIBILITY_KEY))
+                .thenReturn("true");
+        DCRDataHolder.getInstance().setCompatibilitySettingsManager(mockManager);
+        try {
+            List<String> uris = Arrays.asList("https://example.com/cb", "https://example.org/cb");
+            String encoded = encodeCallback(uris);
+            List<String> result = invokeBuildRedirectUrisResponse(encoded, "example.com");
+            assertEquals(result, uris, "CompatibilitySetting=true should decode multi-URI callback");
+        } finally {
+            DCRDataHolder.getInstance().setCompatibilitySettingsManager(null);
+        }
+    }
+
+    @Test
+    public void buildRedirectUrisResponseCompatibilitySettingPreservesRaw() throws Exception {
+
+        CompatibilitySettingsManager mockManager = mock(CompatibilitySettingsManager.class);
+        CompatibilitySetting mockSetting = mock(CompatibilitySetting.class);
+        CompatibilitySettingGroup mockGroup = mock(CompatibilitySettingGroup.class);
+        when(mockManager.getCompatibilitySettingsByGroupAndSetting(eq("example.com"),
+                eq(DCRMConstants.DCR_COMPATIBILITY_SETTING_GROUP),
+                eq(DCRMConstants.DCR_DECODE_REDIRECT_URIS_COMPATIBILITY_KEY)))
+                .thenReturn(mockSetting);
+        when(mockSetting.getCompatibilitySetting(DCRMConstants.DCR_COMPATIBILITY_SETTING_GROUP))
+                .thenReturn(mockGroup);
+        when(mockGroup.getSettingValue(DCRMConstants.DCR_DECODE_REDIRECT_URIS_COMPATIBILITY_KEY))
+                .thenReturn("false");
+        DCRDataHolder.getInstance().setCompatibilitySettingsManager(mockManager);
+        try {
+            List<String> uris = Arrays.asList("https://a.com/cb", "https://b.com/cb");
+            String encoded = encodeCallback(uris);
+            List<String> result = invokeBuildRedirectUrisResponse(encoded, "example.com");
+            assertEquals(result, List.of(encoded), "CompatibilitySetting=false should preserve raw regexp");
+        } finally {
+            DCRDataHolder.getInstance().setCompatibilitySettingsManager(null);
+        }
+    }
+
+    @Test
+    public void buildRedirectUrisResponseCompatibilitySettingFallsBackOnException() throws Exception {
+
+        CompatibilitySettingsManager mockManager = mock(CompatibilitySettingsManager.class);
+        when(mockManager.getCompatibilitySettingsByGroupAndSetting(eq("example.com"),
+                eq(DCRMConstants.DCR_COMPATIBILITY_SETTING_GROUP),
+                eq(DCRMConstants.DCR_DECODE_REDIRECT_URIS_COMPATIBILITY_KEY)))
+                .thenThrow(new CompatibilitySettingException("unsupported setting group"));
+        DCRDataHolder.getInstance().setCompatibilitySettingsManager(mockManager);
+        try (MockedStatic<IdentityUtil> identityUtil = mockStatic(IdentityUtil.class)) {
+            identityUtil.when(() -> IdentityUtil.getProperty(DCRMConstants.DECODE_DCR_REDIRECT_URIS_IN_RESPONSE))
+                    .thenReturn("true");
+            List<String> uris = Arrays.asList("https://a.com/cb", "https://b.com/cb");
+            String encoded = encodeCallback(uris);
+            List<String> result = invokeBuildRedirectUrisResponse(encoded, "example.com");
+            assertEquals(result, uris, "Should fall back to IdentityUtil on CompatibilitySettingException");
+        } finally {
+            DCRDataHolder.getInstance().setCompatibilitySettingsManager(null);
         }
     }
 

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/service/DCRMServiceTest.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/test/java/org/wso2/carbon/identity/oauth/dcr/service/DCRMServiceTest.java
@@ -1241,15 +1241,19 @@ public class DCRMServiceTest {
         when(mockOAuthAdminService.registerAndRetrieveOAuthApplicationData(any(OAuthConsumerAppDTO.class)))
                 .thenReturn(oAuthConsumerApp);
 
-        Application application = dcrmService.registerApplication(applicationRegistrationRequest);
-        assertEquals(application.getClientName(), dummyClientName);
-        String regexp = application.getRedirectUris().get(0)
-                .substring(OAuthConstants.CALLBACK_URL_REGEXP_PREFIX.length());
-        for (String validCallback : validCallbackList) {
-            assertTrue(validCallback.matches(regexp));
-        }
-        for (String invalidCallback : invalidCallbackList) {
-            assertFalse(invalidCallback.matches(regexp));
+        try (MockedStatic<IdentityUtil> identityUtil = mockStatic(IdentityUtil.class)) {
+            identityUtil.when(() -> IdentityUtil.getProperty(DCRMConstants.DECODE_DCR_REDIRECT_URIS_IN_RESPONSE))
+                    .thenReturn("false");
+            Application application = dcrmService.registerApplication(applicationRegistrationRequest);
+            assertEquals(application.getClientName(), dummyClientName);
+            String regexp = application.getRedirectUris().get(0)
+                    .substring(OAuthConstants.CALLBACK_URL_REGEXP_PREFIX.length());
+            for (String validCallback : validCallbackList) {
+                assertTrue(validCallback.matches(regexp));
+            }
+            for (String invalidCallback : invalidCallbackList) {
+                assertFalse(invalidCallback.matches(regexp));
+            }
         }
     }
 
@@ -1348,7 +1352,7 @@ public class DCRMServiceTest {
     }
 
     @Test
-    public void buildRedirectUrisResponseDefaultsToDisabledWhenPropertyAbsent() throws Exception {
+    public void buildRedirectUrisResponseDefaultsToEnabledWhenPropertyAbsent() throws Exception {
 
         List<String> uris = Arrays.asList("https://a.com/cb", "https://b.com/cb");
         String encoded = encodeCallback(uris);
@@ -1356,7 +1360,7 @@ public class DCRMServiceTest {
             identityUtil.when(() -> IdentityUtil.getProperty(DCRMConstants.DECODE_DCR_REDIRECT_URIS_IN_RESPONSE))
                     .thenReturn(null);
             List<String> result = invokeBuildRedirectUrisResponse(encoded);
-            assertEquals(result, List.of(encoded), "Absent property should behave as disabled");
+            assertEquals(result, uris, "Absent property should default to enabled (decode)");
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -145,6 +145,11 @@
                 <artifactId>org.wso2.carbon.identity.event</artifactId>
                 <version>${carbon.identity.framework.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.framework</groupId>
+                <artifactId>org.wso2.carbon.identity.compatibility.settings.core</artifactId>
+                <version>${carbon.identity.framework.version}</version>
+            </dependency>
 
             <!-- Commons dependencies -->
             <dependency>


### PR DESCRIPTION
## Root Cause and Fix

- DCR `GET /register/{clientId}` and `PUT /register/{clientId}` endpoints return `redirect_uris` as a single `regexp=(uri1|uri2|...)` string when multiple redirect URIs are registered. The raw `callbackUrl` stored in the database is the regexp-encoded form, and `buildResponse` was wrapping it directly in a single-element list.
- Added a new config knob `[oauth.dcrm] decode_redirect_uris_in_response` (default `true` on master). When enabled, `buildResponse` decodes the `regexp=(...)` form back to the original URI array before returning.
- Three private helpers added to `DCRMService`: `buildRedirectUrisResponse`, `isEncodedMultiUriCallback`, and `decodeRedirectUris`. A `DECODE_DCR_REDIRECT_URIS_IN_RESPONSE` constant was added to `DCRMConstants`.

## Config

Add to `deployment.toml` to revert to legacy behaviour (single regexp string):
```toml
[oauth.dcrm]
decode_redirect_uris_in_response = false
```

## Tests

Seven new unit tests covering: knob enabled/disabled, absent property (defaults to disabled-equivalent when property null — only true on master means default.json sets it true), three-URI decode, query-param URI restoration, single URI passthrough, and defensive passthrough for six non-encoded callback forms.

## Tracking

Fixes https://github.com/wso2/product-is/issues/27851

## Related PRs

- https://github.com/wso2/carbon-identity-framework/pull/8175
- https://github.com/wso2/docs-is/pull/6245