### PR TITLE
Surface client errors as 4xx when agent application creation fails

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/listener/UserApplicationCreationListener.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/listener/UserApplicationCreationListener.java
@@ -66,6 +66,8 @@ public class UserApplicationCreationListener extends AbstractIdentityUserOperati
     private static final Log log = LogFactory.getLog(UserApplicationCreationListener.class);
     private static final String AGENT_LISTENER_ENABLE = "AgentIdentity.ApplicationCreatorListener.Enabled";
     private static final String AGENT_LISTENER_ORDER_ID = "AgentIdentity.ApplicationCreatorListener.Order";
+    // Error code set by the resource limit enforcement when application creation is blocked by the tier quota.
+    private static final String ERROR_CODE_RESOURCE_LIMIT_REACHED = "RLS-10001";
     boolean isEnabled = false;
 
     public UserApplicationCreationListener() {
@@ -155,10 +157,11 @@ public class UserApplicationCreationListener extends AbstractIdentityUserOperati
                         " Agent may be left in an inconsistent state.", deleteException);
             }
 
-            if (e instanceof IdentityApplicationManagementClientException) {
-                // Client errors (e.g. application limit reached) should surface as a client
-                // exception so the SCIM layer returns a 4xx with the actual error instead of
-                // a generic 500. The cause is intentionally not chained: the SCIM layer
+            if (e instanceof IdentityApplicationManagementClientException
+                    && ERROR_CODE_RESOURCE_LIMIT_REACHED.equals(e.getErrorCode())) {
+                // The application limit reached error should surface as a client exception
+                // so the SCIM layer returns a 4xx with the actual error instead of a
+                // generic 500. The cause is intentionally not chained: the SCIM layer
                 // resolves the root cause of the exception chain, and it must resolve to
                 // this UserStoreClientException. The full stack trace is already logged above.
                 throw new UserStoreClientException(

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/listener/UserApplicationCreationListener.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/listener/UserApplicationCreationListener.java
@@ -21,6 +21,7 @@ package org.wso2.carbon.identity.oauth.listener;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.application.common.IdentityApplicationManagementClientException;
 import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
 import org.wso2.carbon.identity.application.common.model.AssociatedRolesConfig;
 import org.wso2.carbon.identity.application.common.model.InboundAuthenticationConfig;
@@ -40,6 +41,7 @@ import org.wso2.carbon.identity.oauth.dto.OAuthConsumerAppDTO;
 import org.wso2.carbon.identity.oauth.internal.OAuthComponentServiceHolder;
 import org.wso2.carbon.identity.oauth2.OAuth2Constants;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
+import org.wso2.carbon.user.core.UserStoreClientException;
 import org.wso2.carbon.user.core.UserStoreException;
 import org.wso2.carbon.user.core.UserStoreManager;
 import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
@@ -153,6 +155,15 @@ public class UserApplicationCreationListener extends AbstractIdentityUserOperati
                         " Agent may be left in an inconsistent state.", deleteException);
             }
 
+            if (e instanceof IdentityApplicationManagementClientException) {
+                // Client errors (e.g. application limit reached) should surface as a client
+                // exception so the SCIM layer returns a 4xx with the actual error instead of
+                // a generic 500. The cause is intentionally not chained: the SCIM layer
+                // resolves the root cause of the exception chain, and it must resolve to
+                // this UserStoreClientException. The full stack trace is already logged above.
+                throw new UserStoreClientException(
+                        "Agent application creation failed: " + e.getMessage(), e.getErrorCode());
+            }
             throw new UserStoreException(
                     "Agent application creation failed for agent ", e);
         }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/listener/UserApplicationCreationListener.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/listener/UserApplicationCreationListener.java
@@ -141,8 +141,19 @@ public class UserApplicationCreationListener extends AbstractIdentityUserOperati
             return true;
 
         } catch (IdentityApplicationManagementException e) {
-            log.error("Error occurred while creating agent application for agent and Rolling back agent " +
-                    "creation.", e);
+            boolean isResourceLimitError = e instanceof IdentityApplicationManagementClientException
+                    && ERROR_CODE_RESOURCE_LIMIT_REACHED.equals(e.getErrorCode());
+            if (isResourceLimitError) {
+                // A client-induced failure (4xx). Logging at debug level to avoid flooding the error log
+                // when a client repeatedly retries at the limit.
+                if (log.isDebugEnabled()) {
+                    log.debug("Agent application creation blocked by the resource limit. Rolling back agent "
+                            + "creation.", e);
+                }
+            } else {
+                log.error("Error occurred while creating agent application for agent and Rolling back agent " +
+                        "creation.", e);
+            }
 
             try {
                 if (!(userStoreManager instanceof AbstractUserStoreManager)) {
@@ -157,13 +168,12 @@ public class UserApplicationCreationListener extends AbstractIdentityUserOperati
                         " Agent may be left in an inconsistent state.", deleteException);
             }
 
-            if (e instanceof IdentityApplicationManagementClientException
-                    && ERROR_CODE_RESOURCE_LIMIT_REACHED.equals(e.getErrorCode())) {
+            if (isResourceLimitError) {
                 // The application limit reached error should surface as a client exception
                 // so the SCIM layer returns a 4xx with the actual error instead of a
                 // generic 500. The cause is intentionally not chained: the SCIM layer
                 // resolves the root cause of the exception chain, and it must resolve to
-                // this UserStoreClientException. The full stack trace is already logged above.
+                // this UserStoreClientException.
                 throw new UserStoreClientException(
                         "Agent application creation failed: " + e.getMessage(), e.getErrorCode());
             }

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/listener/UserApplicationCreationListenerTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/listener/UserApplicationCreationListenerTest.java
@@ -24,6 +24,7 @@ import org.mockito.MockedStatic;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+import org.wso2.carbon.identity.application.common.IdentityApplicationManagementClientException;
 import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
 import org.wso2.carbon.identity.application.common.model.ServiceProvider;
 import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
@@ -33,6 +34,7 @@ import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.oauth.internal.OAuthComponentServiceHolder;
 import org.wso2.carbon.identity.oauth2.OAuth2Constants;
 import org.wso2.carbon.identity.testutil.IdentityBaseTest;
+import org.wso2.carbon.user.core.UserStoreClientException;
 import org.wso2.carbon.user.core.UserStoreException;
 import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
 import org.wso2.carbon.user.core.common.User;
@@ -240,6 +242,83 @@ public class UserApplicationCreationListenerTest extends IdentityBaseTest {
         } catch (UserStoreException e) {
             // Must throw UserStoreException so the failure propagates to the API layer,
             // which then returns an HTTP error and prevents the UI from showing a false success.
+            assertTrue(e.getMessage().contains("Agent application creation failed for agent"),
+                    "Exception message should indicate agent application creation failure");
+        }
+
+        // Verify the agent was deleted (rollback) before the exception was thrown.
+        try {
+            verify(userStoreManager).deleteUserWithID(agentUserId);
+        } catch (UserStoreException e) {
+            fail("Verification failed: " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void testDoPostAddUserWithID_AppLimitReachedRollsBackAndThrowsClientException()
+            throws IdentityApplicationManagementException {
+
+        String agentUserId = "agent-user-id-124";
+        try {
+            setupCommonMocks();
+        } catch (UserStoreException e) {
+            fail("Setup failed: " + e.getMessage());
+        }
+        setupAgentUserMocks();
+        when(user.getUserID()).thenReturn(agentUserId);
+        doThrow(new IdentityApplicationManagementClientException("RLS-10001",
+                "Maximum number of allowed applications have been reached."))
+                .when(applicationManagementService)
+                .createApplication(any(ApplicationDTO.class), anyString(), anyString());
+
+        try {
+            listener.doPostAddUserWithID(user, "password", new String[]{"role1"},
+                    new HashMap<>(), null, userStoreManager);
+            fail("Expected UserStoreClientException to be thrown when the application limit is reached");
+        } catch (UserStoreClientException e) {
+            // The resource limit failure must surface as a client exception carrying the original
+            // error code so the SCIM layer maps it to a 4xx response instead of a generic 500.
+            assertEquals(e.getErrorCode(), "RLS-10001");
+            assertTrue(e.getMessage().contains("Maximum number of allowed applications have been reached."),
+                    "Exception message should carry the original limit-reached message");
+        } catch (UserStoreException e) {
+            fail("Expected UserStoreClientException but got a plain UserStoreException");
+        }
+
+        // Verify the agent was deleted (rollback) before the exception was thrown.
+        try {
+            verify(userStoreManager).deleteUserWithID(agentUserId);
+        } catch (UserStoreException e) {
+            fail("Verification failed: " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void testDoPostAddUserWithID_OtherClientErrorStillThrowsUserStoreException()
+            throws IdentityApplicationManagementException {
+
+        String agentUserId = "agent-user-id-125";
+        try {
+            setupCommonMocks();
+        } catch (UserStoreException e) {
+            fail("Setup failed: " + e.getMessage());
+        }
+        setupAgentUserMocks();
+        when(user.getUserID()).thenReturn(agentUserId);
+        doThrow(new IdentityApplicationManagementClientException("APP-00001", "Invalid application data."))
+                .when(applicationManagementService)
+                .createApplication(any(ApplicationDTO.class), anyString(), anyString());
+
+        try {
+            listener.doPostAddUserWithID(user, "password", new String[]{"role1"},
+                    new HashMap<>(), null, userStoreManager);
+            fail("Expected UserStoreException to be thrown when application creation fails");
+        } catch (UserStoreClientException e) {
+            fail("Client exceptions other than the resource limit must not be converted to "
+                    + "UserStoreClientException");
+        } catch (UserStoreException e) {
+            // Only the resource-limit error code is mapped to a client exception; everything else
+            // keeps the existing behavior.
             assertTrue(e.getMessage().contains("Agent application creation failed for agent"),
                     "Exception message should indicate agent application creation failure");
         }


### PR DESCRIPTION
### Proposed changes in this pull request

When a user-serving agent is created via `POST /scim2/Agents` with `IsUserServingAgent: true`, `UserApplicationCreationListener` creates an OAuth application for the agent. If that application creation fails with a client error — for example when the tenant's application limit is reached (`RLS-10001`) — the listener currently rethrows a generic `UserStoreException`. The SCIM layer cannot map that to a client error, so the API returns:

```
HTTP 500
{"detail":"Error in adding the user: A***... to the user store.","status":"500"}
```

This hides the actual cause from the client.

**Change:** in the catch block of `doPostAddUserWithID`, if the exception is an `IdentityApplicationManagementClientException` **with error code `RLS-10001` (resource limit reached)**, rethrow it as a `UserStoreClientException` carrying the original error code and message. Other client exceptions keep the existing behavior — the mapping is intentionally scoped to the limit-reached case only. `SCIMUserManager.createUser` resolves `UserStoreClientException` (directly or as the root cause of a wrapped `UserStoreException`) to a `BadRequestException`. The cause is intentionally not chained, because the SCIM layer resolves the root cause of the chain and it must resolve to the `UserStoreClientException`; the exception is logged before rethrowing.

The limit-reached client failure is logged at debug level (it is an expected, client-induced 4xx outcome and would otherwise flood the error log on repeated retries at the limit); all other failures keep error-level logging with the stack trace. Unit tests cover the limit-reached path (rollback + `UserStoreClientException` with code `RLS-10001`) and the scoping (other client error codes keep the existing `UserStoreException` behavior).

With this PR alone, the failure surfaces as a 400 through the SCIM layer's generic client-error handling. This is an intermediate state: wso2-extensions/identity-inbound-provisioning-scim2#799 builds on this error code and maps the case to its final form —

```
HTTP 403
{"scimType":"applicationLimitReached","detail":"Agent application creation failed. Maximum number of allowed applications have been reached.","status":"403"}
```

Both PRs should be shipped together; the end-to-end behavior change users observe is 500 → 403.

The rollback behavior (deleting the agent user when application creation fails) is unchanged.

Verified end-to-end on a local IS deployment with resource limiting enabled (together with the scim2 PR): at the application limit the API returns the 403 above, rollback still removes the agent, and both the plain-agent path and the user-serving-agent path with a free application slot still return 201.

### When should this PR be merged

Should be released together with wso2-extensions/identity-inbound-provisioning-scim2#799 so clients observe the final 403 response instead of the intermediate 400.

### Follow up actions

None.

## Developer Checklist (Mandatory)

- [ ] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact.

---

## Behavioral changes (explicit)

This PR changes the API response of `POST /scim2/Agents` **only** for the case where the agent is user-serving (`IsUserServingAgent: true`) and the automatic application creation fails with the resource-limit client error (`IdentityApplicationManagementClientException` with error code `RLS-10001`):

| | Before | After (with wso2-extensions/identity-inbound-provisioning-scim2#799) |
|---|---|---|
| HTTP status | `500` | `403` |
| `scimType` | – | `applicationLimitReached` |
| `detail` | `Error in adding the user: A***... to the user store.` (masked, unrelated to the real cause) | `Agent application creation failed. Maximum number of allowed applications have been reached.` |

(With this PR alone the case surfaces as `400` / `invalidValue` via the SCIM layer's generic client-error handling — an intermediate state; the two PRs should be shipped together.)

No behavioral change for:

- Agent creation succeeding, or failing for any other reason (server errors still return 500).
- Regular (non-agent) user creation.
- The rollback behavior — the agent user is still deleted when application creation fails.

Note: the Console handles the final `403` + `scimType: applicationLimitReached` response in wso2/identity-apps#10538.





