### PR TITLE
Refactor group handling in scope validation to improve clarity and functionality

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/AuthzUtil.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/AuthzUtil.java
@@ -44,11 +44,12 @@ import org.wso2.carbon.identity.organization.management.organization.agent.shari
 import org.wso2.carbon.identity.organization.management.organization.user.sharing.util.OrganizationSharedUserUtil;
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
 import org.wso2.carbon.identity.role.v2.mgt.core.exception.IdentityRoleManagementException;
+import org.wso2.carbon.user.api.RealmConfiguration;
 import org.wso2.carbon.user.api.UserStoreException;
-import org.wso2.carbon.user.api.UserStoreManager;
 import org.wso2.carbon.user.core.NotImplementedException;
+import org.wso2.carbon.user.core.UserCoreConstants;
+import org.wso2.carbon.user.core.UserStoreManager;
 import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
-import org.wso2.carbon.user.core.common.Group;
 import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.carbon.user.core.util.UserCoreUtil;
 import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
@@ -63,11 +64,10 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static org.wso2.carbon.identity.core.util.IdentityCoreConstants.MULTI_ATTRIBUTE_SEPARATOR;
 import static org.wso2.carbon.identity.oauth2.util.OAuth2Util.INTERNAL_LOGIN_SCOPE;
 import static org.wso2.carbon.identity.role.v2.mgt.core.RoleConstants.APPLICATION;
 import static org.wso2.carbon.identity.role.v2.mgt.core.RoleConstants.ORGANIZATION;
-import static org.wso2.carbon.user.core.UserCoreConstants.APPLICATION_DOMAIN;
-import static org.wso2.carbon.user.core.UserCoreConstants.INTERNAL_DOMAIN;
 
 /**
  * Utility methods for the authorization related functionality.
@@ -131,9 +131,9 @@ public class AuthzUtil {
     public static List<String> getRoles(String userId, String tenantDomain) throws IdentityOAuth2Exception {
 
         List<String> roleIds = new ArrayList<>(getRoleIdsOfUser(userId, tenantDomain));
-        List<String> groups = getUserGroups(userId, tenantDomain);
-        if (!groups.isEmpty()) {
-            roleIds.addAll(getRoleIdsOfGroups(groups, tenantDomain));
+        List<String> groupNames = getUserGroupNames(userId, tenantDomain);
+        if (!groupNames.isEmpty()) {
+            roleIds.addAll(getRoleIdsOfGroups(groupNames, tenantDomain));
         }
         return roleIds;
     }
@@ -427,60 +427,61 @@ public class AuthzUtil {
      *
      * @param userId User id.
      * @param tenantDomain Tenant domain.
-     * @return - Groups of the user.
+     * @return - Group names of the user.
      */
-    private static List<String> getUserGroups(String userId, String tenantDomain) throws IdentityOAuth2Exception {
+    private static List<String> getUserGroupNames(String userId, String tenantDomain)
+            throws IdentityOAuth2Exception {
 
         if (LOG.isDebugEnabled()) {
             LOG.debug("Started group fetching for scope validation.");
         }
-        List<String> userGroups = new ArrayList<>();
+        List<String> userGroupNames = new ArrayList<>();
         RealmService realmService = UserCoreUtil.getRealmService();
         try {
             int tenantId = OAuth2Util.getTenantId(tenantDomain);
-            UserStoreManager userStoreManager = realmService.getTenantUserRealm(tenantId).getUserStoreManager();
-            List<Group> groups =
-                    ((AbstractUserStoreManager) userStoreManager).getGroupListOfUser(userId,
-                            null, null);
-            for (Group group : groups) {
-                String groupName = group.getGroupName();
-                String groupDomainName = UserCoreUtil.extractDomainFromName(groupName);
-                if (!INTERNAL_DOMAIN.equalsIgnoreCase(groupDomainName) &&
-                        !APPLICATION_DOMAIN.equalsIgnoreCase(groupDomainName)) {
-                    userGroups.add(group.getGroupID());
-                }
+            AbstractUserStoreManager userStoreManager =
+                    (AbstractUserStoreManager) realmService.getTenantUserRealm(tenantId).getUserStoreManager();
+            Map<String, String> userClaims = userStoreManager.getUserClaimValuesWithID(userId,
+                    new String[]{FrameworkConstants.GROUPS_CLAIM}, null);
+            String groupNamesString = userClaims.get(FrameworkConstants.GROUPS_CLAIM);
+            if (StringUtils.isEmpty(groupNamesString)) {
+                return userGroupNames;
             }
-        } catch (IdentityOAuth2Exception e) {
-            throw new IdentityOAuth2Exception(e.getMessage(), e);
-        } catch (UserStoreException e) {
-            if (isDoGetGroupListOfUserNotImplemented(e)) {
-                return userGroups;
+
+            String userStoreDomain = resolveUserStoreDomain(userId, userStoreManager);
+            String separator = resolveMultiAttributeSeparator(userStoreManager
+                    .getSecondaryUserStoreManager(userStoreDomain));
+
+            String[] groupNames = StringUtils.splitByWholeSeparator(groupNamesString, separator);
+            for (String groupName : groupNames) {
+                userGroupNames.add(UserCoreUtil.addDomainToName(groupName, userStoreDomain));
             }
+        } catch (IdentityOAuth2Exception | UserStoreException e) {
             throw new IdentityOAuth2Exception(e.getMessage(), e);
         }
         if (LOG.isDebugEnabled()) {
             LOG.debug("Completed group fetching for scope validation.");
         }
-        return userGroups;
+        return userGroupNames;
     }
 
     /**
-     * Get the role ids of groups.
+     * Get the role ids of group names.
      *
-     * @param groups Groups.
+     * @param groupNames Group names.
      * @param tenantDomain Tenant domain.
-     * @return Role ids of groups.
-     * @throws IdentityOAuth2Exception if an error occurs while retrieving role id list of groups.
+     * @return Role ids of group names.
+     * @throws IdentityOAuth2Exception if an error occurs while retrieving role id list of group names.
      */
-    private static List<String> getRoleIdsOfGroups(List<String> groups, String tenantDomain)
+    private static List<String> getRoleIdsOfGroups(List<String> groupNames, String tenantDomain)
             throws IdentityOAuth2Exception {
 
         try {
             return OAuth2ServiceComponentHolder.getInstance().getRoleManagementServiceV2()
-                    .getRoleIdListOfGroups(groups, tenantDomain);
+                    .getRoleIdListOfGroupNames(groupNames, tenantDomain);
         } catch (IdentityRoleManagementException e) {
-            throw new IdentityOAuth2Exception("Error while retrieving role id list of groups : "
-                    + StringUtils.join(groups, ",") + "tenant domain : " + tenantDomain, e);
+            throw new IdentityOAuth2Exception("Error while retrieving role id list of group names: "
+                    + StringUtils.join(groupNames, ",") + "tenant domain: " + tenantDomain, e);
         }
     }
 
@@ -644,5 +645,60 @@ public class AuthzUtil {
             throw new IdentityOAuth2Exception(
                     "Error resolving authorized scopes for clientId: " + clientId, e);
         }
+    }
+
+    /**
+     * Resolve the user store domain of the given user.
+     *
+     * @param userId           User id.
+     * @param userStoreManager User store manager.
+     * @return User store domain name.
+     */
+    private static String resolveUserStoreDomain(String userId, AbstractUserStoreManager userStoreManager) {
+
+        try {
+            String userName = userStoreManager.getUserNameFromUserID(userId);
+            return UserCoreUtil.extractDomainFromName(userName);
+        } catch (org.wso2.carbon.user.core.UserStoreException e) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Error while retrieving user name from user id : " + userId, e);
+            }
+            return resolvePrimaryUserStoreDomainName();
+        }
+    }
+
+    /**
+     * Resolve the multi attribute separator configured for the given user store.
+     *
+     * @param userStoreManager User store manager.
+     * @return Multi attribute separator.
+     */
+    private static String resolveMultiAttributeSeparator(UserStoreManager userStoreManager) {
+
+        String defaultSeparator = ",";
+        if (userStoreManager == null) {
+            return defaultSeparator;
+        }
+        String separator = userStoreManager.getRealmConfiguration().getUserStoreProperty(MULTI_ATTRIBUTE_SEPARATOR);
+        if (separator == null || separator.trim().isEmpty()) {
+            return defaultSeparator;
+        }
+        return separator;
+    }
+
+    /**
+     * This method resolves the primary user store domain name when it is changed
+     * from `PRIMARY` to a different name; otherwise, it returns `PRIMARY`.
+     *
+     * @return Primary user store domain name.
+     */
+    private static String resolvePrimaryUserStoreDomainName() {
+
+        RealmService realmService = UserCoreUtil.getRealmService();
+        RealmConfiguration realmConfiguration = realmService.getBootstrapRealmConfiguration();
+        if (realmConfiguration.getUserStoreProperty(UserCoreConstants.RealmConfig.PROPERTY_DOMAIN_NAME) != null) {
+            return realmConfiguration.getUserStoreProperty(UserCoreConstants.RealmConfig.PROPERTY_DOMAIN_NAME);
+        }
+        return UserCoreConstants.PRIMARY_DEFAULT_DOMAIN_NAME;
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/util/AuthzUtilTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/util/AuthzUtilTest.java
@@ -28,6 +28,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
 import org.wso2.carbon.identity.application.common.model.AuthorizedScopes;
 import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.application.mgt.AuthorizedAPIManagementService;
@@ -40,20 +41,31 @@ import org.wso2.carbon.identity.organization.management.organization.user.sharin
 import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
 import org.wso2.carbon.identity.role.v2.mgt.core.RoleManagementService;
 import org.wso2.carbon.identity.role.v2.mgt.core.exception.IdentityRoleManagementException;
+import org.wso2.carbon.user.api.RealmConfiguration;
+import org.wso2.carbon.user.api.UserRealm;
+import org.wso2.carbon.user.core.UserStoreManager;
+import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
+import org.wso2.carbon.user.core.service.RealmService;
+import org.wso2.carbon.user.core.util.UserCoreUtil;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.wso2.carbon.identity.core.util.IdentityCoreConstants.MULTI_ATTRIBUTE_SEPARATOR;
 import static org.wso2.carbon.user.core.UserStoreConfigConstants.PRIMARY;
 
 /**
@@ -81,6 +93,8 @@ public class AuthzUtilTest {
     private static final String USER_ID = "test-user-id";
     private static final String ACCESSING_ORGANIZATION = "accessing-org-id";
     private static final String TENANT_DOMAIN = "tenantDomain";
+    private static final int TENANT_ID = 1;
+    private static final String SECONDARY_USER_STORE_DOMAIN = "SECONDARY";
     private static final String USER_RESIDENT_ORG_TENANT = "resident-tenant";
     private static final String ACCESSING_ORG_TENANT = "accessing-tenant";
     private static final String SHARED_AGENT_ID = "shared-agent-id";
@@ -241,11 +255,9 @@ public class AuthzUtilTest {
         when(oAuth2ServiceComponentHolder.getOrganizationManager()).thenReturn(organizationManager);
         when(oAuth2ServiceComponentHolder.getRoleManagementServiceV2()).thenReturn(roleManagementService);
 
-        when(organizationManager.resolveTenantDomain(ACCESSING_ORGANIZATION))
-                .thenReturn(USER_RESIDENT_ORG_TENANT)
-                .thenReturn(ACCESSING_ORG_TENANT);
+        when(organizationManager.resolveTenantDomain(ACCESSING_ORGANIZATION)).thenReturn(ACCESSING_ORG_TENANT);
 
-        authzUtilMockedStatic.when(() -> AuthzUtil.getRoles(USER_ID, USER_RESIDENT_ORG_TENANT))
+        authzUtilMockedStatic.when(() -> AuthzUtil.getRoles(USER_ID, ACCESSING_ORG_TENANT))
                 .thenReturn(sharedUserRoles);
 
         when(roleManagementService.getSharedRoleToMainRoleMappingsBySubOrg(sharedUserRoles, ACCESSING_ORG_TENANT))
@@ -268,11 +280,9 @@ public class AuthzUtilTest {
         when(oAuth2ServiceComponentHolder.getOrganizationManager()).thenReturn(organizationManager);
         when(oAuth2ServiceComponentHolder.getRoleManagementServiceV2()).thenReturn(roleManagementService);
 
-        when(organizationManager.resolveTenantDomain(ACCESSING_ORGANIZATION))
-                .thenReturn(USER_RESIDENT_ORG_TENANT)
-                .thenReturn(ACCESSING_ORG_TENANT);
+        when(organizationManager.resolveTenantDomain(ACCESSING_ORGANIZATION)).thenReturn(ACCESSING_ORG_TENANT);
 
-        authzUtilMockedStatic.when(() -> AuthzUtil.getRoles(USER_ID, USER_RESIDENT_ORG_TENANT))
+        authzUtilMockedStatic.when(() -> AuthzUtil.getRoles(USER_ID, ACCESSING_ORG_TENANT))
                 .thenReturn(sharedUserRoles);
 
         when(roleManagementService.getSharedRoleToMainRoleMappingsBySubOrg(sharedUserRoles, ACCESSING_ORG_TENANT))
@@ -292,11 +302,9 @@ public class AuthzUtilTest {
         when(oAuth2ServiceComponentHolder.getOrganizationManager()).thenReturn(organizationManager);
         when(oAuth2ServiceComponentHolder.getRoleManagementServiceV2()).thenReturn(roleManagementService);
 
-        when(organizationManager.resolveTenantDomain(ACCESSING_ORGANIZATION))
-                .thenReturn(USER_RESIDENT_ORG_TENANT)
-                .thenReturn(ACCESSING_ORG_TENANT);
+        when(organizationManager.resolveTenantDomain(ACCESSING_ORGANIZATION)).thenReturn(ACCESSING_ORG_TENANT);
 
-        authzUtilMockedStatic.when(() -> AuthzUtil.getRoles(USER_ID, USER_RESIDENT_ORG_TENANT))
+        authzUtilMockedStatic.when(() -> AuthzUtil.getRoles(USER_ID, ACCESSING_ORG_TENANT))
                 .thenReturn(sharedUserRoles);
 
         when(roleManagementService.getSharedRoleToMainRoleMappingsBySubOrg(anyList(), anyString()))
@@ -314,11 +322,9 @@ public class AuthzUtilTest {
         when(oAuth2ServiceComponentHolder.getOrganizationManager()).thenReturn(organizationManager);
         when(oAuth2ServiceComponentHolder.getRoleManagementServiceV2()).thenReturn(roleManagementService);
 
-        when(organizationManager.resolveTenantDomain(ACCESSING_ORGANIZATION))
-                .thenReturn(USER_RESIDENT_ORG_TENANT)
-                .thenReturn(ACCESSING_ORG_TENANT);
+        when(organizationManager.resolveTenantDomain(ACCESSING_ORGANIZATION)).thenReturn(ACCESSING_ORG_TENANT);
 
-        authzUtilMockedStatic.when(() -> AuthzUtil.getRoles(null, USER_RESIDENT_ORG_TENANT))
+        authzUtilMockedStatic.when(() -> AuthzUtil.getRoles(null, ACCESSING_ORG_TENANT))
                 .thenReturn(sharedUserRoles);
 
         when(roleManagementService.getSharedRoleToMainRoleMappingsBySubOrg(sharedUserRoles, ACCESSING_ORG_TENANT))
@@ -338,11 +344,9 @@ public class AuthzUtilTest {
         when(oAuth2ServiceComponentHolder.getOrganizationManager()).thenReturn(organizationManager);
         when(oAuth2ServiceComponentHolder.getRoleManagementServiceV2()).thenReturn(roleManagementService);
 
-        when(organizationManager.resolveTenantDomain(""))
-                .thenReturn(USER_RESIDENT_ORG_TENANT)
-                .thenReturn(ACCESSING_ORG_TENANT);
+        when(organizationManager.resolveTenantDomain("")).thenReturn(ACCESSING_ORG_TENANT);
 
-        authzUtilMockedStatic.when(() -> AuthzUtil.getRoles(USER_ID, USER_RESIDENT_ORG_TENANT))
+        authzUtilMockedStatic.when(() -> AuthzUtil.getRoles(USER_ID, ACCESSING_ORG_TENANT))
                 .thenReturn(sharedUserRoles);
 
         when(roleManagementService.getSharedRoleToMainRoleMappingsBySubOrg(sharedUserRoles, ACCESSING_ORG_TENANT))
@@ -391,5 +395,72 @@ public class AuthzUtilTest {
             String result = AuthzUtil.getUserIdOfAssociatedUser(authenticatedUser);
             Assert.assertEquals(result, SHARED_USER_ID);
         }
+    }
+
+    @Test
+    public void testGetRolesWithUserGroups() throws Exception {
+
+        try (MockedStatic<UserCoreUtil> userCoreUtil = mockStatic(UserCoreUtil.class, Mockito.CALLS_REAL_METHODS);
+             MockedStatic<OAuth2Util> oAuth2Util = mockStatic(OAuth2Util.class)) {
+
+            mockUserGroupResolution(userCoreUtil, oAuth2Util);
+            when(roleManagementService.getRoleIdListOfUser(USER_ID, TENANT_DOMAIN))
+                    .thenReturn(new ArrayList<>(Collections.singletonList("user-role")));
+            when(roleManagementService.getRoleIdListOfGroupNames(anyList(), eq(TENANT_DOMAIN)))
+                    .thenReturn(Arrays.asList("group-role1", "group-role2"));
+
+            List<String> roleIds = AuthzUtil.getRoles(USER_ID, TENANT_DOMAIN);
+
+            Assert.assertEquals(roleIds, Arrays.asList("user-role", "group-role1", "group-role2"));
+            // Group names are resolved with the user store domain of the user.
+            verify(roleManagementService).getRoleIdListOfGroupNames(
+                    Arrays.asList("SECONDARY/group1", "SECONDARY/group2"), TENANT_DOMAIN);
+        }
+    }
+
+    @Test(expectedExceptions = IdentityOAuth2Exception.class,
+            expectedExceptionsMessageRegExp = "Error while retrieving role id list of group names: .*")
+    public void testGetRolesWhenGroupRoleResolutionFails() throws Exception {
+
+        try (MockedStatic<UserCoreUtil> userCoreUtil = mockStatic(UserCoreUtil.class, Mockito.CALLS_REAL_METHODS);
+             MockedStatic<OAuth2Util> oAuth2Util = mockStatic(OAuth2Util.class)) {
+
+            mockUserGroupResolution(userCoreUtil, oAuth2Util);
+            when(roleManagementService.getRoleIdListOfUser(USER_ID, TENANT_DOMAIN)).thenReturn(new ArrayList<>());
+            when(roleManagementService.getRoleIdListOfGroupNames(anyList(), eq(TENANT_DOMAIN)))
+                    .thenThrow(new IdentityRoleManagementException("Role management error"));
+
+            AuthzUtil.getRoles(USER_ID, TENANT_DOMAIN);
+        }
+    }
+
+    /**
+     * Mocks a user residing in the SECONDARY user store who belongs to two groups, so that group name resolution
+     * in {@link AuthzUtil#getRoles(String, String)} can be exercised.
+     */
+    private void mockUserGroupResolution(MockedStatic<UserCoreUtil> userCoreUtil, MockedStatic<OAuth2Util> oAuth2Util)
+            throws Exception {
+
+        RealmService realmService = Mockito.mock(RealmService.class);
+        UserRealm userRealm = Mockito.mock(UserRealm.class);
+        AbstractUserStoreManager userStoreManager = Mockito.mock(AbstractUserStoreManager.class);
+        UserStoreManager secondaryUserStoreManager = Mockito.mock(UserStoreManager.class);
+        RealmConfiguration realmConfiguration = Mockito.mock(RealmConfiguration.class);
+
+        userCoreUtil.when(UserCoreUtil::getRealmService).thenReturn(realmService);
+        oAuth2Util.when(() -> OAuth2Util.getTenantId(TENANT_DOMAIN)).thenReturn(TENANT_ID);
+        when(realmService.getTenantUserRealm(TENANT_ID)).thenReturn(userRealm);
+        when(userRealm.getUserStoreManager()).thenReturn(userStoreManager);
+        when(oAuth2ServiceComponentHolder.getRoleManagementServiceV2()).thenReturn(roleManagementService);
+
+        Map<String, String> userClaims = new HashMap<>();
+        userClaims.put(FrameworkConstants.GROUPS_CLAIM, "group1,,,group2");
+        when(userStoreManager.getUserClaimValuesWithID(eq(USER_ID), any(String[].class), isNull()))
+                .thenReturn(userClaims);
+        when(userStoreManager.getUserNameFromUserID(USER_ID)).thenReturn(SECONDARY_USER_STORE_DOMAIN + "/john");
+        when(userStoreManager.getSecondaryUserStoreManager(SECONDARY_USER_STORE_DOMAIN))
+                .thenReturn(secondaryUserStoreManager);
+        when(secondaryUserStoreManager.getRealmConfiguration()).thenReturn(realmConfiguration);
+        when(realmConfiguration.getUserStoreProperty(MULTI_ATTRIBUTE_SEPARATOR)).thenReturn(",,,");
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.identity.oauth/src/test/resources/testng.xml
@@ -141,6 +141,7 @@
             <class name="org.wso2.carbon.identity.oauth2.util.JWTUtilsTest"/>
             <class name="org.wso2.carbon.identity.oauth2.util.JWTSignatureValidationUtilsTest"/>
             <class name="org.wso2.carbon.identity.oauth2.util.TokenMgtUtilTest"/>
+            <class name="org.wso2.carbon.identity.oauth2.util.AuthzUtilTest"/>
             <!--<class name="org.wso2.carbon.identity.openidconnect.DefaultIDTokenBuilderTest"/>-->
             <class name="org.wso2.carbon.identity.openidconnect.DefaultOIDCClaimsCallbackHandlerTest"/>
             <class name="org.wso2.carbon.identity.openidconnect.JWTAccessTokenOIDCClaimsHandler"/>
@@ -246,6 +247,7 @@
             <class name="org.wso2.carbon.identity.oauth2.util.JWTUtilsTest"/>
             <class name="org.wso2.carbon.identity.oauth2.util.JWTSignatureValidationUtilsTest"/>
             <class name="org.wso2.carbon.identity.oauth2.util.TokenMgtUtilTest"/>
+            <class name="org.wso2.carbon.identity.oauth2.util.AuthzUtilTest"/>
             <class name="org.wso2.carbon.identity.openidconnect.DefaultIDTokenBuilderTest"/>
             <class name="org.wso2.carbon.identity.openidconnect.DefaultOIDCClaimsCallbackHandlerTest"/>
             <class name="org.wso2.carbon.identity.openidconnect.JWTAccessTokenOIDCClaimsHandler"/>

--- a/pom.xml
+++ b/pom.xml
@@ -998,7 +998,7 @@
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!-- Carbon Identity Framework version -->
-        <carbon.identity.framework.version>7.11.172</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.11.176</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.25.234, 8.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
         <identity.oauth.xacml.version.range>[2.0.0, 3.0.0)</identity.oauth.xacml.version.range>


### PR DESCRIPTION
### Proposed changes in this pull request
This pull request refactors how user group information is handled in the `AuthzUtil` utility, shifting from using group IDs to using group names and improving compatibility with user store configurations. The changes enhance maintainability and accuracy when resolving group-based roles, especially in environments with custom user store domains or multi-attribute separators.

**Group/Role Resolution Improvements:**

* Refactored group retrieval logic to use group names instead of group IDs, updating method names and comments for clarity [[1]](diffhunk://#diff-3d60d6405fe664872950ba7c6ea4c669a433b9e2c675110e5b66d824ee896496L134-R136) [[2]](diffhunk://#diff-3d60d6405fe664872950ba7c6ea4c669a433b9e2c675110e5b66d824ee896496L430-R484).
* Updated the method for fetching group roles to use group names and call the appropriate service method (`getRoleIdListOfGroupNames`), improving role resolution accuracy.

**User Store Domain and Separator Handling:**

* Introduced helper methods: `resolveUserStoreDomain`, `resolveMultiAttributeSeparator`, and `resolvePrimaryUserStoreDomainName` to robustly determine the user store domain and attribute separators, ensuring correct parsing of group names across different user store configurations.

**Code Cleanup and Imports:**

* Removed unused imports and updated static imports to reflect the new approach of handling group names [[1]](diffhunk://#diff-3d60d6405fe664872950ba7c6ea4c669a433b9e2c675110e5b66d824ee896496R47-L51) [[2]](diffhunk://#diff-3d60d6405fe664872950ba7c6ea4c669a433b9e2c675110e5b66d824ee896496R67-L70).

### Depends on
- https://github.com/wso2/carbon-identity-framework/pull/8235

### Related Issues
- https://github.com/wso2/product-is/issues/28229