### PR TITLE
Refactor multi-valued claim handling for JWT assertions

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/user/impl/UserInfoUserStoreClaimRetriever.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/user/impl/UserInfoUserStoreClaimRetriever.java
@@ -18,11 +18,14 @@
 package org.wso2.carbon.identity.oauth.endpoint.user.impl;
 
 import org.apache.commons.collections.MapUtils;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.application.common.model.ClaimMapping;
+import org.wso2.carbon.identity.claim.metadata.mgt.model.LocalClaim;
 import org.wso2.carbon.identity.core.util.IdentityCoreConstants;
 import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
 import org.wso2.carbon.identity.oauth.endpoint.util.ClaimUtil;
 import org.wso2.carbon.identity.oauth.user.UserInfoClaimRetriever;
+import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -37,6 +40,10 @@ public class UserInfoUserStoreClaimRetriever implements UserInfoClaimRetriever {
 
         Map<String, Object> claims = new HashMap<String, Object>();
         if (MapUtils.isNotEmpty(userAttributes)) {
+            Map<String, LocalClaim> mappedLocalClaims =
+                    OAuthServerConfiguration.getInstance().isHonorMultivaluedClaimMetadata()
+                            ? OAuth2Util.getMappedLocalClaims(PrivilegedCarbonContext
+                            .getThreadLocalCarbonContext().getTenantDomain()) : null;
             for (Map.Entry<ClaimMapping, String> entry : userAttributes.entrySet()) {
 
                 if (entry.getKey().getRemoteClaim() == null || IdentityCoreConstants.MULTI_ATTRIBUTE_SEPARATOR.equals(
@@ -45,10 +52,12 @@ public class UserInfoUserStoreClaimRetriever implements UserInfoClaimRetriever {
                 }
                 String claimValue = entry.getValue();
                 String claimUri = entry.getKey().getRemoteClaim().getClaimUri();
+                String localClaimUri = entry.getKey().getLocalClaim() == null ? null
+                        : entry.getKey().getLocalClaim().getClaimUri();
                 boolean isMultiValueSupportEnabledForUserinfoResponse = OAuthServerConfiguration.getInstance()
                         .getUserInfoMultiValueSupportEnabled();
                 if (isMultiValueSupportEnabledForUserinfoResponse &&
-                        ClaimUtil.isMultiValuedAttribute(claimUri, claimValue)) {
+                        ClaimUtil.isMultiValuedAttribute(claimUri, localClaimUri, claimValue, mappedLocalClaims)) {
                     String[] attributeValues = ClaimUtil.processMultiValuedAttribute(claimValue);
                     claims.put(claimUri, attributeValues);
                 } else {

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/user/impl/UserInfoUserStoreClaimRetriever.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/user/impl/UserInfoUserStoreClaimRetriever.java
@@ -40,10 +40,10 @@ public class UserInfoUserStoreClaimRetriever implements UserInfoClaimRetriever {
 
         Map<String, Object> claims = new HashMap<String, Object>();
         if (MapUtils.isNotEmpty(userAttributes)) {
-            Map<String, LocalClaim> mappedLocalClaims =
+            Map<String, LocalClaim> oidcToLocalClaimMap =
                     OAuthServerConfiguration.getInstance().isHonorMultivaluedClaimMetadata()
-                            ? OAuth2Util.getMappedLocalClaims(PrivilegedCarbonContext
-                            .getThreadLocalCarbonContext().getTenantDomain()) : null;
+                            ? OAuth2Util.getOidcClaimToLocalClaimMap(PrivilegedCarbonContext
+                            .getThreadLocalCarbonContext().getTenantDomain()) : new HashMap<>();
             for (Map.Entry<ClaimMapping, String> entry : userAttributes.entrySet()) {
 
                 if (entry.getKey().getRemoteClaim() == null || IdentityCoreConstants.MULTI_ATTRIBUTE_SEPARATOR.equals(
@@ -51,17 +51,13 @@ public class UserInfoUserStoreClaimRetriever implements UserInfoClaimRetriever {
                     continue;
                 }
                 String claimValue = entry.getValue();
-                String claimUri = entry.getKey().getRemoteClaim().getClaimUri();
-                String localClaimUri = entry.getKey().getLocalClaim() == null ? null
-                        : entry.getKey().getLocalClaim().getClaimUri();
-                boolean isMultiValueSupportEnabledForUserinfoResponse = OAuthServerConfiguration.getInstance()
-                        .getUserInfoMultiValueSupportEnabled();
-                if (isMultiValueSupportEnabledForUserinfoResponse &&
-                        ClaimUtil.isMultiValuedAttribute(claimUri, localClaimUri, claimValue, mappedLocalClaims)) {
+                String oidcClaim = entry.getKey().getRemoteClaim().getClaimUri();
+                if (OAuthServerConfiguration.getInstance().getUserInfoMultiValueSupportEnabled() &&
+                        ClaimUtil.isMultiValuedAttribute(oidcClaim, oidcToLocalClaimMap.get(oidcClaim), claimValue)) {
                     String[] attributeValues = ClaimUtil.processMultiValuedAttribute(claimValue);
-                    claims.put(claimUri, attributeValues);
+                    claims.put(oidcClaim, attributeValues);
                 } else {
-                    claims.put(claimUri, claimValue);
+                    claims.put(oidcClaim, claimValue);
                 }
             }
         }

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/user/impl/UserInfoUserStoreClaimRetriever.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/user/impl/UserInfoUserStoreClaimRetriever.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2013, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2013-2026, WSO2 LLC. (http://www.wso2.com).
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -38,21 +38,27 @@ public class UserInfoUserStoreClaimRetriever implements UserInfoClaimRetriever {
     @Override
     public Map<String, Object> getClaimsMap(Map<ClaimMapping, String> userAttributes) {
 
-        Map<String, Object> claims = new HashMap<String, Object>();
+        Map<String, Object> claims = new HashMap<>();
         if (MapUtils.isNotEmpty(userAttributes)) {
-            Map<String, LocalClaim> oidcToLocalClaimMap =
+            boolean userInfoMultiValueSupportEnabled =
+                    OAuthServerConfiguration.getInstance().getUserInfoMultiValueSupportEnabled();
+            String tenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
+            Map<String, LocalClaim> oidcToLocalClaimMap = userInfoMultiValueSupportEnabled &&
                     OAuthServerConfiguration.getInstance().isHonorMultivaluedClaimMetadata()
-                            ? OAuth2Util.getOidcClaimToLocalClaimMap(PrivilegedCarbonContext
-                            .getThreadLocalCarbonContext().getTenantDomain()) : new HashMap<>();
-            for (Map.Entry<ClaimMapping, String> entry : userAttributes.entrySet()) {
+                            ? OAuth2Util.getOidcClaimToLocalClaimMap(tenantDomain) : new HashMap<>();
 
+            for (Map.Entry<ClaimMapping, String> entry : userAttributes.entrySet()) {
                 if (entry.getKey().getRemoteClaim() == null || IdentityCoreConstants.MULTI_ATTRIBUTE_SEPARATOR.equals(
                         entry.getKey().getRemoteClaim().getClaimUri())) {
                     continue;
                 }
                 String claimValue = entry.getValue();
                 String oidcClaim = entry.getKey().getRemoteClaim().getClaimUri();
-                if (OAuthServerConfiguration.getInstance().getUserInfoMultiValueSupportEnabled() &&
+                if (claimValue == null) {
+                    claims.put(oidcClaim, null);
+                    continue;
+                }
+                if (userInfoMultiValueSupportEnabled &&
                         ClaimUtil.isMultiValuedAttribute(oidcClaim, oidcToLocalClaimMap.get(oidcClaim), claimValue)) {
                     String[] attributeValues = ClaimUtil.processMultiValuedAttribute(claimValue);
                     claims.put(oidcClaim, attributeValues);

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/ClaimUtil.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/ClaimUtil.java
@@ -35,6 +35,8 @@ import org.wso2.carbon.identity.application.common.model.ServiceProvider;
 import org.wso2.carbon.identity.base.IdentityConstants;
 import org.wso2.carbon.identity.base.IdentityException;
 import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataHandler;
+import org.wso2.carbon.identity.claim.metadata.mgt.model.LocalClaim;
+import org.wso2.carbon.identity.claim.metadata.mgt.util.ClaimConstants;
 import org.wso2.carbon.identity.core.util.IdentityCoreConstants;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
@@ -265,6 +267,9 @@ public class ClaimUtil {
                 }
 
                 if (isNotEmpty(userClaims)) {
+                    Map<String, LocalClaim> mappedLocalClaims =
+                            OAuthServerConfiguration.getInstance().isHonorMultivaluedClaimMetadata()
+                                    ? OAuth2Util.getMappedLocalClaims(userTenantDomain) : null;
                     for (Map.Entry<String, String> entry : userClaims.entrySet()) {
                         //set local2sp role mappings
                         if (IdentityUtil.getRoleGroupClaims().stream().anyMatch(roleGroupClaimURI ->
@@ -289,7 +294,8 @@ public class ClaimUtil {
                             boolean isMultiValueSupportEnabledForUserinfoResponse = OAuthServerConfiguration
                                     .getInstance().getUserInfoMultiValueSupportEnabled();
                             if (isMultiValueSupportEnabledForUserinfoResponse &&
-                                    isMultiValuedAttribute(oidcClaimUri, claimValue)) {
+                                    isMultiValuedAttribute(oidcClaimUri, entry.getKey(), claimValue,
+                                            mappedLocalClaims)) {
                                 String[] attributeValues = processMultiValuedAttribute(claimValue);
                                 mappedAppClaims.put(oidcClaimUri, attributeValues);
                             } else {
@@ -573,6 +579,32 @@ public class ClaimUtil {
             return true;
         }
         return StringUtils.contains(claimValue, FrameworkUtils.getMultiAttributeSeparator());
+    }
+
+    /**
+     * Checks whether a user value is multivalued, honouring local claim metadata when available.
+     *
+     * @param oidcClaimUri        OIDC dialect claim URI.
+     * @param localClaimUri       Local claim URI (metadata lookup key).
+     * @param claimValue          Claim value.
+     * @param mappedLocalClaims  Claim metadata from {@link OAuth2Util#getMappedLocalClaims(String)},
+     *                            or {@code null} for legacy separator-based handling.
+     * @return Whether the value should be rendered as multivalued.
+     */
+    public static boolean isMultiValuedAttribute(String oidcClaimUri, String localClaimUri, String claimValue,
+                                                 Map<String, LocalClaim> mappedLocalClaims) {
+
+        if (mappedLocalClaims == null) {
+            return isMultiValuedAttribute(oidcClaimUri, claimValue);
+        }
+        if (GROUPS.equals(oidcClaimUri)) {
+            return true;
+        }
+        LocalClaim localClaim = mappedLocalClaims.get(localClaimUri);
+        if (localClaim == null) {
+            return isMultiValuedAttribute(oidcClaimUri, claimValue);
+        }
+        return Boolean.parseBoolean(localClaim.getClaimProperty(ClaimConstants.MULTI_VALUED_PROPERTY));
     }
 
     /**

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/ClaimUtil.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/ClaimUtil.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2013, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2013-2026, WSO2 LLC. (http://www.wso2.com).
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -15,7 +15,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.wso2.carbon.identity.oauth.endpoint.util;
 
 import org.apache.commons.collections.CollectionUtils;

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/ClaimUtil.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/ClaimUtil.java
@@ -267,9 +267,9 @@ public class ClaimUtil {
                 }
 
                 if (isNotEmpty(userClaims)) {
-                    Map<String, LocalClaim> mappedLocalClaims =
+                    Map<String, LocalClaim> oidcToLocalClaimMap =
                             OAuthServerConfiguration.getInstance().isHonorMultivaluedClaimMetadata()
-                                    ? OAuth2Util.getMappedLocalClaims(userTenantDomain) : null;
+                                    ? OAuth2Util.getOidcClaimToLocalClaimMap(userTenantDomain) : new HashMap<>();
                     for (Map.Entry<String, String> entry : userClaims.entrySet()) {
                         //set local2sp role mappings
                         if (IdentityUtil.getRoleGroupClaims().stream().anyMatch(roleGroupClaimURI ->
@@ -294,8 +294,8 @@ public class ClaimUtil {
                             boolean isMultiValueSupportEnabledForUserinfoResponse = OAuthServerConfiguration
                                     .getInstance().getUserInfoMultiValueSupportEnabled();
                             if (isMultiValueSupportEnabledForUserinfoResponse &&
-                                    isMultiValuedAttribute(oidcClaimUri, entry.getKey(), claimValue,
-                                            mappedLocalClaims)) {
+                                    isMultiValuedAttribute(oidcClaimUri, oidcToLocalClaimMap.get(oidcClaimUri),
+                                            claimValue)) {
                                 String[] attributeValues = processMultiValuedAttribute(claimValue);
                                 mappedAppClaims.put(oidcClaimUri, attributeValues);
                             } else {
@@ -585,24 +585,17 @@ public class ClaimUtil {
      * Checks whether a user value is multivalued, honouring local claim metadata when available.
      *
      * @param oidcClaimUri        OIDC dialect claim URI.
-     * @param localClaimUri       Local claim URI (metadata lookup key).
+     * @param localClaim          Local claim object.
      * @param claimValue          Claim value.
-     * @param mappedLocalClaims  Claim metadata from {@link OAuth2Util#getMappedLocalClaims(String)},
-     *                            or {@code null} for legacy separator-based handling.
      * @return Whether the value should be rendered as multivalued.
      */
-    public static boolean isMultiValuedAttribute(String oidcClaimUri, String localClaimUri, String claimValue,
-                                                 Map<String, LocalClaim> mappedLocalClaims) {
+    public static boolean isMultiValuedAttribute(String oidcClaimUri, LocalClaim localClaim, String claimValue) {
 
-        if (mappedLocalClaims == null) {
+        if (localClaim == null) {
             return isMultiValuedAttribute(oidcClaimUri, claimValue);
         }
         if (GROUPS.equals(oidcClaimUri)) {
             return true;
-        }
-        LocalClaim localClaim = mappedLocalClaims.get(localClaimUri);
-        if (localClaim == null) {
-            return isMultiValuedAttribute(oidcClaimUri, claimValue);
         }
         return Boolean.parseBoolean(localClaim.getClaimProperty(ClaimConstants.MULTI_VALUED_PROPERTY));
     }

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/util/ClaimUtilTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/util/ClaimUtilTest.java
@@ -41,6 +41,8 @@ import org.wso2.carbon.identity.application.common.model.RoleMapping;
 import org.wso2.carbon.identity.application.common.model.ServiceProvider;
 import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataHandler;
+import org.wso2.carbon.identity.claim.metadata.mgt.model.LocalClaim;
+import org.wso2.carbon.identity.claim.metadata.mgt.util.ClaimConstants;
 import org.wso2.carbon.identity.core.util.IdentityCoreConstants;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
@@ -642,6 +644,39 @@ public class ClaimUtilTest {
                 Assert.assertEquals(e.getErrorMessage(), "Access token validation failed",
                         "errorMessage should be the canonical 'Access token validation failed' string");
             }
+        }
+    }
+
+    private static LocalClaim multiValuedLocalClaim(boolean multiValued) {
+
+        LocalClaim localClaim = new LocalClaim("http://wso2.org/claims/testClaim");
+        localClaim.setClaimProperty(ClaimConstants.MULTI_VALUED_PROPERTY, String.valueOf(multiValued));
+        return localClaim;
+    }
+
+    @DataProvider(name = "isMultiValuedAttributeData")
+    public Object[][] isMultiValuedAttributeData() {
+
+        return new Object[][]{
+                // Groups is always rendered as an array, with or without metadata.
+                {"groups", null, "admin", true},
+                {"groups", multiValuedLocalClaim(false), "admin", true},
+                // When metadata is present, the local claim multiValued property decides.
+                {"http://wso2.org/oidc/claim/email", multiValuedLocalClaim(true), "a@b.com", true},
+                {"http://wso2.org/oidc/claim/email", multiValuedLocalClaim(false), "a@b.com,c@d.com", false},
+                // When metadata is absent, fall back to separator-based detection.
+                {"http://wso2.org/oidc/claim/email", null, "a@b.com,c@d.com", true},
+                {"http://wso2.org/oidc/claim/email", null, "a@b.com", false},
+        };
+    }
+
+    @Test(dataProvider = "isMultiValuedAttributeData")
+    public void testIsMultiValuedAttribute(String oidcClaimUri, LocalClaim localClaim, String claimValue,
+                                           boolean expected) {
+
+        try (MockedStatic<FrameworkUtils> frameworkUtils = mockStatic(FrameworkUtils.class)) {
+            frameworkUtils.when(FrameworkUtils::getMultiAttributeSeparator).thenReturn(",");
+            Assert.assertEquals(ClaimUtil.isMultiValuedAttribute(oidcClaimUri, localClaim, claimValue), expected);
         }
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/config/OAuthServerConfiguration.java
@@ -246,6 +246,7 @@ public class OAuthServerConfiguration {
     private List<String> supportedIdTokenEncryptionMethods = new ArrayList<>();
     private String userInfoJWTSignatureAlgorithm = "SHA256withRSA";
     private boolean userInfoMultiValueSupportEnabled = true;
+    private boolean honorMultivaluedClaimMetadata = false;
     private boolean userInfoRemoveInternalPrefixFromRoles = false;
     private boolean isReturnOnlyAppAssociatedRolesInUserInfo = false;
     private boolean isReturnOnlyAppAssociatedRolesInJWTToken = false;
@@ -1827,6 +1828,18 @@ public class OAuthServerConfiguration {
     public boolean getUserInfoMultiValueSupportEnabled() {
 
         return userInfoMultiValueSupportEnabled;
+    }
+
+    /**
+     * Whether a claim is emitted as a JSON array in JWT/ID tokens and the UserInfo response based on
+     * its local claim {@code multiValued} metadata property, instead of the legacy separator-based
+     * detection. Opt-in; default false = legacy behaviour.
+     *
+     * @return True if only multi-valued claims should be converted to arrays.
+     */
+    public boolean isHonorMultivaluedClaimMetadata() {
+
+        return honorMultivaluedClaimMetadata;
     }
 
     /**
@@ -3941,6 +3954,13 @@ public class OAuthServerConfiguration {
                         userInfoMultiValueSupportEnabledElem.getText().trim());
             }
 
+            OMElement honorMultivaluedClaimMetadataElem = openIDConnectConfigElem.getFirstChildWithName(
+                    getQNameWithIdentityNS(ConfigElements.OPENID_CONNECT_HONOR_MULTIVALUED_CLAIM_METADATA));
+            if (honorMultivaluedClaimMetadataElem != null) {
+                honorMultivaluedClaimMetadata = Boolean.parseBoolean(
+                        honorMultivaluedClaimMetadataElem.getText().trim());
+            }
+
             OMElement userInfoResponseRemoveInternalPrefixFromRoles = openIDConnectConfigElem.getFirstChildWithName(
                     getQNameWithIdentityNS(ConfigElements.OPENID_CONNECT_USERINFO_REMOVE_INTERNAL_PREFIX_FROM_ROLES));
             if (userInfoResponseRemoveInternalPrefixFromRoles != null) {
@@ -4696,6 +4716,8 @@ public class OAuthServerConfiguration {
         public static final String OPENID_CONNECT_USERINFO_JWT_SIGNATURE_ALGORITHM = "UserInfoJWTSignatureAlgorithm";
         public static final String OPENID_CONNECT_USERINFO_MULTI_VALUE_SUPPORT_ENABLED =
                 "UserInfoMultiValueSupportEnabled";
+        public static final String OPENID_CONNECT_HONOR_MULTIVALUED_CLAIM_METADATA =
+                "HonorMultivaluedClaimMetadata";
         public static final String OPENID_CONNECT_USERINFO_REMOVE_INTERNAL_PREFIX_FROM_ROLES =
                 "UserInfoRemoveInternalPrefixFromRoles";
         private static final String OPENID_CONNECT_RETURN_APP_ROLES_IN_USERINFO =

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authcontext/JWTTokenGenerator.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authcontext/JWTTokenGenerator.java
@@ -30,6 +30,8 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.base.MultitenantConstants;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
+import org.wso2.carbon.identity.claim.metadata.mgt.model.LocalClaim;
+import org.wso2.carbon.identity.claim.metadata.mgt.util.ClaimConstants;
 import org.wso2.carbon.identity.core.IdentityKeyStoreResolver;
 import org.wso2.carbon.identity.core.util.IdentityCoreConstants;
 import org.wso2.carbon.identity.core.util.IdentityKeyStoreResolverConstants;
@@ -65,6 +67,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -264,11 +267,13 @@ public class JWTTokenGenerator implements AuthorizationContextTokenGenerator {
             }
 
             if (claimValues != null) {
+                Map<String, LocalClaim> oidcToLocalClaimMap =
+                        OAuthServerConfiguration.getInstance().isHonorMultivaluedClaimMetadata()
+                                ? OAuth2Util.getLocalClaimMap(tenantDomain) : new HashMap<>();
                 for (String claimURI : new TreeSet<>(claimValues.keySet())) {
                     String claimVal = claimValues.get(claimURI);
-                    List<String> claimList = new ArrayList<>();
-                    if (useMultiValueSeparator && userAttributeSeparator != null &&
-                            claimVal.contains(userAttributeSeparator)) {
+                    if (isMultiValuedAttribute(oidcToLocalClaimMap.get(claimURI), claimVal)) {
+                        List<String> claimList = new ArrayList<>();
                         StringTokenizer st = new StringTokenizer(claimVal, userAttributeSeparator);
                         while (st.hasMoreElements()) {
                             String attValue = st.nextElement().toString();
@@ -298,6 +303,24 @@ public class JWTTokenGenerator implements AuthorizationContextTokenGenerator {
         OAuth2TokenValidationResponseDTO.AuthorizationContextToken token;
         token = messageContext.getResponseDTO().new AuthorizationContextToken("JWT", jwt.serialize());
         messageContext.getResponseDTO().setAuthorizationContextToken(token);
+    }
+
+
+    /**
+     * Checks whether a user value is multivalued, honouring local claim metadata when available.
+     *
+     * @param localClaim          Local claim object.
+     * @param claimValue          Claim value.
+     * @return Whether the value should be rendered as multivalued.
+     */
+    private boolean isMultiValuedAttribute(LocalClaim localClaim, String claimValue) {
+
+        if (localClaim == null) {
+            // Legacy separator-based detection.
+            return useMultiValueSeparator && userAttributeSeparator != null &&
+                    claimValue.contains(userAttributeSeparator);
+        }
+        return Boolean.parseBoolean(localClaim.getClaimProperty(ClaimConstants.MULTI_VALUED_PROPERTY));
     }
 
     private SortedMap<String, String> filterClaimsFromCache(AuthenticatedUser authenticatedUser, ClaimCacheKey cacheKey,

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authcontext/JWTTokenGenerator.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/authcontext/JWTTokenGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2025, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2012-2026, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -93,6 +93,7 @@ import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
 import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
 import org.wso2.carbon.identity.claim.metadata.mgt.exception.ClaimMetadataException;
 import org.wso2.carbon.identity.claim.metadata.mgt.model.ExternalClaim;
+import org.wso2.carbon.identity.claim.metadata.mgt.model.LocalClaim;
 import org.wso2.carbon.identity.consent.server.configs.mgt.exceptions.ConsentServerConfigsMgtException;
 import org.wso2.carbon.identity.consent.server.configs.mgt.services.ConsentServerConfigsManagementService;
 import org.wso2.carbon.identity.core.IdentityKeyStoreResolver;
@@ -2318,6 +2319,55 @@ public class OAuth2Util {
             }
         } catch (IdentityOAuth2Exception | ClaimMetadataException | OrganizationManagementException e) {
             log.error(e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Builds a claim URI (local and mapped OIDC dialect) to {@link LocalClaim} map. The value is
+     * read-only (shared with the claim metadata cache).
+     *
+     * @param tenantDomain Tenant domain to resolve claim metadata for.
+     * @return Map of {local + OIDC claim URI} to {@link LocalClaim}, or {@code null} if unavailable.
+     */
+    public static Map<String, LocalClaim> getMappedLocalClaims(String tenantDomain) {
+
+        ClaimMetadataManagementService claimMetadataManagementService =
+                OAuth2ServiceComponentHolder.getInstance().getClaimMetadataManagementService();
+        if (claimMetadataManagementService == null) {
+            if (log.isDebugEnabled()) {
+                log.debug("ClaimMetadataManagementService unavailable for tenant: " + tenantDomain);
+            }
+            return null;
+        }
+        try {
+            List<LocalClaim> localClaims = claimMetadataManagementService.getLocalClaims(tenantDomain);
+            if (localClaims == null) {
+                if (log.isDebugEnabled()) {
+                    log.debug("No local claims for tenant: " + tenantDomain);
+                }
+                return null;
+            }
+            Map<String, LocalClaim> mappedLocalClaims = new HashMap<>();
+            for (LocalClaim localClaim : localClaims) {
+                mappedLocalClaims.put(localClaim.getClaimURI(), localClaim);
+            }
+            // Alias each OIDC dialect claim URI to its mapped local claim, so token paths (keyed by the
+            // OIDC URI) resolve the same metadata as the UserInfo path (keyed by the local URI).
+            List<ExternalClaim> oidcClaims =
+                    claimMetadataManagementService.getExternalClaims(OAuthConstants.OIDC_DIALECT, tenantDomain);
+            if (oidcClaims != null) {
+                for (ExternalClaim oidcClaim : oidcClaims) {
+                    LocalClaim mappedLocalClaim = mappedLocalClaims.get(oidcClaim.getMappedLocalClaim());
+                    if (mappedLocalClaim != null) {
+                        mappedLocalClaims.put(oidcClaim.getClaimURI(), mappedLocalClaim);
+                    }
+                }
+            }
+            return mappedLocalClaims;
+        } catch (ClaimMetadataException e) {
+            log.error("Error reading claim metadata for tenant: " + tenantDomain
+                    + ". Falling back to legacy handling.", e);
+            return null;
         }
     }
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -2323,51 +2323,40 @@ public class OAuth2Util {
     }
 
     /**
-     * Builds a claim URI (local and mapped OIDC dialect) to {@link LocalClaim} map. The value is
-     * read-only (shared with the claim metadata cache).
+     * This method is used to get the OIDC claim to local claim mapping for a given tenant domain.
      *
-     * @param tenantDomain Tenant domain to resolve claim metadata for.
-     * @return Map of {local + OIDC claim URI} to {@link LocalClaim}, or {@code null} if unavailable.
+     * @param tenantDomain Tenant domain.
+     * @return Map of OIDC claim to local claim mapping.
      */
-    public static Map<String, LocalClaim> getMappedLocalClaims(String tenantDomain) {
+    public static Map<String, LocalClaim> getOidcClaimToLocalClaimMap(String tenantDomain) {
 
         ClaimMetadataManagementService claimMetadataManagementService =
                 OAuth2ServiceComponentHolder.getInstance().getClaimMetadataManagementService();
-        if (claimMetadataManagementService == null) {
-            if (log.isDebugEnabled()) {
-                log.debug("ClaimMetadataManagementService unavailable for tenant: " + tenantDomain);
-            }
-            return null;
-        }
+        Map<String, LocalClaim> mappedLocalClaims = getLocalClaimMap(tenantDomain);
         try {
-            List<LocalClaim> localClaims = claimMetadataManagementService.getLocalClaims(tenantDomain);
-            if (localClaims == null) {
-                if (log.isDebugEnabled()) {
-                    log.debug("No local claims for tenant: " + tenantDomain);
-                }
-                return null;
-            }
-            Map<String, LocalClaim> mappedLocalClaims = new HashMap<>();
-            for (LocalClaim localClaim : localClaims) {
-                mappedLocalClaims.put(localClaim.getClaimURI(), localClaim);
-            }
-            // Alias each OIDC dialect claim URI to its mapped local claim, so token paths (keyed by the
-            // OIDC URI) resolve the same metadata as the UserInfo path (keyed by the local URI).
             List<ExternalClaim> oidcClaims =
                     claimMetadataManagementService.getExternalClaims(OAuthConstants.OIDC_DIALECT, tenantDomain);
             if (oidcClaims != null) {
-                for (ExternalClaim oidcClaim : oidcClaims) {
-                    LocalClaim mappedLocalClaim = mappedLocalClaims.get(oidcClaim.getMappedLocalClaim());
-                    if (mappedLocalClaim != null) {
-                        mappedLocalClaims.put(oidcClaim.getClaimURI(), mappedLocalClaim);
-                    }
-                }
+                return oidcClaims.stream().collect(Collectors.toMap(ExternalClaim::getClaimURI,
+                        externalClaim -> mappedLocalClaims.get(externalClaim.getMappedLocalClaim())));
             }
-            return mappedLocalClaims;
+            return new HashMap<>();
         } catch (ClaimMetadataException e) {
-            log.error("Error reading claim metadata for tenant: " + tenantDomain
-                    + ". Falling back to legacy handling.", e);
-            return null;
+            log.error("Error reading OIDC claims of tenant: " + tenantDomain, e);
+            return new HashMap<>();
+        }
+    }
+
+    public static Map<String, LocalClaim> getLocalClaimMap(String tenantDomain) {
+
+        ClaimMetadataManagementService claimMetadataManagementService =
+                OAuth2ServiceComponentHolder.getInstance().getClaimMetadataManagementService();
+        try {
+            return claimMetadataManagementService.getLocalClaims(tenantDomain).stream()
+                    .collect(Collectors.toMap(LocalClaim::getClaimURI, localClaim -> localClaim));
+        } catch (ClaimMetadataException e) {
+            log.error("Error reading claim metadata for tenant: " + tenantDomain, e);
+            return new HashMap<>();
         }
     }
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -2325,8 +2325,8 @@ public class OAuth2Util {
     /**
      * This method is used to get the OIDC claim to local claim mapping for a given tenant domain.
      *
-     * @param tenantDomain Tenant domain.
-     * @return Map of OIDC claim to local claim mapping.
+     * `@param` tenantDomain Tenant domain.
+     * `@return` Map of OIDC claim to local claim mapping.
      */
     public static Map<String, LocalClaim> getOidcClaimToLocalClaimMap(String tenantDomain) {
 
@@ -2337,8 +2337,14 @@ public class OAuth2Util {
             List<ExternalClaim> oidcClaims =
                     claimMetadataManagementService.getExternalClaims(OAuthConstants.OIDC_DIALECT, tenantDomain);
             if (oidcClaims != null) {
-                return oidcClaims.stream().collect(Collectors.toMap(ExternalClaim::getClaimURI,
-                        externalClaim -> mappedLocalClaims.get(externalClaim.getMappedLocalClaim())));
+                Map<String, LocalClaim> oidcClaimToLocalClaimMap = new HashMap<>();
+                for (ExternalClaim oidcClaim : oidcClaims) {
+                    LocalClaim mappedLocalClaim = mappedLocalClaims.get(oidcClaim.getMappedLocalClaim());
+                    if (mappedLocalClaim != null) {
+                        oidcClaimToLocalClaimMap.put(oidcClaim.getClaimURI(), mappedLocalClaim);
+                    }
+                }
+                return oidcClaimToLocalClaimMap;
             }
             return new HashMap<>();
         } catch (ClaimMetadataException e) {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/DefaultOIDCClaimsCallbackHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/DefaultOIDCClaimsCallbackHandler.java
@@ -37,6 +37,7 @@ import org.wso2.carbon.identity.application.common.model.ServiceProvider;
 import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.base.IdentityConstants;
 import org.wso2.carbon.identity.base.IdentityException;
+import org.wso2.carbon.identity.claim.metadata.mgt.model.LocalClaim;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.oauth.cache.AuthorizationGrantCache;
 import org.wso2.carbon.identity.oauth.cache.AuthorizationGrantCacheEntry;
@@ -78,8 +79,6 @@ import static org.wso2.carbon.identity.application.authentication.framework.util
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.ACCESS_TOKEN;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.AUTHZ_CODE;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.ID_TOKEN;
-import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCClaims.ADDRESS;
-import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCClaims.GROUPS;
 import static org.wso2.carbon.identity.oauth2.device.constants.Constants.DEVICE_CODE;
 import static org.wso2.carbon.identity.oauth2.util.OAuth2Util.handleGroupClaim;
 import static org.wso2.carbon.identity.openidconnect.OIDCConstants.ID_TOKEN_USER_CLAIMS_PROP_KEY;
@@ -99,7 +98,8 @@ public class DefaultOIDCClaimsCallbackHandler implements CustomClaimsCallbackHan
         try {
             Map<String, Object> userClaimsInOIDCDialect = getUserClaimsInOIDCDialect(tokenReqMessageContext);
             tokenReqMessageContext.addProperty(ID_TOKEN_USER_CLAIMS_PROP_KEY, userClaimsInOIDCDialect.keySet());
-            return setClaimsToJwtClaimSet(jwtClaimsSetBuilder, userClaimsInOIDCDialect);
+            return setClaimsToJwtClaimSet(jwtClaimsSetBuilder, userClaimsInOIDCDialect,
+                    getServiceProviderTenantDomain(tokenReqMessageContext));
         } catch (OAuthSystemException e) {
             if (log.isDebugEnabled()) {
                 log.debug("Error occurred while adding claims of user: " + tokenReqMessageContext.getAuthorizedUser() +
@@ -116,7 +116,8 @@ public class DefaultOIDCClaimsCallbackHandler implements CustomClaimsCallbackHan
 
         try {
             Map<String, Object> userClaimsInOIDCDialect = getUserClaimsInOIDCDialect(authzReqMessageContext);
-            return setClaimsToJwtClaimSet(jwtClaimsSet, userClaimsInOIDCDialect);
+            return setClaimsToJwtClaimSet(jwtClaimsSet, userClaimsInOIDCDialect,
+                    getServiceProviderTenantDomain(authzReqMessageContext));
         } catch (OAuthSystemException e) {
             log.error("Error occurred while adding claims of user: " +
                     authzReqMessageContext.getAuthorizationReqDTO().getUser() + " to the JWTClaimSet used to " +
@@ -870,14 +871,18 @@ public class DefaultOIDCClaimsCallbackHandler implements CustomClaimsCallbackHan
      * @param userClaimsInOIDCDialect
      */
     private JWTClaimsSet setClaimsToJwtClaimSet(JWTClaimsSet.Builder jwtClaimsSetBuilder, Map<String, Object>
-            userClaimsInOIDCDialect) {
+            userClaimsInOIDCDialect, String spTenantDomain) {
 
         JWTClaimsSet jwtClaimsSet = jwtClaimsSetBuilder.build();
         String multiAttributeSeparator = FrameworkUtils.getMultiAttributeSeparator();
+        Map<String, LocalClaim> mappedLocalClaims =
+                OAuthServerConfiguration.getInstance().isHonorMultivaluedClaimMetadata()
+                        ? OAuth2Util.getMappedLocalClaims(spTenantDomain) : null;
         for (Map.Entry<String, Object> claimEntry : userClaimsInOIDCDialect.entrySet()) {
             String claimValue = claimEntry.getValue().toString();
             String claimKey = claimEntry.getKey();
-            if (isMultiValuedAttribute(claimKey, claimValue, multiAttributeSeparator)) {
+            if (OIDCClaimUtil.isMultiValuedAttribute(claimKey, claimValue, multiAttributeSeparator,
+                    mappedLocalClaims)) {
                 JSONArray claimValues = new JSONArray();
                 String[] attributeValues = claimValue.split(Pattern.quote(multiAttributeSeparator));
                 for (String attributeValue : attributeValues) {
@@ -920,20 +925,6 @@ public class DefaultOIDCClaimsCallbackHandler implements CustomClaimsCallbackHan
 
     private boolean isLocalUser(OAuthAuthzReqMessageContext authzReqMessageContext) {
         return !authzReqMessageContext.getAuthorizationReqDTO().getUser().isFederatedUser();
-    }
-
-    private boolean isMultiValuedAttribute(String claimKey, String claimValue, String multiAttributeSeparator) {
-
-        // Address claim contains multi attribute separator but its not a multi valued attribute.
-        if (claimKey.equals(ADDRESS)) {
-            return false;
-        }
-        // To format the groups claim to always return as an array, we should consider single group as
-        // multi value attribute.
-        if (claimKey.equals(GROUPS)) {
-            return true;
-        }
-        return StringUtils.contains(claimValue, multiAttributeSeparator);
     }
 
     private boolean isApiBasedAuthFlow(String accessToken, String authorizationCode) {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/DefaultOIDCClaimsCallbackHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/DefaultOIDCClaimsCallbackHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2023, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2017-2026, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/DefaultOIDCClaimsCallbackHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/DefaultOIDCClaimsCallbackHandler.java
@@ -875,14 +875,14 @@ public class DefaultOIDCClaimsCallbackHandler implements CustomClaimsCallbackHan
 
         JWTClaimsSet jwtClaimsSet = jwtClaimsSetBuilder.build();
         String multiAttributeSeparator = FrameworkUtils.getMultiAttributeSeparator();
-        Map<String, LocalClaim> mappedLocalClaims =
+        Map<String, LocalClaim> oidcToLocalClaimMap =
                 OAuthServerConfiguration.getInstance().isHonorMultivaluedClaimMetadata()
-                        ? OAuth2Util.getMappedLocalClaims(spTenantDomain) : null;
+                        ? OAuth2Util.getOidcClaimToLocalClaimMap(spTenantDomain) : new HashMap<>();
         for (Map.Entry<String, Object> claimEntry : userClaimsInOIDCDialect.entrySet()) {
             String claimValue = claimEntry.getValue().toString();
             String claimKey = claimEntry.getKey();
             if (OIDCClaimUtil.isMultiValuedAttribute(claimKey, claimValue, multiAttributeSeparator,
-                    mappedLocalClaims)) {
+                    oidcToLocalClaimMap.get(claimKey))) {
                 JSONArray claimValues = new JSONArray();
                 String[] attributeValues = claimValue.split(Pattern.quote(multiAttributeSeparator));
                 for (String attributeValue : attributeValues) {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/JWTAccessTokenOIDCClaimsHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/JWTAccessTokenOIDCClaimsHandler.java
@@ -38,6 +38,7 @@ import org.wso2.carbon.identity.base.IdentityConstants;
 import org.wso2.carbon.identity.base.IdentityException;
 import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataHandler;
 import org.wso2.carbon.identity.claim.metadata.mgt.exception.ClaimMetadataException;
+import org.wso2.carbon.identity.claim.metadata.mgt.model.LocalClaim;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.oauth.cache.AuthorizationGrantCache;
@@ -81,8 +82,6 @@ import static org.apache.commons.collections.MapUtils.isNotEmpty;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.ORGANIZATION_LOGIN_IDP_NAME;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.ACCESS_TOKEN;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.AUTHZ_CODE;
-import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCClaims.ADDRESS;
-import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCClaims.GROUPS;
 import static org.wso2.carbon.identity.oauth2.device.constants.Constants.DEVICE_CODE;
 
 /**
@@ -100,7 +99,7 @@ public class JWTAccessTokenOIDCClaimsHandler implements CustomClaimsCallbackHand
             throws IdentityOAuth2Exception {
 
         Map<String, Object> claims = getUserClaimsInOIDCDialect(request);
-        return setClaimsToJwtClaimSet(builder, claims);
+        return setClaimsToJwtClaimSet(builder, claims, getServiceProviderTenantDomain(request));
     }
 
     @Override
@@ -112,7 +111,7 @@ public class JWTAccessTokenOIDCClaimsHandler implements CustomClaimsCallbackHand
           to manage user attributes for the access token.
          */
         Map<String, Object> claims = getUserClaimsInOIDCDialect(request);
-        return setClaimsToJwtClaimSet(builder, claims);
+        return setClaimsToJwtClaimSet(builder, claims, getServiceProviderTenantDomain(request));
     }
 
     /**
@@ -890,19 +889,24 @@ public class JWTAccessTokenOIDCClaimsHandler implements CustomClaimsCallbackHand
     /**
      * This method sets claims to JWTClaimSet.
      *
-     * @param jwtClaimsSetBuilder JWTClaimSet builder.
+     * @param jwtClaimsSetBuilder     JWTClaimSet builder.
      * @param userClaimsInOIDCDialect User claims in OIDC dialect.
+     * @param spTenantDomain          Service provider tenant domain.
      * @return JWTClaimSet with claims.
      */
     private JWTClaimsSet setClaimsToJwtClaimSet(JWTClaimsSet.Builder jwtClaimsSetBuilder, Map<String, Object>
-            userClaimsInOIDCDialect) {
+            userClaimsInOIDCDialect, String spTenantDomain) {
 
         JWTClaimsSet jwtClaimsSet = jwtClaimsSetBuilder.build();
         String multiAttributeSeparator = FrameworkUtils.getMultiAttributeSeparator();
+        Map<String, LocalClaim> mappedLocalClaims =
+                OAuthServerConfiguration.getInstance().isHonorMultivaluedClaimMetadata()
+                        ? OAuth2Util.getMappedLocalClaims(spTenantDomain) : null;
         for (Map.Entry<String, Object> claimEntry : userClaimsInOIDCDialect.entrySet()) {
             String claimValue = claimEntry.getValue().toString();
             String claimKey = claimEntry.getKey();
-            if (isMultiValuedAttribute(claimKey, claimValue, multiAttributeSeparator)) {
+            if (OIDCClaimUtil.isMultiValuedAttribute(claimKey, claimValue, multiAttributeSeparator,
+                    mappedLocalClaims)) {
                 JSONArray claimValues = new JSONArray();
                 String[] attributeValues = claimValue.split(Pattern.quote(multiAttributeSeparator));
                 for (String attributeValue : attributeValues) {
@@ -920,28 +924,6 @@ public class JWTAccessTokenOIDCClaimsHandler implements CustomClaimsCallbackHand
             }
         }
         return jwtClaimsSetBuilder.build();
-    }
-
-    /**
-     * Check weather claim value if multi valued or not.
-     *
-     * @param claimKey Claim key.
-     * @param claimValue Claim value.
-     * @param multiAttributeSeparator Multi attribute separator.
-     * @return True if claim value is multi valued, false otherwise.
-     */
-    private boolean isMultiValuedAttribute(String claimKey, String claimValue, String multiAttributeSeparator) {
-
-        // Address claim contains multi attribute separator but its not a multi valued attribute.
-        if (claimKey.equals(ADDRESS)) {
-            return false;
-        }
-        // To format the groups claim to always return as an array, we should consider single group as
-        // multi value attribute.
-        if (claimKey.equals(GROUPS)) {
-            return true;
-        }
-        return StringUtils.contains(claimValue, multiAttributeSeparator);
     }
 
     /**

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/JWTAccessTokenOIDCClaimsHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/JWTAccessTokenOIDCClaimsHandler.java
@@ -899,14 +899,14 @@ public class JWTAccessTokenOIDCClaimsHandler implements CustomClaimsCallbackHand
 
         JWTClaimsSet jwtClaimsSet = jwtClaimsSetBuilder.build();
         String multiAttributeSeparator = FrameworkUtils.getMultiAttributeSeparator();
-        Map<String, LocalClaim> mappedLocalClaims =
+        Map<String, LocalClaim> oidcToLocalClaimMap =
                 OAuthServerConfiguration.getInstance().isHonorMultivaluedClaimMetadata()
-                        ? OAuth2Util.getMappedLocalClaims(spTenantDomain) : null;
+                        ? OAuth2Util.getOidcClaimToLocalClaimMap(spTenantDomain) : new HashMap<>();
         for (Map.Entry<String, Object> claimEntry : userClaimsInOIDCDialect.entrySet()) {
             String claimValue = claimEntry.getValue().toString();
             String claimKey = claimEntry.getKey();
             if (OIDCClaimUtil.isMultiValuedAttribute(claimKey, claimValue, multiAttributeSeparator,
-                    mappedLocalClaims)) {
+                    oidcToLocalClaimMap.get(claimKey))) {
                 JSONArray claimValues = new JSONArray();
                 String[] attributeValues = claimValue.split(Pattern.quote(multiAttributeSeparator));
                 for (String attributeValue : attributeValues) {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/JWTAccessTokenOIDCClaimsHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/JWTAccessTokenOIDCClaimsHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2024-2026, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -15,7 +15,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.wso2.carbon.identity.openidconnect;
 
 import com.nimbusds.jwt.JWTClaimsSet;

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/OIDCClaimUtil.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/OIDCClaimUtil.java
@@ -33,6 +33,8 @@ import org.wso2.carbon.identity.base.IdentityConstants;
 import org.wso2.carbon.identity.base.IdentityException;
 import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataHandler;
 import org.wso2.carbon.identity.claim.metadata.mgt.exception.ClaimMetadataException;
+import org.wso2.carbon.identity.claim.metadata.mgt.model.LocalClaim;
+import org.wso2.carbon.identity.claim.metadata.mgt.util.ClaimConstants;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.oauth.cache.AuthorizationGrantCache;
@@ -756,5 +758,38 @@ public class OIDCClaimUtil {
         }
 
         return userClaimsInOidcDialect;
+    }
+
+    /**
+     * Whether a claim should be rendered as an array, keyed on the claim URI (OIDC or local dialect).
+     * With metadata ({@code mappedLocalClaims} present and the claim found) the local claim
+     * {@code multiValued} property decides; otherwise legacy separator-based detection is used.
+     * Special cases: {@code address} is never an array, {@code groups} is always an array.
+     *
+     * @param claimKey                Claim URI (OIDC or local dialect).
+     * @param claimValue              Raw claim value.
+     * @param multiAttributeSeparator Multi attribute separator.
+     * @param mappedLocalClaims       Mapped local claims from {@link OAuth2Util#getMappedLocalClaims(String)},
+     *                                or {@code null}.
+     * @return True if the claim should be rendered as a multivalued attribute.
+     */
+    public static boolean isMultiValuedAttribute(String claimKey, String claimValue, String multiAttributeSeparator,
+                                                 Map<String, LocalClaim> mappedLocalClaims) {
+
+        // Address claim contains the multi attribute separator but is not a multi valued attribute.
+        if (OAuthConstants.OIDCClaims.ADDRESS.equals(claimKey)) {
+            return false;
+        }
+        // Groups claim is always formatted as an array (a single group is still returned as an array).
+        if (OAuthConstants.OIDCClaims.GROUPS.equals(claimKey)) {
+            return true;
+        }
+        if (mappedLocalClaims != null) {
+            LocalClaim localClaim = mappedLocalClaims.get(claimKey);
+            if (localClaim != null) {
+                return Boolean.parseBoolean(localClaim.getClaimProperty(ClaimConstants.MULTI_VALUED_PROPERTY));
+            }
+        }
+        return StringUtils.contains(claimValue, multiAttributeSeparator);
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/OIDCClaimUtil.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/OIDCClaimUtil.java
@@ -1,19 +1,20 @@
 /*
- * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2017-2026, WSO2 LLC. (http://www.wso2.com).
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
  * You may obtain a copy of the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
-
 package org.wso2.carbon.identity.openidconnect;
 
 import org.apache.commons.collections.MapUtils;

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/OIDCClaimUtil.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/OIDCClaimUtil.java
@@ -762,19 +762,18 @@ public class OIDCClaimUtil {
 
     /**
      * Whether a claim should be rendered as an array, keyed on the claim URI (OIDC or local dialect).
-     * With metadata ({@code mappedLocalClaims} present and the claim found) the local claim
+     * With metadata ({@code localClaim} present and the claim found) the local claim
      * {@code multiValued} property decides; otherwise legacy separator-based detection is used.
      * Special cases: {@code address} is never an array, {@code groups} is always an array.
      *
      * @param claimKey                Claim URI (OIDC or local dialect).
      * @param claimValue              Raw claim value.
      * @param multiAttributeSeparator Multi attribute separator.
-     * @param mappedLocalClaims       Mapped local claims from {@link OAuth2Util#getMappedLocalClaims(String)},
-     *                                or {@code null}.
+     * @param localClaim              Local claim object.
      * @return True if the claim should be rendered as a multivalued attribute.
      */
     public static boolean isMultiValuedAttribute(String claimKey, String claimValue, String multiAttributeSeparator,
-                                                 Map<String, LocalClaim> mappedLocalClaims) {
+                                                 LocalClaim localClaim) {
 
         // Address claim contains the multi attribute separator but is not a multi valued attribute.
         if (OAuthConstants.OIDCClaims.ADDRESS.equals(claimKey)) {
@@ -784,11 +783,8 @@ public class OIDCClaimUtil {
         if (OAuthConstants.OIDCClaims.GROUPS.equals(claimKey)) {
             return true;
         }
-        if (mappedLocalClaims != null) {
-            LocalClaim localClaim = mappedLocalClaims.get(claimKey);
-            if (localClaim != null) {
-                return Boolean.parseBoolean(localClaim.getClaimProperty(ClaimConstants.MULTI_VALUED_PROPERTY));
-            }
+        if (localClaim != null) {
+            return Boolean.parseBoolean(localClaim.getClaimProperty(ClaimConstants.MULTI_VALUED_PROPERTY));
         }
         return StringUtils.contains(claimValue, multiAttributeSeparator);
     }

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/util/OAuth2UtilTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/util/OAuth2UtilTest.java
@@ -65,6 +65,7 @@ import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
 import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
 import org.wso2.carbon.identity.claim.metadata.mgt.exception.ClaimMetadataException;
 import org.wso2.carbon.identity.claim.metadata.mgt.model.ExternalClaim;
+import org.wso2.carbon.identity.claim.metadata.mgt.model.LocalClaim;
 import org.wso2.carbon.identity.common.testng.WithCarbonHome;
 import org.wso2.carbon.identity.core.IdentityKeyStoreResolver;
 import org.wso2.carbon.identity.core.ServiceURLBuilder;
@@ -3103,6 +3104,71 @@ public class OAuth2UtilTest {
             OAuth2Util.initiateOIDCScopes(SUPER_TENANT_ID);
             verify(log, times(1))
                     .error(claimMetadataException.getMessage(), claimMetadataException);
+        }
+    }
+
+    @Test
+    public void testGetLocalClaimMap() throws Exception {
+
+        try (MockedStatic<OAuth2ServiceComponentHolder> mockedHolder =
+                     mockStatic(OAuth2ServiceComponentHolder.class)) {
+            OAuth2ServiceComponentHolder holder = mock(OAuth2ServiceComponentHolder.class);
+            ClaimMetadataManagementService claimService = mock(ClaimMetadataManagementService.class);
+            mockedHolder.when(OAuth2ServiceComponentHolder::getInstance).thenReturn(holder);
+            when(holder.getClaimMetadataManagementService()).thenReturn(claimService);
+
+            LocalClaim emailLocalClaim = new LocalClaim("http://wso2.org/claims/emailaddress");
+            LocalClaim groupsLocalClaim = new LocalClaim("http://wso2.org/claims/groups");
+            when(claimService.getLocalClaims(SUPER_TENANT_DOMAIN_NAME))
+                    .thenReturn(Arrays.asList(emailLocalClaim, groupsLocalClaim));
+
+            Map<String, LocalClaim> localClaimMap = OAuth2Util.getLocalClaimMap(SUPER_TENANT_DOMAIN_NAME);
+
+            Assert.assertEquals(localClaimMap.size(), 2);
+            Assert.assertSame(localClaimMap.get("http://wso2.org/claims/emailaddress"), emailLocalClaim);
+            Assert.assertSame(localClaimMap.get("http://wso2.org/claims/groups"), groupsLocalClaim);
+
+            // On a claim metadata failure an empty map is returned instead of propagating the exception.
+            when(claimService.getLocalClaims(SUPER_TENANT_DOMAIN_NAME))
+                    .thenThrow(new ClaimMetadataException("error"));
+            Assert.assertTrue(OAuth2Util.getLocalClaimMap(SUPER_TENANT_DOMAIN_NAME).isEmpty());
+        }
+    }
+
+    @Test
+    public void testGetOidcClaimToLocalClaimMap() throws Exception {
+
+        try (MockedStatic<OAuth2ServiceComponentHolder> mockedHolder =
+                     mockStatic(OAuth2ServiceComponentHolder.class)) {
+            OAuth2ServiceComponentHolder holder = mock(OAuth2ServiceComponentHolder.class);
+            ClaimMetadataManagementService claimService = mock(ClaimMetadataManagementService.class);
+            mockedHolder.when(OAuth2ServiceComponentHolder::getInstance).thenReturn(holder);
+            when(holder.getClaimMetadataManagementService()).thenReturn(claimService);
+
+            LocalClaim emailLocalClaim = new LocalClaim("http://wso2.org/claims/emailaddress");
+            when(claimService.getLocalClaims(SUPER_TENANT_DOMAIN_NAME))
+                    .thenReturn(Collections.singletonList(emailLocalClaim));
+
+            ExternalClaim mappedOidcClaim = new ExternalClaim(OIDC_DIALECT,
+                    "http://wso2.org/oidc/claim/email", "http://wso2.org/claims/emailaddress");
+            // This OIDC claim maps to a local claim that is not present in the local claim map (e.g. a
+            // dangling mapping); it must be skipped rather than cause a null value in the built map.
+            ExternalClaim danglingOidcClaim = new ExternalClaim(OIDC_DIALECT,
+                    "http://wso2.org/oidc/claim/unknown", "http://wso2.org/claims/deleted");
+            when(claimService.getExternalClaims(OIDC_DIALECT, SUPER_TENANT_DOMAIN_NAME))
+                    .thenReturn(Arrays.asList(mappedOidcClaim, danglingOidcClaim));
+
+            Map<String, LocalClaim> oidcToLocalClaimMap =
+                    OAuth2Util.getOidcClaimToLocalClaimMap(SUPER_TENANT_DOMAIN_NAME);
+
+            Assert.assertEquals(oidcToLocalClaimMap.size(), 1);
+            Assert.assertSame(oidcToLocalClaimMap.get("http://wso2.org/oidc/claim/email"), emailLocalClaim);
+            Assert.assertFalse(oidcToLocalClaimMap.containsKey("http://wso2.org/oidc/claim/unknown"));
+
+            // On a claim metadata failure an empty map is returned instead of propagating the exception.
+            when(claimService.getExternalClaims(OIDC_DIALECT, SUPER_TENANT_DOMAIN_NAME))
+                    .thenThrow(new ClaimMetadataException("error"));
+            Assert.assertTrue(OAuth2Util.getOidcClaimToLocalClaimMap(SUPER_TENANT_DOMAIN_NAME).isEmpty());
         }
     }
 

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/openidconnect/OIDCClaimUtilTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/openidconnect/OIDCClaimUtilTest.java
@@ -20,10 +20,14 @@ package org.wso2.carbon.identity.openidconnect;
 
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.wso2.carbon.identity.application.authentication.framework.handler.approles.ApplicationRolesResolver;
 import org.wso2.carbon.identity.application.authentication.framework.handler.approles.exception.ApplicationRolesException;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
+import org.wso2.carbon.identity.claim.metadata.mgt.model.LocalClaim;
+import org.wso2.carbon.identity.claim.metadata.mgt.util.ClaimConstants;
+import org.wso2.carbon.identity.oauth.common.OAuthConstants;
 import org.wso2.carbon.identity.openidconnect.internal.OpenIDConnectServiceComponentHolder;
 
 import static org.mockito.Mockito.mock;
@@ -63,5 +67,41 @@ public class OIDCClaimUtilTest {
             assertEquals(roles.length, 2);
             assertTrue(roles[0].equals("role1") && roles[1].equals("role2"));
         }
+    }
+
+    private static final String SEPARATOR = ",";
+
+    private static LocalClaim multiValuedLocalClaim(boolean multiValued) {
+
+        LocalClaim localClaim = new LocalClaim("http://wso2.org/claims/testClaim");
+        localClaim.setClaimProperty(ClaimConstants.MULTI_VALUED_PROPERTY, String.valueOf(multiValued));
+        return localClaim;
+    }
+
+    @DataProvider(name = "isMultiValuedAttributeData")
+    public Object[][] isMultiValuedAttributeData() {
+
+        return new Object[][]{
+                // Address is never rendered as an array, even when the value contains the separator
+                // or the local claim metadata marks it as multivalued.
+                {OAuthConstants.OIDCClaims.ADDRESS, "no 1,street", multiValuedLocalClaim(true), false},
+                {OAuthConstants.OIDCClaims.ADDRESS, "no 1,street", null, false},
+                // Groups is always rendered as an array, even for a single value or without metadata.
+                {OAuthConstants.OIDCClaims.GROUPS, "admin", null, true},
+                {OAuthConstants.OIDCClaims.GROUPS, "admin", multiValuedLocalClaim(false), true},
+                // When metadata is present, the local claim multiValued property decides.
+                {"email", "a@b.com", multiValuedLocalClaim(true), true},
+                {"email", "a@b.com,c@d.com", multiValuedLocalClaim(false), false},
+                // When metadata is absent, fall back to separator-based detection.
+                {"email", "a@b.com,c@d.com", null, true},
+                {"email", "a@b.com", null, false},
+        };
+    }
+
+    @Test(dataProvider = "isMultiValuedAttributeData")
+    public void testIsMultiValuedAttribute(String claimKey, String claimValue, LocalClaim localClaim,
+                                           boolean expected) {
+
+        assertEquals(OIDCClaimUtil.isMultiValuedAttribute(claimKey, claimValue, SEPARATOR, localClaim), expected);
     }
 }


### PR DESCRIPTION
### Proposed changes in this pull request

This pull request introduces support for honoring the `multiValued` property in local claim metadata when determining whether to emit a claim as a JSON array in OIDC tokens and UserInfo responses. This behavior is opt-in and controlled by a new configuration property, allowing deployments to choose between the legacy separator-based detection and the metadata-driven approach. The implementation touches several components to ensure consistent handling across the token generation and claim retrieval flows.

**Multi-valued claim handling improvements:**

* Added a new configuration property `HonorMultivaluedClaimMetadata` to `OAuthServerConfiguration` and its parsing logic, enabling opt-in for using the local claim's `multiValued` metadata to determine if claims should be rendered as arrays. [[1]](diffhunk://#diff-5f10342f64703745216bd89fc24dc5786f7c6cdaaa56072a3d9d2b087126d263R249) [[2]](diffhunk://#diff-5f10342f64703745216bd89fc24dc5786f7c6cdaaa56072a3d9d2b087126d263R3957-R3963) [[3]](diffhunk://#diff-5f10342f64703745216bd89fc24dc5786f7c6cdaaa56072a3d9d2b087126d263R4719-R4720) [[4]](diffhunk://#diff-5f10342f64703745216bd89fc24dc5786f7c6cdaaa56072a3d9d2b087126d263R1833-R1844)
* Updated claim retrieval logic in `ClaimUtil`, `UserInfoUserStoreClaimRetriever`, and `JWTTokenGenerator` to use the claim metadata for multi-valued detection when the new configuration is enabled, falling back to the legacy separator-based detection otherwise. [[1]](diffhunk://#diff-10ffe4494aeba863be4f9df48edf0d12147fd2eca6ab7513f6efe6c163ff27e0R21-R28) [[2]](diffhunk://#diff-10ffe4494aeba863be4f9df48edf0d12147fd2eca6ab7513f6efe6c163ff27e0R43-R60) [[3]](diffhunk://#diff-d5cad8d44255d78839fa553671197cc8cb230f68acba9b048312ea261febeb5cR38-R39) [[4]](diffhunk://#diff-d5cad8d44255d78839fa553671197cc8cb230f68acba9b048312ea261febeb5cR270-R272) [[5]](diffhunk://#diff-d5cad8d44255d78839fa553671197cc8cb230f68acba9b048312ea261febeb5cL292-R298) [[6]](diffhunk://#diff-d5cad8d44255d78839fa553671197cc8cb230f68acba9b048312ea261febeb5cR584-R602) [[7]](diffhunk://#diff-de9f00dfe5348f44b99bb3587f7df8a3754bc506d9792ae216b2aa27357f9ba5R33-R34) [[8]](diffhunk://#diff-de9f00dfe5348f44b99bb3587f7df8a3754bc506d9792ae216b2aa27357f9ba5R70) [[9]](diffhunk://#diff-de9f00dfe5348f44b99bb3587f7df8a3754bc506d9792ae216b2aa27357f9ba5R270-L271) [[10]](diffhunk://#diff-de9f00dfe5348f44b99bb3587f7df8a3754bc506d9792ae216b2aa27357f9ba5R308-R325)
* Added utility methods `getOidcClaimToLocalClaimMap` and `getLocalClaimMap` in `OAuth2Util` to efficiently map OIDC claims to their corresponding local claims and access their metadata. [[1]](diffhunk://#diff-9d4b1a340ecdbc719edf565e22baf522bb4738051645d22ce50930875ccc151dR96) [[2]](diffhunk://#diff-9d4b1a340ecdbc719edf565e22baf522bb4738051645d22ce50930875ccc151dR2325-R2362)

**Token and UserInfo claim emission:**

* Modified the logic in `DefaultOIDCClaimsCallbackHandler` to pass the tenant domain to the claim-setting method, ensuring correct claim metadata is used per tenant. [[1]](diffhunk://#diff-f8edabe852db8ff4c597a6c21cc84ace7df5ddc6f89e803bc966df439b1a7c87R40) [[2]](diffhunk://#diff-f8edabe852db8ff4c597a6c21cc84ace7df5ddc6f89e803bc966df439b1a7c87L81-L82) [[3]](diffhunk://#diff-f8edabe852db8ff4c597a6c21cc84ace7df5ddc6f89e803bc966df439b1a7c87L102-R102) [[4]](diffhunk://#diff-f8edabe852db8ff4c597a6c21cc84ace7df5ddc6f89e803bc966df439b1a7c87L119-R120)

These changes collectively provide a more robust and standards-aligned mechanism for handling multi-valued claims in OIDC and OAuth2 responses, with backward compatibility preserved via configuration.

### Related Issues
- https://github.com/wso2/product-is/issues/27652