### PR TITLE
Fix client secret regeneration failure when encryption is enabled

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/tokenprocessor/EncryptionDecryptionPersistenceProcessor.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/tokenprocessor/EncryptionDecryptionPersistenceProcessor.java
@@ -35,8 +35,8 @@ public class EncryptionDecryptionPersistenceProcessor implements TokenPersistenc
     protected static final Log LOG = LogFactory.getLog(EncryptionDecryptionPersistenceProcessor.class);
 
     /**
-     * Client ID is not to be decrypt as it's not encrypted
-     * 
+     * Client ID is not to be decrypt as it's not encrypted.
+     *
      * @param processedClientId
      * @return
      * @throws IdentityOAuth2Exception
@@ -47,8 +47,8 @@ public class EncryptionDecryptionPersistenceProcessor implements TokenPersistenc
     }
 
     /**
-     * Client ID is not required to be encrypted
-     * 
+     * Client ID is not required to be encrypted.
+     *
      * @param clientId
      * @return
      * @throws IdentityOAuth2Exception

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/tokenprocessor/EncryptionDecryptionPersistenceProcessor.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/tokenprocessor/EncryptionDecryptionPersistenceProcessor.java
@@ -36,6 +36,7 @@ public class EncryptionDecryptionPersistenceProcessor implements TokenPersistenc
 
     /**
      * Client ID is not to be decrypt as it's not encrypted
+     * 
      * @param processedClientId
      * @return
      * @throws IdentityOAuth2Exception
@@ -47,6 +48,7 @@ public class EncryptionDecryptionPersistenceProcessor implements TokenPersistenc
 
     /**
      * Client ID is not required to be encrypted
+     * 
      * @param clientId
      * @return
      * @throws IdentityOAuth2Exception
@@ -56,12 +58,26 @@ public class EncryptionDecryptionPersistenceProcessor implements TokenPersistenc
         return clientId;
     }
 
+    /**
+     * Decrypts the preprocessed client secret.
+     * If decryption fails, the client secret may have been stored in plain text
+     * before encryption was enabled. It returns the plain text as-is for backward
+     * compatibility.
+     *
+     * @param processedClientSecret The processed client secret.
+     * @return The decrypted or plain text client secret.
+     * @throws IdentityOAuth2Exception If an error occurs during processing.
+     */
     @Override
     public String getPreprocessedClientSecret(String processedClientSecret) throws IdentityOAuth2Exception {
         try {
             return decrypt(processedClientSecret);
         } catch (CryptoException e) {
-            throw new IdentityOAuth2Exception("Error while retrieving preprocessed client secret", e);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Failed to decrypt client secret. The secret may be stored in plain text " +
+                        "(created before encryption was enabled). Returning as plain text.");
+            }
+            return processedClientSecret;
         }
     }
 
@@ -133,7 +149,7 @@ public class EncryptionDecryptionPersistenceProcessor implements TokenPersistenc
     }
 
     private String encrypt(String plainText) throws CryptoException {
-        return  CryptoUtil.getDefaultCryptoUtil().encryptAndBase64Encode(
+        return CryptoUtil.getDefaultCryptoUtil().encryptAndBase64Encode(
                 plainText.getBytes(Charsets.UTF_8));
     }
 

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dao/TokenManagementDAOImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dao/TokenManagementDAOImpl.java
@@ -598,11 +598,8 @@ public class TokenManagementDAOImpl extends AbstractOAuthDAO implements TokenMan
                 updateStateStatement.execute();
 
             } else if (OAuthConstants.ACTION_REGENERATE.equals(action)) {
-                TokenPersistenceProcessor tokenPersistenceProcessor = getPersistenceProcessor();
-                if (OAuthServerConfiguration.getInstance().isClientSecretHashOnlyEnabled()) {
-                    tokenPersistenceProcessor = OAuthServerConfiguration.getInstance()
-                            .getClientSecretPersistenceProcessor();
-                }
+                TokenPersistenceProcessor tokenPersistenceProcessor =
+                        OAuthServerConfiguration.getInstance().getClientSecretPersistenceProcessor();
                 String newSecretKey;
                 if (properties.containsKey(OAuthConstants.OAUTH_APP_NEW_SECRET_KEY)) {
                     newSecretKey = properties.getProperty(OAuthConstants.OAUTH_APP_NEW_SECRET_KEY);

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/tokenprocessor/EncryptionDecryptionPersistenceProcessorTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/tokenprocessor/EncryptionDecryptionPersistenceProcessorTest.java
@@ -131,8 +131,17 @@ public class EncryptionDecryptionPersistenceProcessorTest {
         }
     }
 
-    @Test(expectedExceptions = IdentityOAuth2Exception.class)
-    public void testIdentityOAuth2ExceptionForGetPreprocessedClientSecret()
+    /**
+     * Tests the backward compatibility of getPreprocessedClientSecret.
+     * When decryption fails with CryptoException, the client secret may have been stored
+     * in plain text before encryption was enabled. The method should return the plain text
+     * value as-is for backward compatibility, instead of throwing an exception.
+     *
+     * @throws CryptoException if cryptography operation fails
+     * @throws IdentityOAuth2Exception if OAuth2 error occurs
+     */
+    @Test
+    public void testGetPreprocessedClientSecretWithPlainTextFallback()
             throws CryptoException, IdentityOAuth2Exception {
 
         try (MockedStatic<CryptoUtil> cryptoUtil = mockStatic(CryptoUtil.class)) {
@@ -141,7 +150,8 @@ public class EncryptionDecryptionPersistenceProcessorTest {
             cryptoUtil.when(() -> CryptoUtil.getDefaultCryptoUtil(any(ServerConfigurationService.class),
                     any(RegistryService.class))).thenReturn(mockCryptoUtil);
             cryptoUtil.when(CryptoUtil::getDefaultCryptoUtil).thenReturn(mockCryptoUtil);
-            testclass.getPreprocessedClientSecret("test");
+
+            assertEquals(testclass.getPreprocessedClientSecret("plainTextSecret"), "plainTextSecret");
         }
     }
 

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/tokenprocessor/EncryptionDecryptionPersistenceProcessorTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/tokenprocessor/EncryptionDecryptionPersistenceProcessorTest.java
@@ -55,6 +55,22 @@ public class EncryptionDecryptionPersistenceProcessorTest {
     }
 
     @Test
+    public void testGetPreprocessedClientSecretWithSuccessfulDecryption()
+            throws CryptoException, IdentityOAuth2Exception {
+
+        try (MockedStatic<CryptoUtil> cryptoUtil = mockStatic(CryptoUtil.class)) {
+            CryptoUtil mockCryptoUtil = mock(CryptoUtil.class);
+            byte[] decryptedSecret = "decryptedSecret".getBytes(StandardCharsets.UTF_8);
+            when(mockCryptoUtil.base64DecodeAndDecrypt("encryptedSecret")).thenReturn(decryptedSecret);
+            cryptoUtil.when(() -> CryptoUtil.getDefaultCryptoUtil(any(ServerConfigurationService.class),
+                    any(RegistryService.class))).thenReturn(mockCryptoUtil);
+            cryptoUtil.when(CryptoUtil::getDefaultCryptoUtil).thenReturn(mockCryptoUtil);
+
+            assertEquals(testclass.getPreprocessedClientSecret("encryptedSecret"), "decryptedSecret");
+        }
+    }
+
+    @Test
     public void testGetPreprocessed() throws CryptoException, IdentityOAuth2Exception {
 
         try (MockedStatic<CryptoUtil> cryptoUtil = mockStatic(CryptoUtil.class)) {
@@ -65,7 +81,6 @@ public class EncryptionDecryptionPersistenceProcessorTest {
                     any(RegistryService.class))).thenReturn(mockCryptoUtil);
             cryptoUtil.when(CryptoUtil::getDefaultCryptoUtil).thenReturn(mockCryptoUtil);
 
-            assertEquals(testclass.getPreprocessedClientSecret("test"), "test");
             assertEquals(testclass.getPreprocessedAuthzCode("test"), "test");
             assertEquals(testclass.getPreprocessedRefreshToken("test"), "test");
             assertEquals(testclass.getPreprocessedAccessTokenIdentifier("test"), "test");


### PR DESCRIPTION
## Purpose
Fixes wso2/product-is#28136

Client secret regeneration fails with `APP-65001` when `client_secret_persistence_processor` is configured to use `EncryptionDecryptionPersistenceProcessor`.

## Goals
- Allow client secret regeneration to succeed when client secret encryption is enabled.
- Maintain backward compatibility for OAuth applications whose client secrets were stored in plain text before encryption was enabled.
- Ensure regenerated client secrets are persisted using the configured client secret persistence processor.

## Approach
Two changes were made in `identity-inbound-auth-oauth`:

1. **Read path (`EncryptionDecryptionPersistenceProcessor`)**  
   Updated `getPreprocessedClientSecret()` to return the stored value as-is when decryption fails with `CryptoException`. This handles legacy plain-text secrets that cannot be decrypted after encryption is enabled.

2. **Write path (`TokenManagementDAOImpl`)**  
   Updated the regenerate flow to use `OAuthServerConfiguration.getInstance().getClientSecretPersistenceProcessor()` when persisting the new client secret, instead of the default token persistence processor.

3. **Tests**  
   Added/updated unit tests in `EncryptionDecryptionPersistenceProcessorTest` for successful decryption and plain-text fallback behavior.

## User stories
- As an administrator, I want to regenerate an OAuth/OIDC application's client secret when client secret encryption is enabled, so that secret rotation works without server errors.
- As a platform operator, I want existing applications with legacy plain-text secrets to remain functional after enabling encryption, so that migration does not break secret regeneration.

## Release note
Fixed an issue where regenerating the client secret of an OAuth/OIDC application failed when client secret encryption was enabled.

## Documentation
N/A — No documentation changes are required. Existing configuration for `client_secret_persistence_processor` remains unchanged.

## Training
N/A — No training content changes are required.

## Certification
N/A — No certification exam content is impacted by this change.

## Marketing
N/A — No marketing content changes are required.

## Automation tests
- **Unit tests**
  - Updated `EncryptionDecryptionPersistenceProcessorTest` to cover:
    - Successful decryption of encrypted client secrets
    - Plain-text fallback when decryption fails
  - Existing tests for other token types (authz code, access token, refresh token) continue to verify failure behavior is unchanged.
- **Integration tests**
  - Not added — manual integration testing with WSO2 IS was not performed locally due to environment limitations. Reviewers are requested to verify the regenerate-secret flow with encryption enabled.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
- Ran FindSecurityBugs plugin and verified report? **no** (not run locally)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**

No client secrets or sensitive values are logged. The fallback path only returns the stored DB value without exposing additional information.

## Samples
N/A — No sample applications or configurations are added or changed.

## Related PRs
N/A

## Migrations (if applicable)
N/A — No database or data migration is required. Existing plain-text secrets continue to work via backward-compatible read handling; newly regenerated secrets are stored using the configured client secret persistence processor.

## Test environment
Manual testing with WSO2 IS was **not performed locally** (IS environment not available).

Verified by:
- Unit tests in `EncryptionDecryptionPersistenceProcessorTest`
- Code review of regenerate read/write flow

**Suggested verification for reviewers:**
1. Enable in `deployment.toml`:
   ```toml
   [oauth.extensions]
   client_secret_persistence_processor = "org.wso2.carbon.identity.oauth.tokenprocessor.EncryptionDecryptionPersistenceProcessor"