### PR TITLE
Support agent JWT client authentication and agent owner binding on CIBA

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.ciba/pom.xml
+++ b/components/org.wso2.carbon.identity.oauth.ciba/pom.xml
@@ -162,6 +162,8 @@
                             version ="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.application.common.*;
                             version ="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.claim.metadata.mgt.*;
+                            version ="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.multi.attribute.login.mgt.*;
                             version ="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.application.authentication.framework.store.*;

--- a/components/org.wso2.carbon.identity.oauth.ciba/src/main/java/org/wso2/carbon/identity/oauth/ciba/api/CibaAuthServiceImpl.java
+++ b/components/org.wso2.carbon.identity.oauth.ciba/src/main/java/org/wso2/carbon/identity/oauth/ciba/api/CibaAuthServiceImpl.java
@@ -31,6 +31,7 @@ import org.wso2.carbon.identity.oauth.ciba.exceptions.CibaClientException;
 import org.wso2.carbon.identity.oauth.ciba.exceptions.CibaCoreException;
 import org.wso2.carbon.identity.oauth.ciba.handlers.CibaUserNotificationHandler;
 import org.wso2.carbon.identity.oauth.ciba.handlers.CibaUserResolver;
+import org.wso2.carbon.identity.oauth.ciba.handlers.CibaUserValidator;
 import org.wso2.carbon.identity.oauth.ciba.internal.CibaServiceComponentHolder;
 import org.wso2.carbon.identity.oauth.ciba.model.CibaAuthCodeDO;
 import org.wso2.carbon.identity.oauth.ciba.model.CibaAuthCodeRequest;
@@ -95,6 +96,8 @@ public class CibaAuthServiceImpl implements CibaAuthService {
             throw new CibaCoreException("Failed to resolve user for CIBA request from client: " +
                     cibaAuthCodeRequest.getIssuer());
         }
+        // Run pluggable validators against the resolved user.
+        validateResolvedUser(resolvedUser, cibaAuthCodeRequest, tenantDomain);
         if (resolvedUser.getUserId() != null) {
             cibaAuthCodeDO.setResolvedUserId(resolvedUser.getUserId());
         }
@@ -146,6 +149,28 @@ public class CibaAuthServiceImpl implements CibaAuthService {
             log.debug("Successfully resolved user for CIBA request from client: " + clientId);
         }
         return resolvedUser;
+    }
+
+    /**
+     * Runs all registered pluggable {@link CibaUserValidator}s that apply to the request against the
+     * resolved user. Any applicable validator that fails will short-circuit the CIBA request.
+     *
+     * @param resolvedUser        The resolved user.
+     * @param cibaAuthCodeRequest The CIBA auth code request.
+     * @param tenantDomain        The tenant domain.
+     * @throws CibaClientException If a validator rejects the resolved user.
+     * @throws CibaCoreException   If a validator fails due to a server-side error.
+     */
+    private void validateResolvedUser(CibaUserResolver.ResolvedUser resolvedUser,
+                                      CibaAuthCodeRequest cibaAuthCodeRequest, String tenantDomain)
+            throws CibaClientException, CibaCoreException {
+
+        List<CibaUserValidator> validators = CibaServiceComponentHolder.getInstance().getCibaUserValidators();
+        for (CibaUserValidator validator : validators) {
+            if (validator.isApplicable(cibaAuthCodeRequest)) {
+                validator.validate(resolvedUser, cibaAuthCodeRequest, tenantDomain);
+            }
+        }
     }
 
     /**

--- a/components/org.wso2.carbon.identity.oauth.ciba/src/main/java/org/wso2/carbon/identity/oauth/ciba/api/CibaAuthServiceImpl.java
+++ b/components/org.wso2.carbon.identity.oauth.ciba/src/main/java/org/wso2/carbon/identity/oauth/ciba/api/CibaAuthServiceImpl.java
@@ -72,7 +72,7 @@ public class CibaAuthServiceImpl implements CibaAuthService {
             throw new CibaCoreException("Error fetching app information for client: " + clientID, e);
         }
 
-        if (appDO.isBypassClientCredentials()) {
+        if (appDO.isBypassClientCredentials() && !cibaAuthCodeRequest.isAuthenticatedWithAgentJWT()) {
             throw new CibaClientException("CIBA cannot be used with public clients. Client: " + clientID + " " +
                     "is configured as a public client.");
         }

--- a/components/org.wso2.carbon.identity.oauth.ciba/src/main/java/org/wso2/carbon/identity/oauth/ciba/common/CibaConstants.java
+++ b/components/org.wso2.carbon.identity.oauth.ciba/src/main/java/org/wso2/carbon/identity/oauth/ciba/common/CibaConstants.java
@@ -48,6 +48,12 @@ public class CibaConstants {
     public static final String NOTIFICATION_CHANNEL = "notification_channel";
     public static final String AUTH_URL = "auth_url";
 
+    // Local claim URI of the agent owner attribute, used for agent CIBA owner binding.
+    public static final String AGENT_OWNER_CLAIM_URI = "http://wso2.org/claims/agent/Owner";
+
+    // OIDC claim dialect URI, used to resolve the token claim name of a local claim.
+    public static final String OIDC_DIALECT = "http://wso2.org/oidc/claim";
+
     // CIBA User Authentication Endpoint constants.
     public static final String CIBA_AUTH_CODE_KEY = "authCodeKey";
     public static final String CIBA_USER_AUTH_ENDPOINT = "/oauth2/ciba_authorize";

--- a/components/org.wso2.carbon.identity.oauth.ciba/src/main/java/org/wso2/carbon/identity/oauth/ciba/handlers/AgentCibaUserValidator.java
+++ b/components/org.wso2.carbon.identity.oauth.ciba/src/main/java/org/wso2/carbon/identity/oauth/ciba/handlers/AgentCibaUserValidator.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth.ciba.handlers;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataHandler;
+import org.wso2.carbon.identity.claim.metadata.mgt.exception.ClaimMetadataException;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.oauth.ciba.common.CibaConstants;
+import org.wso2.carbon.identity.oauth.ciba.exceptions.CibaClientException;
+import org.wso2.carbon.identity.oauth.ciba.exceptions.CibaCoreException;
+import org.wso2.carbon.identity.oauth.ciba.model.CibaAuthCodeRequest;
+
+import java.util.Map;
+
+/**
+ * {@link CibaUserValidator} that is executed only for the agent CIBA (on-behalf-of) flow.
+ * <p>
+ * When an agent runs CIBA with its own token as the {@code actor_token}, this validator enforces
+ * owner binding: the user resolved from the {@code login_hint} must be the owner of the acting
+ * agent. The agent owner is read from the {@code agent_owner} claim carried in the actor token.
+ * The claim name under which that value appears in the token is resolved via the OIDC dialect
+ * ({@value CibaConstants#OIDC_DIALECT}): the external OIDC claim URI mapped to the local claim
+ * {@value CibaConstants#AGENT_OWNER_CLAIM_URI}.
+ */
+public class AgentCibaUserValidator implements CibaUserValidator {
+
+    private static final Log log = LogFactory.getLog(AgentCibaUserValidator.class);
+
+    @Override
+    public boolean isApplicable(CibaAuthCodeRequest cibaAuthCodeRequest) {
+
+        // Applies only to the agent CIBA flow: agent identity enabled and an actor is present.
+        return IdentityUtil.isAgentIdentityEnabled() && cibaAuthCodeRequest != null
+                && StringUtils.isNotBlank(cibaAuthCodeRequest.getRequestedActor());
+    }
+
+    @Override
+    public void validate(CibaUserResolver.ResolvedUser resolvedUser, CibaAuthCodeRequest cibaAuthCodeRequest,
+                         String tenantDomain) throws CibaClientException, CibaCoreException {
+
+        if (resolvedUser == null) {
+            throw new CibaClientException("Cannot validate agent owner binding: resolved user is null.");
+        }
+
+        Map<String, String> actorTokenClaims = cibaAuthCodeRequest.getActorTokenClaims();
+        if (actorTokenClaims == null || actorTokenClaims.isEmpty()) {
+            throw new CibaClientException("Actor token claims are not available to validate agent owner binding.");
+        }
+
+        // Resolve the token claim name that carries the agent owner value via the OIDC dialect.
+        String ownerClaimName = resolveAgentOwnerClaimName(tenantDomain);
+        if (StringUtils.isBlank(ownerClaimName)) {
+            if (log.isDebugEnabled()) {
+                log.debug("The agent owner claim (" + CibaConstants.AGENT_OWNER_CLAIM_URI +
+                        ") is not mapped in the OIDC dialect. Skipping agent owner binding validation.");
+            }
+            return;
+        }
+
+        String agentOwner = actorTokenClaims.get(ownerClaimName);
+        if (StringUtils.isBlank(agentOwner)) {
+            if (log.isDebugEnabled()) {
+                log.debug("The agent owner claim is missing in the actor token. " +
+                        "Skipping agent owner binding validation.");
+            }
+            return;
+        }
+
+        if (!matchesResolvedUser(agentOwner, resolvedUser)) {
+            if (log.isDebugEnabled()) {
+                log.debug("Agent owner binding failed for CIBA request from client: " +
+                        cibaAuthCodeRequest.getIssuer() + ". Resolved user does not match the agent owner.");
+            }
+            throw new CibaClientException("The CIBA user does not match the owner of the acting agent.");
+        }
+
+        if (log.isDebugEnabled()) {
+            log.debug("Agent owner binding validated for CIBA request from client: " +
+                    cibaAuthCodeRequest.getIssuer());
+        }
+    }
+
+    /**
+     * Resolves the token claim name that carries the agent owner value, by looking up the OIDC
+     * dialect ({@value CibaConstants#OIDC_DIALECT}) external claim mapped to the local agent owner
+     * claim ({@value CibaConstants#AGENT_OWNER_CLAIM_URI}).
+     *
+     * @param tenantDomain The tenant domain.
+     * @return The OIDC (token) claim name for the agent owner, or {@code null} if not mapped.
+     * @throws CibaCoreException If the OIDC claim mapping could not be retrieved.
+     */
+    private String resolveAgentOwnerClaimName(String tenantDomain) throws CibaCoreException {
+
+        try {
+            Map<String, String> localToOidcClaimMap = ClaimMetadataHandler.getInstance()
+                    .getMappingsMapFromOtherDialectToCarbon(CibaConstants.OIDC_DIALECT, null, tenantDomain, true);
+            return localToOidcClaimMap.get(CibaConstants.AGENT_OWNER_CLAIM_URI);
+        } catch (ClaimMetadataException e) {
+            throw new CibaCoreException("Error resolving the OIDC claim mapping for the agent owner claim: "
+                    + CibaConstants.AGENT_OWNER_CLAIM_URI, e);
+        }
+    }
+
+    /**
+     * Checks whether the agent owner value refers to the resolved user. The owner is expected in the
+     * form {@code <userId>@<tenantDomain>}, but a bare user ID is also accepted.
+     *
+     * @param agentOwner   The agent owner value from the actor token.
+     * @param resolvedUser The user resolved from the CIBA request.
+     * @return {@code true} if the owner refers to the resolved user.
+     */
+    private boolean matchesResolvedUser(String agentOwner, CibaUserResolver.ResolvedUser resolvedUser) {
+
+        String userId = resolvedUser.getUserId();
+        if (StringUtils.isBlank(userId)) {
+            return false;
+        }
+        String expectedWithTenant = userId + "@" + resolvedUser.getTenantDomain();
+        if (agentOwner.equalsIgnoreCase(expectedWithTenant) || agentOwner.equalsIgnoreCase(userId)) {
+            return true;
+        }
+        // Fall back to comparing the user ID portion before the tenant suffix.
+        int atIndex = agentOwner.lastIndexOf('@');
+        if (atIndex > 0) {
+            return agentOwner.substring(0, atIndex).equalsIgnoreCase(userId);
+        }
+        return false;
+    }
+}

--- a/components/org.wso2.carbon.identity.oauth.ciba/src/main/java/org/wso2/carbon/identity/oauth/ciba/handlers/CibaUserValidator.java
+++ b/components/org.wso2.carbon.identity.oauth.ciba/src/main/java/org/wso2/carbon/identity/oauth/ciba/handlers/CibaUserValidator.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oauth.ciba.handlers;
+
+import org.wso2.carbon.identity.oauth.ciba.exceptions.CibaClientException;
+import org.wso2.carbon.identity.oauth.ciba.exceptions.CibaCoreException;
+import org.wso2.carbon.identity.oauth.ciba.model.CibaAuthCodeRequest;
+
+/**
+ * Pluggable validator that runs additional checks on the user resolved for a CIBA authentication
+ * request. Multiple validators can be registered as OSGi services; each validator decides whether
+ * it applies to a given request via {@link #isApplicable(CibaAuthCodeRequest)} and, when it does, runs
+ * its checks in {@link #validate(CibaUserResolver.ResolvedUser, CibaAuthCodeRequest, String)}.
+ */
+public interface CibaUserValidator {
+
+    /**
+     * Determines whether this validator should be executed for the given CIBA request.
+     *
+     * @param cibaAuthCodeRequest The CIBA authentication request.
+     * @return {@code true} if this validator applies to the request, {@code false} otherwise.
+     */
+    boolean isApplicable(CibaAuthCodeRequest cibaAuthCodeRequest);
+
+    /**
+     * Validates the resolved user against the CIBA request context. Implementations must throw a
+     * {@link CibaClientException} when the user fails validation.
+     *
+     * @param resolvedUser        The user resolved from the CIBA request.
+     * @param cibaAuthCodeRequest The CIBA authentication request.
+     * @param tenantDomain        The tenant domain of the request.
+     * @throws CibaClientException If the resolved user fails validation.
+     * @throws CibaCoreException   If validation could not be completed due to a server-side error.
+     */
+    void validate(CibaUserResolver.ResolvedUser resolvedUser, CibaAuthCodeRequest cibaAuthCodeRequest,
+                  String tenantDomain) throws CibaClientException, CibaCoreException;
+}

--- a/components/org.wso2.carbon.identity.oauth.ciba/src/main/java/org/wso2/carbon/identity/oauth/ciba/internal/CibaServiceComponent.java
+++ b/components/org.wso2.carbon.identity.oauth.ciba/src/main/java/org/wso2/carbon/identity/oauth/ciba/internal/CibaServiceComponent.java
@@ -31,8 +31,10 @@ import org.wso2.carbon.identity.event.services.IdentityEventService;
 import org.wso2.carbon.identity.multi.attribute.login.mgt.MultiAttributeLoginService;
 import org.wso2.carbon.identity.oauth.ciba.api.CibaAuthService;
 import org.wso2.carbon.identity.oauth.ciba.api.CibaAuthServiceImpl;
+import org.wso2.carbon.identity.oauth.ciba.handlers.AgentCibaUserValidator;
 import org.wso2.carbon.identity.oauth.ciba.handlers.CibaResponseTypeRequestValidator;
 import org.wso2.carbon.identity.oauth.ciba.handlers.CibaUserResolver;
+import org.wso2.carbon.identity.oauth.ciba.handlers.CibaUserValidator;
 import org.wso2.carbon.identity.oauth.ciba.handlers.DefaultCibaUserResolver;
 import org.wso2.carbon.identity.oauth.ciba.notifications.CibaEmailNotificationChannel;
 import org.wso2.carbon.identity.oauth.ciba.notifications.CibaNotificationChannel;
@@ -77,7 +79,11 @@ public class CibaServiceComponent {
                     new CibaResponseTypeRequestValidator(), null);
             context.getBundleContext().registerService(CibaUserResolver.class.getName(),
                     DefaultCibaUserResolver.getInstance(), null);
-            
+
+            // Register the agent CIBA user validator (owner binding for the agent OBO flow).
+            context.getBundleContext().registerService(CibaUserValidator.class.getName(),
+                    new AgentCibaUserValidator(), null);
+
             if (log.isDebugEnabled()) {
                 log.debug("CIBA component bundle is activated. Registered default notification channels.");
             }
@@ -201,6 +207,31 @@ public class CibaServiceComponent {
         CibaServiceComponentHolder.getInstance().setCibaUserResolver(null);
         if (log.isDebugEnabled()) {
             log.debug("CibaUserResolver unset in CIBA component.");
+        }
+    }
+
+    @Reference(
+            name = "ciba.user.validator",
+            service = CibaUserValidator.class,
+            cardinality = ReferenceCardinality.MULTIPLE,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetCibaUserValidator"
+    )
+    protected void setCibaUserValidator(CibaUserValidator cibaUserValidator) {
+
+        CibaServiceComponentHolder.getInstance().addCibaUserValidator(cibaUserValidator);
+        if (log.isDebugEnabled()) {
+            log.debug("CibaUserValidator registered in CIBA component: " +
+                    cibaUserValidator.getClass().getName());
+        }
+    }
+
+    protected void unsetCibaUserValidator(CibaUserValidator cibaUserValidator) {
+
+        CibaServiceComponentHolder.getInstance().removeCibaUserValidator(cibaUserValidator);
+        if (log.isDebugEnabled()) {
+            log.debug("CibaUserValidator unregistered in CIBA component: " +
+                    cibaUserValidator.getClass().getName());
         }
     }
 }

--- a/components/org.wso2.carbon.identity.oauth.ciba/src/main/java/org/wso2/carbon/identity/oauth/ciba/internal/CibaServiceComponentHolder.java
+++ b/components/org.wso2.carbon.identity.oauth.ciba/src/main/java/org/wso2/carbon/identity/oauth/ciba/internal/CibaServiceComponentHolder.java
@@ -21,6 +21,7 @@ package org.wso2.carbon.identity.oauth.ciba.internal;
 import org.wso2.carbon.identity.event.services.IdentityEventService;
 import org.wso2.carbon.identity.multi.attribute.login.mgt.MultiAttributeLoginService;
 import org.wso2.carbon.identity.oauth.ciba.handlers.CibaUserResolver;
+import org.wso2.carbon.identity.oauth.ciba.handlers.CibaUserValidator;
 import org.wso2.carbon.identity.oauth.ciba.handlers.DefaultCibaUserResolver;
 import org.wso2.carbon.identity.oauth.ciba.notifications.CibaNotificationChannel;
 import org.wso2.carbon.user.core.service.RealmService;
@@ -45,6 +46,7 @@ public class CibaServiceComponentHolder {
     private MultiAttributeLoginService multiAttributeLoginService;
     private CibaUserResolver cibaUserResolver;
     private final List<CibaNotificationChannel> notificationChannels = new ArrayList<>();
+    private final List<CibaUserValidator> cibaUserValidators = new ArrayList<>();
 
     private CibaServiceComponentHolder() {
     }
@@ -153,5 +155,35 @@ public class CibaServiceComponentHolder {
     public void setCibaUserResolver(CibaUserResolver cibaUserResolver) {
 
         this.cibaUserResolver = cibaUserResolver;
+    }
+
+    /**
+     * Add a pluggable CIBA user validator.
+     *
+     * @param cibaUserValidator CibaUserValidator implementation.
+     */
+    public void addCibaUserValidator(CibaUserValidator cibaUserValidator) {
+
+        cibaUserValidators.add(cibaUserValidator);
+    }
+
+    /**
+     * Remove a pluggable CIBA user validator.
+     *
+     * @param cibaUserValidator CibaUserValidator implementation to remove.
+     */
+    public void removeCibaUserValidator(CibaUserValidator cibaUserValidator) {
+
+        cibaUserValidators.remove(cibaUserValidator);
+    }
+
+    /**
+     * Get all registered CIBA user validators.
+     *
+     * @return Unmodifiable list of registered CibaUserValidator instances.
+     */
+    public List<CibaUserValidator> getCibaUserValidators() {
+
+        return Collections.unmodifiableList(cibaUserValidators);
     }
 }

--- a/components/org.wso2.carbon.identity.oauth.ciba/src/main/java/org/wso2/carbon/identity/oauth/ciba/model/CibaAuthCodeRequest.java
+++ b/components/org.wso2.carbon.identity.oauth.ciba/src/main/java/org/wso2/carbon/identity/oauth/ciba/model/CibaAuthCodeRequest.java
@@ -41,6 +41,7 @@ public class CibaAuthCodeRequest {
     private String transactionContext;
     private String notificationChannel;
     private String requestedActor;
+    private boolean authenticatedWithAgentJWT;
 
     public String getRequestedActor() {
 
@@ -206,5 +207,20 @@ public class CibaAuthCodeRequest {
     public void setNotificationChannel(String notificationChannel) {
 
         this.notificationChannel = notificationChannel;
+    }
+
+    /**
+     * Whether the agent JWT client authenticator authenticated this request.
+     *
+     * @return true if the agent JWT client authentication method authenticated the request.
+     */
+    public boolean isAuthenticatedWithAgentJWT() {
+
+        return authenticatedWithAgentJWT;
+    }
+
+    public void setAuthenticatedWithAgentJWT(boolean authenticatedWithAgentJWT) {
+
+        this.authenticatedWithAgentJWT = authenticatedWithAgentJWT;
     }
 }

--- a/components/org.wso2.carbon.identity.oauth.ciba/src/main/java/org/wso2/carbon/identity/oauth/ciba/model/CibaAuthCodeRequest.java
+++ b/components/org.wso2.carbon.identity.oauth.ciba/src/main/java/org/wso2/carbon/identity/oauth/ciba/model/CibaAuthCodeRequest.java
@@ -19,6 +19,8 @@
 package org.wso2.carbon.identity.oauth.ciba.model;
 
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Captures the authentication request validated parameters.
@@ -42,6 +44,28 @@ public class CibaAuthCodeRequest {
     private String notificationChannel;
     private String requestedActor;
     private boolean authenticatedWithAgentJWT;
+    private Map<String, String> actorTokenClaims = new HashMap<>();
+
+    /**
+     * Returns the claims carried in the actor token sent with the CIBA authentication request.
+     * The map is keyed by the claim name as it appears in the actor token.
+     *
+     * @return Map of actor token claims. Never {@code null}.
+     */
+    public Map<String, String> getActorTokenClaims() {
+
+        return actorTokenClaims;
+    }
+
+    /**
+     * Sets the claims carried in the actor token sent with the CIBA authentication request.
+     *
+     * @param actorTokenClaims Map of actor token claims.
+     */
+    public void setActorTokenClaims(Map<String, String> actorTokenClaims) {
+
+        this.actorTokenClaims = actorTokenClaims != null ? actorTokenClaims : new HashMap<>();
+    }
 
     public String getRequestedActor() {
 

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/ciba/OAuth2CibaEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/ciba/OAuth2CibaEndpoint.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.oauth.endpoint.ciba;
 
+import com.nimbusds.jwt.JWTClaimsSet;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -158,12 +159,13 @@ public class OAuth2CibaEndpoint {
             cibaAuthCodeRequest.setAuthenticatedWithAgentJWT(
                     isAuthenticatedWithAgentJWT(oAuthClientAuthnContext));
 
-            // Validate actor_token and store actor subject for OBO delegation.
+            // Validate actor_token and store actor subject and claims for OBO delegation.
             String actorToken = request.getParameter(OAuthConstants.ACTOR_TOKEN);
             if (IdentityUtil.isAgentIdentityEnabled() && StringUtils.isNotBlank(actorToken)) {
                 try {
-                    String actorSub = ActorTokenValidator.validateAndGetSubject(actorToken, tenantDomain);
-                    cibaAuthCodeRequest.setRequestedActor(actorSub);
+                    JWTClaimsSet actorClaims = ActorTokenValidator.validateAndGetClaims(actorToken, tenantDomain);
+                    cibaAuthCodeRequest.setRequestedActor(actorClaims.getSubject());
+                    cibaAuthCodeRequest.setActorTokenClaims(toStringClaimMap(actorClaims));
                 } catch (IdentityOAuth2Exception e) {
                     throw new CibaAuthFailureException(OAuth2ErrorCodes.INVALID_REQUEST,
                             "Invalid actor_token: " + e.getMessage(), e);
@@ -236,6 +238,26 @@ public class OAuth2CibaEndpoint {
     private CibaAuthCodeRequest getCibaAuthCodeRequest(String authRequest) throws CibaAuthFailureException {
 
         return cibaAuthRequestValidator.prepareAuthCodeRequest(authRequest);
+    }
+
+    /**
+     * Converts the actor token claim set into a string-valued map keyed by claim name.
+     *
+     * @param claimsSet The validated actor token claim set.
+     * @return Map of claim name to string claim value.
+     */
+    private Map<String, String> toStringClaimMap(JWTClaimsSet claimsSet) {
+
+        Map<String, String> claims = new HashMap<>();
+        if (claimsSet == null) {
+            return claims;
+        }
+        for (Map.Entry<String, Object> entry : claimsSet.getClaims().entrySet()) {
+            if (entry.getValue() != null) {
+                claims.put(entry.getKey(), String.valueOf(entry.getValue()));
+            }
+        }
+        return claims;
     }
 
     /**

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/ciba/OAuth2CibaEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/ciba/OAuth2CibaEndpoint.java
@@ -44,6 +44,7 @@ import org.wso2.carbon.identity.oauth.endpoint.util.factory.CibaAuthServiceFacto
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.RequestObjectException;
 import org.wso2.carbon.identity.oauth2.bean.OAuthClientAuthnContext;
+import org.wso2.carbon.identity.oauth2.internal.OAuth2ServiceComponentHolder;
 import org.wso2.carbon.identity.oauth2.model.OAuth2Parameters;
 import org.wso2.carbon.identity.oauth2.token.handlers.grant.ActorTokenValidator;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
@@ -81,6 +82,9 @@ public class OAuth2CibaEndpoint {
     private CibaAuthCodeRequest cibaAuthCodeRequest;
     private CibaAuthCodeResponse cibaAuthCodeResponse;
     private static final String REQUEST_PARAM_VALUE_BUILDER = "request_param_value_builder";
+
+    //Client authentication method name advertised by the agent JWT client authenticator.
+    private static final String AGENT_JWT_CLIENT_AUTH_METHOD = "agent_jwt";
 
     @POST
     @Path("/")
@@ -150,6 +154,9 @@ public class OAuth2CibaEndpoint {
                 // Build CibaAuthCodeRequest from individual parameters
                 cibaAuthCodeRequest = getCibaAuthCodeRequestFromParams(params, oAuthClientAuthnContext.getClientId());
             }
+
+            cibaAuthCodeRequest.setAuthenticatedWithAgentJWT(
+                    isAuthenticatedWithAgentJWT(oAuthClientAuthnContext));
 
             // Validate actor_token and store actor subject for OBO delegation.
             String actorToken = request.getParameter(OAuthConstants.ACTOR_TOKEN);
@@ -364,6 +371,28 @@ public class OAuth2CibaEndpoint {
             oAuthClientAuthnContext.setErrorCode(OAuthError.TokenResponse.INVALID_REQUEST);
         }
         return oAuthClientAuthnContext;
+    }
+
+    /**
+     * Whether the agent JWT client authenticator - the one advertising the {@code agent_jwt} client authentication
+     * method - authenticated this request.
+     *
+     * @param oAuthClientAuthnContext Client authentication context of the request.
+     * @return true if the agent JWT client authentication method authenticated the request.
+     */
+    private boolean isAuthenticatedWithAgentJWT(OAuthClientAuthnContext oAuthClientAuthnContext) {
+
+        if (!oAuthClientAuthnContext.isAuthenticated()) {
+            return false;
+        }
+        List executedAuthenticators = oAuthClientAuthnContext.getExecutedAuthenticators();
+        if (executedAuthenticators == null || executedAuthenticators.isEmpty()) {
+            return false;
+        }
+        return OAuth2ServiceComponentHolder.getAuthenticationHandlers().stream()
+                .filter(authenticator -> executedAuthenticators.contains(authenticator.getName()))
+                .flatMap(authenticator -> authenticator.getSupportedClientAuthenticationMethods().stream())
+                .anyMatch(authMethod -> AGENT_JWT_CLIENT_AUTH_METHOD.equals(authMethod.getName()));
     }
 
     private String getSpTenantDomain(String clientId) throws InvalidRequestException {

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/ciba/OAuth2CibaEndpointTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/ciba/OAuth2CibaEndpointTest.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.oauth.endpoint.ciba;
 
+import com.nimbusds.jwt.JWTClaimsSet;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockedConstruction;
@@ -769,9 +770,13 @@ public class OAuth2CibaEndpointTest {
                      mockStatic(CibaAuthServiceFactory.class)) {
 
             identityUtil.when(IdentityUtil::isAgentIdentityEnabled).thenReturn(true);
+            JWTClaimsSet actorClaims = new JWTClaimsSet.Builder()
+                    .subject("actor-subject-001")
+                    .claim("agent_owner", "owner-user-id@carbon.super")
+                    .build();
             actorTokenValidator.when(() ->
-                    ActorTokenValidator.validateAndGetSubject("actor.jwt.token", "carbon.super"))
-                    .thenReturn("actor-subject-001");
+                    ActorTokenValidator.validateAndGetClaims("actor.jwt.token", "carbon.super"))
+                    .thenReturn(actorClaims);
             loggerUtils.when(LoggerUtils::isDiagnosticLogsEnabled).thenReturn(false);
             identityTenantUtil.when(() -> IdentityTenantUtil.getTenantId(anyString()))
                     .thenReturn(MultitenantConstants.SUPER_TENANT_ID);
@@ -788,6 +793,8 @@ public class OAuth2CibaEndpointTest {
             Assert.assertEquals(cibaResponse.getStatus(), HttpServletResponse.SC_OK);
             verify(authService).generateAuthCodeResponse(captor.capture());
             Assert.assertEquals(captor.getValue().getRequestedActor(), "actor-subject-001");
+            Assert.assertEquals(captor.getValue().getActorTokenClaims().get("agent_owner"),
+                    "owner-user-id@carbon.super");
         }
     }
 
@@ -825,7 +832,7 @@ public class OAuth2CibaEndpointTest {
             oAuth2CibaEndpoint.ciba(httpServletRequest, httpServletResponse, paramMap);
 
             actorTokenValidator.verify(() ->
-                    ActorTokenValidator.validateAndGetSubject(anyString(), anyString()), never());
+                    ActorTokenValidator.validateAndGetClaims(anyString(), anyString()), never());
         }
     }
 
@@ -852,7 +859,7 @@ public class OAuth2CibaEndpointTest {
 
             identityUtil.when(IdentityUtil::isAgentIdentityEnabled).thenReturn(true);
             actorTokenValidator.when(() ->
-                    ActorTokenValidator.validateAndGetSubject(anyString(), anyString()))
+                    ActorTokenValidator.validateAndGetClaims(anyString(), anyString()))
                     .thenThrow(new IdentityOAuth2Exception("Signature validation failed for actor token"));
             loggerUtils.when(LoggerUtils::isDiagnosticLogsEnabled).thenReturn(false);
             identityTenantUtil.when(() -> IdentityTenantUtil.getTenantId(anyString()))
@@ -899,7 +906,7 @@ public class OAuth2CibaEndpointTest {
             oAuth2CibaEndpoint.ciba(httpServletRequest, httpServletResponse, paramMap);
 
             actorTokenValidator.verify(() ->
-                    ActorTokenValidator.validateAndGetSubject(anyString(), anyString()), never());
+                    ActorTokenValidator.validateAndGetClaims(anyString(), anyString()), never());
         }
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/client/authentication/PublicClientAuthenticator.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/client/authentication/PublicClientAuthenticator.java
@@ -50,6 +50,11 @@ public class PublicClientAuthenticator extends AbstractOAuthClientAuthenticator 
     private static final Log log = LogFactory.getLog(PublicClientAuthenticator.class);
     private static final String GRANT_TYPE = "grant_type";
     private static final String RESPONSE_MODE = "response_mode";
+    private static final String CLIENT_ASSERTION_TYPE = "client_assertion_type";
+
+    // Client assertion type of the agent JWT client authenticator
+    private static final String AGENT_JWT_ASSERTION_TYPE =
+            "urn:wso2:params:oauth:client-assertion-type:agent-jwt-bearer";
 
     /**
      * Returns the execution order of this authenticator.
@@ -89,6 +94,14 @@ public class PublicClientAuthenticator extends AbstractOAuthClientAuthenticator 
     @Override
     public boolean canAuthenticate(HttpServletRequest request, Map<String, List> bodyParams, OAuthClientAuthnContext
             context) {
+
+        // An agent JWT client assertion is a credential in its own right, so this authenticator must stand aside.
+        if (isAgentJWTAssertionRequest(bodyParams)) {
+            if (log.isDebugEnabled()) {
+                log.debug("An agent JWT client assertion is present. The public client authenticator does not engage.");
+            }
+            return false;
+        }
 
         List<String> publicClientSupportedGrantTypes = OAuthServerConfiguration.getInstance().
                 getPublicClientSupportedGrantTypesList();
@@ -155,6 +168,23 @@ public class PublicClientAuthenticator extends AbstractOAuthClientAuthenticator 
     public String getName() {
 
         return PUBLIC_CLIENT_AUTHENTICATOR;
+    }
+
+    /**
+     * Returns whether the request carries the agent JWT client assertion type, which is owned by the agent JWT client
+     * authenticator in a separate bundle.
+     *
+     * @param bodyParams Body parameter map of the incoming request.
+     * @return true if an agent JWT client assertion is present.
+     */
+    private boolean isAgentJWTAssertionRequest(Map<String, List> bodyParams) {
+
+        if (bodyParams == null) {
+            return false;
+        }
+        List assertionTypes = bodyParams.get(CLIENT_ASSERTION_TYPE);
+        return assertionTypes != null && !assertionTypes.isEmpty()
+                && AGENT_JWT_ASSERTION_TYPE.equals(String.valueOf(assertionTypes.getFirst()));
     }
 
     /**

--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/ActorTokenValidator.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/ActorTokenValidator.java
@@ -57,6 +57,21 @@ public class ActorTokenValidator {
     public static String validateAndGetSubject(String actorToken, String tenantDomain)
             throws IdentityOAuth2Exception {
 
+        return validateAndGetClaims(actorToken, tenantDomain).getSubject();
+    }
+
+    /**
+     * Validates the actor token JWT and returns its full claim set.
+     *
+     * @param actorToken   Raw JWT string representing the actor token.
+     * @param tenantDomain Tenant domain used for IDP lookup and issuer validation.
+     * @return The validated {@link JWTClaimsSet} of the actor token.
+     * @throws IdentityOAuth2Exception If the JWT is invalid, the signature fails,
+     *                                 the token is expired, or the issuer is unexpected.
+     */
+    public static JWTClaimsSet validateAndGetClaims(String actorToken, String tenantDomain)
+            throws IdentityOAuth2Exception {
+
         SignedJWT signedJWT;
         try {
             signedJWT = JWTUtils.parseJWT(actorToken);
@@ -91,6 +106,6 @@ public class ActorTokenValidator {
                     + ", Received: " + jwtIssuer);
         }
 
-        return claimsSet.getSubject();
+        return claimsSet;
     }
 }


### PR DESCRIPTION
### Purpose

Two related additions for the agent CIBA on-behalf-of flow.

**1. Let an agent authenticate the CIBA request with its own access token.** The agent JWT client authenticator lives in `identity-oauth-privatekey-jwthandler` and advertises the `agent_jwt` client authentication method. This PR makes the CIBA path work with it:

- `PublicClientAuthenticator` stands down when the request carries an agent JWT client assertion. Both authenticators would otherwise engage and `OAuthClientAuthnService#failOnMultipleAuthenticators` rejects the request for using more than one authentication method.
- `OAuth2CibaEndpoint` records on `CibaAuthCodeRequest` whether the `agent_jwt` method authenticated the request, matching on the method name so this component does not have to depend on the bundle that contributes the authenticator.
- `CibaAuthServiceImpl` lets such a request through the public-client restriction. The app has to stay public for the agent to obtain its token through the app-native flow, yet the CIBA request itself carries a credential bound to the agent. No other client authentication method lifts the restriction.

**2. `CibaUserValidator`, a pluggable check on the user resolved for a CIBA request.** Validators register as OSGi services; each decides via `isApplicable` whether it runs. `AgentCibaUserValidator` is the first implementation: for the agent OBO flow it enforces owner binding, so the user resolved from `login_hint` must be the owner of the acting agent. The owner is read from the `agent_owner` claim in the actor token, whose token claim name is resolved through the OIDC dialect mapping of `http://wso2.org/claims/agent/Owner`.

Owner binding is enforced only when the information to enforce it is actually present. If the local claim is not mapped in the OIDC dialect, or the actor token does not carry the claim, the validator logs at debug level and returns without failing the request.

`ActorTokenValidator.validateAndGetClaims` is added so the endpoint can keep the full actor token claim set; `validateAndGetSubject` now delegates to it and is unchanged for existing callers.

### Testing

- `OAuth2CibaEndpointTest` - 31/31 pass.
- Verified at runtime on an IS 7.3.0 pack: owner match issues an `auth_req_id` and the token poll proceeds to `authorization_pending`; a non-owner `login_hint` is rejected; an unmapped claim and a missing claim each skip with the debug line and no error; the owner stored both as `<userId>@<tenantDomain>` and as a bare user id matches.
- Regression checked against plain CIBA, CIBA with `actor_token` under `client_secret_basic`, `private_key_jwt` on both `/oauth2/token` and `/oauth2/ciba`, and the public client bypass on `/oauth2/authorize` - all unchanged.

### Related

Requires wso2-extensions/identity-oauth-privatekey-jwthandler#30, which contributes the `agent_jwt` client authenticator.
