### PR TITLE
Distinguish invalid vs past client secret expiry in DCR error responses

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/DCRMConstants.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/DCRMConstants.java
@@ -49,7 +49,8 @@ public class DCRMConstants {
         BAD_REQUEST_INVALID_SP_NAME("Client Name is not adhering to the regex: %s"),
         BAD_REQUEST_INVALID_SP_TEMPLATE_NAME("Invalid service provider template name: %s"),
         BAD_REQUEST_INVALID_INPUT("%s"),
-        BAD_REQUEST_INVALID_CLIENT_SECRET_EXPIRY("The provided client secret expiry time is in the past: %s"),
+        BAD_REQUEST_CLIENT_SECRET_EXPIRY_INVALID("The provided expiry time for the client secret is invalid."),
+        BAD_REQUEST_CLIENT_SECRET_EXPIRY_IN_PAST("The provided expiry time for the client secret is in the past."),
         BAD_REQUEST_CLIENT_SECRET_EXPIRY_NOT_SUPPORTED("Client secret expiry is not supported as the multiple " +
                 "client secret support is disabled."),
         BAD_REQUEST_INVALID_SP_INPUT("Invalid data sent for the service provider : %s"),

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/service/DCRMService.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/service/DCRMService.java
@@ -776,9 +776,9 @@ public class DCRMService {
         }
         // Per RFC 7591, a client_secret_expires_at of zero denotes a never-expiring secret.
         if (registrationRequest.getClientSecretExpiresAt() != null) {
-            /* The expiry is carried as Unix epoch seconds on the DTO. A negative value is invalid; a non-zero
-               value already in the past is rejected. Zero denotes a never-expiring secret. */
-            if (registrationRequest.getClientSecretExpiresAt() < 0) {
+            // Reject negatives and values that overflow when converted to milliseconds below.
+            if (registrationRequest.getClientSecretExpiresAt() < 0
+                    || registrationRequest.getClientSecretExpiresAt() > Long.MAX_VALUE / 1000L) {
                 throw DCRMUtils.generateClientException(
                         DCRMConstants.ErrorMessages.BAD_REQUEST_CLIENT_SECRET_EXPIRY_INVALID, null);
             }

--- a/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/service/DCRMService.java
+++ b/components/org.wso2.carbon.identity.oauth.dcr/src/main/java/org/wso2/carbon/identity/oauth/dcr/service/DCRMService.java
@@ -776,12 +776,16 @@ public class DCRMService {
         }
         // Per RFC 7591, a client_secret_expires_at of zero denotes a never-expiring secret.
         if (registrationRequest.getClientSecretExpiresAt() != null) {
-            // The expiry is carried as Unix epoch seconds on the DTO.
+            /* The expiry is carried as Unix epoch seconds on the DTO. A negative value is invalid; a non-zero
+               value already in the past is rejected. Zero denotes a never-expiring secret. */
+            if (registrationRequest.getClientSecretExpiresAt() < 0) {
+                throw DCRMUtils.generateClientException(
+                        DCRMConstants.ErrorMessages.BAD_REQUEST_CLIENT_SECRET_EXPIRY_INVALID, null);
+            }
             if (registrationRequest.getClientSecretExpiresAt() != 0 && OAuth2Util.isExpiryTimeInPast(
                     registrationRequest.getClientSecretExpiresAt() * 1000L)) {
                 throw DCRMUtils.generateClientException(
-                        DCRMConstants.ErrorMessages.BAD_REQUEST_INVALID_CLIENT_SECRET_EXPIRY,
-                        String.valueOf(registrationRequest.getClientSecretExpiresAt()));
+                        DCRMConstants.ErrorMessages.BAD_REQUEST_CLIENT_SECRET_EXPIRY_IN_PAST, null);
             }
             oAuthConsumerApp.setOauthConsumerSecretExpiryTime(registrationRequest.getClientSecretExpiresAt());
         }


### PR DESCRIPTION
### Purpose

Align the DCR client-secret-expiry validation error with the Application Management REST API. A negative `ext_param_client_secret_expires_at` (e.g. `-1`) was incorrectly reported as "in the past"; it is now reported as invalid, and only a genuine past timestamp is reported as "in the past".

### Changes

- `DCRMConstants` — replace the single `BAD_REQUEST_INVALID_CLIENT_SECRET_EXPIRY` ("...is in the past: %s") with two messages matching the Application Management REST API wording:
  - `BAD_REQUEST_CLIENT_SECRET_EXPIRY_INVALID` — "The provided expiry time for the client secret is invalid."
  - `BAD_REQUEST_CLIENT_SECRET_EXPIRY_IN_PAST` — "The provided expiry time for the client secret is in the past."
- `DCRMService` — validate a negative expiry as invalid before the past-time check.
