### PR TITLE
Fix redundant DB connection acquisition in refresh token

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dao/TokenManagementDAOImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dao/TokenManagementDAOImpl.java
@@ -63,7 +63,6 @@ import java.util.UUID;
 
 import static org.wso2.carbon.identity.oauth2.util.OAuth2Util.IS_EXTENDED_TOKEN;
 import static org.wso2.carbon.identity.oauth2.util.OAuth2Util.getUserResidentTenantDomain;
-import static org.wso2.carbon.identity.oauth2.util.OAuth2Util.isAccessTokenExtendedTableExist;
 
 /*
 NOTE
@@ -106,13 +105,14 @@ public class TokenManagementDAOImpl extends AbstractOAuthDAO implements TokenMan
         PreparedStatement prepStmt = null;
         ResultSet resultSet = null;
         String sql;
+        boolean isTokenExtendedTableExist = OAuth2ServiceComponentHolder.isTokenExtendedTableExist();
 
         try {
             String driverName = connection.getMetaData().getDriverName();
             boolean isMysqlOrMarinaDBOrH2 =
                     driverName.contains("MySQL") || driverName.contains("MariaDB") || driverName.contains("H2");
 
-            if (isAccessTokenExtendedTableExist()) {
+            if (isTokenExtendedTableExist) {
                 if (isMysqlOrMarinaDBOrH2) {
                     sql = SQLQueries.RETRIEVE_ACCESS_TOKEN_VALIDATION_DATA_WITH_EXTENDED_ATTRIBUTES_CONSENTED_MYSQL;
                 } else if (connection.getMetaData().getDatabaseProductName().contains("DB2")) {
@@ -195,7 +195,7 @@ public class TokenManagementDAOImpl extends AbstractOAuthDAO implements TokenMan
                     AuthenticatedUser user = OAuth2Util.createAuthenticatedUser(userName, userDomain, tenantDomain,
                             authenticatedIDP);
                     user.setAuthenticatedSubjectIdentifier(subjectIdentifier);
-                    if (isAccessTokenExtendedTableExist() && resultSet.getString(17) != null &&
+                    if (isTokenExtendedTableExist && resultSet.getString(17) != null &&
                             resultSet.getString(18) != null) {
                         extendedParams.put(resultSet.getString(17), resultSet.getString(18));
                     }
@@ -222,7 +222,7 @@ public class TokenManagementDAOImpl extends AbstractOAuthDAO implements TokenMan
                             !validationDataDO.getScope()[0].equals(resultSet.getString(5))) {
                         scopes.add(resultSet.getString(5));
                     }
-                    if (isAccessTokenExtendedTableExist() && resultSet.getString(17) != null &&
+                    if (isTokenExtendedTableExist && resultSet.getString(17) != null &&
                             resultSet.getString(18) != null) {
                         extendedParams.put(resultSet.getString(17), resultSet.getString(18));
                     }


### PR DESCRIPTION

  ### Proposed changes in this pull request

  Addresses connection-pool exhaustion caused by a single thread holding two DB
  connections at once (see wso2/product-is#25493). When a method already holds an
  open connection and then calls a helper that internally opens *another*
  connection just to read DB metadata, both are held simultaneously — under load
  this can exhaust the pool.

  This PR removes three such redundant second-connection acquisitions:

  1. **`TokenManagementDAOImpl.validateRefreshToken`** — replaced the
     `OAuth2Util.isAccessTokenExtendedTableExist()` calls (each runs a fresh
     `IdentityDatabaseUtil.isTableExists()` lookup on a new connection, two of
     them *inside the result-set loop* → once per row) with the value already
     cached at startup via `OAuth2ServiceComponentHolder.isTokenExtendedTableExist()`,
     read once into a local variable. Same table (`IDN_OAUTH2_ACCESS_TOKEN_ATTRIBUTES`),
     no behavioural change.


Issues related
- https://github.com/wso2/product-is/issues/25493

