### PR TITLE
Add overridable resolveAudiences hook for access token audience resolution

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AbstractAuthorizationGrantHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AbstractAuthorizationGrantHandler.java
@@ -693,9 +693,25 @@ public abstract class AbstractAuthorizationGrantHandler implements Authorization
         long validityPeriodInMillis = getConfiguredExpiryTimeForApplication(tokReqMsgCtx, consumerKey, oAuthAppBean);
         tokReqMsgCtx.setValidityPeriod(validityPeriodInMillis);
         tokReqMsgCtx.setAccessTokenIssuedTime(timestamp.getTime());
-        tokReqMsgCtx.setAudiences(OAuth2Util.getOIDCAudience(consumerKey, oAuthAppBean));
+        tokReqMsgCtx.setAudiences(resolveAudiences(tokReqMsgCtx, consumerKey, oAuthAppBean));
 
         updateRefreshTokenValidityPeriodInMessageContext(oAuthAppBean, existingTokenBean, tokReqMsgCtx);
+    }
+
+    /**
+     * Resolve the audience list to set on the access token. Defaults to the application's configured OIDC
+     * audiences; grant handlers may override to constrain it based on the request.
+     *
+     * @param tokReqMsgCtx Token request message context.
+     * @param consumerKey  Consumer key of the application.
+     * @param oAuthAppBean Application information.
+     * @return the audience list to set on the token.
+     * @throws IdentityOAuth2Exception if an error occurred while resolving the audiences.
+     */
+    protected List<String> resolveAudiences(OAuthTokenReqMessageContext tokReqMsgCtx, String consumerKey,
+                                            OAuthAppDO oAuthAppBean) throws IdentityOAuth2Exception {
+
+        return OAuth2Util.getOIDCAudience(consumerKey, oAuthAppBean);
     }
 
     private void setRefreshTokenDetails(OAuthTokenReqMessageContext tokReqMsgCtx, AccessTokenDO existingTokenBean,


### PR DESCRIPTION
 ## Description                                                                                                                                                                                                                         
                                                                                                                                                                                                                                         
  Introduces an overridable extension point for resolving the audience list set on an issued access token.                                                                                                                               
                                                                                                                                                                                                                                         
  - Extracts audience resolution in `updateMessageContextToCreateNewToken(...)` into a new `protected resolveAudiences(tokReqMsgCtx, consumerKey, oAuthAppBean)` method.                                                                 
  - The default implementation returns `OAuth2Util.getOIDCAudience(consumerKey, oAuthAppBean)`, so the existing behaviour is unchanged for all current grant handlers.                                                                
  - Subclasses can now override `resolveAudiences(...)` to constrain the audience based on the request, without duplicating the surrounding token-creation logic.                                
                                                                                                                                                                                                                                         
  **Related to:** https://github.com/wso2/product-is/issues/26675                                                                                                                                                                                                  
                                                                                                                                                                                                                                         
  ## Changed files                                                                                                                                                                                                                       
                                                                                                                                                                                                                                         
  - `AbstractAuthorizationGrantHandler.java` — add the `resolveAudiences(...)` hook and route audience resolution through it. 