### PR TITLE
Bump org.json.wso2 dependency to 3.0.0.wso2v9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1072,7 +1072,7 @@
         <thetransactioncompany.cors-filter.wso2.version>1.7.0.wso2v1</thetransactioncompany.cors-filter.wso2.version>
         <thetransactioncompany.utils.wso2.version>1.9.0.wso2v1</thetransactioncompany.utils.wso2.version>
 
-        <json.wso2.version>3.0.0.wso2v4</json.wso2.version>
+        <json.wso2.version>3.0.0.wso2v9</json.wso2.version>
         <json.wso2.version.range>[3.0.0.wso2v1, 4.0.0)</json.wso2.version.range>
 
         <opensaml.version>3.3.1</opensaml.version>


### PR DESCRIPTION
## Summary
- Bumps the `json.wso2.version` property from `3.0.0.wso2v4` to `3.0.0.wso2v9`.

## Related
Related to wso2/product-is#28299

## Test plan
- [x] `mvn clean install -DskipTests` on the full reactor — build succeeds against the new version.
- [x] Verified in a locally-assembled `product-is` distribution that the resulting pack ships `json_3.0.0.wso2v9.jar`.