### PR TITLE
Revoke tokens on user logout for applications without a token binding

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dao/OAuthAppDAO.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/dao/OAuthAppDAO.java
@@ -1147,9 +1147,7 @@ public class OAuthAppDAO {
         addOrUpdateOIDCSpProperty(preprocessedClientId, spTenantId, spOIDCProperties, TOKEN_BINDING_TYPE,
                 oauthAppDO.getTokenBindingType(), prepStatementForPropertyAdd, preparedStatementForPropertyUpdate);
 
-        // Token binding is required to enable following features.
         if (oauthAppDO.getTokenBindingType() == null) {
-            oauthAppDO.setTokenRevocationWithIDPSessionTerminationEnabled(false);
             oauthAppDO.setTokenBindingValidationEnabled(false);
         }
 
@@ -1938,9 +1936,8 @@ public class OAuthAppDAO {
             addToBatchForOIDCPropertyAdd(processedClientId, spTenantId, prepStmtAddOIDCProperty, TOKEN_BINDING_TYPE,
                     consumerAppDO.getTokenBindingType());
 
-            // Token binding is required to enable following features.
+            // Token binding validation requires a token binding type, token revocation on logout does not.
             if (consumerAppDO.getTokenBindingType() == null) {
-                consumerAppDO.setTokenRevocationWithIDPSessionTerminationEnabled(false);
                 consumerAppDO.setTokenBindingValidationEnabled(false);
             }
 
@@ -2148,14 +2145,13 @@ public class OAuthAppDAO {
         }
         oauthApp.setTokenBindingType(tokenBindingType);
 
+        boolean isTokenRevocationEnabled = Boolean.parseBoolean(
+                getFirstPropertyValue(spOIDCProperties, TOKEN_REVOCATION_WITH_IDP_SESSION_TERMINATION));
+        oauthApp.setTokenRevocationWithIDPSessionTerminationEnabled(isTokenRevocationEnabled);
+
         if (tokenBindingType == null) {
-            oauthApp.setTokenRevocationWithIDPSessionTerminationEnabled(false);
             oauthApp.setTokenBindingValidationEnabled(false);
         } else {
-            boolean isTokenRevocationEnabled = Boolean.parseBoolean(
-                    getFirstPropertyValue(spOIDCProperties, TOKEN_REVOCATION_WITH_IDP_SESSION_TERMINATION));
-            oauthApp.setTokenRevocationWithIDPSessionTerminationEnabled(isTokenRevocationEnabled);
-
             boolean isTokenBindingValidationEnabled = Boolean
                     .parseBoolean(getFirstPropertyValue(spOIDCProperties, TOKEN_BINDING_VALIDATION));
             oauthApp.setTokenBindingValidationEnabled(isTokenBindingValidationEnabled);

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/bindings/handlers/TokenBindingExpiryEventHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/bindings/handlers/TokenBindingExpiryEventHandler.java
@@ -110,6 +110,17 @@ public class TokenBindingExpiryEventHandler extends AbstractEventHandler {
                 if (!OAuth2Constants.TokenBinderType.SSO_SESSION_BASED_TOKEN_BINDER.equals(bindingType)) {
                     revokeTokensForCommonAuthCookie(request, context.getLastAuthenticatedUser());
                 }
+
+                /*
+                 Tokens issued to an application that has no token binding configured carry no binding reference
+                 pointing back to the terminated session, hence neither of the lookups above is able to find them.
+                 Fall back to the token to session mapping, which is persisted for every token belonging to a
+                 session irrespective of the token binding configuration of the application. Each token found this
+                 way is still filtered by the token revocation on IDP session termination configuration of its own
+                 application, so applications that have not opted in are left untouched.
+                */
+                revokeTokensMappedToSession(getSessionIdentifierFromEventProperties(eventProperties),
+                        getAuthenticatedUser(eventProperties, context), true);
             } else {
                 revokeTokensForCommonAuthCookie(request, getAuthenticatedUser(eventProperties, context));
             }
@@ -159,6 +170,9 @@ public class TokenBindingExpiryEventHandler extends AbstractEventHandler {
      */
     private String getSessionIdentifier(Map<String, Object> paramMap) {
 
+        if (paramMap == null) {
+            return null;
+        }
         String sessionContextIdentifier = null;
         for (Map.Entry<String, Object> entry : paramMap.entrySet()) {
             if (StringUtils.equals(entry.getKey(), FrameworkConstants.AnalyticsAttributes.SESSION_ID)) {
@@ -170,6 +184,18 @@ public class TokenBindingExpiryEventHandler extends AbstractEventHandler {
             }
         }
         return sessionContextIdentifier;
+    }
+
+    /**
+     * Get the session context identifier carried by the event properties.
+     *
+     * @param eventProperties Event properties.
+     * @return Session context identifier.
+     */
+    private String getSessionIdentifierFromEventProperties(Map<String, Object> eventProperties) {
+
+        return getSessionIdentifier((Map<String, Object>) eventProperties.get(
+                IdentityEventConstants.EventProperty.PARAMS));
     }
 
     /**
@@ -378,6 +404,26 @@ public class TokenBindingExpiryEventHandler extends AbstractEventHandler {
      */
     private void revokeTokensMappedToSession(String sessionId, AuthenticatedUser user) throws IdentityOAuth2Exception {
 
+        revokeTokensMappedToSession(sessionId, user, false);
+    }
+
+    /**
+     * Get the access tokens mapped for the session identifier and revoke those tokens.
+     *
+     * @param sessionId                       Session context identifier.
+     * @param user                            Authenticated user.
+     * @param enforceAppLevelRevocationConfig Whether to skip the tokens of the applications that have not enabled
+     *                                        token revocation on IDP session termination.
+     * @throws IdentityOAuth2Exception
+     */
+    private void revokeTokensMappedToSession(String sessionId, AuthenticatedUser user,
+                                             boolean enforceAppLevelRevocationConfig)
+            throws IdentityOAuth2Exception {
+
+        if (StringUtils.isBlank(sessionId) || user == null) {
+            return;
+        }
+
         Set<String> tokenIds =
                 OAuthTokenPersistenceFactory.getInstance().getAccessTokenDAO()
                         .getTokenIdBySessionIdentifier(sessionId);
@@ -396,7 +442,7 @@ public class TokenBindingExpiryEventHandler extends AbstractEventHandler {
                 if (log.isDebugEnabled()) {
                     log.debug(String.format("Could not find access token mapped for tokenId: %s", tokenId));
                 }
-                return;
+                continue;
             }
             AccessTokenDO accessTokenDO = null;
             try {
@@ -422,6 +468,13 @@ public class TokenBindingExpiryEventHandler extends AbstractEventHandler {
                 AuthenticatedUser authenticatedUser = new AuthenticatedUser(accessTokenDO.getAuthzUser());
 
                 String consumerKey = accessTokenDO.getConsumerKey();
+                if (enforceAppLevelRevocationConfig && !isTokenRevocationEnabledForApp(consumerKey)) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Token revocation on IDP session termination is not enabled for the application "
+                                + "with consumerKey: " + consumerKey + ". Hence skipping the token revocation.");
+                    }
+                    continue;
+                }
                 if (authenticatedUser.isFederatedUser()) {
                     isFederatedRoleBasedAuthzEnabled = OAuth2Util.isFederatedRoleBasedAuthzEnabled(consumerKey);
                 }
@@ -495,6 +548,28 @@ public class TokenBindingExpiryEventHandler extends AbstractEventHandler {
             }
         }
         return authenticatedUser;
+    }
+
+    /**
+     * Check whether token revocation after session termination is enabled for the application that owns the given
+     * consumer key.
+     *
+     * @param consumerKey Consumer key of the application.
+     * @return true if token revocation after logout is enabled, false otherwise.
+     */
+    private boolean isTokenRevocationEnabledForApp(String consumerKey) {
+
+        try {
+            OAuthAppDO oAuthAppDO = OAuth2Util.getAppInformationByClientId(consumerKey);
+            return isTokenRevocationWithIDPSessionTerminationEnabledForOAuthApp(oAuthAppDO,
+                    oAuthAppDO.getTokenBindingType());
+        } catch (IdentityOAuth2Exception | InvalidOAuthClientException e) {
+            if (log.isDebugEnabled()) {
+                log.debug("Error while retrieving the application for the consumerKey: " + consumerKey
+                        + ". Hence skipping the token revocation.", e);
+            }
+            return false;
+        }
     }
 
     /**

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/bindings/handlers/TokenBindingExpiryEventHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/bindings/handlers/TokenBindingExpiryEventHandler.java
@@ -564,10 +564,9 @@ public class TokenBindingExpiryEventHandler extends AbstractEventHandler {
             return isTokenRevocationWithIDPSessionTerminationEnabledForOAuthApp(oAuthAppDO,
                     oAuthAppDO.getTokenBindingType());
         } catch (IdentityOAuth2Exception | InvalidOAuthClientException e) {
-            if (log.isDebugEnabled()) {
-                log.debug("Error while retrieving the application for the consumerKey: " + consumerKey
-                        + ". Hence skipping the token revocation.", e);
-            }
+            // Skipping leaves the token active, so this must be visible without debug logs enabled.
+            log.warn("Error while retrieving the application for the consumerKey: " + consumerKey
+                    + ". Hence skipping the token revocation.", e);
             return false;
         }
     }

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/dao/OAuthAppDAOTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/dao/OAuthAppDAOTest.java
@@ -242,6 +242,47 @@ public class OAuthAppDAOTest extends TestOAuthDAOBase {
         }
     }
 
+    /**
+     * Token revocation on IDP session termination must be preserved for an application that has no token binding
+     * configured. Tokens are mapped to their session irrespective of the token binding, so the absence of a binding
+     * is not a reason to drop the opt-in. Token binding validation, in contrast, does require a binding type and
+     * must stay disabled.
+     */
+    @Test
+    public void testTokenRevocationOnSessionTerminationPreservedWithoutTokenBinding() throws Exception {
+
+        try (MockedStatic<OAuthServerConfiguration> oAuthServerConfiguration = mockStatic(
+                OAuthServerConfiguration.class);
+             MockedStatic<IdentityTenantUtil> identityTenantUtil = mockStatic(IdentityTenantUtil.class);
+             MockedStatic<IdentityUtil> identityUtil = mockStatic(IdentityUtil.class);
+             MockedStatic<IdentityDatabaseUtil> identityDatabaseUtil = mockStatic(IdentityDatabaseUtil.class);
+             MockedStatic<OrganizationManagementUtil> organizationManagementUtil =
+                     mockStatic(OrganizationManagementUtil.class)) {
+            setupMocksForTest(oAuthServerConfiguration, identityTenantUtil, identityUtil, organizationManagementUtil);
+            OAuthAppDO appDO = getDefaultOAuthAppDO();
+            appDO.setTokenBindingType(OAuthConstants.OIDCConfigProperties.TOKEN_BINDING_TYPE_NONE);
+            appDO.setTokenRevocationWithIDPSessionTerminationEnabled(true);
+            appDO.setTokenBindingValidationEnabled(true);
+
+            try (Connection connection = getConnection(DB_NAME)) {
+                mockIdentityUtilDataBaseConnection(connection, identityDatabaseUtil);
+                addOAuthApplication(appDO, TENANT_ID);
+
+                OAuthAppDO retrievedApp = new OAuthAppDAO().getAppInformation(appDO.getOauthConsumerKey(), TENANT_ID);
+                assertNotNull(retrievedApp);
+                assertNull(retrievedApp.getTokenBindingType(),
+                        "A token binding type of 'None' should be persisted as null.");
+                assertTrue(retrievedApp.isTokenRevocationWithIDPSessionTerminationEnabled(),
+                        "Token revocation on IDP session termination should be preserved when the application has "
+                                + "no token binding type configured.");
+                assertFalse(retrievedApp.isTokenBindingValidationEnabled(),
+                        "Token binding validation should be disabled when there is no token binding type.");
+            }
+        } finally {
+            resetPrivilegedCarbonContext();
+        }
+    }
+
     @Test
     public void testAddOAuthApplicationWithAppResidentOrgId() throws Exception {
 

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/dao/OAuthAppDAOTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth/dao/OAuthAppDAOTest.java
@@ -243,10 +243,8 @@ public class OAuthAppDAOTest extends TestOAuthDAOBase {
     }
 
     /**
-     * Token revocation on IDP session termination must be preserved for an application that has no token binding
-     * configured. Tokens are mapped to their session irrespective of the token binding, so the absence of a binding
-     * is not a reason to drop the opt-in. Token binding validation, in contrast, does require a binding type and
-     * must stay disabled.
+     * Token revocation on IDP session termination must survive a round trip for an application with no token
+     * binding, while token binding validation must still be disabled.
      */
     @Test
     public void testTokenRevocationOnSessionTerminationPreservedWithoutTokenBinding() throws Exception {
@@ -270,8 +268,6 @@ public class OAuthAppDAOTest extends TestOAuthDAOBase {
 
                 OAuthAppDO retrievedApp = new OAuthAppDAO().getAppInformation(appDO.getOauthConsumerKey(), TENANT_ID);
                 assertNotNull(retrievedApp);
-                assertNull(retrievedApp.getTokenBindingType(),
-                        "A token binding type of 'None' should be persisted as null.");
                 assertTrue(retrievedApp.isTokenRevocationWithIDPSessionTerminationEnabled(),
                         "Token revocation on IDP session termination should be preserved when the application has "
                                 + "no token binding type configured.");

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/bindings/handlers/TokenBindingExpiryEventHandlerTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/token/bindings/handlers/TokenBindingExpiryEventHandlerTest.java
@@ -1,0 +1,272 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com)
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth2.token.bindings.handlers;
+
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
+import org.wso2.carbon.identity.application.authentication.framework.context.SessionContext;
+import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
+import org.wso2.carbon.identity.common.testng.WithCarbonHome;
+import org.wso2.carbon.identity.event.IdentityEventConstants;
+import org.wso2.carbon.identity.event.event.Event;
+import org.wso2.carbon.identity.oauth.OAuthUtil;
+import org.wso2.carbon.identity.oauth.common.exception.InvalidOAuthClientException;
+import org.wso2.carbon.identity.oauth.dao.OAuthAppDO;
+import org.wso2.carbon.identity.oauth.internal.util.AccessTokenEventUtil;
+import org.wso2.carbon.identity.oauth2.dao.AccessTokenDAO;
+import org.wso2.carbon.identity.oauth2.dao.OAuthTokenPersistenceFactory;
+import org.wso2.carbon.identity.oauth2.model.AccessTokenDO;
+import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for the session mapping based revocation carried out by {@link TokenBindingExpiryEventHandler}
+ * on a front channel logout, for applications that have no access token binding configured.
+ */
+@WithCarbonHome
+public class TokenBindingExpiryEventHandlerTest {
+
+    private static final String CONSUMER_KEY = "test_consumer_key";
+    private static final String SESSION_ID = "test_session_context_identifier";
+    private static final String TOKEN_ID = "test_token_id";
+    private static final String ACCESS_TOKEN = "test_access_token";
+
+    private TokenBindingExpiryEventHandler handler;
+    private AutoCloseable closeable;
+
+    @Mock
+    private OAuthTokenPersistenceFactory mockTokenPersistenceFactory;
+    @Mock
+    private AccessTokenDAO mockAccessTokenDAO;
+    @Mock
+    private HttpServletRequest mockRequest;
+    @Mock
+    private AuthenticationContext mockContext;
+    @Mock
+    private OAuthAppDO mockOAuthAppDO;
+    @Mock
+    private AccessTokenDO mockAccessTokenDO;
+
+    private MockedStatic<OAuth2Util> oAuth2Util;
+    private MockedStatic<OAuthTokenPersistenceFactory> tokenPersistenceFactory;
+    private MockedStatic<OAuthUtil> oAuthUtil;
+    private MockedStatic<AccessTokenEventUtil> accessTokenEventUtil;
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+
+        closeable = MockitoAnnotations.openMocks(this);
+        handler = new TokenBindingExpiryEventHandler();
+
+        oAuth2Util = mockStatic(OAuth2Util.class);
+        tokenPersistenceFactory = mockStatic(OAuthTokenPersistenceFactory.class);
+        oAuthUtil = mockStatic(OAuthUtil.class);
+        accessTokenEventUtil = mockStatic(AccessTokenEventUtil.class);
+
+        tokenPersistenceFactory.when(OAuthTokenPersistenceFactory::getInstance)
+                .thenReturn(mockTokenPersistenceFactory);
+        lenient().when(mockTokenPersistenceFactory.getAccessTokenDAO()).thenReturn(mockAccessTokenDAO);
+        lenient().when(mockTokenPersistenceFactory.getAccessTokenDAOImpl(anyString())).thenReturn(mockAccessTokenDAO);
+
+        // A front channel OIDC logout of an application that has no token binding type.
+        lenient().when(mockRequest.getParameter(FrameworkConstants.RequestParams.TYPE))
+                .thenReturn(FrameworkConstants.RequestType.CLAIM_TYPE_OIDC);
+        lenient().when(mockContext.getRelyingParty()).thenReturn(CONSUMER_KEY);
+        lenient().when(mockContext.getLastAuthenticatedUser()).thenReturn(new AuthenticatedUser());
+        lenient().when(mockOAuthAppDO.getTokenBindingType()).thenReturn(null);
+        oAuth2Util.when(() -> OAuth2Util.getAppInformationByClientId(CONSUMER_KEY)).thenReturn(mockOAuthAppDO);
+
+        // One token mapped to the terminated session.
+        lenient().when(mockAccessTokenDAO.getTokenIdBySessionIdentifier(SESSION_ID))
+                .thenReturn(Collections.singleton(TOKEN_ID));
+        lenient().when(mockAccessTokenDAO.getAccessTokenByTokenId(TOKEN_ID)).thenReturn(ACCESS_TOKEN);
+        lenient().when(mockAccessTokenDO.getConsumerKey()).thenReturn(CONSUMER_KEY);
+        lenient().when(mockAccessTokenDO.getAccessToken()).thenReturn(ACCESS_TOKEN);
+        lenient().when(mockAccessTokenDO.getAuthzUser()).thenReturn(new AuthenticatedUser());
+        lenient().when(mockAccessTokenDO.getTokenBinding()).thenReturn(null);
+        oAuth2Util.when(() -> OAuth2Util.getAccessTokenDOFromTokenIdentifier(ACCESS_TOKEN, false))
+                .thenReturn(mockAccessTokenDO);
+    }
+
+    @AfterMethod
+    public void tearDown() throws Exception {
+
+        closeMockSafely(oAuth2Util);
+        closeMockSafely(tokenPersistenceFactory);
+        closeMockSafely(oAuthUtil);
+        closeMockSafely(accessTokenEventUtil);
+        if (closeable != null) {
+            closeable.close();
+        }
+    }
+
+    private void closeMockSafely(MockedStatic<?> mock) {
+
+        if (mock != null) {
+            try {
+                mock.close();
+            } catch (Exception e) {
+                // Ignore if already closed.
+            }
+        }
+    }
+
+    private Event sessionTerminateEvent() {
+
+        Map<String, Object> paramMap = new HashMap<>();
+        paramMap.put(FrameworkConstants.AnalyticsAttributes.SESSION_ID, SESSION_ID);
+        paramMap.put(FrameworkConstants.AnalyticsAttributes.USER, new AuthenticatedUser());
+
+        Map<String, Object> eventProperties = new HashMap<>();
+        eventProperties.put(IdentityEventConstants.EventProperty.REQUEST, mockRequest);
+        eventProperties.put(IdentityEventConstants.EventProperty.CONTEXT, mockContext);
+        eventProperties.put(IdentityEventConstants.EventProperty.PARAMS, paramMap);
+
+        return new Event(IdentityEventConstants.EventName.SESSION_TERMINATE.name(), eventProperties);
+    }
+
+    /**
+     * The defect this fixes: an unbound token has no binding reference pointing back to the session, so it has to
+     * be found through the token to session mapping instead.
+     */
+    @Test
+    public void testUnboundTokenIsRevokedOnFrontChannelLogoutWhenAppOptedIn() throws Exception {
+
+        when(mockOAuthAppDO.isTokenRevocationWithIDPSessionTerminationEnabled()).thenReturn(true);
+
+        handler.handleEvent(sessionTerminateEvent());
+
+        verify(mockAccessTokenDAO, times(1)).revokeAccessTokens(any(String[].class), anyBoolean());
+    }
+
+    /**
+     * User initiated logout honours the per application opt-in, so that revocation does not silently break
+     * use cases such as offline_access.
+     */
+    @Test
+    public void testUnboundTokenIsNotRevokedOnFrontChannelLogoutWhenAppNotOptedIn() throws Exception {
+
+        when(mockOAuthAppDO.isTokenRevocationWithIDPSessionTerminationEnabled()).thenReturn(false);
+
+        handler.handleEvent(sessionTerminateEvent());
+
+        verify(mockAccessTokenDAO, never()).revokeAccessTokens(any(String[].class), anyBoolean());
+    }
+
+    /**
+     * A failed application lookup must not revoke, since the opt-in cannot be established.
+     */
+    @Test
+    public void testTokenIsNotRevokedWhenApplicationLookupFails() throws Exception {
+
+        /*
+         The first lookup is the one handleEvent does to read the binding type; it has to succeed so that the
+         flow actually reaches the session mapping. The second is the one made while resolving the opt-in.
+        */
+        oAuth2Util.when(() -> OAuth2Util.getAppInformationByClientId(CONSUMER_KEY))
+                .thenReturn(mockOAuthAppDO)
+                .thenThrow(new InvalidOAuthClientException("No application found."));
+
+        handler.handleEvent(sessionTerminateEvent());
+
+        verify(mockAccessTokenDAO, times(1)).getTokenIdBySessionIdentifier(SESSION_ID);
+        verify(mockAccessTokenDAO, never()).revokeAccessTokens(any(String[].class), anyBoolean());
+    }
+
+    /**
+     * A mapping row whose token no longer resolves must be skipped without abandoning the remaining tokens of
+     * the session.
+     */
+    @Test
+    public void testUnresolvableTokenDoesNotAbortTheSessionSweep() throws Exception {
+
+        String staleTokenId = "stale_token_id";
+        when(mockOAuthAppDO.isTokenRevocationWithIDPSessionTerminationEnabled()).thenReturn(true);
+        // TestNG iterates the set in insertion order, so the stale id is visited first.
+        when(mockAccessTokenDAO.getTokenIdBySessionIdentifier(SESSION_ID))
+                .thenReturn(new java.util.LinkedHashSet<>(java.util.Arrays.asList(staleTokenId, TOKEN_ID)));
+        when(mockAccessTokenDAO.getAccessTokenByTokenId(staleTokenId)).thenReturn(null);
+
+        handler.handleEvent(sessionTerminateEvent());
+
+        verify(mockAccessTokenDAO, times(1)).revokeAccessTokens(any(String[].class), anyBoolean());
+    }
+
+    /**
+     * A request-less session termination is a forced one: password change, account lock, user deletion, admin
+     * session termination or federated backchannel logout. Those must revoke regardless of the per application
+     * opt-in, otherwise a token would survive the very flows meant to kill it.
+     */
+    @Test
+    public void testForcedSessionTerminationRevokesEvenWhenAppNotOptedIn() throws Exception {
+
+        lenient().when(mockOAuthAppDO.isTokenRevocationWithIDPSessionTerminationEnabled()).thenReturn(false);
+
+        Map<String, Object> paramMap = new HashMap<>();
+        paramMap.put(FrameworkConstants.AnalyticsAttributes.SESSION_ID, SESSION_ID);
+        paramMap.put(FrameworkConstants.AnalyticsAttributes.USER, new AuthenticatedUser());
+
+        Map<String, Object> eventProperties = new HashMap<>();
+        eventProperties.put(IdentityEventConstants.EventProperty.PARAMS, paramMap);
+        eventProperties.put(IdentityEventConstants.EventProperty.SESSION_CONTEXT, new SessionContext());
+
+        handler.handleEvent(new Event(IdentityEventConstants.EventName.SESSION_TERMINATE.name(), eventProperties));
+
+        verify(mockAccessTokenDAO, times(1)).revokeAccessTokens(any(String[].class), anyBoolean());
+    }
+
+    /**
+     * An event that carries no session identifier must be a no-op rather than a failure.
+     */
+    @Test
+    public void testEventWithoutSessionIdentifierIsIgnored() throws Exception {
+
+        Map<String, Object> eventProperties = new HashMap<>();
+        eventProperties.put(IdentityEventConstants.EventProperty.REQUEST, mockRequest);
+        eventProperties.put(IdentityEventConstants.EventProperty.CONTEXT, mockContext);
+        eventProperties.put(IdentityEventConstants.EventProperty.PARAMS, null);
+
+        handler.handleEvent(new Event(IdentityEventConstants.EventName.SESSION_TERMINATE.name(), eventProperties));
+
+        verify(mockAccessTokenDAO, never()).revokeAccessTokens(any(String[].class), anyBoolean());
+        verify(mockAccessTokenDAO, never()).getTokenIdBySessionIdentifier(eq(SESSION_ID));
+    }
+}

--- a/components/org.wso2.carbon.identity.oauth/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.identity.oauth/src/test/resources/testng.xml
@@ -46,6 +46,7 @@
             <class name="org.wso2.carbon.identity.oauth2.authcontext.JWTTokenGeneratorTest"/>
             <class name="org.wso2.carbon.identity.oauth2.token.SubjectTokenIssuerTest"/>
             <class name="org.wso2.carbon.identity.oauth2.token.bindings.impl.SSOSessionBasedTokenBinderTest"/>
+            <class name="org.wso2.carbon.identity.oauth2.token.bindings.handlers.TokenBindingExpiryEventHandlerTest"/>
             <class name="org.wso2.carbon.identity.oauth2.impersonation.ImpersonatorPermissionValidatorTest"/>
             <class name="org.wso2.carbon.identity.oauth2.impersonation.SubjectScopeValidatorTest"/>
             <class name="org.wso2.carbon.identity.oauth2.impersonation.UserAccountStatusValidatorTest"/>


### PR DESCRIPTION
## Problem

An access token issued to an OAuth application whose access token binding type is **None** stays introspectable after an RP initiated logout, even though the IDP session is terminated.

Reproduced on a stock IS 7.4.0 pack with a plain OAuth app (code grant, binding type `None`), logging out from the same browser:

```
before logout: active=true
session TERMINATED (re-auth required)
after  logout: active=true      <-- token survived
```

## Cause

`TokenBindingExpiryEventHandler.handleEvent` picks one of two paths depending on whether the `SESSION_TERMINATE` event carries an `HttpServletRequest`:

```java
if (request == null) {
    revokeAccessTokensMappedForSessions(event);   // resolves tokens by session
    return;
}
...
revokeTokensForCommonAuthCookie(request, ...);    // resolves tokens by token binding reference
```

Front channel logout always carries the request, so it always takes the second path. That path derives `sha256(commonAuthId)` and calls `getAccessTokensByBindingRef(...)`. A token issued without a token binding has no binding reference pointing back to the session, so the lookup returns an empty set and nothing is revoked:

```
DEBUG TokenBindingExpiryEventHandler - SESSION_TERMINATE event received to TokenBindingExpiryEventHandler.
DEBUG TokenBindingExpiryEventHandler - No bound tokens found for the the provided binding reference: 9d1884...
```

A second, independent gate then makes the fix impossible to express: `OAuthAppDAO` force disabled `tokenRevocationWithIDPSessionTerminationEnabled` whenever the binding type was `None`, in both the read and the write paths, while the console still rendered the corresponding toggle for those applications.

## Fix

**1. Use the token to session mapping in the front channel path.**

`OAuthTokenSessionMappingEventHandler` persists a mapping for every token that belongs to a session, keyed by the session context identifier, irrespective of the application's token binding configuration. The request-less branch of this same handler already resolves tokens through it and already handles unbound tokens explicitly. The capability existed and was simply unreachable from a browser logout.

**2. Stop force disabling the opt-in when there is no token binding.**

Token binding *validation* compares binding attributes presented at token validation against the binding of the token, so it genuinely requires a binding type and stays disabled. Token revocation on IDP session termination does not, since tokens are mapped to their session regardless of binding.

**3. Do not abort the session sweep on one unresolvable token.**

`revokeTokensMappedToSession` returned instead of continuing when a mapped token id no longer resolved to an access token, so a single stale mapping row silently skipped every remaining token in that session.

## When the per application opt-in applies

This is the reason `revokeTokensMappedToSession` takes an `enforceAppLevelRevocationConfig` flag rather than always enforcing the toggle, and it is worth being explicit about:

| Trigger | Reaches | Honours the per app toggle |
|---|---|---|
| RP initiated logout (front channel) | `request != null` | **yes** — this PR |
| Password change, account lock, user deletion | `request == null` | no, revokes unconditionally |
| Admin / MyAccount session termination | `request == null` | no, revokes unconditionally |
| Federated IdP initiated backchannel logout | `request == null` | no, revokes unconditionally |

The forced termination flows exist precisely to kill a session that must not survive — after a password reset or an account lock, tokens have to die regardless of what the application would prefer. Making them respect an opt-out would be a security regression, so their behaviour is deliberately unchanged here.

User initiated logout is the opposite case. Revoking unconditionally there would break `offline_access`: a backend holding a refresh token would stop working the moment the user closed their browser. So that path respects the application's choice.

## Behaviour change

Only for applications that have **explicitly enabled** token revocation on IDP session termination and have no token binding type. That combination could not previously be stored, so no existing application changes behaviour on upgrade. The default remains opt-out.

## Testing

`OAuthAppDAOTest.testTokenRevocationOnSessionTerminationPreservedWithoutTokenBinding` asserts the opt-in survives a round trip with binding type `None` and that binding validation stays off. It fails without the fix:

```
java.lang.AssertionError: Token revocation on IDP session termination should be preserved
when the application has no token binding type configured. expected [true] but found [false]
```

Full module suite green: `Tests run: 3823, Failures: 0, Errors: 0, Skipped: 0`, checkstyle clean.

Verified end to end on an IS 7.4.0 pack with the patched bundle deployed, in both directions:

| `revokeTokensWhenIDPSessionTerminated` | token after logout | |
|---|---|---|
| `true`  | `active=false` | revoked as expected |
| `false` | `active=true`  | opt-out respected |