### PR TITLE
Add diagnostic logs for refresh token validation failures

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
+++ b/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
@@ -854,6 +854,14 @@ public final class OAuthConstants {
             public static final String IMPERSONATOR = "impersonator";
             public static final String ACTOR = "actor";
             public static final String REQUESTED_AUTHORIZATION_DETAILS = "requested authorization details";
+            public static final String TOKEN_ID = "token id";
+            public static final String REFRESH_TOKEN_STATE = "refresh token state";
+            public static final String REFRESH_TOKEN_ISSUED_TIME = "refresh token issued time";
+            public static final String REFRESH_TOKEN_VALIDITY_PERIOD = "refresh token validity period (ms)";
+            /* Only the hash of a refresh token is ever logged and only when token logging is explicitly
+             permitted, since refresh tokens themselves cannot be logged. */
+            public static final String REFRESH_TOKEN_HASH = "refresh token hash";
+            public static final String ERROR_CODE = "error code";
         }
 
         /**

--- a/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
+++ b/components/org.wso2.carbon.identity.oauth.common/src/main/java/org/wso2/carbon/identity/oauth/common/OAuthConstants.java
@@ -858,8 +858,6 @@ public final class OAuthConstants {
             public static final String REFRESH_TOKEN_STATE = "refresh token state";
             public static final String REFRESH_TOKEN_ISSUED_TIME = "refresh token issued time";
             public static final String REFRESH_TOKEN_VALIDITY_PERIOD = "refresh token validity period (ms)";
-            /* Only the hash of a refresh token is ever logged and only when token logging is explicitly
-             permitted, since refresh tokens themselves cannot be logged. */
             public static final String REFRESH_TOKEN_HASH = "refresh token hash";
             public static final String ERROR_CODE = "error code";
         }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/tokenprocessor/DefaultRefreshTokenGrantProcessor.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/tokenprocessor/DefaultRefreshTokenGrantProcessor.java
@@ -368,6 +368,17 @@ public class DefaultRefreshTokenGrantProcessor implements RefreshTokenGrantProce
             if (log.isDebugEnabled()) {
                 log.debug(String.format("Invalid Refresh Token provided for Client with Client Id : %s", clientId));
             }
+            if (LoggerUtils.isDiagnosticLogsEnabled()) {
+                LoggerUtils.triggerDiagnosticLogEvent(new DiagnosticLog.DiagnosticLogBuilder(
+                        OAuthConstants.LogConstants.OAUTH_INBOUND_SERVICE,
+                        OAuthConstants.LogConstants.ActionIDs.VALIDATE_REFRESH_TOKEN)
+                        .inputParam(LogConstants.InputKeys.CLIENT_ID, clientId)
+                        .resultMessage("The provided refresh token is invalid. No token was found for the given " +
+                                "refresh token and client id combination. The refresh token could have been " +
+                                "issued for a different application, already revoked or cleaned up after expiry.")
+                        .logDetailLevel(DiagnosticLog.LogDetailLevel.APPLICATION)
+                        .resultStatus(DiagnosticLog.ResultStatus.FAILED));
+            }
             throw new IdentityOAuth2Exception("Persisted access token data not found");
         }
         return true;

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/tokenprocessor/DefaultRefreshTokenGrantProcessor.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/tokenprocessor/DefaultRefreshTokenGrantProcessor.java
@@ -78,7 +78,7 @@ public class DefaultRefreshTokenGrantProcessor implements RefreshTokenGrantProce
         OAuth2AccessTokenReqDTO tokenReq = tokenReqMessageContext.getOauth2AccessTokenReqDTO();
         RefreshTokenValidationDataDO validationBean = OAuthTokenPersistenceFactory.getInstance().getTokenManagementDAO()
                 .validateRefreshToken(tokenReq.getClientId(), tokenReq.getRefreshToken());
-        validatePersistedAccessToken(validationBean, tokenReq.getClientId());
+        validatePersistedAccessToken(validationBean, tokenReq);
         validateReuseRefreshToken(validationBean, tokenReq.getClientId(), tokenReq.getTenantDomain());
         return validationBean;
     }
@@ -361,18 +361,21 @@ public class DefaultRefreshTokenGrantProcessor implements RefreshTokenGrantProce
         return accessTokenDO;
     }
 
-    private boolean validatePersistedAccessToken(RefreshTokenValidationDataDO validationBean, String clientId)
+    private boolean validatePersistedAccessToken(RefreshTokenValidationDataDO validationBean,
+                                                 OAuth2AccessTokenReqDTO tokenReq)
             throws IdentityOAuth2Exception {
 
         if (validationBean.getAccessToken() == null) {
             if (log.isDebugEnabled()) {
-                log.debug(String.format("Invalid Refresh Token provided for Client with Client Id : %s", clientId));
+                log.debug(String.format("Invalid Refresh Token provided for Client with Client Id : %s",
+                        tokenReq.getClientId()));
             }
             if (LoggerUtils.isDiagnosticLogsEnabled()) {
                 LoggerUtils.triggerDiagnosticLogEvent(new DiagnosticLog.DiagnosticLogBuilder(
                         OAuthConstants.LogConstants.OAUTH_INBOUND_SERVICE,
                         OAuthConstants.LogConstants.ActionIDs.VALIDATE_REFRESH_TOKEN)
-                        .inputParam(LogConstants.InputKeys.CLIENT_ID, clientId)
+                        .inputParam(LogConstants.InputKeys.CLIENT_ID, tokenReq.getClientId())
+                        .inputParam(LogConstants.InputKeys.TENANT_DOMAIN, tokenReq.getTenantDomain())
                         .resultMessage("The provided refresh token is invalid. No token was found for the given " +
                                 "refresh token and client id combination. The refresh token could have been " +
                                 "issued for a different application, already revoked or cleaned up after expiry.")

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuer.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuer.java
@@ -509,6 +509,23 @@ public class AccessTokenIssuer {
             if (log.isDebugEnabled()) {
                 log.debug("Invalid Grant provided by the client Id: " + tokenReqDTO.getClientId());
             }
+            /* The grant handlers log the specific reason for the failure. This log guarantees that the diagnostic
+             logs of a token request never end at the application validation, even if a grant handler could not
+             resolve a specific reason for the failure. */
+            if (LoggerUtils.isDiagnosticLogsEnabled()) {
+                LoggerUtils.triggerDiagnosticLogEvent(new DiagnosticLog.DiagnosticLogBuilder(
+                        OAuthConstants.LogConstants.OAUTH_INBOUND_SERVICE,
+                        OAuthConstants.LogConstants.ActionIDs.ISSUE_ACCESS_TOKEN)
+                        .inputParam(LogConstants.InputKeys.CLIENT_ID, tokenReqDTO.getClientId())
+                        .inputParam(OAuthConstants.LogConstants.InputKeys.GRANT_TYPE, grantType)
+                        .inputParam(OAuthConstants.LogConstants.InputKeys.ERROR_CODE, errorCode)
+                        .resultMessage("Authorization grant validation failed. " + (StringUtils.isNotBlank(error)
+                                ? LoggerUtils.getSanitizedErrorMessage(error,
+                                        OAuth2Util.getUserIdentifierFromRequest(tokenReqDTO))
+                                : StringUtils.EMPTY))
+                        .logDetailLevel(DiagnosticLog.LogDetailLevel.APPLICATION)
+                        .resultStatus(DiagnosticLog.ResultStatus.FAILED));
+            }
             tokenRespDTO = handleError(errorCode, error, tokenReqDTO);
             setResponseHeaders(tokReqMsgCtx, tokenRespDTO);
             triggerPostListeners(tokenReqDTO, tokenRespDTO, tokReqMsgCtx, isRefreshRequest);

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuer.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuer.java
@@ -511,7 +511,10 @@ public class AccessTokenIssuer {
             }
             /* The grant handlers log the specific reason for the failure. This log guarantees that the diagnostic
              logs of a token request never end at the application validation, even if a grant handler could not
-             resolve a specific reason for the failure. */
+             resolve a specific reason for the failure. The internal error message is deliberately not included.
+             It is not guaranteed to be free of user identifiers, and LoggerUtils.getSanitizedErrorMessage() can
+             only mask the value of the username request parameter, which grant types other than the password
+             grant do not carry. The error code carries the reason without carrying identifiers. */
             if (LoggerUtils.isDiagnosticLogsEnabled()) {
                 LoggerUtils.triggerDiagnosticLogEvent(new DiagnosticLog.DiagnosticLogBuilder(
                         OAuthConstants.LogConstants.OAUTH_INBOUND_SERVICE,
@@ -519,10 +522,7 @@ public class AccessTokenIssuer {
                         .inputParam(LogConstants.InputKeys.CLIENT_ID, tokenReqDTO.getClientId())
                         .inputParam(OAuthConstants.LogConstants.InputKeys.GRANT_TYPE, grantType)
                         .inputParam(OAuthConstants.LogConstants.InputKeys.ERROR_CODE, errorCode)
-                        .resultMessage("Authorization grant validation failed. " + (StringUtils.isNotBlank(error)
-                                ? LoggerUtils.getSanitizedErrorMessage(error,
-                                        OAuth2Util.getUserIdentifierFromRequest(tokenReqDTO))
-                                : StringUtils.EMPTY))
+                        .resultMessage("Authorization grant validation failed for the provided grant type.")
                         .logDetailLevel(DiagnosticLog.LogDetailLevel.APPLICATION)
                         .resultStatus(DiagnosticLog.ResultStatus.FAILED));
             }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuer.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuer.java
@@ -509,12 +509,7 @@ public class AccessTokenIssuer {
             if (log.isDebugEnabled()) {
                 log.debug("Invalid Grant provided by the client Id: " + tokenReqDTO.getClientId());
             }
-            /* The grant handlers log the specific reason for the failure. This log guarantees that the diagnostic
-             logs of a token request never end at the application validation, even if a grant handler could not
-             resolve a specific reason for the failure. The internal error message is deliberately not included.
-             It is not guaranteed to be free of user identifiers, and LoggerUtils.getSanitizedErrorMessage() can
-             only mask the value of the username request parameter, which grant types other than the password
-             grant do not carry. The error code carries the reason without carrying identifiers. */
+            // The internal error message is not logged since it is not guaranteed to be free of user identifiers.
             if (LoggerUtils.isDiagnosticLogsEnabled()) {
                 LoggerUtils.triggerDiagnosticLogEvent(new DiagnosticLog.DiagnosticLogBuilder(
                         OAuthConstants.LogConstants.OAUTH_INBOUND_SERVICE,
@@ -536,6 +531,16 @@ public class AccessTokenIssuer {
         if (!isAuthorized) {
             if (log.isDebugEnabled()) {
                 log.debug("Invalid authorization for client Id : " + tokenReqDTO.getClientId());
+            }
+            if (LoggerUtils.isDiagnosticLogsEnabled()) {
+                LoggerUtils.triggerDiagnosticLogEvent(new DiagnosticLog.DiagnosticLogBuilder(
+                        OAuthConstants.LogConstants.OAUTH_INBOUND_SERVICE,
+                        OAuthConstants.LogConstants.ActionIDs.ISSUE_ACCESS_TOKEN)
+                        .inputParam(LogConstants.InputKeys.CLIENT_ID, tokenReqDTO.getClientId())
+                        .inputParam(OAuthConstants.LogConstants.InputKeys.GRANT_TYPE, grantType)
+                        .resultMessage("The application is not authorized to use the provided grant type.")
+                        .logDetailLevel(DiagnosticLog.LogDetailLevel.APPLICATION)
+                        .resultStatus(DiagnosticLog.ResultStatus.FAILED));
             }
             tokenRespDTO = handleError(OAuthError.TokenResponse.UNAUTHORIZED_CLIENT,
                     "Unauthorized Client!", tokenReqDTO);

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/RefreshGrantHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/RefreshGrantHandler.java
@@ -184,8 +184,17 @@ public class RefreshGrantHandler extends AbstractAuthorizationGrantHandler {
         RefreshTokenValidationDataDO validationBean = (RefreshTokenValidationDataDO) tokReqMsgCtx
                 .getProperty(PREV_ACCESS_TOKEN);
         if (validationBean == null || isRefreshTokenExpired(validationBean)) {
-            logRefreshTokenValidationFailure("The provided refresh token is expired. A new refresh token needs to " +
-                    "be obtained by re-authenticating the user.", tokenReq, validationBean);
+            /* A null validation bean is not an expiry. It means the previous access token was never placed in the
+             message context, therefore the reason is reported separately to avoid pointing the investigation at
+             the refresh token itself. */
+            if (validationBean == null) {
+                logRefreshTokenValidationFailure("The validation data of the refresh token is not available in the " +
+                        "context of the token request, hence the refresh token could not be validated.", tokenReq,
+                        null);
+            } else {
+                logRefreshTokenValidationFailure("The provided refresh token is expired. A new refresh token needs " +
+                        "to be obtained by re-authenticating the user.", tokenReq, validationBean);
+            }
             return handleError(OAuth2ErrorCodes.INVALID_GRANT, "Refresh token is expired.", tokenReq);
         }
 
@@ -413,9 +422,13 @@ public class RefreshGrantHandler extends AbstractAuthorizationGrantHandler {
                 validationBean, getUserStoreDomain(validationBean.getAuthorizedUser()))) {
             return true;
         } else {
-            logRefreshTokenValidationFailure("The provided refresh token is not the latest refresh token issued " +
-                    "for the application. It has already been replaced by a newer refresh token through refresh " +
-                    "token rotation.", tokenReq, validationBean);
+            /* This is reached either when the token was replaced through refresh token rotation, or when the token
+             is no longer active and no access token issued against it remains usable. The state of the token is
+             included as an input parameter so that the two can be told apart. */
+            logRefreshTokenValidationFailure("The provided refresh token is not the currently valid refresh token " +
+                    "for the application. It has either been replaced by a newer refresh token through refresh " +
+                    "token rotation, or it is no longer active along with the access token issued against it.",
+                    tokenReq, validationBean);
             removeIfCached(tokenReq, validationBean);
             throw new IdentityOAuth2Exception("Invalid refresh token value in the request");
         }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/RefreshGrantHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/RefreshGrantHandler.java
@@ -37,6 +37,8 @@ import org.wso2.carbon.identity.application.authentication.framework.inbound.Fra
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
 import org.wso2.carbon.identity.base.IdentityConstants;
+import org.wso2.carbon.identity.central.log.mgt.utils.LogConstants;
+import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.handler.event.account.lock.exception.AccountLockServiceException;
@@ -82,6 +84,7 @@ import org.wso2.carbon.identity.user.profile.mgt.association.federation.exceptio
 import org.wso2.carbon.identity.user.profile.mgt.association.federation.exception.FederatedAssociationManagerException;
 import org.wso2.carbon.user.core.UserCoreConstants;
 import org.wso2.carbon.user.core.util.UserCoreUtil;
+import org.wso2.carbon.utils.DiagnosticLog;
 
 import java.sql.Timestamp;
 import java.util.Arrays;
@@ -138,6 +141,13 @@ public class RefreshGrantHandler extends AbstractAuthorizationGrantHandler {
                     ", Authorized User : " + validationBean.getAuthorizedUser() +
                     ", Token Scope : " + OAuth2Util.buildScopeString(validationBean.getScope()));
         }
+        if (LoggerUtils.isDiagnosticLogsEnabled()) {
+            DiagnosticLog.DiagnosticLogBuilder diagnosticLogBuilder = getRefreshTokenValidationLogBuilder(tokenReq,
+                    validationBean);
+            diagnosticLogBuilder.resultMessage("Refresh token validation is successful.")
+                    .resultStatus(DiagnosticLog.ResultStatus.SUCCESS);
+            LoggerUtils.triggerDiagnosticLogEvent(diagnosticLogBuilder);
+        }
         setPropertiesForTokenGeneration(tokReqMsgCtx, validationBean);
         return true;
     }
@@ -174,6 +184,8 @@ public class RefreshGrantHandler extends AbstractAuthorizationGrantHandler {
         RefreshTokenValidationDataDO validationBean = (RefreshTokenValidationDataDO) tokReqMsgCtx
                 .getProperty(PREV_ACCESS_TOKEN);
         if (validationBean == null || isRefreshTokenExpired(validationBean)) {
+            logRefreshTokenValidationFailure("The provided refresh token is expired. A new refresh token needs to " +
+                    "be obtained by re-authenticating the user.", tokenReq, validationBean);
             return handleError(OAuth2ErrorCodes.INVALID_GRANT, "Refresh token is expired.", tokenReq);
         }
 
@@ -396,11 +408,14 @@ public class RefreshGrantHandler extends AbstractAuthorizationGrantHandler {
                                                   RefreshTokenValidationDataDO validationBean)
             throws IdentityOAuth2Exception {
 
-        validateRefreshTokenStatus(validationBean, tokenReq.getClientId());
+        validateRefreshTokenStatus(validationBean, tokenReq);
         if (getRefreshTokenGrantProcessor(tokenReq.getRefreshToken()).isLatestRefreshToken(tokenReq,
                 validationBean, getUserStoreDomain(validationBean.getAuthorizedUser()))) {
             return true;
         } else {
+            logRefreshTokenValidationFailure("The provided refresh token is not the latest refresh token issued " +
+                    "for the application. It has already been replaced by a newer refresh token through refresh " +
+                    "token rotation.", tokenReq, validationBean);
             removeIfCached(tokenReq, validationBean);
             throw new IdentityOAuth2Exception("Invalid refresh token value in the request");
         }
@@ -424,16 +439,20 @@ public class RefreshGrantHandler extends AbstractAuthorizationGrantHandler {
         }
     }
 
-    private boolean validateRefreshTokenStatus(RefreshTokenValidationDataDO validationBean, String clientId)
+    private boolean validateRefreshTokenStatus(RefreshTokenValidationDataDO validationBean,
+                                               OAuth2AccessTokenReqDTO tokenReq)
             throws IdentityOAuth2Exception {
 
         String tokenState = validationBean.getRefreshTokenState();
         if (tokenState != null && !OAuthConstants.TokenStates.TOKEN_STATE_ACTIVE.equals(tokenState) &&
                 !OAuthConstants.TokenStates.TOKEN_STATE_EXPIRED.equals(tokenState)) {
             if (log.isDebugEnabled()) {
-                log.debug("Refresh Token state is " + tokenState + " for client: " + clientId + ". Expected 'Active' " +
-                        "or 'EXPIRED'");
+                log.debug("Refresh Token state is " + tokenState + " for client: " + tokenReq.getClientId()
+                        + ". Expected 'Active' or 'EXPIRED'");
             }
+            logRefreshTokenValidationFailure(String.format("The provided refresh token is not in a usable state. " +
+                            "Current state of the refresh token is '%s' while either 'ACTIVE' or 'EXPIRED' is " +
+                            "expected.", tokenState), tokenReq, validationBean);
             throw new IdentityOAuth2Exception("Invalid refresh token state");
         }
         return true;
@@ -710,6 +729,79 @@ public class RefreshGrantHandler extends AbstractAuthorizationGrantHandler {
             OAuthCache.getInstance().clearCacheEntry(accessTokenCacheKey, tenantDomain);
         }
 
+    }
+
+    /**
+     * Records a refresh token validation failure as a diagnostic log so that the reason for a failed refresh grant
+     * request is available in the logs. Without this, the diagnostic logs of a failed refresh grant request end at
+     * the application validation, leaving no trace of why the request failed.
+     *
+     * @param resultMessage  Reason for the validation failure.
+     * @param tokenReq       Token request received for the refresh grant.
+     * @param validationBean Validation data of the refresh token. Can be null.
+     */
+    private void logRefreshTokenValidationFailure(String resultMessage, OAuth2AccessTokenReqDTO tokenReq,
+                                                  RefreshTokenValidationDataDO validationBean) {
+
+        if (!LoggerUtils.isDiagnosticLogsEnabled()) {
+            return;
+        }
+        DiagnosticLog.DiagnosticLogBuilder diagnosticLogBuilder = getRefreshTokenValidationLogBuilder(tokenReq,
+                validationBean);
+        diagnosticLogBuilder.resultMessage(resultMessage)
+                .resultStatus(DiagnosticLog.ResultStatus.FAILED);
+        LoggerUtils.triggerDiagnosticLogEvent(diagnosticLogBuilder);
+    }
+
+    /**
+     * Builds a diagnostic log entry for the refresh token validation with the context available for the request.
+     * Refresh tokens cannot be logged, therefore the token itself is never added. Instead the internal token id,
+     * the state and the issued time of the token are added since none of them can be used to obtain a token. The
+     * SHA-256 hash of the refresh token is added only when token logging is explicitly permitted through the
+     * {@code REFRESH_TOKEN} identity token configuration, which allows a specific token reported by an application
+     * developer to be correlated with the logs.
+     *
+     * @param tokenReq       Token request received for the refresh grant.
+     * @param validationBean Validation data of the refresh token. Can be null.
+     * @return Diagnostic log builder with the available refresh token context.
+     */
+    private DiagnosticLog.DiagnosticLogBuilder getRefreshTokenValidationLogBuilder(
+            OAuth2AccessTokenReqDTO tokenReq, RefreshTokenValidationDataDO validationBean) {
+
+        DiagnosticLog.DiagnosticLogBuilder diagnosticLogBuilder = new DiagnosticLog.DiagnosticLogBuilder(
+                OAuthConstants.LogConstants.OAUTH_INBOUND_SERVICE,
+                OAuthConstants.LogConstants.ActionIDs.VALIDATE_REFRESH_TOKEN)
+                .inputParam(LogConstants.InputKeys.CLIENT_ID, tokenReq.getClientId())
+                .inputParam(LogConstants.InputKeys.TENANT_DOMAIN, tokenReq.getTenantDomain())
+                .logDetailLevel(DiagnosticLog.LogDetailLevel.APPLICATION);
+
+        if (StringUtils.isNotBlank(tokenReq.getRefreshToken())
+                && IdentityUtil.isTokenLoggable(IdentityConstants.IdentityTokens.REFRESH_TOKEN)) {
+            diagnosticLogBuilder.inputParam(OAuthConstants.LogConstants.InputKeys.REFRESH_TOKEN_HASH,
+                    DigestUtils.sha256Hex(tokenReq.getRefreshToken()));
+        }
+        if (validationBean == null) {
+            return diagnosticLogBuilder;
+        }
+        if (StringUtils.isNotBlank(validationBean.getTokenId())) {
+            diagnosticLogBuilder.inputParam(OAuthConstants.LogConstants.InputKeys.TOKEN_ID,
+                    validationBean.getTokenId());
+        }
+        if (StringUtils.isNotBlank(validationBean.getRefreshTokenState())) {
+            diagnosticLogBuilder.inputParam(OAuthConstants.LogConstants.InputKeys.REFRESH_TOKEN_STATE,
+                    validationBean.getRefreshTokenState());
+        }
+        if (validationBean.getIssuedTime() != null) {
+            diagnosticLogBuilder.inputParam(OAuthConstants.LogConstants.InputKeys.REFRESH_TOKEN_ISSUED_TIME,
+                    validationBean.getIssuedTime().toString());
+        }
+        diagnosticLogBuilder.inputParam(OAuthConstants.LogConstants.InputKeys.REFRESH_TOKEN_VALIDITY_PERIOD,
+                validationBean.getValidityPeriodInMillis());
+        if (validationBean.getAuthorizedUser() != null) {
+            diagnosticLogBuilder.inputParam(LogConstants.InputKeys.USER,
+                    validationBean.getAuthorizedUser().getLoggableMaskedUserId());
+        }
+        return diagnosticLogBuilder;
     }
 
     private boolean isRefreshTokenExpired(RefreshTokenValidationDataDO validationBean) {

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/RefreshGrantHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/RefreshGrantHandler.java
@@ -141,13 +141,6 @@ public class RefreshGrantHandler extends AbstractAuthorizationGrantHandler {
                     ", Authorized User : " + validationBean.getAuthorizedUser() +
                     ", Token Scope : " + OAuth2Util.buildScopeString(validationBean.getScope()));
         }
-        if (LoggerUtils.isDiagnosticLogsEnabled()) {
-            DiagnosticLog.DiagnosticLogBuilder diagnosticLogBuilder = getRefreshTokenValidationLogBuilder(tokenReq,
-                    validationBean);
-            diagnosticLogBuilder.resultMessage("Refresh token validation is successful.")
-                    .resultStatus(DiagnosticLog.ResultStatus.SUCCESS);
-            LoggerUtils.triggerDiagnosticLogEvent(diagnosticLogBuilder);
-        }
         setPropertiesForTokenGeneration(tokReqMsgCtx, validationBean);
         return true;
     }
@@ -228,6 +221,10 @@ public class RefreshGrantHandler extends AbstractAuthorizationGrantHandler {
                     .createAccessTokenBean(tokReqMsgCtx, tokenReq, validationBean, getTokenType(tokReqMsgCtx));
         } catch (IllegalArgumentException e) {
             if (StringUtils.equals(OAuth2Util.ACCESS_TOKEN_IS_NOT_ACTIVE_ERROR_MESSAGE, e.getMessage())) {
+                logRefreshTokenValidationFailure("The access token issued against the provided refresh token is no " +
+                        "longer active, hence a new access token could not be issued against the refresh token. A " +
+                        "new refresh token needs to be obtained by re-authenticating the user.", tokenReq,
+                        validationBean);
                 return handleError(OAuth2ErrorCodes.INVALID_GRANT, "Refresh token is expired.", tokenReq);
             }
             throw e;

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/tokenprocessor/DefaultRefreshTokenGrantProcessorTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/tokenprocessor/DefaultRefreshTokenGrantProcessorTest.java
@@ -53,6 +53,7 @@ import org.wso2.carbon.identity.oauth2.token.AccessTokenIssuer;
 import org.wso2.carbon.identity.oauth2.token.OAuthTokenReqMessageContext;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 import org.wso2.carbon.identity.openidconnect.OIDCClaimUtil;
+import org.wso2.carbon.utils.DiagnosticLog;
 
 import java.sql.Timestamp;
 import java.util.HashMap;
@@ -131,7 +132,9 @@ public class DefaultRefreshTokenGrantProcessorTest {
         identityUtilMockedStatic = mockStatic(IdentityUtil.class);
         serviceComponentHolderMockedStatic = mockStatic(OAuth2ServiceComponentHolder.class);
         loggerUtilsMockedStatic = mockStatic(LoggerUtils.class);
-        loggerUtilsMockedStatic.when(LoggerUtils::isDiagnosticLogsEnabled).thenReturn(false);
+        /* Diagnostic logging is reported as enabled so that the diagnostic log building code of the
+         refresh token validation is exercised. The actual log publishing remains mocked out. */
+        loggerUtilsMockedStatic.when(LoggerUtils::isDiagnosticLogsEnabled).thenReturn(true);
 
         persistenceFactoryMockedStatic.when(OAuthTokenPersistenceFactory::getInstance)
                 .thenReturn(mockPersistenceFactory);
@@ -198,6 +201,35 @@ public class DefaultRefreshTokenGrantProcessorTest {
         assertEquals(result.getRefreshTokenState(),
                 OAuthConstants.TokenStates.TOKEN_STATE_GRACEFULLY_ROTATED,
                 "State should remain GRACEFULLY_ROTATED when graceful rotation is disabled");
+    }
+
+    @Test
+    public void testValidateRefreshToken_noPersistedAccessToken_logsInvalidRefreshToken() throws Exception {
+
+        // A refresh token with no persisted access token is the plain invalid refresh token scenario.
+        RefreshTokenValidationDataDO validationBean = refreshTokenBean(
+                OAuthConstants.TokenStates.TOKEN_STATE_ACTIVE, null,
+                new Timestamp(System.currentTimeMillis()));
+        validationBean.setAccessToken(null);
+        when(mockTokenManagementDAO.validateRefreshToken(CLIENT_ID, REFRESH_TOKEN)).thenReturn(validationBean);
+
+        try {
+            processor.validateRefreshToken(buildTokenReqContext(CLIENT_ID, REFRESH_TOKEN, TENANT_DOMAIN));
+            fail("Expected IdentityOAuth2Exception when no persisted access token is found");
+        } catch (IdentityOAuth2Exception e) {
+            assertEquals(e.getMessage(), "Persisted access token data not found");
+        }
+
+        ArgumentCaptor<DiagnosticLog.DiagnosticLogBuilder> captor =
+                ArgumentCaptor.forClass(DiagnosticLog.DiagnosticLogBuilder.class);
+        loggerUtilsMockedStatic.verify(() -> LoggerUtils.triggerDiagnosticLogEvent(captor.capture()));
+        DiagnosticLog diagnosticLog = captor.getValue().build();
+        assertEquals(diagnosticLog.getResultStatus(), DiagnosticLog.ResultStatus.FAILED.name(),
+                "An invalid refresh token should be recorded as a FAILED entry.");
+        assertEquals(diagnosticLog.getActionId(),
+                OAuthConstants.LogConstants.ActionIDs.VALIDATE_REFRESH_TOKEN);
+        assertTrue(diagnosticLog.getResultMessage().contains("refresh token is invalid"),
+                "The log should state that the provided refresh token is invalid.");
     }
 
     @Test(expectedExceptions = IdentityOAuth2Exception.class)

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/tokenprocessor/DefaultRefreshTokenGrantProcessorTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/tokenprocessor/DefaultRefreshTokenGrantProcessorTest.java
@@ -26,6 +26,7 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
+import org.wso2.carbon.identity.central.log.mgt.utils.LogConstants;
 import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
 import org.wso2.carbon.identity.common.testng.WithCarbonHome;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
@@ -132,9 +133,7 @@ public class DefaultRefreshTokenGrantProcessorTest {
         identityUtilMockedStatic = mockStatic(IdentityUtil.class);
         serviceComponentHolderMockedStatic = mockStatic(OAuth2ServiceComponentHolder.class);
         loggerUtilsMockedStatic = mockStatic(LoggerUtils.class);
-        /* Diagnostic logging is reported as enabled so that the diagnostic log building code of the
-         refresh token validation is exercised. The actual log publishing remains mocked out. */
-        loggerUtilsMockedStatic.when(LoggerUtils::isDiagnosticLogsEnabled).thenReturn(true);
+        loggerUtilsMockedStatic.when(LoggerUtils::isDiagnosticLogsEnabled).thenReturn(false);
 
         persistenceFactoryMockedStatic.when(OAuthTokenPersistenceFactory::getInstance)
                 .thenReturn(mockPersistenceFactory);
@@ -206,6 +205,10 @@ public class DefaultRefreshTokenGrantProcessorTest {
     @Test
     public void testValidateRefreshToken_noPersistedAccessToken_logsInvalidRefreshToken() throws Exception {
 
+        /* Diagnostic logging is reported as enabled only for this test, so that the diagnostic log building code
+         is exercised without changing the path taken by the other tests in this class. */
+        loggerUtilsMockedStatic.when(LoggerUtils::isDiagnosticLogsEnabled).thenReturn(true);
+
         // A refresh token with no persisted access token is the plain invalid refresh token scenario.
         RefreshTokenValidationDataDO validationBean = refreshTokenBean(
                 OAuthConstants.TokenStates.TOKEN_STATE_ACTIVE, null,
@@ -222,7 +225,7 @@ public class DefaultRefreshTokenGrantProcessorTest {
 
         ArgumentCaptor<DiagnosticLog.DiagnosticLogBuilder> captor =
                 ArgumentCaptor.forClass(DiagnosticLog.DiagnosticLogBuilder.class);
-        loggerUtilsMockedStatic.verify(() -> LoggerUtils.triggerDiagnosticLogEvent(captor.capture()));
+        loggerUtilsMockedStatic.verify(() -> LoggerUtils.triggerDiagnosticLogEvent(captor.capture()), atLeastOnce());
         DiagnosticLog diagnosticLog = captor.getValue().build();
         assertEquals(diagnosticLog.getResultStatus(), DiagnosticLog.ResultStatus.FAILED.name(),
                 "An invalid refresh token should be recorded as a FAILED entry.");
@@ -230,6 +233,9 @@ public class DefaultRefreshTokenGrantProcessorTest {
                 OAuthConstants.LogConstants.ActionIDs.VALIDATE_REFRESH_TOKEN);
         assertTrue(diagnosticLog.getResultMessage().contains("refresh token is invalid"),
                 "The log should state that the provided refresh token is invalid.");
+        assertEquals(diagnosticLog.getInput().get(LogConstants.InputKeys.CLIENT_ID), CLIENT_ID);
+        assertEquals(diagnosticLog.getInput().get(LogConstants.InputKeys.TENANT_DOMAIN), TENANT_DOMAIN,
+                "The tenant domain should be logged along with the other refresh token validation failures.");
     }
 
     @Test(expectedExceptions = IdentityOAuth2Exception.class)

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuerTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuerTest.java
@@ -38,6 +38,8 @@ import org.wso2.carbon.identity.oauth.cache.AuthorizationGrantCacheEntry;
 import org.wso2.carbon.identity.oauth.cache.AuthorizationGrantCacheKey;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2AccessTokenRespDTO;
 import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
+import org.wso2.carbon.identity.oauth.common.OAuthConstants;
+import org.wso2.carbon.utils.DiagnosticLog;
 
 import java.lang.reflect.Method;
 import java.util.HashMap;
@@ -45,6 +47,7 @@ import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
@@ -172,6 +175,55 @@ public class AccessTokenIssuerTest {
             OAuth2AccessTokenRespDTO resp = (OAuth2AccessTokenRespDTO) result;
             Assert.assertTrue(resp.isError());
             Assert.assertEquals(resp.getErrorMsg(), "sensitive message");
+        }
+    }
+
+    @Test
+    public void testInvalidGrantIsRecordedAsADiagnosticLog() throws Exception {
+
+        AuthorizationGrantHandler handler = Mockito.mock(AuthorizationGrantHandler.class);
+        OAuth2AccessTokenReqDTO req = new OAuth2AccessTokenReqDTO();
+        req.setClientId("test_client_id");
+        req.setGrantType("refresh_token");
+        OAuthTokenReqMessageContext ctx = new OAuthTokenReqMessageContext(req);
+
+        when(handler.isOfTypeApplicationUser(any(OAuthTokenReqMessageContext.class))).thenReturn(true);
+        when(handler.validateGrant(any(OAuthTokenReqMessageContext.class)))
+            .thenThrow(new IdentityOAuth2Exception("Persisted access token data not found"));
+
+        try (MockedStatic<LoggerUtils> loggerUtilsMock = Mockito.mockStatic(LoggerUtils.class);
+             MockedStatic<OAuth2Util> oauth2UtilMock = Mockito.mockStatic(OAuth2Util.class)) {
+
+            loggerUtilsMock.when(LoggerUtils::isDiagnosticLogsEnabled).thenReturn(true);
+            loggerUtilsMock.when(() -> LoggerUtils.getSanitizedErrorMessage(anyString(), anyString()))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+            oauth2UtilMock.when(() -> OAuth2Util.getUserIdentifierFromRequest(req)).thenReturn("user");
+
+            AccessTokenIssuer issuer = Mockito.mock(AccessTokenIssuer.class, Mockito.CALLS_REAL_METHODS);
+            Method method = AccessTokenIssuer.class.getDeclaredMethod("validateGrantAndIssueToken",
+                OAuth2AccessTokenReqDTO.class, OAuthTokenReqMessageContext.class,
+                OAuth2AccessTokenRespDTO.class, AuthorizationGrantHandler.class,
+                String.class, OAuthAppDO.class);
+            method.setAccessible(true);
+            method.invoke(issuer, req, ctx, null, handler, "tenant", null);
+
+            ArgumentCaptor<DiagnosticLog.DiagnosticLogBuilder> captor =
+                ArgumentCaptor.forClass(DiagnosticLog.DiagnosticLogBuilder.class);
+            loggerUtilsMock.verify(() -> LoggerUtils.triggerDiagnosticLogEvent(captor.capture()));
+            DiagnosticLog diagnosticLog = captor.getValue().build();
+
+            Assert.assertEquals(diagnosticLog.getResultStatus(), DiagnosticLog.ResultStatus.FAILED.name(),
+                "A grant validation failure should be recorded as a FAILED entry.");
+            Assert.assertEquals(diagnosticLog.getActionId(),
+                OAuthConstants.LogConstants.ActionIDs.ISSUE_ACCESS_TOKEN);
+            Assert.assertEquals(
+                diagnosticLog.getInput().get(OAuthConstants.LogConstants.InputKeys.GRANT_TYPE), "refresh_token");
+            Assert.assertTrue(
+                diagnosticLog.getResultMessage().contains("Authorization grant validation failed"),
+                "The log should state that the authorization grant validation failed.");
+            Assert.assertTrue(
+                diagnosticLog.getResultMessage().contains("Persisted access token data not found"),
+                "The resolved error should be appended to the log message.");
         }
     }
 

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuerTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuerTest.java
@@ -221,9 +221,14 @@ public class AccessTokenIssuerTest {
             Assert.assertTrue(
                 diagnosticLog.getResultMessage().contains("Authorization grant validation failed"),
                 "The log should state that the authorization grant validation failed.");
-            Assert.assertTrue(
+            /* The internal error message can carry user identifiers which cannot be masked for grant types that do
+             not send the username parameter, hence it must not reach an application level diagnostic log. */
+            Assert.assertFalse(
                 diagnosticLog.getResultMessage().contains("Persisted access token data not found"),
-                "The resolved error should be appended to the log message.");
+                "The internal error message should not be included in the application level log.");
+            Assert.assertNotNull(
+                diagnosticLog.getInput().get(OAuthConstants.LogConstants.InputKeys.ERROR_CODE),
+                "The error code should be recorded so that the failure reason is still traceable.");
         }
     }
 

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuerTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/AccessTokenIssuerTest.java
@@ -233,6 +233,49 @@ public class AccessTokenIssuerTest {
     }
 
     @Test
+    public void testUnauthorizedAccessDelegationIsRecordedAsADiagnosticLog() throws Exception {
+
+        AuthorizationGrantHandler handler = Mockito.mock(AuthorizationGrantHandler.class);
+        OAuth2AccessTokenReqDTO req = new OAuth2AccessTokenReqDTO();
+        req.setClientId("test_client_id");
+        req.setGrantType("refresh_token");
+        OAuthTokenReqMessageContext ctx = new OAuthTokenReqMessageContext(req);
+
+        when(handler.isOfTypeApplicationUser(any(OAuthTokenReqMessageContext.class))).thenReturn(true);
+        when(handler.validateGrant(any(OAuthTokenReqMessageContext.class))).thenReturn(true);
+        // The grant itself is valid, but the application is not authorized to use it.
+        when(handler.authorizeAccessDelegation(any(OAuthTokenReqMessageContext.class))).thenReturn(false);
+
+        try (MockedStatic<LoggerUtils> loggerUtilsMock = Mockito.mockStatic(LoggerUtils.class)) {
+
+            loggerUtilsMock.when(LoggerUtils::isDiagnosticLogsEnabled).thenReturn(true);
+
+            AccessTokenIssuer issuer = Mockito.mock(AccessTokenIssuer.class, Mockito.CALLS_REAL_METHODS);
+            Method method = AccessTokenIssuer.class.getDeclaredMethod("validateGrantAndIssueToken",
+                OAuth2AccessTokenReqDTO.class, OAuthTokenReqMessageContext.class,
+                OAuth2AccessTokenRespDTO.class, AuthorizationGrantHandler.class,
+                String.class, OAuthAppDO.class);
+            method.setAccessible(true);
+            method.invoke(issuer, req, ctx, null, handler, "tenant", null);
+
+            ArgumentCaptor<DiagnosticLog.DiagnosticLogBuilder> captor =
+                ArgumentCaptor.forClass(DiagnosticLog.DiagnosticLogBuilder.class);
+            loggerUtilsMock.verify(() -> LoggerUtils.triggerDiagnosticLogEvent(captor.capture()));
+            DiagnosticLog diagnosticLog = captor.getValue().build();
+
+            Assert.assertEquals(diagnosticLog.getResultStatus(), DiagnosticLog.ResultStatus.FAILED.name(),
+                "An unauthorized access delegation should be recorded as a FAILED entry.");
+            Assert.assertEquals(diagnosticLog.getActionId(),
+                OAuthConstants.LogConstants.ActionIDs.ISSUE_ACCESS_TOKEN);
+            Assert.assertEquals(
+                diagnosticLog.getInput().get(OAuthConstants.LogConstants.InputKeys.GRANT_TYPE), "refresh_token");
+            Assert.assertTrue(
+                diagnosticLog.getResultMessage().contains("not authorized to use the provided grant type"),
+                "The log should state that the application is not authorized to use the grant type.");
+        }
+    }
+
+    @Test
     public void testHandleTokenBindingForRefreshTokenGrant() throws Exception {
 
         OAuth2AccessTokenReqDTO tokenReqDTO = new OAuth2AccessTokenReqDTO();

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/RefreshGrantHandlerTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/RefreshGrantHandlerTest.java
@@ -95,6 +95,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
@@ -581,16 +582,23 @@ public class RefreshGrantHandlerTest {
 
             DiagnosticLog diagnosticLog = captureLastDiagnosticLog();
             assertEquals(diagnosticLog.getResultStatus(), DiagnosticLog.ResultStatus.FAILED.name());
-            assertTrue(diagnosticLog.getResultMessage().contains("not the latest refresh token"),
-                    "The log should state that the refresh token is not the latest one issued.");
+            assertTrue(diagnosticLog.getResultMessage().contains("not the currently valid refresh token"),
+                    "The log should state that the refresh token is not the currently valid one.");
+            /* Rotation is only one of the reasons this branch is reached, so it must not be stated as the cause. */
+            assertTrue(diagnosticLog.getResultMessage().contains("no longer active"),
+                    "The log should also offer the non rotation reason for the failure.");
             assertEquals(diagnosticLog.getInput().get(OAuthConstants.LogConstants.InputKeys.REFRESH_TOKEN_HASH),
                     DigestUtils.sha256Hex("test_refresh_token"),
                     "The hash of the refresh token should be logged when token logging is permitted.");
         }
     }
 
+    /**
+     * Test that a missing previous access token in the request context is reported as missing validation data
+     * rather than as an expired refresh token, since the two have different causes.
+     */
     @Test
-    public void testIssueLogsExpiredRefreshTokenWhenValidationDataIsMissing() throws Exception {
+    public void testIssueLogsMissingValidationDataSeparatelyFromExpiry() throws Exception {
 
         when(oAuthTokenReqMessageContext.getOauth2AccessTokenReqDTO()).thenReturn(oAuth2AccessTokenReqDTO);
         when(oAuthTokenReqMessageContext.getProperty(PREV_ACCESS_TOKEN)).thenReturn(null);
@@ -614,8 +622,11 @@ public class RefreshGrantHandlerTest {
 
             DiagnosticLog diagnosticLog = captureLastDiagnosticLog();
             assertEquals(diagnosticLog.getResultStatus(), DiagnosticLog.ResultStatus.FAILED.name());
-            assertTrue(diagnosticLog.getResultMessage().contains("expired"),
-                    "The log should state that the refresh token is expired.");
+            assertTrue(diagnosticLog.getResultMessage().contains("validation data of the refresh token is not "
+                            + "available"),
+                    "The log should state that the validation data of the refresh token is unavailable.");
+            assertFalse(diagnosticLog.getResultMessage().contains("expired"),
+                    "Missing validation data should not be reported as an expired refresh token.");
         }
     }
 

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/RefreshGrantHandlerTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/RefreshGrantHandlerTest.java
@@ -18,7 +18,9 @@
 
 package org.wso2.carbon.identity.oauth2.token.handlers.grant;
 
+import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.oltu.oauth2.common.exception.OAuthSystemException;
+import org.mockito.ArgumentCaptor;
 import org.mockito.MockedConstruction;
 import org.mockito.MockedStatic;
 import org.testng.annotations.AfterMethod;
@@ -34,6 +36,7 @@ import org.wso2.carbon.identity.application.authentication.framework.util.Framew
 import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
 import org.wso2.carbon.identity.common.testng.WithCarbonHome;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.handler.event.account.lock.exception.AccountLockServiceException;
 import org.wso2.carbon.identity.handler.event.account.lock.service.AccountLockService;
 import org.wso2.carbon.identity.oauth.OAuthUtil;
@@ -71,6 +74,7 @@ import org.wso2.carbon.identity.user.profile.mgt.association.federation.Federate
 import org.wso2.carbon.identity.user.profile.mgt.association.federation.exception.FederatedAssociationManagerClientException;
 import org.wso2.carbon.identity.user.profile.mgt.association.federation.exception.FederatedAssociationManagerException;
 import org.wso2.carbon.user.core.UserCoreConstants;
+import org.wso2.carbon.utils.DiagnosticLog;
 
 import java.sql.Timestamp;
 import java.time.Instant;
@@ -80,6 +84,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -90,6 +95,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkErrorConstants.ErrorMessages.ERROR_WHILE_CHECKING_ACCOUNT_LOCK_STATUS;
@@ -442,6 +449,185 @@ public class RefreshGrantHandlerTest {
             assertTrue(refreshGrantHandler.validateGrant(oAuthTokenReqMessageContext));
             verify(oAuthTokenReqMessageContext).setTokenBinding(tokenBinding);
         }
+    }
+
+    @Test
+    public void testValidateGrantLogsUnusableRefreshTokenState() throws Exception {
+
+        Timestamp issuedTime = new Timestamp(System.currentTimeMillis());
+        when(refreshTokenGrantProcessor.validateRefreshToken(any())).thenReturn(refreshTokenValidationDataDO);
+        when(refreshTokenValidationDataDO.getAuthorizedUser()).thenReturn(new MockAuthenticatedUser("test_user"));
+        when(refreshTokenValidationDataDO.getRefreshTokenState())
+                .thenReturn(OAuthConstants.TokenStates.TOKEN_STATE_REVOKED);
+        when(refreshTokenValidationDataDO.getTokenId()).thenReturn("token-id-1");
+        when(refreshTokenValidationDataDO.getIssuedTime()).thenReturn(issuedTime);
+        when(refreshTokenValidationDataDO.getValidityPeriodInMillis()).thenReturn(3600000L);
+        when(oAuth2ServiceComponentHolder.getRefreshTokenGrantProcessor()).thenReturn(refreshTokenGrantProcessor);
+        when(oAuthTokenReqMessageContext.getOauth2AccessTokenReqDTO()).thenReturn(oAuth2AccessTokenReqDTO);
+        when(oAuth2AccessTokenReqDTO.getClientId()).thenReturn("test_client_id");
+        when(oAuth2AccessTokenReqDTO.getRefreshToken()).thenReturn("test_refresh_token");
+
+        try (MockedStatic<OAuthServerConfiguration> oAuthServerConfigurationMockedStatic =
+                     mockStatic(OAuthServerConfiguration.class);
+             MockedStatic<OAuth2ServiceComponentHolder> oAuth2ServiceComponentHolderMockedStatic =
+                     mockStatic(OAuth2ServiceComponentHolder.class);
+             MockedStatic<IdentityUtil> identityUtilMockedStatic = mockStatic(IdentityUtil.class)) {
+
+            oAuthServerConfigurationMockedStatic.when(OAuthServerConfiguration::getInstance)
+                    .thenReturn(oAuthServerConfiguration);
+            oAuth2ServiceComponentHolderMockedStatic.when(OAuth2ServiceComponentHolder::getInstance)
+                    .thenReturn(oAuth2ServiceComponentHolder);
+            identityUtilMockedStatic.when(() -> IdentityUtil.isTokenLoggable(anyString())).thenReturn(false);
+
+            RefreshGrantHandler refreshGrantHandler = new RefreshGrantHandler();
+            refreshGrantHandler.init();
+            try {
+                refreshGrantHandler.validateGrant(oAuthTokenReqMessageContext);
+                fail("Expected IdentityOAuth2Exception for a refresh token in REVOKED state");
+            } catch (IdentityOAuth2Exception e) {
+                assertEquals(e.getMessage(), "Invalid refresh token state");
+            }
+
+            DiagnosticLog diagnosticLog = captureLastDiagnosticLog();
+            assertEquals(diagnosticLog.getResultStatus(), DiagnosticLog.ResultStatus.FAILED.name());
+            assertEquals(diagnosticLog.getInput().get(OAuthConstants.LogConstants.InputKeys.REFRESH_TOKEN_STATE),
+                    OAuthConstants.TokenStates.TOKEN_STATE_REVOKED,
+                    "The state of the refresh token should be logged.");
+            assertEquals(diagnosticLog.getInput().get(OAuthConstants.LogConstants.InputKeys.TOKEN_ID), "token-id-1");
+            assertEquals(diagnosticLog.getInput()
+                            .get(OAuthConstants.LogConstants.InputKeys.REFRESH_TOKEN_ISSUED_TIME),
+                    issuedTime.toString(), "The issued time of the refresh token should be logged.");
+            assertEquals(diagnosticLog.getInput()
+                            .get(OAuthConstants.LogConstants.InputKeys.REFRESH_TOKEN_VALIDITY_PERIOD), 3600000L);
+            assertNull(diagnosticLog.getInput().get(OAuthConstants.LogConstants.InputKeys.REFRESH_TOKEN_HASH),
+                    "The refresh token hash must not be logged unless token logging is permitted.");
+        }
+    }
+
+    @Test
+    public void testValidateGrantSkipsDiagnosticLogWhenDiagnosticLogsDisabled() throws Exception {
+
+        // No diagnostic log should be published when diagnostic logging is switched off for the tenant.
+        loggerUtils.when(LoggerUtils::isDiagnosticLogsEnabled).thenReturn(false);
+
+        when(refreshTokenGrantProcessor.validateRefreshToken(any())).thenReturn(refreshTokenValidationDataDO);
+        when(refreshTokenValidationDataDO.getAuthorizedUser()).thenReturn(new MockAuthenticatedUser("test_user"));
+        when(refreshTokenValidationDataDO.getRefreshTokenState())
+                .thenReturn(OAuthConstants.TokenStates.TOKEN_STATE_REVOKED);
+        when(oAuth2ServiceComponentHolder.getRefreshTokenGrantProcessor()).thenReturn(refreshTokenGrantProcessor);
+        when(oAuthTokenReqMessageContext.getOauth2AccessTokenReqDTO()).thenReturn(oAuth2AccessTokenReqDTO);
+        when(oAuth2AccessTokenReqDTO.getClientId()).thenReturn("test_client_id");
+
+        try (MockedStatic<OAuthServerConfiguration> oAuthServerConfigurationMockedStatic =
+                     mockStatic(OAuthServerConfiguration.class);
+             MockedStatic<OAuth2ServiceComponentHolder> oAuth2ServiceComponentHolderMockedStatic =
+                     mockStatic(OAuth2ServiceComponentHolder.class)) {
+
+            oAuthServerConfigurationMockedStatic.when(OAuthServerConfiguration::getInstance)
+                    .thenReturn(oAuthServerConfiguration);
+            oAuth2ServiceComponentHolderMockedStatic.when(OAuth2ServiceComponentHolder::getInstance)
+                    .thenReturn(oAuth2ServiceComponentHolder);
+
+            RefreshGrantHandler refreshGrantHandler = new RefreshGrantHandler();
+            refreshGrantHandler.init();
+            try {
+                refreshGrantHandler.validateGrant(oAuthTokenReqMessageContext);
+                fail("Expected IdentityOAuth2Exception for a refresh token in REVOKED state");
+            } catch (IdentityOAuth2Exception e) {
+                assertEquals(e.getMessage(), "Invalid refresh token state");
+            }
+
+            loggerUtils.verify(() -> LoggerUtils.triggerDiagnosticLogEvent(
+                    any(DiagnosticLog.DiagnosticLogBuilder.class)), never());
+        }
+    }
+
+    @Test
+    public void testValidateGrantLogsRefreshTokenNotLatestAndTokenHashWhenLoggable() throws Exception {
+
+        when(refreshTokenGrantProcessor.validateRefreshToken(any())).thenReturn(refreshTokenValidationDataDO);
+        when(refreshTokenValidationDataDO.getAuthorizedUser()).thenReturn(new MockAuthenticatedUser("test_user"));
+        when(refreshTokenValidationDataDO.getRefreshTokenState())
+                .thenReturn(OAuthConstants.TokenStates.TOKEN_STATE_ACTIVE);
+        when(refreshTokenGrantProcessor.isLatestRefreshToken(any(), any(), any())).thenReturn(false);
+        when(oAuth2ServiceComponentHolder.getRefreshTokenGrantProcessor()).thenReturn(refreshTokenGrantProcessor);
+        when(oAuthTokenReqMessageContext.getOauth2AccessTokenReqDTO()).thenReturn(oAuth2AccessTokenReqDTO);
+        when(oAuth2AccessTokenReqDTO.getClientId()).thenReturn("test_client_id");
+        when(oAuth2AccessTokenReqDTO.getRefreshToken()).thenReturn("test_refresh_token");
+
+        try (MockedStatic<OAuthServerConfiguration> oAuthServerConfigurationMockedStatic =
+                     mockStatic(OAuthServerConfiguration.class);
+             MockedStatic<OAuth2ServiceComponentHolder> oAuth2ServiceComponentHolderMockedStatic =
+                     mockStatic(OAuth2ServiceComponentHolder.class);
+             MockedStatic<IdentityUtil> identityUtilMockedStatic = mockStatic(IdentityUtil.class)) {
+
+            oAuthServerConfigurationMockedStatic.when(OAuthServerConfiguration::getInstance)
+                    .thenReturn(oAuthServerConfiguration);
+            oAuth2ServiceComponentHolderMockedStatic.when(OAuth2ServiceComponentHolder::getInstance)
+                    .thenReturn(oAuth2ServiceComponentHolder);
+            // Token logging is permitted, so the hash of the refresh token is expected in the log.
+            identityUtilMockedStatic.when(() -> IdentityUtil.isTokenLoggable(anyString())).thenReturn(true);
+
+            RefreshGrantHandler refreshGrantHandler = new RefreshGrantHandler();
+            refreshGrantHandler.init();
+            /* The grant is rejected for a refresh token which is not the latest. The diagnostic log is written
+             before the cached token entries are cleared, so only the rejection itself is asserted here. */
+            try {
+                refreshGrantHandler.validateGrant(oAuthTokenReqMessageContext);
+                fail("Expected IdentityOAuth2Exception when the refresh token is not the latest");
+            } catch (IdentityOAuth2Exception e) {
+                assertNotNull(e.getMessage());
+            }
+
+            DiagnosticLog diagnosticLog = captureLastDiagnosticLog();
+            assertEquals(diagnosticLog.getResultStatus(), DiagnosticLog.ResultStatus.FAILED.name());
+            assertTrue(diagnosticLog.getResultMessage().contains("not the latest refresh token"),
+                    "The log should state that the refresh token is not the latest one issued.");
+            assertEquals(diagnosticLog.getInput().get(OAuthConstants.LogConstants.InputKeys.REFRESH_TOKEN_HASH),
+                    DigestUtils.sha256Hex("test_refresh_token"),
+                    "The hash of the refresh token should be logged when token logging is permitted.");
+        }
+    }
+
+    @Test
+    public void testIssueLogsExpiredRefreshTokenWhenValidationDataIsMissing() throws Exception {
+
+        when(oAuthTokenReqMessageContext.getOauth2AccessTokenReqDTO()).thenReturn(oAuth2AccessTokenReqDTO);
+        when(oAuthTokenReqMessageContext.getProperty(PREV_ACCESS_TOKEN)).thenReturn(null);
+        when(oAuth2AccessTokenReqDTO.getClientId()).thenReturn("test_client_id");
+        when(oAuth2AccessTokenReqDTO.getRefreshToken()).thenReturn("test_refresh_token");
+
+        try (MockedStatic<OAuthServerConfiguration> oAuthServerConfigurationMockedStatic =
+                     mockStatic(OAuthServerConfiguration.class);
+             MockedStatic<IdentityUtil> identityUtilMockedStatic = mockStatic(IdentityUtil.class)) {
+
+            oAuthServerConfigurationMockedStatic.when(OAuthServerConfiguration::getInstance)
+                    .thenReturn(oAuthServerConfiguration);
+            identityUtilMockedStatic.when(() -> IdentityUtil.isTokenLoggable(anyString())).thenReturn(false);
+
+            RefreshGrantHandler refreshGrantHandler = new RefreshGrantHandler();
+            refreshGrantHandler.init();
+            OAuth2AccessTokenRespDTO respDTO = refreshGrantHandler.issue(oAuthTokenReqMessageContext);
+
+            assertTrue(respDTO.isError(), "An expired refresh token should produce an error response");
+            assertEquals(respDTO.getErrorMsg(), "Refresh token is expired.");
+
+            DiagnosticLog diagnosticLog = captureLastDiagnosticLog();
+            assertEquals(diagnosticLog.getResultStatus(), DiagnosticLog.ResultStatus.FAILED.name());
+            assertTrue(diagnosticLog.getResultMessage().contains("expired"),
+                    "The log should state that the refresh token is expired.");
+        }
+    }
+
+    /**
+     * Returns the diagnostic log built by the most recent triggerDiagnosticLogEvent invocation.
+     */
+    private DiagnosticLog captureLastDiagnosticLog() {
+
+        ArgumentCaptor<DiagnosticLog.DiagnosticLogBuilder> captor =
+                ArgumentCaptor.forClass(DiagnosticLog.DiagnosticLogBuilder.class);
+        loggerUtils.verify(() -> LoggerUtils.triggerDiagnosticLogEvent(captor.capture()), atLeastOnce());
+        return captor.getValue().build();
     }
 
     @Test

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/RefreshGrantHandlerTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/RefreshGrantHandlerTest.java
@@ -21,6 +21,7 @@ package org.wso2.carbon.identity.oauth2.token.handlers.grant;
 import org.apache.oltu.oauth2.common.exception.OAuthSystemException;
 import org.mockito.MockedConstruction;
 import org.mockito.MockedStatic;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -30,6 +31,7 @@ import org.wso2.carbon.identity.application.authentication.framework.exception.F
 import org.wso2.carbon.identity.application.authentication.framework.inbound.FrameworkClientException;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
+import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
 import org.wso2.carbon.identity.common.testng.WithCarbonHome;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.handler.event.account.lock.exception.AccountLockServiceException;
@@ -119,9 +121,14 @@ public class RefreshGrantHandlerTest {
     private OAuthCache mockOAuthCache;
     private AuthorizationGrantCache mockAuthorizationGrantCache;
     private OAuthAppDO oAuthAppDO;
+    private MockedStatic<LoggerUtils> loggerUtils;
 
     @BeforeMethod
     public void init() {
+        /* The refresh token validation writes diagnostic logs. Diagnostic logging is mocked as enabled so that the
+         diagnostic log building code is exercised without requiring a carbon context to resolve the tenant. */
+        loggerUtils = mockStatic(LoggerUtils.class);
+        loggerUtils.when(LoggerUtils::isDiagnosticLogsEnabled).thenReturn(true);
         refreshTokenGrantProcessor = mock(DefaultRefreshTokenGrantProcessor.class);
         oAuthTokenReqMessageContext = mock(OAuthTokenReqMessageContext.class);
         refreshTokenValidationDataDO = mock(RefreshTokenValidationDataDO.class);
@@ -141,6 +148,14 @@ public class RefreshGrantHandlerTest {
         mockAuthorizationGrantCache = mock(AuthorizationGrantCache.class);
 
         oAuthAppDO = mock(OAuthAppDO.class);
+    }
+
+    @AfterMethod
+    public void tearDown() {
+
+        if (loggerUtils != null) {
+            loggerUtils.close();
+        }
     }
 
     @DataProvider(name = "validateGrantWhenUserIsLockedInUserStoreEnd")

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/RefreshGrantHandlerTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/RefreshGrantHandlerTest.java
@@ -133,10 +133,8 @@ public class RefreshGrantHandlerTest {
 
     @BeforeMethod
     public void init() {
-        /* The refresh token validation writes diagnostic logs. Diagnostic logging is mocked as enabled so that the
-         diagnostic log building code is exercised without requiring a carbon context to resolve the tenant. */
-        loggerUtils = mockStatic(LoggerUtils.class);
-        loggerUtils.when(LoggerUtils::isDiagnosticLogsEnabled).thenReturn(true);
+
+        loggerUtils = null;
         refreshTokenGrantProcessor = mock(DefaultRefreshTokenGrantProcessor.class);
         oAuthTokenReqMessageContext = mock(OAuthTokenReqMessageContext.class);
         refreshTokenValidationDataDO = mock(RefreshTokenValidationDataDO.class);
@@ -163,7 +161,19 @@ public class RefreshGrantHandlerTest {
 
         if (loggerUtils != null) {
             loggerUtils.close();
+            loggerUtils = null;
         }
+    }
+
+    /**
+     * Opens the LoggerUtils static mock with diagnostic logging reported as enabled, for a single test. It is opened
+     * per test rather than in the common setup so that the tests which do not assert diagnostic logs keep running
+     * against the real LoggerUtils.
+     */
+    private void mockDiagnosticLogging() {
+
+        loggerUtils = mockStatic(LoggerUtils.class);
+        loggerUtils.when(LoggerUtils::isDiagnosticLogsEnabled).thenReturn(true);
     }
 
     @DataProvider(name = "validateGrantWhenUserIsLockedInUserStoreEnd")
@@ -455,6 +465,8 @@ public class RefreshGrantHandlerTest {
     @Test
     public void testValidateGrantLogsUnusableRefreshTokenState() throws Exception {
 
+        mockDiagnosticLogging();
+
         Timestamp issuedTime = new Timestamp(System.currentTimeMillis());
         when(refreshTokenGrantProcessor.validateRefreshToken(any())).thenReturn(refreshTokenValidationDataDO);
         when(refreshTokenValidationDataDO.getAuthorizedUser()).thenReturn(new MockAuthenticatedUser("test_user"));
@@ -509,6 +521,7 @@ public class RefreshGrantHandlerTest {
     public void testValidateGrantSkipsDiagnosticLogWhenDiagnosticLogsDisabled() throws Exception {
 
         // No diagnostic log should be published when diagnostic logging is switched off for the tenant.
+        loggerUtils = mockStatic(LoggerUtils.class);
         loggerUtils.when(LoggerUtils::isDiagnosticLogsEnabled).thenReturn(false);
 
         when(refreshTokenGrantProcessor.validateRefreshToken(any())).thenReturn(refreshTokenValidationDataDO);
@@ -545,6 +558,8 @@ public class RefreshGrantHandlerTest {
 
     @Test
     public void testValidateGrantLogsRefreshTokenNotLatestAndTokenHashWhenLoggable() throws Exception {
+
+        mockDiagnosticLogging();
 
         when(refreshTokenGrantProcessor.validateRefreshToken(any())).thenReturn(refreshTokenValidationDataDO);
         when(refreshTokenValidationDataDO.getAuthorizedUser()).thenReturn(new MockAuthenticatedUser("test_user"));
@@ -600,6 +615,8 @@ public class RefreshGrantHandlerTest {
     @Test
     public void testIssueLogsMissingValidationDataSeparatelyFromExpiry() throws Exception {
 
+        mockDiagnosticLogging();
+
         when(oAuthTokenReqMessageContext.getOauth2AccessTokenReqDTO()).thenReturn(oAuth2AccessTokenReqDTO);
         when(oAuthTokenReqMessageContext.getProperty(PREV_ACCESS_TOKEN)).thenReturn(null);
         when(oAuth2AccessTokenReqDTO.getClientId()).thenReturn("test_client_id");
@@ -627,6 +644,79 @@ public class RefreshGrantHandlerTest {
                     "The log should state that the validation data of the refresh token is unavailable.");
             assertFalse(diagnosticLog.getResultMessage().contains("expired"),
                     "Missing validation data should not be reported as an expired refresh token.");
+        }
+    }
+
+    /**
+     * Test that an inactive access token behind a refresh token is reported, since this path returns the same
+     * "Refresh token is expired." error as the expiry check but is reached from the token creation instead.
+     */
+    @Test
+    public void testIssueLogsInactiveAccessTokenBehindTheRefreshToken() throws Exception {
+
+        mockDiagnosticLogging();
+
+        String clientId = "app1";
+        String tenantDomain = "carbon.super";
+        MockAuthenticatedUser user = new MockAuthenticatedUser("user");
+        user.setTenantDomain(tenantDomain);
+
+        when(mockOAuthApp.getTokenType()).thenReturn("JWT");
+        when(mockOAuthApp.getOauthConsumerKey()).thenReturn(clientId);
+
+        try (MockedStatic<OAuthServerConfiguration> oAuthServerConfigurationMockedStatic =
+                     mockStatic(OAuthServerConfiguration.class);
+             MockedStatic<OAuthComponentServiceHolder> oAuthComponentServiceHolderMockedStatic =
+                     mockStatic(OAuthComponentServiceHolder.class);
+             MockedStatic<OAuth2ServiceComponentHolder> oAuth2ServiceComponentHolderMockedStatic =
+                     mockStatic(OAuth2ServiceComponentHolder.class);
+             MockedStatic<AppInfoCache> appInfoCacheMockedStatic = mockStatic(AppInfoCache.class);
+             MockedStatic<IdentityUtil> identityUtilMockedStatic = mockStatic(IdentityUtil.class)) {
+
+            oAuthServerConfigurationMockedStatic.when(OAuthServerConfiguration::getInstance)
+                    .thenReturn(oAuthServerConfiguration);
+            appInfoCacheMockedStatic.when(AppInfoCache::getInstance).thenReturn(mockAppInfoCache);
+            when(mockAppInfoCache.getValueFromCache(anyString(), anyString())).thenReturn(mockOAuthApp);
+            oAuth2ServiceComponentHolderMockedStatic.when(OAuth2ServiceComponentHolder::getInstance)
+                    .thenReturn(oAuth2ServiceComponentHolder);
+            oAuthComponentServiceHolderMockedStatic.when(OAuthComponentServiceHolder::getInstance)
+                    .thenReturn(mockOAuthComponentServiceHolder);
+            identityUtilMockedStatic.when(() -> IdentityUtil.isTokenLoggable(anyString())).thenReturn(false);
+
+            when(mockOAuthComponentServiceHolder.getActionExecutorService()).thenReturn(mockActionExecutorService);
+            when(mockActionExecutorService.isExecutionEnabled(any())).thenReturn(false);
+            when(oAuth2ServiceComponentHolder.getRefreshTokenGrantProcessor()).thenReturn(refreshTokenGrantProcessor);
+
+            when(oAuthTokenReqMessageContext.getOauth2AccessTokenReqDTO()).thenReturn(oAuth2AccessTokenReqDTO);
+            when(oAuthTokenReqMessageContext.getProperty(PREV_ACCESS_TOKEN)).thenReturn(mockValidationBean);
+            when(oAuthTokenReqMessageContext.getProperty(AccessTokenIssuer.OAUTH_APP_DO)).thenReturn(mockOAuthApp);
+            when(oAuthTokenReqMessageContext.getAuthorizedUser()).thenReturn(user);
+            when(oAuth2AccessTokenReqDTO.getClientId()).thenReturn(clientId);
+            when(oAuth2AccessTokenReqDTO.getTenantDomain()).thenReturn(tenantDomain);
+
+            // The refresh token itself is within its validity period, so the expiry check above is not the one hit.
+            when(mockValidationBean.getIssuedTime()).thenReturn(Timestamp.from(Instant.now()));
+            when(mockValidationBean.getValidityPeriodInMillis()).thenReturn(3600000L);
+            when(mockValidationBean.getAccessTokenValidityInMillis()).thenReturn(10000L);
+            when(mockValidationBean.getTokenId()).thenReturn("token-id-1");
+            when(mockValidationBean.getAuthorizedUser()).thenReturn(user);
+            when(refreshTokenGrantProcessor.createAccessTokenBean(any(), any(), any(), anyString()))
+                    .thenThrow(new IllegalArgumentException(OAuth2Util.ACCESS_TOKEN_IS_NOT_ACTIVE_ERROR_MESSAGE));
+
+            RefreshGrantHandler refreshGrantHandler = new RefreshGrantHandler();
+            refreshGrantHandler.init();
+            OAuth2AccessTokenRespDTO respDTO = refreshGrantHandler.issue(oAuthTokenReqMessageContext);
+
+            assertTrue(respDTO.isError(), "An inactive access token should produce an error response");
+            assertEquals(respDTO.getErrorMsg(), "Refresh token is expired.");
+
+            DiagnosticLog diagnosticLog = captureLastDiagnosticLog();
+            assertEquals(diagnosticLog.getResultStatus(), DiagnosticLog.ResultStatus.FAILED.name());
+            assertEquals(diagnosticLog.getActionId(),
+                    OAuthConstants.LogConstants.ActionIDs.VALIDATE_REFRESH_TOKEN);
+            assertTrue(diagnosticLog.getResultMessage().contains("no longer active"),
+                    "The log should state that the access token behind the refresh token is no longer active.");
+            assertEquals(diagnosticLog.getInput().get(OAuthConstants.LogConstants.InputKeys.TOKEN_ID), "token-id-1");
         }
     }
 


### PR DESCRIPTION
### Purpose

The diagnostic logs of a failed refresh token grant request stopped after the application validation, providing no information on why the request failed. Diagnostic logs are added for each refresh token validation failure so that the reason is explicit:

- The refresh token is invalid and no persisted token was found for it.
- The refresh token is not in a usable state, including the current state.
- The refresh token is not the latest token issued for the application.
- The refresh token is expired.

A log entry is also added when an authorization grant fails validation, so that the logs of a token request never end at the application validation regardless of the grant type in use.

Refresh tokens are never logged. To still provide context on the token used, the internal token id, the token state, the issued time, the validity period and the masked authorized user are logged. The SHA-256 hash of the refresh token is logged only when token logging is explicitly permitted through the REFRESH_TOKEN identity token configuration.
