### PR TITLE
Fix Null pointer on disabled_response_types.

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpointTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/authz/OAuth2AuthzEndpointTest.java
@@ -114,6 +114,7 @@ import org.wso2.carbon.identity.oauth2.OAuth2Service;
 import org.wso2.carbon.identity.oauth2.OAuth2TokenValidationService;
 import org.wso2.carbon.identity.oauth2.authz.AuthorizationHandlerManager;
 import org.wso2.carbon.identity.oauth2.authz.OAuthAuthzReqMessageContext;
+import org.wso2.carbon.identity.oauth2.authz.handlers.ResponseTypeHandler;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2AuthorizeReqDTO;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2AuthorizeRespDTO;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2ClientValidationResponseDTO;
@@ -1358,6 +1359,197 @@ public class OAuth2AuthzEndpointTest extends TestOAuthEndpointBase {
         }
     }
 
+    /**
+     * Tests that an authorization request with a response type that has a validator configured but no
+     * ResponseTypeHandler registered is rejected. This exercises the new responseTypeHandler == null
+     * guard in CarbonOAuthAuthzRequest.initValidator().
+     */
+    @Test(groups = "testWithConnection")
+    public void testHandleOAuthAuthorizationRequestWithHandlerNotRegistered() throws Exception {
+
+        try (MockedStatic<OAuthServerConfiguration> oAuthServerConfiguration = mockStatic(
+                OAuthServerConfiguration.class)) {
+            mockOAuthServerConfiguration(oAuthServerConfiguration);
+            try (MockedStatic<FrameworkUtils> frameworkUtils = mockStatic(FrameworkUtils.class,
+                    Mockito.CALLS_REAL_METHODS);
+                 MockedStatic<IdentityTenantUtil> identityTenantUtil = mockStatic(IdentityTenantUtil.class);
+                 MockedStatic<LoggerUtils> loggerUtils = mockStatic(LoggerUtils.class);
+                 MockedStatic<CentralLogMgtServiceComponentHolder> centralLogMgtServiceComponentHolder =
+                         mockStatic(CentralLogMgtServiceComponentHolder.class);
+                 MockedStatic<OAuth2Util.OAuthURL> oAuthURL = mockStatic(OAuth2Util.OAuthURL.class);
+                 MockedStatic<ServiceURLBuilder> serviceURLBuilder = mockStatic(ServiceURLBuilder.class);
+                 MockedStatic<EndpointUtil> endpointUtil = mockStatic(EndpointUtil.class, Mockito.CALLS_REAL_METHODS);
+                 MockedStatic<OAuth2ServiceFactory> oAuth2ServiceFactory = mockStatic(OAuth2ServiceFactory.class);
+                 MockedStatic<AuthzUtil> authzUtil = mockStatic(AuthzUtil.class)) {
+
+                oAuth2ServiceFactory.when(OAuth2ServiceFactory::getOAuth2Service).thenReturn(oAuth2Service);
+                authzUtil.when(AuthzUtil::isLegacyAuthzRuntime).thenReturn(false);
+
+                Map<String, String[]> requestParams = new HashMap();
+                Map<String, Object> requestAttributes = new HashMap();
+
+                requestParams.put(CLIENT_ID, new String[]{CLIENT_ID_VALUE});
+                requestParams.put(OAuthConstants.SESSION_DATA_KEY_CONSENT, new String[]{null});
+                requestParams.put(FrameworkConstants.RequestParams.TO_COMMONAUTH, new String[]{"false"});
+                requestParams.put(REDIRECT_URI, new String[]{APP_REDIRECT_URL});
+                // Use TOKEN response type — validator will be present but handler will NOT be registered.
+                requestParams.put(OAuth.OAUTH_RESPONSE_TYPE, new String[]{ResponseType.TOKEN.toString()});
+                requestAttributes.put(FrameworkConstants.RequestParams.FLOW_STATUS,
+                        AuthenticatorFlowStatus.INCOMPLETE);
+                requestAttributes.put(FrameworkConstants.SESSION_DATA_KEY, null);
+
+                mockHttpRequest(requestParams, requestAttributes, HttpMethod.POST);
+
+                // Register TOKEN validator but intentionally omit the TOKEN handler.
+                Map<String, Class<? extends OAuthValidator<HttpServletRequest>>> responseTypeValidators =
+                        new Hashtable<>();
+                responseTypeValidators.put(ResponseType.CODE.toString(), CodeValidator.class);
+                responseTypeValidators.put(ResponseType.TOKEN.toString(), TokenValidator.class);
+                when(mockOAuthServerConfiguration.getSupportedResponseTypeValidators())
+                        .thenReturn(responseTypeValidators);
+
+                // Only CODE has a handler; TOKEN handler is missing → initValidator() must throw.
+                Map<String, ResponseTypeHandler> supportedResponseTypes = new HashMap<>();
+                supportedResponseTypes.put(ResponseType.CODE.toString(), mock(ResponseTypeHandler.class));
+                when(mockOAuthServerConfiguration.getSupportedResponseTypes()).thenReturn(supportedResponseTypes);
+
+                frameworkUtils.when(() -> FrameworkUtils.startTenantFlow(anyString())).thenAnswer(invocation -> null);
+                frameworkUtils.when(FrameworkUtils::endTenantFlow).thenAnswer(invocation -> null);
+                identityTenantUtil.when(() -> IdentityTenantUtil.getTenantDomain(anyInt()))
+                        .thenReturn(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+                identityTenantUtil.when(() -> IdentityTenantUtil.getTenantId(anyString()))
+                        .thenReturn(MultitenantConstants.SUPER_TENANT_ID);
+                loggerUtils.when(LoggerUtils::isDiagnosticLogsEnabled).thenReturn(true);
+
+                IdentityEventService eventServiceMock = mock(IdentityEventService.class);
+                centralLogMgtServiceComponentHolder.when(CentralLogMgtServiceComponentHolder::getInstance)
+                        .thenReturn(centralLogMgtServiceComponentHolderMock);
+                when(centralLogMgtServiceComponentHolderMock.getIdentityEventService()).thenReturn(eventServiceMock);
+                doNothing().when(eventServiceMock).handleEvent(any());
+
+                mockEndpointUtil(false, endpointUtil);
+                when(oAuth2Service.getOauthApplicationState(CLIENT_ID_VALUE)).thenReturn("ACTIVE");
+
+                oAuthURL.when(OAuth2Util.OAuthURL::getOAuth2ErrorPageUrl).thenReturn(ERROR_PAGE_URL);
+
+                OAuth2ClientValidationResponseDTO validationResponseDTO = new OAuth2ClientValidationResponseDTO();
+                validationResponseDTO.setValidClient(true);
+                validationResponseDTO.setCallbackURL(APP_REDIRECT_URL);
+                when(oAuth2Service.validateClientInfo(any())).thenReturn(validationResponseDTO);
+
+                mockServiceURLBuilder(serviceURLBuilder);
+
+                Response response;
+                try {
+                    response = oAuth2AuthzEndpoint.authorize(httpServletRequest, httpServletResponse);
+                } catch (InvalidRequestParentException ire) {
+                    InvalidRequestExceptionMapper invalidRequestExceptionMapper = new InvalidRequestExceptionMapper();
+                    response = invalidRequestExceptionMapper.toResponse(ire);
+                }
+
+                assertNotNull(response, "Response must not be null");
+                assertEquals(response.getStatus(), HttpServletResponse.SC_FOUND, "Unexpected HTTP response status");
+                String location = String.valueOf(response.getMetadata().get(HTTPConstants.HEADER_LOCATION).get(0));
+                assertTrue(location.contains(ERROR_PAGE_URL),
+                        "Expected redirect to error page when response type handler is not registered");
+            }
+        }
+    }
+
+    /**
+     * Tests that an authorization request with a response type that has neither a validator
+     * nor a ResponseTypeHandler registered is rejected.
+     */
+    @Test(groups = "testWithConnection")
+    public void testHandleOAuthAuthorizationRequestWithNoValidatorAndNoHandlerRegistered() throws Exception {
+
+        try (MockedStatic<OAuthServerConfiguration> oAuthServerConfiguration = mockStatic(
+                OAuthServerConfiguration.class)) {
+            mockOAuthServerConfiguration(oAuthServerConfiguration);
+            try (MockedStatic<FrameworkUtils> frameworkUtils = mockStatic(FrameworkUtils.class,
+                    Mockito.CALLS_REAL_METHODS);
+                 MockedStatic<IdentityTenantUtil> identityTenantUtil = mockStatic(IdentityTenantUtil.class);
+                 MockedStatic<LoggerUtils> loggerUtils = mockStatic(LoggerUtils.class);
+                 MockedStatic<CentralLogMgtServiceComponentHolder> centralLogMgtServiceComponentHolder =
+                         mockStatic(CentralLogMgtServiceComponentHolder.class);
+                 MockedStatic<OAuth2Util.OAuthURL> oAuthURL = mockStatic(OAuth2Util.OAuthURL.class);
+                 MockedStatic<ServiceURLBuilder> serviceURLBuilder = mockStatic(ServiceURLBuilder.class);
+                 MockedStatic<EndpointUtil> endpointUtil = mockStatic(EndpointUtil.class, Mockito.CALLS_REAL_METHODS);
+                 MockedStatic<OAuth2ServiceFactory> oAuth2ServiceFactory = mockStatic(OAuth2ServiceFactory.class);
+                 MockedStatic<AuthzUtil> authzUtil = mockStatic(AuthzUtil.class)) {
+
+                oAuth2ServiceFactory.when(OAuth2ServiceFactory::getOAuth2Service).thenReturn(oAuth2Service);
+                authzUtil.when(AuthzUtil::isLegacyAuthzRuntime).thenReturn(false);
+
+                Map<String, String[]> requestParams = new HashMap();
+                Map<String, Object> requestAttributes = new HashMap();
+
+                requestParams.put(CLIENT_ID, new String[]{CLIENT_ID_VALUE});
+                requestParams.put(OAuthConstants.SESSION_DATA_KEY_CONSENT, new String[]{null});
+                requestParams.put(FrameworkConstants.RequestParams.TO_COMMONAUTH, new String[]{"false"});
+                requestParams.put(REDIRECT_URI, new String[]{APP_REDIRECT_URL});
+                // Use an entirely unsupported response type with no validator or handler.
+                requestParams.put(OAuth.OAUTH_RESPONSE_TYPE, new String[]{"unsupported_type"});
+                requestAttributes.put(FrameworkConstants.RequestParams.FLOW_STATUS,
+                        AuthenticatorFlowStatus.INCOMPLETE);
+                requestAttributes.put(FrameworkConstants.SESSION_DATA_KEY, null);
+
+                mockHttpRequest(requestParams, requestAttributes, HttpMethod.POST);
+
+                // Neither validator nor handler registered for "unsupported_type".
+                Map<String, Class<? extends OAuthValidator<HttpServletRequest>>> responseTypeValidators =
+                        new Hashtable<>();
+                responseTypeValidators.put(ResponseType.CODE.toString(), CodeValidator.class);
+                when(mockOAuthServerConfiguration.getSupportedResponseTypeValidators())
+                        .thenReturn(responseTypeValidators);
+
+                Map<String, ResponseTypeHandler> supportedResponseTypes = new HashMap<>();
+                supportedResponseTypes.put(ResponseType.CODE.toString(), mock(ResponseTypeHandler.class));
+                when(mockOAuthServerConfiguration.getSupportedResponseTypes()).thenReturn(supportedResponseTypes);
+
+                frameworkUtils.when(() -> FrameworkUtils.startTenantFlow(anyString())).thenAnswer(invocation -> null);
+                frameworkUtils.when(FrameworkUtils::endTenantFlow).thenAnswer(invocation -> null);
+                identityTenantUtil.when(() -> IdentityTenantUtil.getTenantDomain(anyInt()))
+                        .thenReturn(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+                identityTenantUtil.when(() -> IdentityTenantUtil.getTenantId(anyString()))
+                        .thenReturn(MultitenantConstants.SUPER_TENANT_ID);
+                loggerUtils.when(LoggerUtils::isDiagnosticLogsEnabled).thenReturn(true);
+
+                IdentityEventService eventServiceMock = mock(IdentityEventService.class);
+                centralLogMgtServiceComponentHolder.when(CentralLogMgtServiceComponentHolder::getInstance)
+                        .thenReturn(centralLogMgtServiceComponentHolderMock);
+                when(centralLogMgtServiceComponentHolderMock.getIdentityEventService()).thenReturn(eventServiceMock);
+                doNothing().when(eventServiceMock).handleEvent(any());
+
+                mockEndpointUtil(false, endpointUtil);
+                when(oAuth2Service.getOauthApplicationState(CLIENT_ID_VALUE)).thenReturn("ACTIVE");
+
+                oAuthURL.when(OAuth2Util.OAuthURL::getOAuth2ErrorPageUrl).thenReturn(ERROR_PAGE_URL);
+
+                OAuth2ClientValidationResponseDTO validationResponseDTO = new OAuth2ClientValidationResponseDTO();
+                validationResponseDTO.setValidClient(true);
+                validationResponseDTO.setCallbackURL(APP_REDIRECT_URL);
+                when(oAuth2Service.validateClientInfo(any())).thenReturn(validationResponseDTO);
+
+                mockServiceURLBuilder(serviceURLBuilder);
+
+                Response response;
+                try {
+                    response = oAuth2AuthzEndpoint.authorize(httpServletRequest, httpServletResponse);
+                } catch (InvalidRequestParentException ire) {
+                    InvalidRequestExceptionMapper invalidRequestExceptionMapper = new InvalidRequestExceptionMapper();
+                    response = invalidRequestExceptionMapper.toResponse(ire);
+                }
+
+                assertNotNull(response, "Response must not be null");
+                assertEquals(response.getStatus(), HttpServletResponse.SC_FOUND, "Unexpected HTTP response status");
+                String location = String.valueOf(response.getMetadata().get(HTTPConstants.HEADER_LOCATION).get(0));
+                assertTrue(location.contains(ERROR_PAGE_URL),
+                        "Expected redirect to error page when response type is not registered");
+            }
+        }
+    }
+
     @DataProvider(name = "provideRequestParams")
     public Object[][] provideRequestParams() {
 
@@ -2190,6 +2382,11 @@ public class OAuth2AuthzEndpointTest extends TestOAuthEndpointBase {
                 invocation -> invocation.getArguments()[0]);
         when(mockOAuthServerConfiguration.getOAuthAuthzRequestClassName())
                 .thenReturn("org.wso2.carbon.identity.oauth2.model.CarbonOAuthAuthzRequest");
+
+        Map<String, ResponseTypeHandler> supportedResponseTypes = new HashMap<>();
+        supportedResponseTypes.put(ResponseType.CODE.toString(), mock(ResponseTypeHandler.class));
+        supportedResponseTypes.put(ResponseType.TOKEN.toString(), mock(ResponseTypeHandler.class));
+        when(mockOAuthServerConfiguration.getSupportedResponseTypes()).thenReturn(supportedResponseTypes);
     }
 
     private void mockServiceURLBuilder(MockedStatic<ServiceURLBuilder> serviceURLBuilder) throws URLBuilderException {

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/par/OAuth2ParEndpointTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/par/OAuth2ParEndpointTest.java
@@ -61,6 +61,7 @@ import org.wso2.carbon.identity.oauth.par.core.ParAuthServiceImpl;
 import org.wso2.carbon.identity.oauth.par.model.ParAuthData;
 import org.wso2.carbon.identity.oauth.tokenprocessor.TokenPersistenceProcessor;
 import org.wso2.carbon.identity.oauth2.OAuth2Service;
+import org.wso2.carbon.identity.oauth2.authz.handlers.ResponseTypeHandler;
 import org.wso2.carbon.identity.oauth2.bean.OAuthClientAuthnContext;
 import org.wso2.carbon.identity.oauth2.fapi.utils.FapiUtil;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
@@ -530,6 +531,11 @@ public class OAuth2ParEndpointTest extends TestOAuthEndpointBase {
         responseTypeValidators.put(OAuthConstants.CODE_IDTOKEN, CodeTokenResponseValidator.class);
         lenient().when(mockOAuthServerConfiguration.getSupportedResponseTypeValidators())
                 .thenReturn(responseTypeValidators);
+
+        Map<String, ResponseTypeHandler> supportedResponseTypes = new HashMap<>();
+        supportedResponseTypes.put(OAuthConstants.CODE, mock(ResponseTypeHandler.class));
+        supportedResponseTypes.put(OAuthConstants.CODE_IDTOKEN, mock(ResponseTypeHandler.class));
+        lenient().when(mockOAuthServerConfiguration.getSupportedResponseTypes()).thenReturn(supportedResponseTypes);
 
         lenient().when(mockOAuthServerConfiguration.getPersistenceProcessor()).thenReturn(tokenPersistenceProcessor);
         lenient().when(mockOAuthServerConfiguration.getClientSecretPersistenceProcessor())

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/util/AuthzUtilTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/util/AuthzUtilTest.java
@@ -125,6 +125,7 @@ import org.wso2.carbon.identity.oauth2.OAuth2TokenValidationService;
 import org.wso2.carbon.identity.oauth2.RequestObjectException;
 import org.wso2.carbon.identity.oauth2.authz.AuthorizationHandlerManager;
 import org.wso2.carbon.identity.oauth2.authz.OAuthAuthzReqMessageContext;
+import org.wso2.carbon.identity.oauth2.authz.handlers.ResponseTypeHandler;
 import org.wso2.carbon.identity.oauth2.device.cache.DeviceAuthorizationGrantCache;
 import org.wso2.carbon.identity.oauth2.device.cache.DeviceAuthorizationGrantCacheEntry;
 import org.wso2.carbon.identity.oauth2.device.cache.DeviceAuthorizationGrantCacheKey;
@@ -1724,6 +1725,16 @@ public class AuthzUtilTest extends TestOAuthEndpointBase {
                 invocation -> invocation.getArguments()[0]);
         when(mockOAuthServerConfiguration.getOAuthAuthzRequestClassName())
                 .thenReturn("org.wso2.carbon.identity.oauth2.model.CarbonOAuthAuthzRequest");
+
+        Map<String, ResponseTypeHandler> supportedResponseTypes = new HashMap<>();
+        supportedResponseTypes.put(ResponseType.CODE.toString(), mock(ResponseTypeHandler.class));
+        supportedResponseTypes.put(ResponseType.TOKEN.toString(), mock(ResponseTypeHandler.class));
+        supportedResponseTypes.put(OAuthConstants.ID_TOKEN, mock(ResponseTypeHandler.class));
+        supportedResponseTypes.put(OAuthConstants.IDTOKEN_TOKEN, mock(ResponseTypeHandler.class));
+        supportedResponseTypes.put(OAuthConstants.CODE_TOKEN, mock(ResponseTypeHandler.class));
+        supportedResponseTypes.put(OAuthConstants.CODE_IDTOKEN, mock(ResponseTypeHandler.class));
+        supportedResponseTypes.put(OAuthConstants.CODE_IDTOKEN_TOKEN, mock(ResponseTypeHandler.class));
+        when(mockOAuthServerConfiguration.getSupportedResponseTypes()).thenReturn(supportedResponseTypes);
     }
 
     @DataProvider(name = "provideFailedAuthenticationErrorInfo")

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/model/CarbonOAuthAuthzRequest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/model/CarbonOAuthAuthzRequest.java
@@ -30,6 +30,7 @@ import org.wso2.carbon.identity.central.log.mgt.utils.LogConstants;
 import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
 import org.wso2.carbon.identity.oauth.common.OAuthConstants;
 import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
+import org.wso2.carbon.identity.oauth2.authz.handlers.ResponseTypeHandler;
 import org.wso2.carbon.utils.DiagnosticLog;
 
 import javax.servlet.http.HttpServletRequest;
@@ -58,7 +59,14 @@ public class CarbonOAuthAuthzRequest extends OAuthAuthzRequest {
         Class<? extends OAuthValidator<HttpServletRequest>> clazz = OAuthServerConfiguration
                 .getInstance().getSupportedResponseTypeValidators().get(responseTypeValue);
 
-        if (clazz == null) {
+        // getSupportedResponseTypeValidators() is hardcoded, so any response types disabled via configuration
+        // are not reflected there. getSupportedResponseTypes() is dynamically populated at server startup and
+        // accurately reflects the current configuration. Therefore, supported response type validation must use
+        // getSupportedResponseTypes(), and unsupported response types must be rejected before authentication.
+        ResponseTypeHandler responseTypeHandler =
+                OAuthServerConfiguration.getInstance().getSupportedResponseTypes().get(responseTypeValue);
+
+        if (clazz == null || responseTypeHandler == null) {
             if (log.isDebugEnabled()) {
                 //Do not change this log format as these logs use by external applications
                 log.debug("Unsupported Response Type : " + responseTypeValue +


### PR DESCRIPTION
Fixes : https://github.com/wso2/product-is/issues/27034

This pull request enhances the test coverage and robustness of the OAuth2 authorization endpoint, specifically focusing on scenarios where response type validators and handlers may be missing or misconfigured. It also improves the accuracy of response type validation logic in the `CarbonOAuthAuthzRequest` class to ensure unsupported or misconfigured response types are correctly rejected before authentication.

**Test coverage improvements:**

* Added a test (`testHandleOAuthAuthorizationRequestWithHandlerNotRegistered`) to verify that an authorization request with a validator but without a registered `ResponseTypeHandler` is properly rejected, ensuring the new guard for null handlers in `initValidator()` is exercised.
* Added a test (`testHandleOAuthAuthorizationRequestWithNoValidatorAndNoHandlerRegistered`) to verify that an authorization request with neither a validator nor a handler is also rejected.

**Validation logic improvements:**

* Updated `CarbonOAuthAuthzRequest.initValidator()` to check both for the presence of a validator and a registered `ResponseTypeHandler`, rejecting unsupported response types before authentication. This ensures only response types correctly configured at server startup are accepted.

**Test setup consistency:**

* Updated the test mock setup to always register both `CODE` and `TOKEN` response type handlers by default, ensuring consistent test environments.

**Imports and dependencies:**

* Added missing imports for `ResponseTypeHandler` in both the main class and test class to support the new validation and test logic. [[1]](diffhunk://#diff-1172a5d982d509df8c84f7b2595af92e3d874d0e7c5c290b2b3d61003ba28741R117) [[2]](diffhunk://#diff-65edb92ab2c970b40773b6554ed55820e21d9210f1ce10cdb8790ef86c44fcebR33)