### PR TITLE
Fix exception type for tenant domain retrieval in JWTUtils

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/JWTUtils.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/JWTUtils.java
@@ -479,7 +479,7 @@ public class JWTUtils {
                 return OAuth2Util.getTenantDomainOfOauthApp(accessTokenDO.getConsumerKey());
             } catch (InvalidOAuthClientException e) {
                 throw new IdentityOAuth2ClientException("Error while getting tenant domain from OAuth app with " +
-                        "consumer key: " + accessTokenDO.getConsumerKey());
+                        "consumer key: " + accessTokenDO.getConsumerKey(), e);
             } catch (OrganizationManagementException e) {
                 throw new IdentityOAuth2Exception("Error while getting tenant domain from OAuth app with " +
                         "consumer key: " + accessTokenDO.getConsumerKey(), e);

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/JWTUtils.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/JWTUtils.java
@@ -478,8 +478,8 @@ public class JWTUtils {
                 }
                 return OAuth2Util.getTenantDomainOfOauthApp(accessTokenDO.getConsumerKey());
             } catch (InvalidOAuthClientException e) {
-                throw new IdentityOAuth2Exception("Error while getting tenant domain from OAuth app with consumer key: "
-                        + accessTokenDO.getConsumerKey());
+                throw new IdentityOAuth2ClientException("Error while getting tenant domain from OAuth app with " +
+                        "consumer key: " + accessTokenDO.getConsumerKey());
             } catch (OrganizationManagementException e) {
                 throw new IdentityOAuth2Exception("Error while getting tenant domain from OAuth app with " +
                         "consumer key: " + accessTokenDO.getConsumerKey(), e);


### PR DESCRIPTION
### Proposed changes in this pull request

This pull request makes a minor improvement to exception handling in the `JWTUtils.java` utility. Specifically, it changes the type of exception thrown when an `InvalidOAuthClientException` occurs, providing more accurate error reporting.

- Exception Handling Update:
  * Changed the thrown exception from `IdentityOAuth2Exception` to `IdentityOAuth2ClientException` in the `getSigningTenantDomain` method when catching `InvalidOAuthClientException`, to better reflect the nature of the error.