### PR TITLE
Skip role names that cannot be resolved during scope validation

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/AuthzUtil.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/AuthzUtil.java
@@ -43,6 +43,7 @@ import org.wso2.carbon.identity.oauth2.internal.OAuth2ServiceComponentHolder;
 import org.wso2.carbon.identity.organization.management.organization.agent.sharing.util.OrganizationSharedAgentUtil;
 import org.wso2.carbon.identity.organization.management.organization.user.sharing.util.OrganizationSharedUserUtil;
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
+import org.wso2.carbon.identity.role.v2.mgt.core.exception.IdentityRoleManagementClientException;
 import org.wso2.carbon.identity.role.v2.mgt.core.exception.IdentityRoleManagementException;
 import org.wso2.carbon.user.api.RealmConfiguration;
 import org.wso2.carbon.user.api.UserStoreException;
@@ -410,14 +411,25 @@ public class AuthzUtil {
             throws IdentityOAuth2Exception {
 
         List<String> roleIds = new ArrayList<>();
-        try {
-            for (String roleName: roleNames) {
+        for (String roleName : roleNames) {
+            try {
                 roleIds.add(OAuth2ServiceComponentHolder.getInstance().getRoleManagementServiceV2()
                         .getRoleIdByName(roleName, roleAudience, roleAudienceId, tenantDomain));
+            } catch (IdentityRoleManagementClientException e) {
+                /*
+                The roles claim of a federated user can carry role names that are not defined for this audience in
+                this tenant. Roles created inside a sub organization reach the parent this way during organization
+                login. Such a role cannot grant any scope here, so it is skipped rather than failing the whole
+                authorization request.
+                */
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Skipping role name which is not resolvable for audience: " + roleAudience
+                            + " audience id: " + roleAudienceId + " in tenant domain: " + tenantDomain);
+                }
+            } catch (IdentityRoleManagementException e) {
+                throw new IdentityOAuth2Exception("Error while retrieving role ids of  list of role name : "
+                        + StringUtils.join(roleNames, ",") + " tenant domain : " + tenantDomain, e);
             }
-        } catch (IdentityRoleManagementException e) {
-            throw new IdentityOAuth2Exception("Error while retrieving role ids of  list of role name : "
-                    + StringUtils.join(roleNames, ",") + " tenant domain : " + tenantDomain, e);
         }
         return roleIds;
     }


### PR DESCRIPTION
Resolves part (4) of wso2/product-is#28338.

## Purpose
Authorization fails with `server_error` when a federated user's roles claim carries a role name that is not defined for the application's audience in the token issuing tenant. A single unresolvable name aborts the whole request, so the user cannot obtain a token at all.

Reproduced during B2B organization login: the roles claim is resolved inside the organization the user authenticated in, so it carries roles created within that organization. Those names do not exist in the application's own organization, and scope validation fails hard on the first one.

```
ERROR AuthzUtil - Error occurred while validating requested scopes
Caused by: ScopeValidationHandlerException: Error while validation scope with RBAC Scope Validation handler
Caused by: IdentityOAuth2Exception: Error while retrieving role ids of  list of role name :
           Bulk114,LateRole,LocalAuditor,RootSharedRole  tenant domain : carbon.super
Caused by: IdentityRoleManagementClientException: A role doesn't exist with name: Bulk114
           in the tenantDomain: carbon.super
```

The browser receives:

```
error=server_error&error_description=Server+error+occurred+while+performing+authorization
```

The failure only surfaces when a business scope is requested, since that is what engages `RoleBasedScopeValidationHandler`.

## Goals
A role name that cannot be resolved for the given audience and tenant should contribute no scopes, rather than failing the authorization request for every other role the user holds.

## Approach
`AuthzUtil#getRoleIdsFromNames` wrapped the whole loop in a single try block, so the first unresolvable name aborted the rest. `RoleDAOImpl#getRoleIdByName` raises `IdentityRoleManagementClientException` (error code `INVALID_REQUEST`) when the role does not exist, which is a client level condition rather than a server failure.

The try block now sits inside the loop and the catch is split:

- `IdentityRoleManagementClientException` - the name is skipped and logged at debug level. It cannot grant a scope in this tenant, so it contributes nothing.
- `IdentityRoleManagementException` - still propagated as before, so genuine server failures are not swallowed.

No behaviour changes for role names that do resolve; they map to ids exactly as before.

## User stories
As a user of an organization signing in to a shared application, requesting an API scope returns a token instead of a server error.

## Release note
Fixed an issue where requesting an API scope failed with a server error when the user's roles claim contained a role that is not defined in the token issuing tenant.

## Documentation
N/A - no new configuration or API surface.

## Training
N/A

## Certification
N/A - no impact on certification exams.

## Marketing
N/A

## Automation tests
 - Unit tests
   > Dedicated unit tests for `getRoleIdsFromNames` are still to be added.
 - Integration tests
   > Verified at runtime against a `wso2is-7.4.0-SNAPSHOT` pack through the real authorization-code and organization-login browser flow. Before: `server_error`, no token issued. After: the authorization code is issued, the token carries the roles claim, and scopes granted by roles that do resolve in the tenant are unaffected. Regression checked with a user holding no roles and with a user holding only roles that resolve normally.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
Found while verifying the organization roles changes below. Those two make the roles claim carry roles created inside a sub organization, which is what allows unresolvable names to reach this code path, so this fix should land with or before them:

- https://github.com/wso2-extensions/identity-organization-management/pull/649
- https://github.com/wso2/carbon-identity-framework/pull/8245

## Migrations (if applicable)
No migration required.

## Test environment
JDK 21, macOS 15 (Darwin 25.5.0), H2 (default), Chromium via Playwright for the organization login flow.

## Learning
Isolated the failing call by enabling debug logging on `org.wso2.carbon.identity.oauth2.validators` and `AuthzUtil` on both sides of the organization login hop, which showed the exact audience and tenant the role names were being resolved against.


