### PR TITLE
Retain Act attribute in OBO refresh flow

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dao/TokenManagementDAOImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dao/TokenManagementDAOImpl.java
@@ -218,9 +218,11 @@ public class TokenManagementDAOImpl extends AbstractOAuthDAO implements TokenMan
                     validationDataDO.setAuthorizedUser(user);
 
                 } else {
-                    if (!scopes.contains(resultSet.getString(5)) &&
-                            !validationDataDO.getScope()[0].equals(resultSet.getString(5))) {
-                        scopes.add(resultSet.getString(5));
+                    String scopeValue = resultSet.getString(5);
+                    if (scopeValue != null && !scopes.contains(scopeValue) &&
+                            (ArrayUtils.isEmpty(validationDataDO.getScope()) ||
+                                    !validationDataDO.getScope()[0].equals(scopeValue))) {
+                        scopes.add(scopeValue);
                     }
                     if (isTokenExtendedTableExist && resultSet.getString(17) != null &&
                             resultSet.getString(18) != null) {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/claims/AgentAccessTokenClaimProvider.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/claims/AgentAccessTokenClaimProvider.java
@@ -38,7 +38,8 @@ public class AgentAccessTokenClaimProvider implements JWTAccessTokenClaimProvide
             agentMap.put(AUT, AGENT);
             return agentMap;
         } else if ((GrantType.AUTHORIZATION_CODE.toString().equals(context.getOauth2AccessTokenReqDTO().getGrantType())
-                || CIBA_GRANT_TYPE.equals(context.getOauth2AccessTokenReqDTO().getGrantType()))
+                || CIBA_GRANT_TYPE.equals(context.getOauth2AccessTokenReqDTO().getGrantType())
+                || GrantType.REFRESH_TOKEN.toString().equals(context.getOauth2AccessTokenReqDTO().getGrantType()))
                 && context.getRequestedActor() != null) {
             Map<String, Object> agentMap = new HashMap<>();
             agentMap.put(ACT, Collections.singletonMap(SUB, context.getRequestedActor()));

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AbstractAuthorizationGrantHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/AbstractAuthorizationGrantHandler.java
@@ -89,6 +89,7 @@ import java.util.UUID;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.IMPERSONATING_ACTOR;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OAUTH_APP;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.RENEW_TOKEN_WITHOUT_REVOKING_EXISTING_ENABLE_CONFIG;
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.REQUESTED_ACTOR;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.TokenBindings.NONE;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.TokenStates.TOKEN_STATE_ACTIVE;
 import static org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration.JWT_TOKEN_TYPE;
@@ -655,6 +656,11 @@ public abstract class AbstractAuthorizationGrantHandler implements Authorization
         if (tokReqMsgCtx.isImpersonationRequest()) {
             accessTokenExtendedAttributes =
                     addExtendedAttribute(IMPERSONATING_ACTOR, tokReqMsgCtx.getProperty(IMPERSONATING_ACTOR).toString(),
+                    accessTokenExtendedAttributes);
+        }
+        if (StringUtils.isNotBlank(tokReqMsgCtx.getRequestedActor())) {
+            accessTokenExtendedAttributes =
+                    addExtendedAttribute(REQUESTED_ACTOR, tokReqMsgCtx.getRequestedActor(),
                     accessTokenExtendedAttributes);
         }
         // Add any new extended attributes here using @addExtendedAttribute.

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/RefreshGrantHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/RefreshGrantHandler.java
@@ -326,6 +326,7 @@ public class RefreshGrantHandler extends AbstractAuthorizationGrantHandler {
         tokReqMsgCtx.getOauth2AccessTokenReqDTO().setAccessTokenExtendedAttributes(
                 validationBean.getAccessTokenExtendedAttributes());
         propagateImpersonationInfo(tokReqMsgCtx);
+        propagateRequestedActorInfo(tokReqMsgCtx);
         // Store the old access token as a OAuthTokenReqMessageContext property, this is already
         // a preprocessed token.
         tokReqMsgCtx.addProperty(PREV_ACCESS_TOKEN, validationBean);
@@ -362,6 +363,22 @@ public class RefreshGrantHandler extends AbstractAuthorizationGrantHandler {
                 tokenReqMessageContext.addProperty(OAuthConstants.IMPERSONATING_ACTOR, impersonator);
                 if (log.isDebugEnabled()) {
                     log.debug("Impersonation request identified for the user: " + impersonator);
+                }
+            }
+        }
+    }
+
+    private void propagateRequestedActorInfo(OAuthTokenReqMessageContext tokenReqMessageContext) {
+
+        if (tokenReqMessageContext != null && tokenReqMessageContext.getOauth2AccessTokenReqDTO() != null &&
+                tokenReqMessageContext.getOauth2AccessTokenReqDTO().getAccessTokenExtendedAttributes() != null) {
+            String requestedActor = tokenReqMessageContext.getOauth2AccessTokenReqDTO()
+                    .getAccessTokenExtendedAttributes().getParameters()
+                    .get(OAuthConstants.REQUESTED_ACTOR);
+            if (StringUtils.isNotBlank(requestedActor)) {
+                tokenReqMessageContext.setRequestedActor(requestedActor);
+                if (log.isDebugEnabled()) {
+                    log.debug("Propagating requested actor for the refreshed access token: " + requestedActor);
                 }
             }
         }

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/handlers/claims/AgentAccessTokenClaimProviderTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/handlers/claims/AgentAccessTokenClaimProviderTest.java
@@ -124,7 +124,9 @@ public class AgentAccessTokenClaimProviderTest {
                 // {grantType, requestedActor, expectActClaim}
                 {GrantType.AUTHORIZATION_CODE.toString(), "actor-sub", true},
                 {CIBA_GRANT_TYPE, "actor-sub", true},
+                {GrantType.REFRESH_TOKEN.toString(), "actor-sub", true},
                 {GrantType.AUTHORIZATION_CODE.toString(), null, false},
+                {GrantType.REFRESH_TOKEN.toString(), null, false},
                 {"password", "actor-sub", false},
                 {"client_credentials", "actor-sub", false},
         };


### PR DESCRIPTION
### Proposed changes in this pull request

Currently in the OBO refresh flow the newly issued access token does not include the `act` claim. This PR preserves the existing `act` claim by storing it as an extended attribute in the context and reusing it when issuing the refreshed access token.
