### PR TITLE
Resolve application from the hierarchy when the accessing org id is available

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/client/authentication/PublicClientAuthenticator.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/client/authentication/PublicClientAuthenticator.java
@@ -196,6 +196,11 @@ public class PublicClientAuthenticator extends AbstractOAuthClientAuthenticator 
                 return canBypassClientCredentialsForSharedApp(clientId, tenantDomain);
             }
         }
+        String accessingOrgId = PrivilegedCarbonContext.getThreadLocalCarbonContext()
+                .getAccessingOrganizationId();
+        if (StringUtils.isNotEmpty(accessingOrgId)) {
+            return OAuth2Util.getAppInformationFromOrgHierarchy(clientId, accessingOrgId).isBypassClientCredentials();
+        }
         return OAuth2Util.getAppInformationByClientId(clientId, tenantDomain).isBypassClientCredentials();
     }
 


### PR DESCRIPTION
### Proposed changes in this pull request

- $subject
- When a sub organization application is used as a public client and if we wait until the cache is cleared to execute the followup token call after the initial authorization call or initial token call, the app cannot be retrieved due to tenant domain mismatch. This change will fix that issue.