### PR TITLE
Remove hexifying step of x5t value in JWT (backport of #2400)

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/pom.xml
+++ b/components/org.wso2.carbon.identity.oauth/pom.xml
@@ -350,6 +350,11 @@
             <artifactId>jaxp-ri</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.bitbucket.b_c</groupId>
+            <artifactId>jose4j</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuer.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuer.java
@@ -58,6 +58,7 @@ import org.wso2.carbon.registry.core.utils.UUIDGenerator;
 
 import java.io.ByteArrayInputStream;
 import java.security.Key;
+import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
@@ -374,7 +375,8 @@ public class JWTTokenIssuer extends OauthTokenIssuerImpl {
             Key privateKey = getPrivateKey(tenantDomain, tenantId);
             JWSSigner signer = OAuth2Util.createJWSSigner((RSAPrivateKey) privateKey);
             JWSHeader.Builder headerBuilder = new JWSHeader.Builder((JWSAlgorithm) signatureAlgorithm);
-            String certThumbPrint = OAuth2Util.getThumbPrint(tenantDomain, tenantId);
+            Certificate certificate = OAuth2Util.getCertificate(tenantDomain, tenantId);
+            String certThumbPrint = OAuth2Util.getThumbPrintWithPrevAlgorithm(certificate, false);
             headerBuilder.keyID(OAuth2Util.getKID(OAuth2Util.getCertificate(tenantDomain, tenantId),
                     (JWSAlgorithm) signatureAlgorithm, tenantDomain));
             if (isRefreshToken) {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -3100,7 +3100,8 @@ public class OAuth2Util {
             JWSSigner signer = OAuth2Util.createJWSSigner((RSAPrivateKey) privateKey);
             JWSHeader.Builder headerBuilder = new JWSHeader.Builder((JWSAlgorithm) signatureAlgorithm);
             headerBuilder.keyID(getKID(getCertificate(tenantDomain, tenantId), signatureAlgorithm, tenantDomain));
-            headerBuilder.x509CertThumbprint(new Base64URL(getThumbPrint(tenantDomain, tenantId)));
+            Certificate certificate = getCertificate(tenantDomain, tenantId);
+            headerBuilder.x509CertThumbprint(new Base64URL(getThumbPrintWithPrevAlgorithm(certificate, false)));
             SignedJWT signedJWT = new SignedJWT(headerBuilder.build(), jwtClaimsSet);
             signedJWT.sign(signer);
             return signedJWT;
@@ -3233,25 +3234,44 @@ public class OAuth2Util {
      */
     public static String getThumbPrint(Certificate certificate) throws IdentityOAuth2Exception {
 
-        return getThumbPrintWithAlgorithm(certificate, KID_HASHING_ALGORITHM);
+        return getThumbPrintWithAlgorithm(certificate, KID_HASHING_ALGORITHM, true);
     }
 
     public static String getThumbPrintWithPrevAlgorithm(Certificate certificate)
             throws IdentityOAuth2Exception {
 
-        return getThumbPrintWithAlgorithm(certificate, PREVIOUS_KID_HASHING_ALGORITHM);
+        return getThumbPrintWithAlgorithm(certificate, PREVIOUS_KID_HASHING_ALGORITHM, true);
     }
 
-    private static String getThumbPrintWithAlgorithm(Certificate certificate, String algorithm)
+    /**
+     * Method to obtain certificate thumbprint with SHA-1 algorithm.
+     *
+     * @param certificate      java.security.cert type certificate.
+     * @param requireHexifying True, if thumbprint needs to be hexified before encoding. It should not be hexified
+     *                         if used for the x5t value.
+     * @return Certificate thumbprint as a String.
+     * @throws IdentityOAuth2Exception When failed to obtain the thumbprint.
+     */
+    public static String getThumbPrintWithPrevAlgorithm(Certificate certificate, boolean requireHexifying)
             throws IdentityOAuth2Exception {
+
+        return getThumbPrintWithAlgorithm(certificate, PREVIOUS_KID_HASHING_ALGORITHM, requireHexifying);
+    }
+
+    private static String getThumbPrintWithAlgorithm(Certificate certificate, String algorithm,
+                                                     boolean requireHexifying) throws IdentityOAuth2Exception {
         try {
             MessageDigest digestValue = MessageDigest.getInstance(algorithm);
             byte[] der = certificate.getEncoded();
             digestValue.update(der);
             byte[] digestInBytes = digestValue.digest();
-            String publicCertThumbprint = hexify(digestInBytes);
-            String thumbprint = new String(new Base64(0, null, true).
-                    encode(publicCertThumbprint.getBytes(Charsets.UTF_8)), Charsets.UTF_8);
+            String thumbprint;
+            if (requireHexifying) {
+                thumbprint = new String(new Base64(0, null, true).encode(
+                        hexify(digestInBytes).getBytes(Charsets.UTF_8)), Charsets.UTF_8);
+            } else {
+                thumbprint = new String(new Base64(0, null, true).encode(digestInBytes), Charsets.UTF_8);
+            }
             if (log.isDebugEnabled()) {
                 log.debug(String.format("Thumbprint value: %s calculated for Certificate: %s using algorithm: %s",
                         thumbprint, certificate, digestValue.getAlgorithm()));

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuerTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/JWTTokenIssuerTest.java
@@ -16,6 +16,8 @@
 
 package org.wso2.carbon.identity.oauth2.token;
 
+import com.hazelcast.com.fasterxml.jackson.core.JsonProcessingException;
+import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.JWSSigner;
 import com.nimbusds.jose.crypto.RSASSASigner;
@@ -23,6 +25,10 @@ import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.PlainJWT;
 import com.nimbusds.jwt.SignedJWT;
 import org.joda.time.Duration;
+import org.jose4j.jwt.consumer.InvalidJwtException;
+import org.jose4j.jwt.consumer.JwtConsumer;
+import org.jose4j.jwt.consumer.JwtConsumerBuilder;
+import org.jose4j.keys.resolvers.X509VerificationKeyResolver;
 import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -55,6 +61,8 @@ import org.wso2.carbon.identity.testutil.powermock.PowerMockIdentityBaseTest;
 
 import java.nio.file.Paths;
 import java.security.KeyStore;
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
 import java.security.interfaces.RSAPrivateKey;
 import java.util.Arrays;
 import java.util.Calendar;
@@ -65,6 +73,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertNull;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyObject;
@@ -381,11 +390,12 @@ public class JWTTokenIssuerTest extends PowerMockIdentityBaseTest {
                                    long expectedExpiry) throws Exception {
 
             OAuthAppDO appDO = spy(new OAuthAppDO());
+            when(oAuthServerConfiguration.getUserAccessTokenValidityPeriodInSeconds())
+                .thenReturn(DEFAULT_USER_ACCESS_TOKEN_EXPIRY_TIME);
             mockGrantHandlers();
             mockCustomClaimsCallbackHandler();
             mockStatic(OAuth2Util.class);
             when(OAuth2Util.getAppInformationByClientId(anyString())).thenReturn(appDO);
-            when(OAuth2Util.getThumbPrint(anyString(), anyInt())).thenReturn(THUMBPRINT);
             when(OAuth2Util.isTokenPersistenceEnabled()).thenReturn(true);
 
             System.setProperty(CarbonBaseConstants.CARBON_HOME,
@@ -393,6 +403,10 @@ public class JWTTokenIssuerTest extends PowerMockIdentityBaseTest {
             KeyStore wso2KeyStore = getKeyStoreFromFile("wso2carbon.jks", "wso2carbon",
                     System.getProperty(CarbonBaseConstants.CARBON_HOME));
             RSAPrivateKey rsaPrivateKey = (RSAPrivateKey) wso2KeyStore.getKey("wso2carbon", "wso2carbon".toCharArray());
+            Certificate cert = wso2KeyStore.getCertificate("wso2carbon");
+            when(OAuth2Util.getCertificate(anyString(), anyInt())).thenReturn(cert);
+            when(OAuth2Util.class, "getThumbPrintWithPrevAlgorithm", any(), anyBoolean()).thenCallRealMethod();
+            when(OAuth2Util.class, "getThumbPrintWithAlgorithm", any(), anyString(), anyBoolean()).thenCallRealMethod();
 
             when((OAuth2Util.getPrivateKey(anyString(), anyInt()))).thenReturn(rsaPrivateKey);
             JWSSigner signer = new RSASSASigner(rsaPrivateKey);
@@ -414,10 +428,26 @@ public class JWTTokenIssuerTest extends PowerMockIdentityBaseTest {
                     (OAuthTokenReqMessageContext) tokenReqMessageContext,
                     (OAuthAuthzReqMessageContext) authzReqMessageContext);
             SignedJWT signedJWT = SignedJWT.parse(jwtToken);
+            validateX5tInJWT(jwtToken, cert);
             assertNotNull(jwtToken);
             assertNotNull(signedJWT.getHeader());
             assertNotNull(signedJWT.getHeader().getType());
             assertEquals(signedJWT.getHeader().getType().toString(), DEFAULT_TYP_HEADER_VALUE);
+    }
+
+    private void validateX5tInJWT(String jwt, Certificate cert) throws JOSEException, JsonProcessingException {
+
+        try {
+            X509VerificationKeyResolver x509VerificationKeyResolver =
+                    new X509VerificationKeyResolver((X509Certificate) cert);
+            JwtConsumer jwtConsumer = new JwtConsumerBuilder()
+                    .setVerificationKeyResolver(x509VerificationKeyResolver)
+                    .build();
+            jwtConsumer.process(jwt);
+        } catch (InvalidJwtException e) {
+            assertTrue(e.getMessage() != null && e.getMessage().contains("The JWT is no longer valid"),
+                    "Invalid x5t value in JWT token.");
+        }
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -621,6 +621,12 @@
                 <version>${commons-codec.test.version}</version>
                 <scope>test</scope>
             </dependency>
+            <dependency>
+                <groupId>org.bitbucket.b_c</groupId>
+                <artifactId>jose4j</artifactId>
+                <version>${jose4j.version}</version>
+                <scope>test</scope>
+            </dependency>
 
             <!--
                 See https://github.com/wso2-extensions/identity-inbound-auth-oauth/issues/543 for the requirement to
@@ -677,6 +683,7 @@
                 <version>${jaxp-ri.version}</version>
                 <scope>test</scope>
             </dependency>
+
 
 
         </dependencies>
@@ -977,6 +984,7 @@
         <commons-codec.test.version>1.4</commons-codec.test.version>
         <org.wso2.carbon.identity.testutil.version>5.23.18</org.wso2.carbon.identity.testutil.version>
         <jaxp-ri.version>1.4.5</jaxp-ri.version>
+        <jose4j.version>0.9.5</jose4j.version>
         <!--SAML component version for test-->
         <carbon.identity.sso.saml.version>5.7.0</carbon.identity.sso.saml.version>
         <spring-context.version>5.1.1.RELEASE</spring-context.version>


### PR DESCRIPTION
## Description

This backports the fix from #2400 ("Fix x5t incompatibility issue of JWT token") onto the `6.14.x` branch.

#2400 was merged to `master` on 2024-03-06, but by that point `master` had already diverged into the WSO2 Identity Server 7.x line. The fix was never carried back into the `6.x` maintenance branches (`6.13.x` / `6.14.x`), which is what WSO2 API Manager's resident Key Manager actually depends on (`carbon.identity-inbound-auth-oauth.version` in carbon-apimgt currently pins `6.14.20`). As a result, the original bug reported in [wso2/api-manager#2838](https://github.com/wso2/api-manager/issues/2838) is still present in every APIM version up to and including the current development line, despite the issue being labeled `Resolution/Fixed` upstream.

### Original bug

The `x5t` value in JWTs issued by the resident Key Manager is generated by hex-encoding the SHA-1 certificate thumbprint before Base64URL-encoding it. This extra hexify step isn't part of [RFC 7515 §4.1.7](https://datatracker.ietf.org/doc/html/rfc7515#section-4.1.7), so spec-compliant validators (e.g. `jose4j`) fail to resolve the signing certificate from `x5t` and reject the token.

### Fix

Same approach as #2400: `getThumbPrintWithAlgorithm` gains a `requireHexifying` boolean parameter. When `false`, the raw digest bytes are Base64URL-encoded directly instead of being hex-encoded first. Only the two call sites that build the JWT `x5t` header (`OAuth2Util.signJWTWithRSA` and `JWTTokenIssuer.signJWTWithRSA`) are switched to pass `false`.

### Related

- Fixes wso2/api-manager#2838
- Backport of #2400 