### PR TITLE
Create the agent configuration resource type on demand

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/agent/services/AgentConfigMgtServiceImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/agent/services/AgentConfigMgtServiceImpl.java
@@ -23,6 +23,7 @@ import org.wso2.carbon.identity.configuration.mgt.core.ConfigurationManager;
 import org.wso2.carbon.identity.configuration.mgt.core.exception.ConfigurationManagementException;
 import org.wso2.carbon.identity.configuration.mgt.core.model.Resource;
 import org.wso2.carbon.identity.configuration.mgt.core.model.ResourceAdd;
+import org.wso2.carbon.identity.configuration.mgt.core.model.ResourceTypeAdd;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.oauth2.agent.cache.AgentConfigCache;
 import org.wso2.carbon.identity.oauth2.agent.cache.AgentConfigCacheEntry;
@@ -34,7 +35,9 @@ import org.wso2.carbon.identity.oauth2.agent.utils.Util;
 import org.wso2.carbon.identity.oauth2.internal.OAuth2ServiceComponentHolder;
 
 import static org.wso2.carbon.identity.configuration.mgt.core.constant.ConfigurationConstants.ErrorMessages.ERROR_CODE_RESOURCE_DOES_NOT_EXISTS;
+import static org.wso2.carbon.identity.configuration.mgt.core.constant.ConfigurationConstants.ErrorMessages.ERROR_CODE_RESOURCE_TYPE_DOES_NOT_EXISTS;
 import static org.wso2.carbon.identity.oauth2.agent.utils.Constants.AGENT_RESOURCE_NAME;
+import static org.wso2.carbon.identity.oauth2.agent.utils.Constants.AGENT_RESOURCE_TYPE_DESCRIPTION;
 import static org.wso2.carbon.identity.oauth2.agent.utils.Constants.AGENT_RESOURCE_TYPE_NAME;
 import static org.wso2.carbon.identity.oauth2.agent.utils.Util.handleClientException;
 import static org.wso2.carbon.identity.oauth2.agent.utils.Util.handleServerException;
@@ -86,7 +89,7 @@ public class AgentConfigMgtServiceImpl implements AgentConfigMgtService {
         validateTenantDomain(tenantDomain);
         try {
             ResourceAdd resourceAdd = Util.parseConfig(agentConfig);
-            getConfigurationManager().replaceResource(AGENT_RESOURCE_TYPE_NAME, resourceAdd);
+            replaceResource(resourceAdd);
             clearAgentConfigCache(tenantDomain);
         } catch (ConfigurationManagementException e) {
             throw handleServerException(ErrorMessage.ERROR_CODE_AGENT_CONFIG_UPDATE, e, tenantDomain);
@@ -156,11 +159,45 @@ public class AgentConfigMgtServiceImpl implements AgentConfigMgtService {
             }
             return null;
         } catch (ConfigurationManagementException e) {
-            if (ERROR_CODE_RESOURCE_DOES_NOT_EXISTS.getCode().equals(e.getErrorCode())) {
+            if (ERROR_CODE_RESOURCE_DOES_NOT_EXISTS.getCode().equals(e.getErrorCode()) ||
+                    ERROR_CODE_RESOURCE_TYPE_DOES_NOT_EXISTS.getCode().equals(e.getErrorCode())) {
                 return null;
             }
             throw e;
         }
+    }
+
+    /**
+     * Persists the agent configuration resource, creating the resource type on demand if it does not yet exist.
+     *
+     * @param resourceAdd The resource to persist.
+     * @throws ConfigurationManagementException If there is an error in the configuration management process.
+     */
+    private void replaceResource(ResourceAdd resourceAdd) throws ConfigurationManagementException {
+
+        try {
+            getConfigurationManager().replaceResource(AGENT_RESOURCE_TYPE_NAME, resourceAdd);
+        } catch (ConfigurationManagementException e) {
+            if (ERROR_CODE_RESOURCE_TYPE_DOES_NOT_EXISTS.getCode().equals(e.getErrorCode())) {
+                createResourceType();
+                getConfigurationManager().replaceResource(AGENT_RESOURCE_TYPE_NAME, resourceAdd);
+                return;
+            }
+            throw e;
+        }
+    }
+
+    /**
+     * Creates the agent configuration resource type.
+     *
+     * @throws ConfigurationManagementException If there is an error in creating the resource type.
+     */
+    private void createResourceType() throws ConfigurationManagementException {
+
+        ResourceTypeAdd resourceType = new ResourceTypeAdd();
+        resourceType.setName(AGENT_RESOURCE_TYPE_NAME);
+        resourceType.setDescription(AGENT_RESOURCE_TYPE_DESCRIPTION);
+        getConfigurationManager().addResourceType(resourceType);
     }
 
     private AgentConfig getAgentConfigFromCache(String tenantDomain) {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/agent/services/AgentConfigMgtServiceImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/agent/services/AgentConfigMgtServiceImpl.java
@@ -35,6 +35,7 @@ import org.wso2.carbon.identity.oauth2.agent.utils.Util;
 import org.wso2.carbon.identity.oauth2.internal.OAuth2ServiceComponentHolder;
 
 import static org.wso2.carbon.identity.configuration.mgt.core.constant.ConfigurationConstants.ErrorMessages.ERROR_CODE_RESOURCE_DOES_NOT_EXISTS;
+import static org.wso2.carbon.identity.configuration.mgt.core.constant.ConfigurationConstants.ErrorMessages.ERROR_CODE_RESOURCE_TYPE_ALREADY_EXISTS;
 import static org.wso2.carbon.identity.configuration.mgt.core.constant.ConfigurationConstants.ErrorMessages.ERROR_CODE_RESOURCE_TYPE_DOES_NOT_EXISTS;
 import static org.wso2.carbon.identity.oauth2.agent.utils.Constants.AGENT_RESOURCE_NAME;
 import static org.wso2.carbon.identity.oauth2.agent.utils.Constants.AGENT_RESOURCE_TYPE_DESCRIPTION;
@@ -194,10 +195,16 @@ public class AgentConfigMgtServiceImpl implements AgentConfigMgtService {
      */
     private void createResourceType() throws ConfigurationManagementException {
 
-        ResourceTypeAdd resourceType = new ResourceTypeAdd();
-        resourceType.setName(AGENT_RESOURCE_TYPE_NAME);
-        resourceType.setDescription(AGENT_RESOURCE_TYPE_DESCRIPTION);
-        getConfigurationManager().addResourceType(resourceType);
+        try {
+            ResourceTypeAdd resourceType = new ResourceTypeAdd();
+            resourceType.setName(AGENT_RESOURCE_TYPE_NAME);
+            resourceType.setDescription(AGENT_RESOURCE_TYPE_DESCRIPTION);
+            getConfigurationManager().addResourceType(resourceType);
+        } catch (ConfigurationManagementException e) {
+            if (!ERROR_CODE_RESOURCE_TYPE_ALREADY_EXISTS.getCode().equals(e.getErrorCode())) {
+                throw e;
+            }
+        }
     }
 
     private AgentConfig getAgentConfigFromCache(String tenantDomain) {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/agent/services/AgentConfigMgtServiceImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/agent/services/AgentConfigMgtServiceImpl.java
@@ -160,8 +160,7 @@ public class AgentConfigMgtServiceImpl implements AgentConfigMgtService {
             }
             return null;
         } catch (ConfigurationManagementException e) {
-            if (ERROR_CODE_RESOURCE_DOES_NOT_EXISTS.getCode().equals(e.getErrorCode()) ||
-                    ERROR_CODE_RESOURCE_TYPE_DOES_NOT_EXISTS.getCode().equals(e.getErrorCode())) {
+            if (isResourceNotFound(e) || isResourceTypeNotFound(e)) {
                 return null;
             }
             throw e;
@@ -179,7 +178,7 @@ public class AgentConfigMgtServiceImpl implements AgentConfigMgtService {
         try {
             getConfigurationManager().replaceResource(AGENT_RESOURCE_TYPE_NAME, resourceAdd);
         } catch (ConfigurationManagementException e) {
-            if (ERROR_CODE_RESOURCE_TYPE_DOES_NOT_EXISTS.getCode().equals(e.getErrorCode())) {
+            if (isResourceTypeNotFound(e)) {
                 createResourceType();
                 getConfigurationManager().replaceResource(AGENT_RESOURCE_TYPE_NAME, resourceAdd);
                 return;
@@ -201,7 +200,7 @@ public class AgentConfigMgtServiceImpl implements AgentConfigMgtService {
             resourceType.setDescription(AGENT_RESOURCE_TYPE_DESCRIPTION);
             getConfigurationManager().addResourceType(resourceType);
         } catch (ConfigurationManagementException e) {
-            if (!ERROR_CODE_RESOURCE_TYPE_ALREADY_EXISTS.getCode().equals(e.getErrorCode())) {
+            if (!isResourceTypeAlreadyExists(e)) {
                 throw e;
             }
         }
@@ -228,5 +227,20 @@ public class AgentConfigMgtServiceImpl implements AgentConfigMgtService {
 
         AgentConfigCacheKey cacheKey = new AgentConfigCacheKey(tenantDomain);
         AgentConfigCache.getInstance().clearCacheEntry(cacheKey, tenantDomain);
+    }
+
+    private boolean isResourceNotFound(ConfigurationManagementException e) {
+
+        return ERROR_CODE_RESOURCE_DOES_NOT_EXISTS.getCode().equals(e.getErrorCode());
+    }
+
+    private boolean isResourceTypeNotFound(ConfigurationManagementException e) {
+
+        return ERROR_CODE_RESOURCE_TYPE_DOES_NOT_EXISTS.getCode().equals(e.getErrorCode());
+    }
+
+    private boolean isResourceTypeAlreadyExists(ConfigurationManagementException e) {
+
+        return ERROR_CODE_RESOURCE_TYPE_ALREADY_EXISTS.getCode().equals(e.getErrorCode());
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/agent/utils/Constants.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/agent/utils/Constants.java
@@ -24,6 +24,8 @@ package org.wso2.carbon.identity.oauth2.agent.utils;
 public class Constants {
 
     public static final String AGENT_RESOURCE_TYPE_NAME = "AGENT_CONFIGURATION";
+    public static final String AGENT_RESOURCE_TYPE_DESCRIPTION = "A resource type to keep the tenant agent " +
+            "configurations.";
     public static final String AGENT_RESOURCE_NAME = "TENANT_AGENT_CONFIGURATION";
     public static final String AGENTS_EXTERNALLY_MANAGED = "agentsExternallyManaged";
 }

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/agent/services/AgentConfigMgtServiceImplTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/agent/services/AgentConfigMgtServiceImplTest.java
@@ -26,6 +26,7 @@ import org.wso2.carbon.identity.configuration.mgt.core.exception.ConfigurationMa
 import org.wso2.carbon.identity.configuration.mgt.core.model.Attribute;
 import org.wso2.carbon.identity.configuration.mgt.core.model.Resource;
 import org.wso2.carbon.identity.configuration.mgt.core.model.ResourceAdd;
+import org.wso2.carbon.identity.configuration.mgt.core.model.ResourceTypeAdd;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.oauth2.agent.cache.AgentConfigCache;
 import org.wso2.carbon.identity.oauth2.agent.cache.AgentConfigCacheEntry;
@@ -51,6 +52,8 @@ import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 import static org.wso2.carbon.identity.configuration.mgt.core.constant.ConfigurationConstants.ErrorMessages.ERROR_CODE_RESOURCE_DOES_NOT_EXISTS;
+import static org.wso2.carbon.identity.configuration.mgt.core.constant.ConfigurationConstants.ErrorMessages.ERROR_CODE_RESOURCE_TYPE_ALREADY_EXISTS;
+import static org.wso2.carbon.identity.configuration.mgt.core.constant.ConfigurationConstants.ErrorMessages.ERROR_CODE_RESOURCE_TYPE_DOES_NOT_EXISTS;
 import static org.wso2.carbon.identity.oauth2.agent.utils.Constants.AGENTS_EXTERNALLY_MANAGED;
 import static org.wso2.carbon.identity.oauth2.agent.utils.Constants.AGENT_RESOURCE_NAME;
 import static org.wso2.carbon.identity.oauth2.agent.utils.Constants.AGENT_RESOURCE_TYPE_NAME;
@@ -219,6 +222,115 @@ public class AgentConfigMgtServiceImplTest {
             fail("Expected AgentConfigMgtServerException.");
         } catch (AgentConfigMgtException e) {
             assertTrue(e instanceof AgentConfigMgtServerException);
+        }
+    }
+
+    @Test
+    public void testSetAgentConfigCreatesResourceTypeOnDemand() throws Exception {
+
+        try (MockedStatic<IdentityTenantUtil> tenantUtil = mockStatic(IdentityTenantUtil.class);
+             MockedStatic<AgentConfigCache> cacheStatic = mockStatic(AgentConfigCache.class);
+             MockedStatic<OAuth2ServiceComponentHolder> holderStatic =
+                     mockStatic(OAuth2ServiceComponentHolder.class)) {
+
+            tenantUtil.when(() -> IdentityTenantUtil.getTenantId(TENANT_DOMAIN)).thenReturn(-1234);
+            AgentConfigCache cache = mock(AgentConfigCache.class);
+            cacheStatic.when(AgentConfigCache::getInstance).thenReturn(cache);
+            ConfigurationManager configurationManager = mock(ConfigurationManager.class);
+            mockHolder(holderStatic, configurationManager);
+            // The first write fails because the resource type is not registered; the retry succeeds.
+            when(configurationManager.replaceResource(eq(AGENT_RESOURCE_TYPE_NAME), any(ResourceAdd.class)))
+                    .thenThrow(new ConfigurationManagementException("no type",
+                            ERROR_CODE_RESOURCE_TYPE_DOES_NOT_EXISTS.getCode()))
+                    .thenReturn(new Resource());
+
+            service.setAgentConfig(new AgentConfig(), TENANT_DOMAIN);
+
+            verify(configurationManager).addResourceType(any(ResourceTypeAdd.class));
+            verify(configurationManager, times(2))
+                    .replaceResource(eq(AGENT_RESOURCE_TYPE_NAME), any(ResourceAdd.class));
+            verify(cache).clearCacheEntry(any(AgentConfigCacheKey.class), eq(TENANT_DOMAIN));
+        }
+    }
+
+    @Test
+    public void testSetAgentConfigWhenResourceTypeCreatedConcurrently() throws Exception {
+
+        try (MockedStatic<IdentityTenantUtil> tenantUtil = mockStatic(IdentityTenantUtil.class);
+             MockedStatic<AgentConfigCache> cacheStatic = mockStatic(AgentConfigCache.class);
+             MockedStatic<OAuth2ServiceComponentHolder> holderStatic =
+                     mockStatic(OAuth2ServiceComponentHolder.class)) {
+
+            tenantUtil.when(() -> IdentityTenantUtil.getTenantId(TENANT_DOMAIN)).thenReturn(-1234);
+            AgentConfigCache cache = mock(AgentConfigCache.class);
+            cacheStatic.when(AgentConfigCache::getInstance).thenReturn(cache);
+            ConfigurationManager configurationManager = mock(ConfigurationManager.class);
+            mockHolder(holderStatic, configurationManager);
+            when(configurationManager.replaceResource(eq(AGENT_RESOURCE_TYPE_NAME), any(ResourceAdd.class)))
+                    .thenThrow(new ConfigurationManagementException("no type",
+                            ERROR_CODE_RESOURCE_TYPE_DOES_NOT_EXISTS.getCode()))
+                    .thenReturn(new Resource());
+            // A concurrent writer already created the type; this is treated as success.
+            when(configurationManager.addResourceType(any(ResourceTypeAdd.class)))
+                    .thenThrow(new ConfigurationManagementException("exists",
+                            ERROR_CODE_RESOURCE_TYPE_ALREADY_EXISTS.getCode()));
+
+            service.setAgentConfig(new AgentConfig(), TENANT_DOMAIN);
+
+            verify(configurationManager, times(2))
+                    .replaceResource(eq(AGENT_RESOURCE_TYPE_NAME), any(ResourceAdd.class));
+            verify(cache).clearCacheEntry(any(AgentConfigCacheKey.class), eq(TENANT_DOMAIN));
+        }
+    }
+
+    @Test
+    public void testSetAgentConfigWrapsResourceTypeCreationFailure() throws Exception {
+
+        try (MockedStatic<IdentityTenantUtil> tenantUtil = mockStatic(IdentityTenantUtil.class);
+             MockedStatic<AgentConfigCache> cacheStatic = mockStatic(AgentConfigCache.class);
+             MockedStatic<OAuth2ServiceComponentHolder> holderStatic =
+                     mockStatic(OAuth2ServiceComponentHolder.class)) {
+
+            tenantUtil.when(() -> IdentityTenantUtil.getTenantId(TENANT_DOMAIN)).thenReturn(-1234);
+            cacheStatic.when(AgentConfigCache::getInstance).thenReturn(mock(AgentConfigCache.class));
+            ConfigurationManager configurationManager = mock(ConfigurationManager.class);
+            mockHolder(holderStatic, configurationManager);
+            when(configurationManager.replaceResource(eq(AGENT_RESOURCE_TYPE_NAME), any(ResourceAdd.class)))
+                    .thenThrow(new ConfigurationManagementException("no type",
+                            ERROR_CODE_RESOURCE_TYPE_DOES_NOT_EXISTS.getCode()));
+            // Resource type creation fails for a reason other than "already exists" and must propagate.
+            when(configurationManager.addResourceType(any(ResourceTypeAdd.class)))
+                    .thenThrow(new ConfigurationManagementException("boom", "OTHER-ERROR"));
+
+            service.setAgentConfig(new AgentConfig(), TENANT_DOMAIN);
+            fail("Expected AgentConfigMgtServerException.");
+        } catch (AgentConfigMgtException e) {
+            assertTrue(e instanceof AgentConfigMgtServerException);
+        }
+    }
+
+    @Test
+    public void testGetAgentConfigReturnsDefaultWhenResourceTypeMissing() throws Exception {
+
+        try (MockedStatic<AgentConfigCache> cacheStatic = mockStatic(AgentConfigCache.class);
+             MockedStatic<OAuth2ServiceComponentHolder> holderStatic =
+                     mockStatic(OAuth2ServiceComponentHolder.class)) {
+
+            AgentConfigCache cache = mock(AgentConfigCache.class);
+            cacheStatic.when(AgentConfigCache::getInstance).thenReturn(cache);
+            when(cache.getValueFromCache(any(AgentConfigCacheKey.class), eq(TENANT_DOMAIN))).thenReturn(null);
+
+            ConfigurationManager configurationManager = mock(ConfigurationManager.class);
+            mockHolder(holderStatic, configurationManager);
+            // A "resource type does not exist" error also maps to the default configuration.
+            when(configurationManager.getResource(AGENT_RESOURCE_TYPE_NAME, AGENT_RESOURCE_NAME, true))
+                    .thenThrow(new ConfigurationManagementException("no type",
+                            ERROR_CODE_RESOURCE_TYPE_DOES_NOT_EXISTS.getCode()));
+
+            AgentConfig result = service.getAgentConfig(TENANT_DOMAIN);
+
+            assertNotNull(result);
+            assertFalse(result.isAgentsExternallyManaged());
         }
     }
 


### PR DESCRIPTION
### Purpose                                                                                                                                                                                                                            
                                                                                                                                                                                                                                         
  `AgentConfigMgtServiceImpl` assumed the `AGENT_CONFIGURATION` configuration resource type already existed in the database. On existing deployments that upgrade without re-running the full DB init script, that type is absent, so setting/reading/deleting the agent configuration fails. This change makes the service self-sufficient so users are not forced to apply a manual DB change.                                                                                                                                                           

Related to: https://github.com/wso2/product-is/issues/28110                                                                                                                                                                 
                                                                                                                                                                                                                                         
  ### Changes                                                                                                                                                                                                                            
                                                                                                                                                                                                                                         
  - **Write (`setAgentConfig`):** if `replaceResource` fails with `ERROR_CODE_RESOURCE_TYPE_DOES_NOT_EXISTS`, create the resource type via `addResourceType` and retry the write.                                                                                                                                                                                                                 
  - **Read/Delete (`getResource` helper):** treat both `ERROR_CODE_RESOURCE_DOES_NOT_EXISTS` and `ERROR_CODE_RESOURCE_TYPE_DOES_NOT_EXISTS` as "no configuration" so that reads fall back to the default config and deletes become a clean no-op when the type has never been created.                                                                                                                                                                                                     
  - Added `Constants.AGENT_RESOURCE_TYPE_DESCRIPTION` (`"A resource type to keep the tenant agent configurations."`) so the on-demand type matches the description used in the DB init scripts.