### PR TITLE
Introduce custom fields in OAuth2-Token-Error-Response

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/token/OAuth2TokenEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/token/OAuth2TokenEndpoint.java
@@ -310,7 +310,14 @@ public class OAuth2TokenEndpoint {
 
             if (MapUtils.isNotEmpty(oauth2AccessTokenResp.getErrorParameterMap())) {
                 for (Map.Entry<String, Object> entry: oauth2AccessTokenResp.getErrorParameterMap().entrySet()) {
-                    oAuthErrorResponseBuilder.setParam(entry.getKey(), entry.getValue().toString());
+                    if (entry.getValue() != null) {
+                        oAuthErrorResponseBuilder.setParam(entry.getKey(), entry.getValue().toString());
+                    } else {
+                        if (log.isDebugEnabled()) {
+                            log.debug("Skipping custom OAuth error parameter '" + entry.getKey()
+                                    + "' as its value is null.");
+                        }
+                    }
                 }
             }
 

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/token/OAuth2TokenEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/token/OAuth2TokenEndpoint.java
@@ -303,11 +303,18 @@ public class OAuth2TokenEndpoint {
             return handleServerError();
         } else {
             // Otherwise send back HTTP 400 Status Code
-            OAuthResponse response = OAuthASResponse
+            OAuthResponse.OAuthErrorResponseBuilder oAuthErrorResponseBuilder = OAuthASResponse
                     .errorResponse(HttpServletResponse.SC_BAD_REQUEST)
                     .setError(oauth2AccessTokenResp.getErrorCode())
-                    .setErrorDescription(oauth2AccessTokenResp.getErrorMsg())
-                    .buildJSONMessage();
+                    .setErrorDescription(oauth2AccessTokenResp.getErrorMsg());
+
+            if (MapUtils.isNotEmpty(oauth2AccessTokenResp.getErrorParameterMap())) {
+                for (Map.Entry<String, Object> entry: oauth2AccessTokenResp.getErrorParameterMap().entrySet()) {
+                    oAuthErrorResponseBuilder.setParam(entry.getKey(), entry.getValue().toString());
+                }
+            }
+
+            OAuthResponse response = oAuthErrorResponseBuilder.buildJSONMessage();
 
             ResponseHeader[] headers = oauth2AccessTokenResp.getResponseHeaders();
             ResponseBuilder respBuilder = Response.status(response.getResponseStatus());

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dto/OAuth2AccessTokenRespDTO.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dto/OAuth2AccessTokenRespDTO.java
@@ -48,6 +48,8 @@ public class OAuth2AccessTokenRespDTO {
     private Map<String, Object> parameterObjects;
     private boolean isConsentedToken;
 
+    private Map<String, Object> errorParameterMap;
+
     public ResponseHeader[] getResponseHeaders() {
         if (responseHeaders == null) {
             return new ResponseHeader[0];
@@ -227,6 +229,28 @@ public class OAuth2AccessTokenRespDTO {
     }
 
     /**
+     * Get error parameter map
+     *
+     * @return a map of error parameters
+     */
+    public Map<String, Object> getErrorParameterMap() {
+
+        return Collections.unmodifiableMap(getErrorMap());
+    }
+
+    /**
+     * Add error parameter to custom error parameter map
+     *
+     * @param key custom error key
+     * @param value value of the corresponding key
+     */
+    public void addErrorParameter(String key, Object value) {
+
+        getErrorMap().put(key, value);
+    }
+
+
+    /**
      * Get all custom parameters.
      *
      * @return a key value map of all custom parameters.
@@ -261,5 +285,19 @@ public class OAuth2AccessTokenRespDTO {
     public void setIsConsentedToken(boolean isConsentedToken) {
 
         this.isConsentedToken = isConsentedToken;
+    }
+
+    /**
+     * Get error parameter map
+     *
+     * @return the map of error parameter map is returned. A default map will be returned if values are not added to
+     * the error parameter map
+     */
+    private Map<String, Object> getErrorMap() {
+
+        if (errorParameterMap == null) {
+            errorParameterMap = new HashMap<>();
+        }
+        return errorParameterMap;
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuer.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuer.java
@@ -19,6 +19,7 @@
 package org.wso2.carbon.identity.oauth2.token;
 
 import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
@@ -190,7 +191,7 @@ public class AccessTokenIssuer {
             }
             tokenRespDTO = handleError(OAuth2ErrorCodes.INVALID_REQUEST, "The client MUST NOT use more than one " +
                     "authentication method in each", tokenReqDTO);
-            setResponseHeaders(tokReqMsgCtx, tokenRespDTO);
+            setResponse(tokReqMsgCtx, tokenRespDTO);
             triggerPostListeners(tokenReqDTO, tokenRespDTO, tokReqMsgCtx, isRefreshRequest);
             return tokenRespDTO;
         }
@@ -211,7 +212,7 @@ public class AccessTokenIssuer {
             }
             tokenRespDTO = handleError(OAuthError.TokenResponse.UNSUPPORTED_GRANT_TYPE,
                     errorMsg, tokenReqDTO);
-            setResponseHeaders(tokReqMsgCtx, tokenRespDTO);
+            setResponse(tokReqMsgCtx, tokenRespDTO);
             triggerPostListeners(tokenReqDTO, tokenRespDTO, tokReqMsgCtx, isRefreshRequest);
             return tokenRespDTO;
         }
@@ -234,7 +235,7 @@ public class AccessTokenIssuer {
             tokenRespDTO = handleError(
                     OAuth2ErrorCodes.INVALID_CLIENT,
                     "Unsupported Client Authentication Method!", tokenReqDTO);
-            setResponseHeaders(tokReqMsgCtx, tokenRespDTO);
+            setResponse(tokReqMsgCtx, tokenRespDTO);
             triggerPostListeners(tokenReqDTO, tokenRespDTO, tokReqMsgCtx, isRefreshRequest);
             return tokenRespDTO;
         }
@@ -250,7 +251,7 @@ public class AccessTokenIssuer {
             tokenRespDTO = handleError(
                     oAuthClientAuthnContext.getErrorCode(),
                     oAuthClientAuthnContext.getErrorMessage(), tokenReqDTO);
-            setResponseHeaders(tokReqMsgCtx, tokenRespDTO);
+            setResponse(tokReqMsgCtx, tokenRespDTO);
             triggerPostListeners(tokenReqDTO, tokenRespDTO, tokReqMsgCtx, isRefreshRequest);
             return tokenRespDTO;
         }
@@ -307,7 +308,7 @@ public class AccessTokenIssuer {
                         "issue-access-token", null);
             }
             tokenRespDTO = handleError(OAuthError.TokenResponse.UNAUTHORIZED_CLIENT, error, tokenReqDTO);
-            setResponseHeaders(tokReqMsgCtx, tokenRespDTO);
+            setResponse(tokReqMsgCtx, tokenRespDTO);
             triggerPostListeners(tokenReqDTO, tokenRespDTO, tokReqMsgCtx, isRefreshRequest);
             return tokenRespDTO;
         }
@@ -349,7 +350,7 @@ public class AccessTokenIssuer {
                 log.debug("Invalid Grant provided by the client Id: " + tokenReqDTO.getClientId());
             }
             tokenRespDTO = handleError(errorCode, error, tokenReqDTO);
-            setResponseHeaders(tokReqMsgCtx, tokenRespDTO);
+            setResponse(tokReqMsgCtx, tokenRespDTO);
             triggerPostListeners(tokenReqDTO, tokenRespDTO, tokReqMsgCtx, isRefreshRequest);
             return tokenRespDTO;
         }
@@ -361,7 +362,7 @@ public class AccessTokenIssuer {
             }
             tokenRespDTO = handleError(OAuthError.TokenResponse.UNAUTHORIZED_CLIENT,
                     "Unauthorized Client!", tokenReqDTO);
-            setResponseHeaders(tokReqMsgCtx, tokenRespDTO);
+            setResponse(tokReqMsgCtx, tokenRespDTO);
             triggerPostListeners(tokenReqDTO, tokenRespDTO, tokReqMsgCtx, isRefreshRequest);
             return tokenRespDTO;
         }
@@ -381,7 +382,7 @@ public class AccessTokenIssuer {
                         null);
             }
             tokenRespDTO = handleError(OAuthError.TokenResponse.INVALID_SCOPE, "Invalid Scope!", tokenReqDTO);
-            setResponseHeaders(tokReqMsgCtx, tokenRespDTO);
+            setResponse(tokReqMsgCtx, tokenRespDTO);
             triggerPostListeners(tokenReqDTO, tokenRespDTO, tokReqMsgCtx, isRefreshRequest);
             return tokenRespDTO;
         }
@@ -401,7 +402,7 @@ public class AccessTokenIssuer {
 
             tokenRespDTO = authzGrantHandler.issue(tokReqMsgCtx);
             if (tokenRespDTO.isError()) {
-                setResponseHeaders(tokReqMsgCtx, tokenRespDTO);
+                setResponse(tokReqMsgCtx, tokenRespDTO);
                 return tokenRespDTO;
             }
         } finally {
@@ -422,7 +423,7 @@ public class AccessTokenIssuer {
             tokenRespDTO.setAuthorizedScopes(scopeString.toString().trim());
         }
 
-        setResponseHeaders(tokReqMsgCtx, tokenRespDTO);
+        setResponse(tokReqMsgCtx, tokenRespDTO);
 
         //Do not change this log format as these logs use by external applications
         if (log.isDebugEnabled()) {
@@ -997,15 +998,41 @@ public class AccessTokenIssuer {
     /**
      * Set headers in OAuth2AccessTokenRespDTO
      *
+     * @param tokenRespDTO
+     * @param headers
+     */
+    private void setResponseHeaders(OAuth2AccessTokenRespDTO tokenRespDTO, ResponseHeader[] headers) {
+
+        tokenRespDTO.setResponseHeaders(headers);
+    }
+
+    /**
+     * Set custom error parameters in OAuth2AccessTokenRespDTO
+     * @param tokenRespDTO
+     * @param errorMap
+     */
+    private void setCustomErrorParameters(OAuth2AccessTokenRespDTO tokenRespDTO, Map<String, Object> errorMap) {
+
+        for (Map.Entry<String, Object> entry: errorMap.entrySet()) {
+            tokenRespDTO.addErrorParameter(entry.getKey(), entry.getValue());
+        }
+    }
+
+    /**
+     * Set custom response parameters and headers
      * @param tokReqMsgCtx
      * @param tokenRespDTO
      */
-    private void setResponseHeaders(OAuthTokenReqMessageContext tokReqMsgCtx,
-                                    OAuth2AccessTokenRespDTO tokenRespDTO) {
+    private void setResponse(OAuthTokenReqMessageContext tokReqMsgCtx, OAuth2AccessTokenRespDTO tokenRespDTO) {
 
         if (tokReqMsgCtx.getProperty(OAuthConstants.RESPONSE_HEADERS_PROPERTY) != null) {
-            tokenRespDTO.setResponseHeaders(
-                    (ResponseHeader[]) tokReqMsgCtx.getProperty(OAuthConstants.RESPONSE_HEADERS_PROPERTY));
+            ResponseHeader[] headers =
+                    (ResponseHeader[]) tokReqMsgCtx.getProperty(OAuthConstants.RESPONSE_HEADERS_PROPERTY);
+            setResponseHeaders(tokenRespDTO, headers);
+        }
+
+        if (MapUtils.isNotEmpty(tokReqMsgCtx.getErrorParameterMap())) {
+            setCustomErrorParameters(tokenRespDTO, tokReqMsgCtx.getErrorParameterMap());
         }
     }
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/OAuthTokenReqMessageContext.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/OAuthTokenReqMessageContext.java
@@ -23,6 +23,9 @@ import org.wso2.carbon.identity.oauth.common.OAuthConstants;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2AccessTokenReqDTO;
 import org.wso2.carbon.identity.oauth2.token.bindings.TokenBinding;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Properties;
 
 /**
@@ -49,6 +52,7 @@ public class OAuthTokenReqMessageContext {
     private Properties properties = new Properties();
 
     private String[] authorizedInternalScopes;
+    private Map<String, Object> errorParameterMap;
 
     private TokenBinding tokenBinding;
 
@@ -171,4 +175,39 @@ public class OAuthTokenReqMessageContext {
 
         isConsentedToken = consentedToken;
     }
+
+    /**
+     * Get error parameter map
+     *
+     * @return The map of error parameters
+     */
+    public Map<String, Object> getErrorParameterMap() {
+
+        return Collections.unmodifiableMap(getErrorMap());
+    }
+
+    /**
+     * Add key values to error parameter map
+     * @param key custom error key
+     * @param value value of the corresponding key
+     */
+    public void addErrorParameter(String key, Object value) {
+
+        getErrorMap().put(key, value);
+    }
+
+    /**
+     * Get error parameter map
+     *
+     * @return the map of error parameter map is returned. A default map will be returned if values are not added to
+     * the error parameter map
+     */
+    private Map<String, Object> getErrorMap() {
+
+        if (errorParameterMap == null) {
+            errorParameterMap = new HashMap<>();
+        }
+        return errorParameterMap;
+    }
+
 }


### PR DESCRIPTION
### Purpose

porting fixes from: https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/1943/commits
Fixes: https://github.com/wso2/api-manager/issues/5117

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OAuth token error responses can now include additional custom details, making failures more informative.
  * Token responses continue to carry response headers while also preserving custom error parameters when available.

* **Bug Fixes**
  * Improved handling of token issuance errors so custom error information is reliably returned to clients.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->