### PR TITLE
Reject requests with multiple Authorization headers in userinfo endpoint

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/user/impl/UserInforRequestDefaultValidator.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/user/impl/UserInforRequestDefaultValidator.java
@@ -57,7 +57,7 @@ public class UserInforRequestDefaultValidator implements UserInfoRequestValidato
         // A request must not carry more than one Authorization header (RFC 6750 / RFC 7230).
         // Using getHeaders() to detect duplicates; getHeader() would silently return only the first.
         Enumeration<String> authorizationHeaders = request.getHeaders(HttpHeaders.AUTHORIZATION);
-        String authzHeaders = null;
+        String authzHeader = null;
         if (authorizationHeaders != null) {
             List<String> headerList = Collections.list(authorizationHeaders);
             if (headerList.size() > 1) {
@@ -65,11 +65,11 @@ public class UserInforRequestDefaultValidator implements UserInfoRequestValidato
                         "Multiple Authorization headers found in the request");
             }
             if (!headerList.isEmpty()) {
-                authzHeaders = headerList.get(0);
+                authzHeader = headerList.get(0);
             }
         }
 
-        if (authzHeaders == null) {
+        if (authzHeader == null) {
             String contentTypeHeaders = request.getHeader(HttpHeaders.CONTENT_TYPE);
             // To validate the Content_Type header.
             if (StringUtils.isBlank(contentTypeHeaders)) {
@@ -114,7 +114,7 @@ public class UserInforRequestDefaultValidator implements UserInfoRequestValidato
             }
         }
 
-        String[] authzHeaderInfo = authzHeaders.trim().split(" ");
+        String[] authzHeaderInfo = authzHeader.trim().split(" ");
 
         if (authzHeaderInfo.length < 2) {
             throw new UserInfoEndpointException(

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/user/impl/UserInforRequestDefaultValidator.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/user/impl/UserInforRequestDefaultValidator.java
@@ -29,6 +29,9 @@ import java.nio.charset.CharacterCodingException;
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.List;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.HttpMethod;
@@ -51,7 +54,21 @@ public class UserInforRequestDefaultValidator implements UserInfoRequestValidato
     @Override
     public String validateRequest(HttpServletRequest request) throws UserInfoEndpointException {
 
-        String authzHeaders = request.getHeader(HttpHeaders.AUTHORIZATION);
+        // A request must not carry more than one Authorization header (RFC 6750 / RFC 7230).
+        // Using getHeaders() to detect duplicates; getHeader() would silently return only the first.
+        Enumeration<String> authorizationHeaders = request.getHeaders(HttpHeaders.AUTHORIZATION);
+        String authzHeaders = null;
+        if (authorizationHeaders != null) {
+            List<String> headerList = Collections.list(authorizationHeaders);
+            if (headerList.size() > 1) {
+                throw new UserInfoEndpointException(OAuthError.ResourceResponse.INVALID_REQUEST,
+                        "Multiple Authorization headers found in the request");
+            }
+            if (!headerList.isEmpty()) {
+                authzHeaders = headerList.get(0);
+            }
+        }
+
         if (authzHeaders == null) {
             String contentTypeHeaders = request.getHeader(HttpHeaders.CONTENT_TYPE);
             // To validate the Content_Type header.

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/user/impl/UserInforRequestDefaultValidatorTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/user/impl/UserInforRequestDefaultValidatorTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth.endpoint.user.impl;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.oauth.user.UserInfoEndpointException;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Enumeration;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.core.HttpHeaders;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+
+/**
+ * Test cases for {@link UserInforRequestDefaultValidator}.
+ */
+public class UserInforRequestDefaultValidatorTest {
+
+    private UserInforRequestDefaultValidator validator;
+
+    @BeforeMethod
+    public void setUp() {
+
+        validator = new UserInforRequestDefaultValidator();
+    }
+
+    @Test(expectedExceptions = UserInfoEndpointException.class)
+    public void testMultipleAuthorizationHeadersRejected() throws Exception {
+
+        HttpServletRequest request = mock(HttpServletRequest.class);
+
+        Enumeration<String> multipleHeaders =
+                Collections.enumeration(Arrays.asList("Bearer token1", "Bearer token2"));
+        when(request.getHeaders(HttpHeaders.AUTHORIZATION)).thenReturn(multipleHeaders);
+
+        validator.validateRequest(request);
+    }
+
+    @Test
+    public void testSingleAuthorizationHeaderAccepted() throws Exception {
+
+        HttpServletRequest request = mock(HttpServletRequest.class);
+
+        Enumeration<String> singleHeader =
+                Collections.enumeration(Collections.singletonList("Bearer token1"));
+        when(request.getHeaders(HttpHeaders.AUTHORIZATION)).thenReturn(singleHeader);
+
+        String token = validator.validateRequest(request);
+        assertEquals(token, "token1", "Validator should return the token from a single Authorization header.");
+    }
+}

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/user/impl/UserInforRequestDefaultValidatorTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/user/impl/UserInforRequestDefaultValidatorTest.java
@@ -22,10 +22,13 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import org.wso2.carbon.identity.oauth.user.UserInfoEndpointException;
 
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Enumeration;
 
+import javax.servlet.ServletInputStream;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.HttpHeaders;
 
@@ -69,5 +72,46 @@ public class UserInforRequestDefaultValidatorTest {
 
         String token = validator.validateRequest(request);
         assertEquals(token, "token1", "Validator should return the token from a single Authorization header.");
+    }
+
+    @Test
+    public void testNoAuthorizationHeaderFallsBackToBody() throws Exception {
+
+        HttpServletRequest request = mock(HttpServletRequest.class);
+
+        // No Authorization header -> empty enumeration
+        when(request.getHeaders(HttpHeaders.AUTHORIZATION))
+                .thenReturn(Collections.emptyEnumeration());
+
+        // Form-encoded content type so it enters the body-parsing path
+        when(request.getHeader(HttpHeaders.CONTENT_TYPE))
+                .thenReturn("application/x-www-form-urlencoded");
+
+        // Non-GET method (GET is rejected on this path)
+        when(request.getMethod()).thenReturn("POST");
+
+        // Body carrying the access token
+        String body = "access_token=token1";
+        when(request.getInputStream()).thenReturn(toServletInputStream(body));
+
+        String token = validator.validateRequest(request);
+        assertEquals(token, "token1",
+                "Validator should extract the token from the body when no Authorization header is present.");
+    }
+
+    /**
+     * Wraps a string in a ServletInputStream for mocking request bodies.
+     */
+    private ServletInputStream toServletInputStream(String content) {
+
+        ByteArrayInputStream byteStream =
+                new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
+        return new ServletInputStream() {
+            @Override
+            public int read() {
+
+                return byteStream.read();
+            }
+        };
     }
 }


### PR DESCRIPTION
### Proposed changes in this pull request

The userinfo request validator read the `Authorization` header via `request.getHeader()`, which returns only the first value when the header is present multiple times. As a result, requests carrying more than one `Authorization` header were not rejected, contrary to RFC 6750 section 2.1.

This change uses `request.getHeaders()` in `UserInforRequestDefaultValidator.validateRequest()` to detect duplicate `Authorization` headers and rejects such requests with an `INVALID_REQUEST` error. Single-header and no-header behaviour is unchanged.

- Modified `UserInforRequestDefaultValidator` to reject requests with multiple `Authorization` headers.
- Added `UserInforRequestDefaultValidatorTest` with test cases for the multiple-header (rejected) and single-header (accepted) scenarios.

Reproduced against IS 7.3.0: a single valid `Authorization` header is accepted, while two `Authorization` headers were previously accepted (only the first was read) and are now rejected.

Fixes wso2/product-is#28038

Note: the same `getHeader()` pattern exists in other call sites (e.g. `OAuth2Util`, `OAuthRevocationEndpoint`). I have scoped this PR to the userinfo path described in the issue — happy to extend it to the other paths in this PR or a follow-up, whichever is preferred.

### When should this PR be merged

No preconditions. Ready to merge once reviewed and CI passes.

### Follow up actions

Optionally extend the same duplicate-header validation to the other call sites that use `request.getHeader()` for the `Authorization` header.