### PR TITLE
Recompute UserInfo sub for alternate subject identifiers on token reissue

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/user/impl/UserInfoJSONResponseBuilderTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/user/impl/UserInfoJSONResponseBuilderTest.java
@@ -36,6 +36,7 @@ import org.wso2.carbon.identity.application.authentication.framework.util.Framew
 import org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants;
 import org.wso2.carbon.identity.core.persistence.JDBCPersistenceManager;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.oauth.cache.AuthorizationGrantCache;
 import org.wso2.carbon.identity.oauth.common.OAuthConstants;
 import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
@@ -506,6 +507,122 @@ public class UserInfoJSONResponseBuilderTest extends UserInfoResponseBaseTest {
             Map<String, Object> claimsInResponse = JSONUtils.parseJSON(responseString);
             assertSubjectClaimPresent(claimsInResponse);
             assertEquals(claimsInResponse.get(sub), isPairwiseSubject ? expectedPPID : expectedSubjectValue);
+        } finally {
+            PrivilegedCarbonContext.endTenantFlow();
+        }
+    }
+
+    /*
+     * Regression coverage for issue #7720: when an application uses an alternate subject identifier and the same
+     * opaque access token is reissued after the subject-source claim (email) changed, the persisted subject
+     * identifier on the token is stale while the fresh value is present in userClaims under OAuth2Util.SUB.
+     * The gate knob OAuth.RecomputeSubjectClaimForAlternateSubjectIdentifier controls whether UserInfo returns the
+     * fresh value (knob on) or the stale persisted value (knob off, pre-fix behaviour).
+     */
+
+    private Map<String, Object> buildUserInfoForRecomputeScenario(String subjectClaimUri,
+                                                                   boolean includeFreshSubInClaims,
+                                                                   boolean enableKnob) throws Exception {
+
+        try (MockedStatic<JDBCPersistenceManager> jdbcPersistenceManager =
+                     mockStatic(JDBCPersistenceManager.class);
+             MockedStatic<AuthorizationGrantCache> authorizationGrantCache =
+                     mockStatic(AuthorizationGrantCache.class);
+             MockedStatic<FrameworkUtils> frameworkUtils = mockStatic(FrameworkUtils.class);
+             MockedStatic<ClaimUtil> claimUtil = mockStatic(ClaimUtil.class);
+             MockedStatic<OAuth2Util> oAuth2Util = mockStatic(OAuth2Util.class, Mockito.CALLS_REAL_METHODS);
+             MockedStatic<IdentityTenantUtil> identityTenantUtil = mockStatic(IdentityTenantUtil.class);
+             MockedStatic<UserInfoEndpointConfig> userInfoEndpointConfig =
+                     mockStatic(UserInfoEndpointConfig.class);
+             MockedStatic<IdentityUtil> identityUtil = mockStatic(IdentityUtil.class)) {
+
+            AuthenticatedUser authzUser = new AuthenticatedUser();
+            authzUser.setUserName(AUTHORIZED_USER_NAME);
+            authzUser.setTenantDomain(TENANT_DOT_COM);
+            authzUser.setUserStoreDomain(JDBC_DOMAIN);
+            authzUser.setUserId(AUTHORIZED_USER_ID);
+            // Persisted (stale) subject identifier as stored on the reissued access token.
+            authzUser.setAuthenticatedSubjectIdentifier(STALE_SUBJECT_VALUE);
+
+            Map<String, Object> inputClaims = new HashMap<>();
+            inputClaims.put(email, FRESH_SUBJECT_VALUE);
+            if (includeFreshSubInClaims) {
+                inputClaims.put(OAuth2Util.SUB, FRESH_SUBJECT_VALUE);
+            }
+
+            setUpRequestObjectService();
+            prepareForSubjectClaimTest(authzUser, inputClaims, false, false, false, authorizationGrantCache,
+                    frameworkUtils, claimUtil, oAuth2Util, identityTenantUtil, userInfoEndpointConfig);
+            if (subjectClaimUri != null) {
+                setAlternateSubjectClaimUri(subjectClaimUri);
+            }
+            when(userInfoJSONResponseBuilder.retrieveUserClaims(any(OAuth2TokenValidationResponseDTO.class)))
+                    .thenReturn(inputClaims);
+            Mockito.when(IdentityTenantUtil.getTenantId(isNull())).thenReturn(-1234);
+            mockDataSource(jdbcPersistenceManager);
+            mockObjectsRelatedToTokenValidation(oAuth2Util);
+            if (enableKnob) {
+                identityUtil.when(() -> IdentityUtil.getProperty(RECOMPUTE_SUBJECT_CLAIM_KNOB)).thenReturn("true");
+            }
+
+            String responseString =
+                    userInfoJSONResponseBuilder.getResponseString(
+                            getTokenResponseDTO(authzUser.toFullQualifiedUsername()));
+            return JSONUtils.parseJSON(responseString);
+        }
+    }
+
+    @Test
+    public void testSubjectRecomputedForAlternateSubjectWhenKnobEnabled() throws Exception {
+
+        try {
+            Map<String, Object> claimsInResponse =
+                    buildUserInfoForRecomputeScenario(ALTERNATE_SUBJECT_CLAIM_URI, true, true);
+            assertSubjectClaimPresent(claimsInResponse);
+            // Knob on: sub reflects the fresh subject-source claim value, matching the ID token sub.
+            assertEquals(claimsInResponse.get(sub), FRESH_SUBJECT_VALUE);
+        } finally {
+            PrivilegedCarbonContext.endTenantFlow();
+        }
+    }
+
+    @Test
+    public void testSubjectStaleForAlternateSubjectWhenKnobDisabled() throws Exception {
+
+        try {
+            Map<String, Object> claimsInResponse =
+                    buildUserInfoForRecomputeScenario(ALTERNATE_SUBJECT_CLAIM_URI, true, false);
+            assertSubjectClaimPresent(claimsInResponse);
+            // Knob off (default): behaviour is byte-identical to the unpatched pack - sub stays stale.
+            assertEquals(claimsInResponse.get(sub), STALE_SUBJECT_VALUE);
+        } finally {
+            PrivilegedCarbonContext.endTenantFlow();
+        }
+    }
+
+    @Test
+    public void testSubjectUnchangedForDefaultSubjectWhenKnobEnabled() throws Exception {
+
+        try {
+            // No alternate subject identifier configured (blank subject claim URI) -> knob branch is a no-op.
+            Map<String, Object> claimsInResponse = buildUserInfoForRecomputeScenario(null, true, true);
+            assertSubjectClaimPresent(claimsInResponse);
+            assertEquals(claimsInResponse.get(sub), STALE_SUBJECT_VALUE);
+        } finally {
+            PrivilegedCarbonContext.endTenantFlow();
+        }
+    }
+
+    @Test
+    public void testSubjectFallsBackWhenSubClaimAbsentWithKnobEnabled() throws Exception {
+
+        try {
+            // Alternate subject configured and knob on, but the subject claim is absent from userClaims
+            // (e.g. not a requested claim) -> fall back to the persisted identifier, no NPE.
+            Map<String, Object> claimsInResponse =
+                    buildUserInfoForRecomputeScenario(ALTERNATE_SUBJECT_CLAIM_URI, false, true);
+            assertSubjectClaimPresent(claimsInResponse);
+            assertEquals(claimsInResponse.get(sub), STALE_SUBJECT_VALUE);
         } finally {
             PrivilegedCarbonContext.endTenantFlow();
         }

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/user/impl/UserInfoJWTResponseTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/user/impl/UserInfoJWTResponseTest.java
@@ -38,6 +38,7 @@ import org.wso2.carbon.identity.application.common.util.IdentityApplicationConst
 import org.wso2.carbon.identity.common.testng.WithCarbonHome;
 import org.wso2.carbon.identity.core.persistence.JDBCPersistenceManager;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.oauth.cache.AuthorizationGrantCache;
 import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
 import org.wso2.carbon.identity.oauth.endpoint.util.ClaimUtil;
@@ -54,6 +55,7 @@ import org.wso2.carbon.identity.organization.management.service.util.Utils;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -436,5 +438,118 @@ public class UserInfoJWTResponseTest extends UserInfoResponseBaseTest {
         lenient().when(dataSource.getConnection()).thenReturn(con);
         jdbcPersistenceManager.when(JDBCPersistenceManager::getInstance).thenReturn(mockJdbcPersistenceManager);
         lenient().when(mockJdbcPersistenceManager.getDataSource()).thenReturn(dataSource);
+    }
+
+    /*
+     * Regression coverage for issue #7720 on the JWT UserInfo response: when an application uses an alternate
+     * subject identifier and the same opaque access token is reissued after the subject-source claim (email)
+     * changed, the persisted subject identifier on the token is stale while the fresh value is present in
+     * userClaims under OAuth2Util.SUB. The gate knob OAuth.RecomputeSubjectClaimForAlternateSubjectIdentifier
+     * controls whether the JWT sub returns the fresh value (knob on) or the stale persisted value (knob off).
+     */
+
+    private JWTClaimsSet buildUserInfoForRecomputeScenario(String subjectClaimUri,
+                                                           boolean includeFreshSubInClaims,
+                                                           boolean enableKnob) throws Exception {
+
+        try (MockedStatic<FrameworkUtils> frameworkUtils = mockStatic(FrameworkUtils.class);
+             MockedStatic<IdentityTenantUtil> identityTenantUtil = mockStatic(IdentityTenantUtil.class);
+             MockedStatic<JDBCPersistenceManager> jdbcPersistenceManager =
+                     mockStatic(JDBCPersistenceManager.class);
+             MockedStatic<AuthorizationGrantCache> authorizationGrantCache =
+                     mockStatic(AuthorizationGrantCache.class);
+             MockedStatic<ClaimUtil> claimUtil = mockStatic(ClaimUtil.class);
+             MockedStatic<OAuth2Util> oAuth2Util = mockStatic(OAuth2Util.class, Mockito.CALLS_REAL_METHODS);
+             MockedStatic<UserInfoEndpointConfig> userInfoEndpointConfig =
+                     mockStatic(UserInfoEndpointConfig.class);
+             MockedStatic<IdentityUtil> identityUtil = mockStatic(IdentityUtil.class)) {
+
+            AuthenticatedUser authzUser = new AuthenticatedUser();
+            authzUser.setUserName(AUTHORIZED_USER_NAME);
+            authzUser.setTenantDomain(TENANT_DOT_COM);
+            authzUser.setUserStoreDomain(JDBC_DOMAIN);
+            authzUser.setUserId(AUTHORIZED_USER_ID);
+            // Persisted (stale) subject identifier as stored on the reissued access token.
+            authzUser.setAuthenticatedSubjectIdentifier(STALE_SUBJECT_VALUE);
+
+            Map<String, Object> inputClaims = new HashMap<>();
+            inputClaims.put(email, FRESH_SUBJECT_VALUE);
+            if (includeFreshSubInClaims) {
+                inputClaims.put(OAuth2Util.SUB, FRESH_SUBJECT_VALUE);
+            }
+
+            prepareForSubjectClaimTest(authzUser, inputClaims, false, false, false, authorizationGrantCache,
+                    frameworkUtils, claimUtil, oAuth2Util, identityTenantUtil, userInfoEndpointConfig);
+            if (subjectClaimUri != null) {
+                setAlternateSubjectClaimUri(subjectClaimUri);
+            }
+            mockObjectsRelatedToTokenValidation(oAuth2Util);
+            frameworkUtils.when(() -> FrameworkUtils.resolveUserIdFromUsername(anyInt(), anyString(), anyString()))
+                    .thenReturn(authzUser.getUserId());
+            identityTenantUtil.when(() -> IdentityTenantUtil.getTenantId(isNull())).thenReturn(-1234);
+            userInfoJWTResponse = spy(new UserInfoJWTResponse());
+            when(userInfoJWTResponse.retrieveUserClaims(any(OAuth2TokenValidationResponseDTO.class)))
+                    .thenReturn(inputClaims);
+            mockDataSource(jdbcPersistenceManager);
+            if (enableKnob) {
+                identityUtil.when(() -> IdentityUtil.getProperty(RECOMPUTE_SUBJECT_CLAIM_KNOB)).thenReturn("true");
+            }
+
+            String responseString =
+                    userInfoJWTResponse.getResponseString(getTokenResponseDTO(authzUser.toFullQualifiedUsername()));
+            JWT jwt = JWTParser.parse(responseString);
+            assertNotNull(jwt);
+            assertNotNull(jwt.getJWTClaimsSet());
+            return jwt.getJWTClaimsSet();
+        }
+    }
+
+    @Test
+    public void testSubjectRecomputedForAlternateSubjectWhenKnobEnabled() throws Exception {
+
+        try {
+            JWTClaimsSet claimsSet = buildUserInfoForRecomputeScenario(ALTERNATE_SUBJECT_CLAIM_URI, true, true);
+            // Knob on: sub reflects the fresh subject-source claim value, matching the ID token sub.
+            assertEquals(claimsSet.getSubject(), FRESH_SUBJECT_VALUE);
+        } finally {
+            PrivilegedCarbonContext.endTenantFlow();
+        }
+    }
+
+    @Test
+    public void testSubjectStaleForAlternateSubjectWhenKnobDisabled() throws Exception {
+
+        try {
+            JWTClaimsSet claimsSet = buildUserInfoForRecomputeScenario(ALTERNATE_SUBJECT_CLAIM_URI, true, false);
+            // Knob off (default): behaviour is byte-identical to the unpatched pack - sub stays stale.
+            assertEquals(claimsSet.getSubject(), STALE_SUBJECT_VALUE);
+        } finally {
+            PrivilegedCarbonContext.endTenantFlow();
+        }
+    }
+
+    @Test
+    public void testSubjectUnchangedForDefaultSubjectWhenKnobEnabled() throws Exception {
+
+        try {
+            // No alternate subject identifier configured (blank subject claim URI) -> knob branch is a no-op.
+            JWTClaimsSet claimsSet = buildUserInfoForRecomputeScenario(null, true, true);
+            assertEquals(claimsSet.getSubject(), STALE_SUBJECT_VALUE);
+        } finally {
+            PrivilegedCarbonContext.endTenantFlow();
+        }
+    }
+
+    @Test
+    public void testSubjectFallsBackWhenSubClaimAbsentWithKnobEnabled() throws Exception {
+
+        try {
+            // Alternate subject configured and knob on, but the subject claim is absent from userClaims
+            // (e.g. not a requested claim) -> fall back to the persisted identifier, no NPE.
+            JWTClaimsSet claimsSet = buildUserInfoForRecomputeScenario(ALTERNATE_SUBJECT_CLAIM_URI, false, true);
+            assertEquals(claimsSet.getSubject(), STALE_SUBJECT_VALUE);
+        } finally {
+            PrivilegedCarbonContext.endTenantFlow();
+        }
     }
 }

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/user/impl/UserInfoResponseBaseTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/user/impl/UserInfoResponseBaseTest.java
@@ -10,6 +10,7 @@ import org.wso2.carbon.identity.application.authentication.framework.model.Authe
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
 import org.wso2.carbon.identity.application.common.model.LocalAndOutboundAuthenticationConfig;
 import org.wso2.carbon.identity.application.common.model.ServiceProvider;
+import org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants;
 import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.oauth.cache.AuthorizationGrantCache;
@@ -102,6 +103,15 @@ public class UserInfoResponseBaseTest {
 
     public static final String CUSTOM_CLAIM_VALUE = "custom_claim_value";
     public static final String[] OIDC_SCOPE_ARRAY = new String[]{OIDC_SCOPE};
+
+    // Fixtures for the alternate-subject-identifier recompute knob (issue #7720).
+    public static final String RECOMPUTE_SUBJECT_CLAIM_KNOB =
+            "OAuth.RecomputeSubjectClaimForAlternateSubjectIdentifier";
+    public static final String ALTERNATE_SUBJECT_CLAIM_URI = "http://wso2.org/claims/emailaddress";
+    // Value persisted on the access token at first issuance (before the email change).
+    public static final String STALE_SUBJECT_VALUE = "bob@gmail.com";
+    // Current value of the subject-source claim, present fresh in userClaims (after the email change).
+    public static final String FRESH_SUBJECT_VALUE = "bob1@gmail.com";
     private static final String DEFAULT_TOKEN_TYPE = "Default";
     private static final String JWT_TOKEN_TYPE = "JWT";
     private static final String SUBJECT_TYPE = "subject_type";
@@ -243,6 +253,17 @@ public class UserInfoResponseBaseTest {
         serviceProvider.getLocalAndOutBoundAuthenticationConfig()
                 .setUseUserstoreDomainInLocalSubjectIdentifier(appendUserStoreDomain);
         OAuth2ServiceComponentHolder.setApplicationMgtService(applicationManagementService);
+    }
+
+    /**
+     * Configure the service provider (prepared by {@link #prepareApplicationManagementService}) with an alternate
+     * subject identifier, i.e. a user-attribute claim URI used as the OIDC subject.
+     */
+    protected void setAlternateSubjectClaimUri(String subjectClaimUri) throws Exception {
+
+        ServiceProvider serviceProvider = applicationManagementService.getServiceProviderByClientId(
+                CLIENT_ID, IdentityApplicationConstants.OAuth2.NAME, SUPER_TENANT_DOMAIN_NAME);
+        serviceProvider.getLocalAndOutBoundAuthenticationConfig().setSubjectClaimUri(subjectClaimUri);
     }
 
     protected void prepareUserInfoEndpointConfig(MockedStatic<UserInfoEndpointConfig> userInfoEndpointConfig) {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/AbstractUserInfoResponseBuilder.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/AbstractUserInfoResponseBuilder.java
@@ -65,6 +65,8 @@ import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCClaims.RO
 public abstract class AbstractUserInfoResponseBuilder implements UserInfoResponseBuilder {
 
     private static final Log log = LogFactory.getLog(AbstractUserInfoResponseBuilder.class);
+    private static final String RECOMPUTE_SUBJECT_CLAIM_FOR_ALTERNATE_SUBJECT_IDENTIFIER =
+            "OAuth.RecomputeSubjectClaimForAlternateSubjectIdentifier";
 
     @Override
     public String getResponseString(OAuth2TokenValidationResponseDTO tokenResponse)
@@ -240,6 +242,17 @@ public abstract class AbstractUserInfoResponseBuilder implements UserInfoRespons
                                      String spTenantDomain,
                                      OAuth2TokenValidationResponseDTO tokenResponse)
             throws UserInfoEndpointException, OAuthSystemException {
+
+        if (Boolean.parseBoolean(IdentityUtil.getProperty(RECOMPUTE_SUBJECT_CLAIM_FOR_ALTERNATE_SUBJECT_IDENTIFIER))) {
+            ServiceProvider serviceProvider = getServiceProvider(spTenantDomain, clientId);
+            String subjectClaimUri = serviceProvider.getLocalAndOutBoundAuthenticationConfig().getSubjectClaimUri();
+            if (StringUtils.isNotBlank(subjectClaimUri)) {
+                Object subjectClaimValue = userClaims.get(OAuth2Util.SUB);
+                if (subjectClaimValue != null && StringUtils.isNotBlank(subjectClaimValue.toString())) {
+                    return subjectClaimValue.toString();
+                }
+            }
+        }
 
         AuthenticatedUser authenticatedUser;
         try {

--- a/pom.xml
+++ b/pom.xml
@@ -998,7 +998,7 @@
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!-- Carbon Identity Framework version -->
-        <carbon.identity.framework.version>7.11.166</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.11.90</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.25.234, 8.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
         <identity.oauth.xacml.version.range>[2.0.0, 3.0.0)</identity.oauth.xacml.version.range>

--- a/pom.xml
+++ b/pom.xml
@@ -998,7 +998,7 @@
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!-- Carbon Identity Framework version -->
-        <carbon.identity.framework.version>7.11.90</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.11.166</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.25.234, 8.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
         <identity.oauth.xacml.version.range>[2.0.0, 3.0.0)</identity.oauth.xacml.version.range>


### PR DESCRIPTION
## Summary
When an application is configured with an alternate subject identifier (e.g. email set as the subject instead of the default user ID), and the same still-valid opaque access token is reissued after the underlying subject-source claim changes, the ID token `sub` and UserInfo `email` correctly reflect the new value, but the UserInfo `sub` stays frozen at the value computed at original token issuance — causing UserInfo's own claims to disagree with each other and with the ID token.

Root cause: `AbstractUserInfoResponseBuilder.getSubjectClaim(...)` returns the persisted `AuthenticatedUser` subject identifier from the access token record instead of the fresh subject-claim value.

## Change
Gated behind a new opt-in `deployment.toml` knob, default off (preserves current behavior unless explicitly enabled):
- New property `OAuth.RecomputeSubjectClaimForAlternateSubjectIdentifier` (default `false`).
- When `true` and the application has a non-blank alternate subject claim URI, `getSubjectClaim(...)` returns the fresh value from `userClaims.get(OAuth2Util.SUB)` instead of the persisted identifier; falls back to the original behavior if the fresh value is absent/blank.
- Default-subject apps (no alternate identifier configured) are unaffected — the new branch never executes for them.

The corresponding `deployment.toml` → `identity.xml` template change (default `false`) is being submitted separately to `wso2/carbon-identity-framework`.

## Testing
Verified against a freshly built pack in both knob states:
- Default-off: UserInfo `sub` unchanged from current behavior (stale on reissue) — no behavior change.
- Default-on: UserInfo `sub` matches the ID token `sub` exactly after the subject-source claim changes and the same token is reissued.
- Default-subject app, knob on: no change, confirmed no regression.

Closes wso2/product-is#28126