### PR TITLE
Fix duplicate access token claims causing DB constraint violation on migrated apps

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImpl.java
@@ -104,6 +104,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -3246,7 +3247,7 @@ public class OAuthAdminServiceImpl {
         ApplicationManagementService applicationMgtService = OAuth2ServiceComponentHolder
                 .getApplicationMgtService();
         try {
-            List<String> jwtAccessTokenClaims = new ArrayList<>();
+            Set<String> jwtAccessTokenClaims = new LinkedHashSet<>();
             ServiceProvider serviceProvider = applicationMgtService.getServiceProvider(oauthApp.getApplicationName(),
                     tenantDomain);
             if (serviceProvider != null) {


### PR DESCRIPTION
## Purpose

Fixes https://github.com/wso2/product-is/issues/27775

When an OIDC application migrated from IS 6.x (i.e. `SP_APP.VERSION = v1.0.0`) has duplicate entries in `requestedClaims` for the same local claim URI, the migration helper `OAuthAdminServiceImpl.addAccessTokenClaims` accumulated duplicate OIDC claim URIs into a `List<String>`. The subsequent batch-insert in the DAO then violated the `TOKEN_CLAIMS_CONSTRAINT` unique key on `IDN_OAUTH2_TOKEN_CLAIMS(APP_ID, CLAIM_URI)`, causing an HTTP 500 on every update to the OIDC inbound configuration of affected apps:

```
java.sql.BatchUpdateException: ... ERROR: duplicate key value violates unique constraint "token_claims_constraint"
  Detail: Key (app_id, claim_uri)=(243, street_address) already exists.
```

## Approach

Change the accumulator from `ArrayList` to `LinkedHashSet` so duplicate OIDC claim URIs are silently deduplicated while preserving insertion order. One-line data-structure change — no logic changes.

## Testing

- Created an OIDC app with `streetaddress` requested twice + `givenname` once in `requestedClaims`.
- Set `SP_APP.VERSION = v1.0.0` to simulate a pre-IS-7.1 migrated app.
- PUT the OIDC inbound config with `accessToken.type = JWT` → **HTTP 200** (was HTTP 500 before the fix).
- Verified `IDN_OAUTH2_TOKEN_CLAIMS` contains exactly one `street_address` and one `given_name` — no duplicates, no constraint violation.
