### PR TITLE
Fix authorization code cache not cleared on application secret regeneration

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/OAuthAdminServiceImpl.java
@@ -1778,7 +1778,8 @@ public class OAuthAdminServiceImpl {
             Set<String> authorizationCodes = OAuthTokenPersistenceFactory.getInstance().getAuthorizationCodeDAO()
                     .getActiveAuthorizationCodesByConsumerKey(consumerKey);
             for (String authorizationCode : authorizationCodes) {
-                OAuthCacheKey cacheKey = new OAuthCacheKey(authorizationCode);
+                OAuthCacheKey cacheKey = new OAuthCacheKey(
+                        OAuth2Util.buildCacheKeyStringForAuthzCode(consumerKey, authorizationCode));
                 OAuthCache.getInstance().clearCacheEntry(cacheKey);
             }
             if (LOG.isDebugEnabled()) {


### PR DESCRIPTION
## Purpose

Fixes the authorization code cache not being cleared when an OAuth application's client secret is regenerated (or its state is changed), which let a revoked authorization code still be exchanged for tokens.

## Problem

When an application secret is regenerated, `OAuthAdminServiceImpl.updateAppAndRevokeTokensAndAuthzCodes()` revokes the application's active authorization codes in the database and attempts to evict them from the `OAuthCache`.

The authorization code is added to the `OAuthCache` at issuance under a **composite key** (`consumerKey + ":" + authorizationCode`, built via `OAuth2Util.buildCacheKeyStringForAuthzCode()`), and the token endpoint reads it back using the same composite key. However, the revocation path cleared the cache using the **bare authorization code** as the key.

Because the keys did not match, the eviction was a no-op: the cached authorization code (still in `ACTIVE` state) remained in the cache. On redemption, the token endpoint served the stale cached entry and skipped the database, so the authorization code — already revoked in the database — could still be exchanged for an access token, refresh token, and ID token.

## Solution

Clear the cache using the same composite key that is used when the authorization code is cached and when it is looked up during redemption.

## Steps to reproduce / verify

1. Register an OAuth app with the `authorization_code` grant.
2. Obtain an authorization code but do not redeem it yet.
3. Regenerate the application's client secret.
4. Redeem the authorization code.

Before this change the code is exchanged successfully; after this change redemption falls through to the database, observes the revoked state, and is rejected.

## Notes

Access tokens and refresh tokens were already revoked correctly by this flow; only the authorization code cache eviction used the wrong key.
