### PR TITLE
Fix RAR schema validation for integral numeric schema keywords

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.rar/src/main/java/org/wso2/carbon/identity/oauth/rar/core/AuthorizationDetailsSchemaValidatorImpl.java
+++ b/components/org.wso2.carbon.identity.oauth.rar/src/main/java/org/wso2/carbon/identity/oauth/rar/core/AuthorizationDetailsSchemaValidatorImpl.java
@@ -37,7 +37,14 @@ import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.identity.oauth.rar.exception.AuthorizationDetailsProcessingException;
 import org.wso2.carbon.identity.oauth.rar.model.AuthorizationDetail;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.wso2.carbon.identity.oauth.rar.util.AuthorizationDetailsConstants.SCHEMA_VALIDATION_FAILED_ERR_MSG_FORMAT;
 import static org.wso2.carbon.identity.oauth.rar.util.AuthorizationDetailsConstants.TYPE_VALIDATION_FAILED_ERR_MSG_FORMAT;
@@ -68,6 +75,8 @@ public class AuthorizationDetailsSchemaValidatorImpl implements AuthorizationDet
 
     private static final String ADDITIONAL_PROPERTIES = "additionalProperties";
     private static final String BASE_URI = "https://wso2.com/identity-server/schemas";
+    private static final Set<String> NON_NEGATIVE_INTEGER_SCHEMA_KEYWORDS = Set.of("minItems", "maxItems",
+            "minLength", "maxLength", "minProperties", "maxProperties");
 
     private static volatile AuthorizationDetailsSchemaValidator instance;
     private final JsonSchemaOptions jsonSchemaOptions;
@@ -218,9 +227,94 @@ public class AuthorizationDetailsSchemaValidatorImpl implements AuthorizationDet
             return false;
         }
 
-        final JsonObject jsonSchema = new JsonObject(schema);
+        final JsonObject jsonSchema = new JsonObject(this.normalizeSchemaMap(schema));
         jsonSchema.put(ADDITIONAL_PROPERTIES, false); // Ensure no unknown fields are allowed
 
         return this.isSchemaCompliant(jsonSchema, authorizationDetail);
+    }
+
+    private Map<String, Object> normalizeSchemaMap(final Map<String, Object> schema) {
+
+        final Map<String, Object> normalizedSchema = new HashMap<>();
+        for (Map.Entry<String, Object> entry : schema.entrySet()) {
+            normalizedSchema.put(entry.getKey(), this.normalizeSchemaValue(entry.getKey(), entry.getValue()));
+        }
+        return normalizedSchema;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Object normalizeSchemaValue(final String key, final Object value) {
+
+        if (NON_NEGATIVE_INTEGER_SCHEMA_KEYWORDS.contains(key)) {
+            return this.normalizeNonNegativeIntegerSchemaKeyword(value);
+        }
+        if (value instanceof Map) {
+            return this.normalizeSchemaMap((Map<String, Object>) value);
+        }
+        if (value instanceof Collection) {
+            return this.normalizeSchemaCollection((Collection<?>) value);
+        }
+        return value;
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<Object> normalizeSchemaCollection(final Collection<?> values) {
+
+        final List<Object> normalizedValues = new ArrayList<>(values.size());
+        for (Object value : values) {
+            if (value instanceof Map) {
+                normalizedValues.add(this.normalizeSchemaMap((Map<String, Object>) value));
+            } else if (value instanceof Collection) {
+                normalizedValues.add(this.normalizeSchemaCollection((Collection<?>) value));
+            } else {
+                normalizedValues.add(value);
+            }
+        }
+        return normalizedValues;
+    }
+
+    private Object normalizeNonNegativeIntegerSchemaKeyword(final Object value) {
+
+        if (!(value instanceof Number)) {
+            return value;
+        }
+
+        final Number number = (Number) value;
+        if (number instanceof Integer) {
+            return number;
+        }
+        if (number instanceof Byte || number instanceof Short) {
+            final int intValue = number.intValue();
+            return intValue >= 0 ? intValue : value;
+        }
+        if (number instanceof Long) {
+            final long longValue = number.longValue();
+            return longValue >= 0 && longValue <= Integer.MAX_VALUE ? (int) longValue : value;
+        }
+        if (number instanceof BigInteger) {
+            return this.normalizeBigInteger((BigInteger) number, value);
+        }
+        if (number instanceof BigDecimal) {
+            try {
+                return this.normalizeBigInteger(((BigDecimal) number).toBigIntegerExact(), value);
+            } catch (ArithmeticException e) {
+                return value;
+            }
+        }
+
+        final double doubleValue = number.doubleValue();
+        if (Double.isFinite(doubleValue) && doubleValue >= 0 && doubleValue <= Integer.MAX_VALUE
+                && doubleValue == Math.rint(doubleValue)) {
+            return (int) doubleValue;
+        }
+        return value;
+    }
+
+    private Object normalizeBigInteger(final BigInteger integerValue, final Object originalValue) {
+
+        if (integerValue.signum() >= 0 && integerValue.compareTo(BigInteger.valueOf(Integer.MAX_VALUE)) <= 0) {
+            return integerValue.intValue();
+        }
+        return originalValue;
     }
 }

--- a/components/org.wso2.carbon.identity.oauth.rar/src/main/java/org/wso2/carbon/identity/oauth/rar/core/AuthorizationDetailsSchemaValidatorImpl.java
+++ b/components/org.wso2.carbon.identity.oauth.rar/src/main/java/org/wso2/carbon/identity/oauth/rar/core/AuthorizationDetailsSchemaValidatorImpl.java
@@ -245,7 +245,7 @@ public class AuthorizationDetailsSchemaValidatorImpl implements AuthorizationDet
     @SuppressWarnings("unchecked")
     private Object normalizeSchemaValue(final String key, final Object value) {
 
-        if (NON_NEGATIVE_INTEGER_SCHEMA_KEYWORDS.contains(key)) {
+        if (value instanceof Number && NON_NEGATIVE_INTEGER_SCHEMA_KEYWORDS.contains(key)) {
             return this.normalizeNonNegativeIntegerSchemaKeyword(value);
         }
         if (value instanceof Map) {

--- a/components/org.wso2.carbon.identity.oauth.rar/src/test/java/org/wso2/carbon/identity/oauth/rar/AuthorizationDetailsSchemaValidatorTest.java
+++ b/components/org.wso2.carbon.identity.oauth.rar/src/test/java/org/wso2/carbon/identity/oauth/rar/AuthorizationDetailsSchemaValidatorTest.java
@@ -130,6 +130,109 @@ public class AuthorizationDetailsSchemaValidatorTest {
         this.uut.isSchemaCompliant(this.getTestSchemaWithDoubleIntegerKeywords(), testAuthorizationDetail);
     }
 
+    @Test
+    public void shouldReturnTrue_whenPropertyNameMatchesIntegerSchemaKeyword()
+            throws AuthorizationDetailsProcessingException {
+
+        TestDAOUtils.TestAuthorizationDetail testAuthorizationDetail = new TestDAOUtils.TestAuthorizationDetail();
+        testAuthorizationDetail.setType(TEST_TYPE);
+        testAuthorizationDetail.setDetail("maxLength", Collections.singletonList("initiate"));
+
+        assertTrue(this.uut.isSchemaCompliant(this.getTestSchemaWithKeywordNamedProperty(), testAuthorizationDetail));
+    }
+
+    @Test
+    public void shouldReturnTrue_whenIntegerKeywordsAreAtBoundaryValues()
+            throws AuthorizationDetailsProcessingException {
+
+        TestDAOUtils.TestAuthorizationDetail testAuthorizationDetail = new TestDAOUtils.TestAuthorizationDetail();
+        testAuthorizationDetail.setType(TEST_TYPE);
+        testAuthorizationDetail.setActions(Collections.singletonList("initiate"));
+
+        final Map<String, Object> items = new HashMap<>();
+        items.put("type", "string");
+
+        final Map<String, Object> actions = new HashMap<>();
+        actions.put("type", "array");
+        actions.put("items", items);
+        actions.put("minItems", 0.0d);
+        actions.put("maxItems", (double) Integer.MAX_VALUE);
+
+        final Map<String, Object> type = new HashMap<>();
+        type.put("type", "string");
+        type.put("enum", Collections.singletonList("test_type_v1"));
+
+        final Map<String, Object> properties = new HashMap<>();
+        properties.put("type", type);
+        properties.put("actions", actions);
+
+        final Map<String, Object> schema = new HashMap<>();
+        schema.put("type", "object");
+        schema.put("required", Collections.singletonList("type"));
+        schema.put("properties", properties);
+
+        assertTrue(this.uut.isSchemaCompliant(schema, testAuthorizationDetail));
+    }
+
+    @Test
+    public void shouldReturnTrue_whenIntegerKeywordsAreNestedInsideSchemaLists()
+            throws AuthorizationDetailsProcessingException {
+
+        TestDAOUtils.TestAuthorizationDetail testAuthorizationDetail = new TestDAOUtils.TestAuthorizationDetail();
+        testAuthorizationDetail.setType(TEST_TYPE);
+        testAuthorizationDetail.setName("test_name_v1");
+
+        final Map<String, Object> minLengthConstraint = new HashMap<>();
+        minLengthConstraint.put("type", "string");
+        minLengthConstraint.put("minLength", 2.0d);
+
+        final Map<String, Object> maxLengthConstraint = new HashMap<>();
+        maxLengthConstraint.put("type", "string");
+        maxLengthConstraint.put("maxLength", 20.0d);
+
+        final Map<String, Object> name = new HashMap<>();
+        name.put("allOf", Arrays.asList(minLengthConstraint, maxLengthConstraint));
+
+        final Map<String, Object> type = new HashMap<>();
+        type.put("type", "string");
+        type.put("enum", Collections.singletonList("test_type_v1"));
+
+        final Map<String, Object> properties = new HashMap<>();
+        properties.put("type", type);
+        properties.put("name", name);
+
+        final Map<String, Object> schema = new HashMap<>();
+        schema.put("type", "object");
+        schema.put("required", Collections.singletonList("type"));
+        schema.put("properties", properties);
+
+        assertTrue(this.uut.isSchemaCompliant(schema, testAuthorizationDetail));
+    }
+
+    @Test
+    public void shouldNotMutateCallerOwnedSchema_whenValidatingMapSchema()
+            throws AuthorizationDetailsProcessingException {
+
+        TestDAOUtils.TestAuthorizationDetail testAuthorizationDetail = new TestDAOUtils.TestAuthorizationDetail();
+        testAuthorizationDetail.setType(TEST_TYPE);
+        testAuthorizationDetail.setName("test_name_v1");
+        testAuthorizationDetail.setActions(Arrays.asList("initiate", "cancel"));
+        testAuthorizationDetail.setDetail("amount", 5);
+
+        Map<String, Object> schema = this.getTestSchemaWithMixedNumericKeywords();
+
+        assertTrue(this.uut.isSchemaCompliant(schema, testAuthorizationDetail));
+
+        // The validator must not inject `additionalProperties` into the caller owned map.
+        assertFalse(schema.containsKey("additionalProperties"));
+        // Nested maps and nested lists must be left exactly as the caller provided them.
+        assertEquals(schema, this.getTestSchemaWithMixedNumericKeywords());
+
+        Map<String, Object> amountSchema = this.getPropertySchema(schema, "amount");
+        assertTrue(amountSchema.get("minimum") instanceof Double);
+        assertTrue(amountSchema.get("multipleOf") instanceof Double);
+    }
+
     @Test(expectedExceptions = {AuthorizationDetailsProcessingException.class})
     public void shouldThrowAuthorizationDetailsProcessingException_whenSchemaIsInvalid1()
             throws AuthorizationDetailsProcessingException {
@@ -204,6 +307,72 @@ public class AuthorizationDetailsSchemaValidatorTest {
         final Map<String, Object> schema = new HashMap<>();
         schema.put("type", "object");
         schema.put("required", Arrays.asList("type", "actions", "name"));
+        schema.put("properties", properties);
+        return schema;
+    }
+
+    private Map<String, Object> getTestSchemaWithMixedNumericKeywords() {
+
+        final Map<String, Object> items = new HashMap<>();
+        items.put("type", "string");
+
+        final Map<String, Object> actions = new HashMap<>();
+        actions.put("type", "array");
+        actions.put("items", items);
+        actions.put("minItems", 1.0d);
+        actions.put("maxItems", 3.0d);
+
+        final Map<String, Object> type = new HashMap<>();
+        type.put("type", "string");
+        type.put("enum", Collections.singletonList("test_type_v1"));
+
+        final Map<String, Object> name = new HashMap<>();
+        name.put("type", "string");
+        name.put("minLength", 1.0d);
+        name.put("maxLength", 20.0d);
+
+        // `minimum` and `multipleOf` accept non integral values and must never be converted.
+        final Map<String, Object> amount = new HashMap<>();
+        amount.put("type", "number");
+        amount.put("minimum", 1.0d);
+        amount.put("multipleOf", 1.0d);
+
+        final Map<String, Object> properties = new HashMap<>();
+        properties.put("type", type);
+        properties.put("actions", actions);
+        properties.put("name", name);
+        properties.put("amount", amount);
+
+        final Map<String, Object> schema = new HashMap<>();
+        schema.put("type", "object");
+        schema.put("required", Arrays.asList("type", "actions", "name"));
+        schema.put("properties", properties);
+        return schema;
+    }
+
+    private Map<String, Object> getTestSchemaWithKeywordNamedProperty() {
+
+        final Map<String, Object> type = new HashMap<>();
+        type.put("type", "string");
+        type.put("enum", Collections.singletonList("test_type_v1"));
+
+        final Map<String, Object> items = new HashMap<>();
+        items.put("type", "string");
+
+        // An authorization detail property may legitimately be named after a schema keyword.
+        final Map<String, Object> keywordNamedProperty = new HashMap<>();
+        keywordNamedProperty.put("type", "array");
+        keywordNamedProperty.put("items", items);
+        keywordNamedProperty.put("minItems", 1.0d);
+        keywordNamedProperty.put("maxItems", 3.0d);
+
+        final Map<String, Object> properties = new HashMap<>();
+        properties.put("type", type);
+        properties.put("maxLength", keywordNamedProperty);
+
+        final Map<String, Object> schema = new HashMap<>();
+        schema.put("type", "object");
+        schema.put("required", Collections.singletonList("type"));
         schema.put("properties", properties);
         return schema;
     }

--- a/components/org.wso2.carbon.identity.oauth.rar/src/test/java/org/wso2/carbon/identity/oauth/rar/AuthorizationDetailsSchemaValidatorTest.java
+++ b/components/org.wso2.carbon.identity.oauth.rar/src/test/java/org/wso2/carbon/identity/oauth/rar/AuthorizationDetailsSchemaValidatorTest.java
@@ -34,6 +34,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 import static org.wso2.carbon.identity.oauth.rar.util.TestConstants.TEST_SCHEMA;
@@ -92,6 +93,43 @@ public class AuthorizationDetailsSchemaValidatorTest {
         assertTrue(this.uut.isSchemaCompliant(TEST_SCHEMA, testAuthorizationDetail));
     }
 
+    @Test
+    public void shouldReturnTrue_whenMapSchemaContainsIntegralDoubleIntegerKeywords()
+            throws AuthorizationDetailsProcessingException {
+
+        TestDAOUtils.TestAuthorizationDetail testAuthorizationDetail = new TestDAOUtils.TestAuthorizationDetail();
+        testAuthorizationDetail.setType(TEST_TYPE);
+        testAuthorizationDetail.setName("test_name_v1");
+        testAuthorizationDetail.setActions(Arrays.asList("initiate", "cancel"));
+
+        Map<String, Object> schema = this.getTestSchemaWithDoubleIntegerKeywords();
+
+        assertTrue(this.uut.isSchemaCompliant(schema, testAuthorizationDetail));
+
+        Map<String, Object> actionsSchema = this.getPropertySchema(schema, "actions");
+        Map<String, Object> nameSchema = this.getPropertySchema(schema, "name");
+        assertTrue(actionsSchema.get("minItems") instanceof Double);
+        assertTrue(actionsSchema.get("maxItems") instanceof Double);
+        assertTrue(nameSchema.get("minLength") instanceof Double);
+        assertTrue(nameSchema.get("maxLength") instanceof Double);
+        assertEquals(actionsSchema.get("minItems"), 1.0d);
+        assertEquals(actionsSchema.get("maxItems"), 3.0d);
+        assertEquals(nameSchema.get("minLength"), 1.0d);
+        assertEquals(nameSchema.get("maxLength"), 20.0d);
+    }
+
+    @Test(expectedExceptions = {AuthorizationDetailsProcessingException.class})
+    public void shouldThrowAuthorizationDetailsProcessingException_whenMapSchemaViolatesNormalizedMaxItems()
+            throws AuthorizationDetailsProcessingException {
+
+        TestDAOUtils.TestAuthorizationDetail testAuthorizationDetail = new TestDAOUtils.TestAuthorizationDetail();
+        testAuthorizationDetail.setType(TEST_TYPE);
+        testAuthorizationDetail.setName("test_name_v1");
+        testAuthorizationDetail.setActions(Arrays.asList("initiate", "cancel", "confirm", "revoke"));
+
+        this.uut.isSchemaCompliant(this.getTestSchemaWithDoubleIntegerKeywords(), testAuthorizationDetail);
+    }
+
     @Test(expectedExceptions = {AuthorizationDetailsProcessingException.class})
     public void shouldThrowAuthorizationDetailsProcessingException_whenSchemaIsInvalid1()
             throws AuthorizationDetailsProcessingException {
@@ -136,5 +174,43 @@ public class AuthorizationDetailsSchemaValidatorTest {
         schema.put("required", Collections.singletonList("type"));
         schema.put("properties", properties);
         return schema;
+    }
+
+    private Map<String, Object> getTestSchemaWithDoubleIntegerKeywords() {
+
+        final Map<String, Object> items = new HashMap<>();
+        items.put("type", "string");
+
+        final Map<String, Object> actions = new HashMap<>();
+        actions.put("type", "array");
+        actions.put("items", items);
+        actions.put("minItems", 1.0d);
+        actions.put("maxItems", 3.0d);
+
+        final Map<String, Object> type = new HashMap<>();
+        type.put("type", "string");
+        type.put("enum", Collections.singletonList("test_type_v1"));
+
+        final Map<String, Object> name = new HashMap<>();
+        name.put("type", "string");
+        name.put("minLength", 1.0d);
+        name.put("maxLength", 20.0d);
+
+        final Map<String, Object> properties = new HashMap<>();
+        properties.put("type", type);
+        properties.put("actions", actions);
+        properties.put("name", name);
+
+        final Map<String, Object> schema = new HashMap<>();
+        schema.put("type", "object");
+        schema.put("required", Arrays.asList("type", "actions", "name"));
+        schema.put("properties", properties);
+        return schema;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> getPropertySchema(final Map<String, Object> schema, final String propertyName) {
+
+        return (Map<String, Object>) ((Map<String, Object>) schema.get("properties")).get(propertyName);
     }
 }


### PR DESCRIPTION
## Purpose

Fixes wso2/product-is#28292.

The RAR authorization details schema validator could fail with a
`ClassCastException` when JSON schema integer keywords such as `minItems`,
`maxItems`, `minLength`, or `maxLength` were represented as integral
`Double` values.

## Approach

This PR adds recursive schema-map normalization before creating the Vert.x
`JsonObject` used by the validator.

The normalization:

- Converts only supported schema-size keywords:
  - `minItems`
  - `maxItems`
  - `minLength`
  - `maxLength`
  - `minProperties`
  - `maxProperties`
- Converts only integral, non-negative numeric values within Java `Integer`
  range.
- Leaves fractional, negative, out-of-range, and unrelated numeric keyword
  values unchanged.
- Deep-copies normalized schema content so the caller-owned schema map is
  not mutated.
- Preserves the existing `additionalProperties=false` behavior.

## Tests

Added regression coverage for integral `Double` values in:

- `minItems`
- `maxItems`
- `minLength`
- `maxLength`

The tests also assert that the original caller-owned schema map still
contains the original `Double` values after validation.

## Verification

- Confirmed the new regression tests fail on the old implementation with:
  `ClassCastException: Double cannot be cast to Integer`
- Ran focused `AuthorizationDetailsSchemaValidatorTest`: 8 tests passed
- Ran full RAR TestNG suite: 40 tests passed
- Ran package build with tests/checkstyle/jacoco skipped
- Ran `git diff --check`

## Local environment notes

The exact unskipped Maven command could not be completed locally because
the machine has Java 17 and Java 25, but not Java 21.

Additional local blockers were unrelated to this change:

- Java 17 cannot compile target 21.
- Java 25 trips repository tooling.
- Unskipped Checkstyle fails on a pre-existing unrelated issue in
  `TestDAOUtils.java:77`.
- JaCoCo 0.8.12 cannot instrument JDK 25 classes locally.