### PR TITLE
Fix sub organization OIDC logout id token signature validation

### DIFF
--- a/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/servlet/OIDCLogoutServlet.java
+++ b/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/servlet/OIDCLogoutServlet.java
@@ -77,6 +77,7 @@ import org.wso2.carbon.identity.oidc.session.internal.OIDCSessionManagementCompo
 import org.wso2.carbon.identity.oidc.session.model.APIError;
 import org.wso2.carbon.identity.oidc.session.model.LogoutContext;
 import org.wso2.carbon.identity.oidc.session.util.OIDCSessionManagementUtil;
+import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
 import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
@@ -556,6 +557,22 @@ public class OIDCLogoutServlet extends HttpServlet {
                     && tokenIssuer.equals(OAuth2OIDCConfigOrgUsageScopeUtils
                             .getIssuerLocation(issuerDetails.getIssuerTenantDomain()))) {
                 return issuerDetails.getIssuerTenantDomain();
+            }
+            /*
+             An application that predates the token issuer setting has no issuer configured, which is the
+             state of applications migrated from before the setting existed. Issuance then falls back to the
+             tenant serving the request, so the root organization of this application's own organization is
+             also a legitimate issuer for it. That is the same pair of tenants the setting itself allows.
+            */
+            if (issuerDetails == null || StringUtils.isEmpty(issuerDetails.getIssuerTenantDomain())) {
+                OrganizationManager organizationManager = OIDCSessionManagementComponentServiceHolder
+                        .getInstance().getOrganizationManager();
+                String primaryTenantDomain = organizationManager.resolveTenantDomain(organizationManager
+                        .getPrimaryOrganizationId(organizationManager.resolveOrganizationId(appTenantDomain)));
+                if (tokenIssuer.equals(OAuth2OIDCConfigOrgUsageScopeUtils
+                        .getIssuerLocation(primaryTenantDomain))) {
+                    return primaryTenantDomain;
+                }
             }
             /*
              The qualified issuer forms, /t/<tenant-domain>/oauth2/token and /o/<organization-id>/oauth2/token,

--- a/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/servlet/OIDCLogoutServlet.java
+++ b/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/servlet/OIDCLogoutServlet.java
@@ -543,7 +543,15 @@ public class OIDCLogoutServlet extends HttpServlet {
                         .getOrganizationManager().resolveTenantDomain(accessingOrgId);
                 oAuthAppDO = OAuth2Util.getAppInformationByClientId(clientId, accessingTenantDomain);
             } else {
+                /*
+                 No accessing organization means the request is already served in the tenant that owns the
+                 application, which is the case for the organization qualified and tenant qualified
+                 endpoints of the organization itself and for the root organization. The token was issued
+                 in that same tenant, so the key to validate it with is the application owner tenant key
+                 and the issuer claim does not need to be consulted.
+                */
                 oAuthAppDO = OAuth2Util.getAppInformationByClientId(clientId);
+                return OAuth2Util.getTenantDomainOfOauthApp(oAuthAppDO);
             }
             String appTenantDomain = OAuth2Util.getTenantDomainOfOauthApp(oAuthAppDO);
 

--- a/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/servlet/OIDCLogoutServlet.java
+++ b/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/servlet/OIDCLogoutServlet.java
@@ -529,13 +529,21 @@ public class OIDCLogoutServlet extends HttpServlet {
             String accessingOrgId = PrivilegedCarbonContext.getThreadLocalCarbonContext()
                     .getApplicationResidentOrganizationId();
             /*
-             The tenant qualified organization endpoints are served in the root tenant, where a lookup by
-             client id alone cannot find an application registered in a sub organization, so the application
-             is resolved through the organization hierarchy when an accessing organization is present.
+             The tenant qualified organization endpoints are served in the root tenant, so a lookup by client
+             id alone resolves against the root tenant and cannot find an application registered in a sub
+             organization. When an accessing organization is present the request is on one of those
+             endpoints, so the application is looked up in that organization's own tenant instead. Without
+             an accessing organization the request is already served in the tenant that owns the
+             application, and the existing lookup is used.
             */
-            OAuthAppDO oAuthAppDO = StringUtils.isNotEmpty(accessingOrgId)
-                    ? OAuth2Util.getAppInformationFromOrgHierarchy(clientId, accessingOrgId)
-                    : OAuth2Util.getAppInformationByClientId(clientId);
+            OAuthAppDO oAuthAppDO;
+            if (StringUtils.isNotEmpty(accessingOrgId)) {
+                String accessingTenantDomain = OIDCSessionManagementComponentServiceHolder.getInstance()
+                        .getOrganizationManager().resolveTenantDomain(accessingOrgId);
+                oAuthAppDO = OAuth2Util.getAppInformationByClientId(clientId, accessingTenantDomain);
+            } else {
+                oAuthAppDO = OAuth2Util.getAppInformationByClientId(clientId);
+            }
             String appTenantDomain = OAuth2Util.getTenantDomainOfOauthApp(oAuthAppDO);
 
             // The application owner tenant, which issues when the request is served in that tenant.

--- a/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/servlet/OIDCLogoutServlet.java
+++ b/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/servlet/OIDCLogoutServlet.java
@@ -84,8 +84,6 @@ import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.UnsupportedEncodingException;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.security.interfaces.RSAPublicKey;
 import java.text.ParseException;
 import java.util.Enumeration;
@@ -97,8 +95,6 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import javax.servlet.Servlet;
 import javax.servlet.ServletException;
@@ -129,10 +125,6 @@ import static org.wso2.carbon.identity.oidc.session.util.OIDCSessionManagementUt
 public class OIDCLogoutServlet extends HttpServlet {
 
     private static final Log log = LogFactory.getLog(OIDCLogoutServlet.class);
-    private static final Pattern TENANT_QUALIFIED_ISSUER_PATTERN =
-            Pattern.compile("/t/([^/]+)/oauth2/token$");
-    private static final Pattern ORGANIZATION_QUALIFIED_ISSUER_PATTERN =
-            Pattern.compile("/o/([^/]+)/oauth2/token$");
     private static final String REQUEST_PARAM_SP = "sp";
     private static final String UTF_8 = "UTF-8";
     private static final long serialVersionUID = -9203934217770142011L;
@@ -555,47 +547,11 @@ public class OIDCLogoutServlet extends HttpServlet {
             }
             String appTenantDomain = OAuth2Util.getTenantDomainOfOauthApp(oAuthAppDO);
 
-            // The tenant of the token issuer configured on the application.
-            IssuerDetails issuerDetails = oAuthAppDO.getIssuerDetails();
-            if (issuerDetails != null && StringUtils.isNotEmpty(issuerDetails.getIssuerTenantDomain())
-                    && tokenIssuer.equals(OAuth2OIDCConfigOrgUsageScopeUtils
-                            .getIssuerLocation(issuerDetails.getIssuerTenantDomain()))) {
-                return issuerDetails.getIssuerTenantDomain();
-            }
-            /*
-             An application that predates the token issuer setting has no issuer configured, which is the
-             state of applications migrated from before the setting existed. Issuance then falls back to the
-             tenant serving the request, so the root organization of this application's own organization is
-             also a legitimate issuer for it. That is the same pair of tenants the setting itself allows.
-            */
-            if (issuerDetails == null || StringUtils.isEmpty(issuerDetails.getIssuerTenantDomain())) {
-                OrganizationManager organizationManager = OIDCSessionManagementComponentServiceHolder
-                        .getInstance().getOrganizationManager();
-                String primaryTenantDomain = organizationManager.resolveTenantDomain(organizationManager
-                        .getPrimaryOrganizationId(organizationManager.resolveOrganizationId(appTenantDomain)));
-                if (tokenIssuer.equals(OAuth2OIDCConfigOrgUsageScopeUtils
-                        .getIssuerLocation(primaryTenantDomain))) {
-                    return primaryTenantDomain;
-                }
-            }
-            /*
-             The qualified issuer forms, /t/<tenant-domain>/oauth2/token and /o/<organization-id>/oauth2/token,
-             which are used when the relying party obtains the token through those endpoints. Both name a
-             tenant in the path. That tenant must be one of the two tenants that may issue for this
-             application, so that an issuer naming an unrelated tenant is not accepted, and the issuer must
-             have an origin this server builds.
-            */
-            String issuerTenant = tenantNamedByIssuer(tokenIssuer);
-            if (StringUtils.isNotEmpty(issuerTenant)
-                    && hasSameOrigin(tokenIssuer, OAuth2OIDCConfigOrgUsageScopeUtils
-                            .getIssuerLocation(appTenantDomain))) {
-                if (StringUtils.equals(appTenantDomain, issuerTenant)) {
-                    return appTenantDomain;
-                }
-                if (issuerDetails != null
-                        && StringUtils.equals(issuerDetails.getIssuerTenantDomain(), issuerTenant)) {
-                    return issuerTenant;
-                }
+            // The tenant that issues id tokens for this application. Its own issuer location is accepted
+            // as the issuer of the token.
+            String issuingTenantDomain = resolveIssuingTenantDomain(oAuthAppDO, appTenantDomain);
+            if (tokenIssuer.equals(OAuth2OIDCConfigOrgUsageScopeUtils.getIssuerLocation(issuingTenantDomain))) {
+                return issuingTenantDomain;
             }
             if (log.isDebugEnabled()) {
                 log.debug("The issuer of the id token does not match any issuer of the application. Client id: "
@@ -637,50 +593,28 @@ public class OIDCLogoutServlet extends HttpServlet {
     }
 
     /**
-     * Compare the origin, that is the scheme and the authority, of two issuer values. The organization
-     * qualified issuer is matched on its organization segment, so the origin is checked separately to keep
-     * the key from being selected on the strength of a host this server did not issue for.
+     * Resolve the tenant that issues id tokens for an application. That is the token issuer configured on
+     * the application. An application that predates the token issuer setting has none configured, which is
+     * the state of applications migrated from before the setting existed. Issuance then falls back to the
+     * tenant serving the request, so the root organization of the application's own organization issues for
+     * it instead. Either way the result is one of the two tenants the setting itself allows.
      *
-     * @param issuer         issuer claim of the id token
-     * @param expectedIssuer an issuer built by this server
-     * @return true if both have the same origin
+     * @param oAuthAppDO      the application
+     * @param appTenantDomain tenant domain that owns the application
+     * @return the tenant domain that issues for this application
+     * @throws OrganizationManagementException if the organization of the application cannot be resolved
      */
-    private boolean hasSameOrigin(String issuer, String expectedIssuer) {
+    private String resolveIssuingTenantDomain(OAuthAppDO oAuthAppDO, String appTenantDomain)
+            throws OrganizationManagementException {
 
-        try {
-            URI issuerUri = new URI(issuer);
-            URI expectedUri = new URI(expectedIssuer);
-            return StringUtils.equalsIgnoreCase(issuerUri.getScheme(), expectedUri.getScheme())
-                    && StringUtils.equalsIgnoreCase(issuerUri.getAuthority(), expectedUri.getAuthority());
-        } catch (URISyntaxException e) {
-            if (log.isDebugEnabled()) {
-                log.debug("Could not compare the origin of the issuer: " + issuer, e);
-            }
-            return false;
+        IssuerDetails issuerDetails = oAuthAppDO.getIssuerDetails();
+        if (issuerDetails != null && StringUtils.isNotEmpty(issuerDetails.getIssuerTenantDomain())) {
+            return issuerDetails.getIssuerTenantDomain();
         }
-    }
-
-    /**
-     * Read the tenant named by the path of a qualified issuer. A tenant is addressable in two ways, and each
-     * way names it differently while the signing key stays the same: /t/&lt;tenant-domain&gt;/oauth2/token names
-     * the tenant directly, and /o/&lt;organization-id&gt;/oauth2/token names the organization that owns it.
-     *
-     * @param issuer issuer claim of the id token
-     * @return the tenant domain named in the issuer, or null if the issuer names no tenant
-     * @throws OrganizationManagementException if the organization in the issuer cannot be resolved
-     */
-    private String tenantNamedByIssuer(String issuer) throws OrganizationManagementException {
-
-        Matcher tenantMatcher = TENANT_QUALIFIED_ISSUER_PATTERN.matcher(issuer);
-        if (tenantMatcher.find()) {
-            return tenantMatcher.group(1);
-        }
-        Matcher organizationMatcher = ORGANIZATION_QUALIFIED_ISSUER_PATTERN.matcher(issuer);
-        if (organizationMatcher.find()) {
-            return OIDCSessionManagementComponentServiceHolder.getInstance().getOrganizationManager()
-                    .resolveTenantDomain(organizationMatcher.group(1));
-        }
-        return null;
+        OrganizationManager organizationManager = OIDCSessionManagementComponentServiceHolder.getInstance()
+                .getOrganizationManager();
+        return organizationManager.resolveTenantDomain(organizationManager.getPrimaryOrganizationId(
+                organizationManager.resolveOrganizationId(appTenantDomain)));
     }
 
     /**

--- a/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/servlet/OIDCLogoutServlet.java
+++ b/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/servlet/OIDCLogoutServlet.java
@@ -529,10 +529,17 @@ public class OIDCLogoutServlet extends HttpServlet {
              expected to use the same endpoint form for login and for logout, so a token reaching here was
              issued by that tenant.
             */
-            String accessingTenantDomain = OIDCSessionManagementComponentServiceHolder.getInstance()
-                    .getOrganizationManager().resolveTenantDomain(accessingOrgId);
+            OrganizationManager organizationManager = OIDCSessionManagementComponentServiceHolder
+                    .getInstance().getOrganizationManager();
+            if (organizationManager == null) {
+                log.error("Organization management service is not available. The tenant domain to validate "
+                        + "the id token signature cannot be resolved.");
+                return null;
+            }
+            String accessingTenantDomain = organizationManager.resolveTenantDomain(accessingOrgId);
             OAuthAppDO oAuthAppDO = OAuth2Util.getAppInformationByClientId(clientId, accessingTenantDomain);
-            return resolveIssuingTenantDomain(oAuthAppDO, OAuth2Util.getTenantDomainOfOauthApp(oAuthAppDO));
+            return resolveIssuingTenantDomain(oAuthAppDO, OAuth2Util.getTenantDomainOfOauthApp(oAuthAppDO),
+                    organizationManager);
         } catch (ParseException e) {
             if (log.isDebugEnabled()) {
                 log.debug("Error occurred while reading the id token.", e);
@@ -542,14 +549,6 @@ public class OIDCLogoutServlet extends HttpServlet {
             if (log.isDebugEnabled()) {
                 log.debug("Error occurred while resolving the tenant domain to validate the id token signature.", e);
             }
-            return null;
-        } catch (RuntimeException e) {
-            /*
-             Issuer resolution reaches services that may be unavailable, for example when organization
-             management is not active, and those fail with unchecked exceptions. Treat that as an
-             unresolved tenant so that the request is denied rather than failing with a server error.
-            */
-            log.error("Error occurred while resolving the tenant domain to validate the id token signature.", e);
             return null;
         }
     }
@@ -561,20 +560,20 @@ public class OIDCLogoutServlet extends HttpServlet {
      * tenant serving the request, so the root organization of the application's own organization issues for
      * it instead. Either way the result is one of the two tenants the setting itself allows.
      *
-     * @param oAuthAppDO      the application
-     * @param appTenantDomain tenant domain that owns the application
+     * @param oAuthAppDO          the application
+     * @param appTenantDomain     tenant domain that owns the application
+     * @param organizationManager the organization manager, already checked to be available
      * @return the tenant domain that issues for this application
      * @throws OrganizationManagementException if the organization of the application cannot be resolved
      */
-    private String resolveIssuingTenantDomain(OAuthAppDO oAuthAppDO, String appTenantDomain)
+    private String resolveIssuingTenantDomain(OAuthAppDO oAuthAppDO, String appTenantDomain,
+                                              OrganizationManager organizationManager)
             throws OrganizationManagementException {
 
         IssuerDetails issuerDetails = oAuthAppDO.getIssuerDetails();
         if (issuerDetails != null && StringUtils.isNotEmpty(issuerDetails.getIssuerTenantDomain())) {
             return issuerDetails.getIssuerTenantDomain();
         }
-        OrganizationManager organizationManager = OIDCSessionManagementComponentServiceHolder.getInstance()
-                .getOrganizationManager();
         return organizationManager.resolveTenantDomain(organizationManager.getPrimaryOrganizationId(
                 organizationManager.resolveOrganizationId(appTenantDomain)));
     }

--- a/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/servlet/OIDCLogoutServlet.java
+++ b/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/servlet/OIDCLogoutServlet.java
@@ -555,10 +555,6 @@ public class OIDCLogoutServlet extends HttpServlet {
             }
             String appTenantDomain = OAuth2Util.getTenantDomainOfOauthApp(oAuthAppDO);
 
-            // The application owner tenant, which issues when the request is served in that tenant.
-            if (tokenIssuer.equals(OAuth2OIDCConfigOrgUsageScopeUtils.getIssuerLocation(appTenantDomain))) {
-                return appTenantDomain;
-            }
             // The tenant of the token issuer configured on the application.
             IssuerDetails issuerDetails = oAuthAppDO.getIssuerDetails();
             if (issuerDetails != null && StringUtils.isNotEmpty(issuerDetails.getIssuerTenantDomain())

--- a/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/servlet/OIDCLogoutServlet.java
+++ b/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/servlet/OIDCLogoutServlet.java
@@ -59,6 +59,9 @@ import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
 import org.wso2.carbon.identity.oauth.dao.OAuthAppDO;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2ClientException;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
+import org.wso2.carbon.identity.oauth2.config.exceptions.OAuth2OIDCConfigOrgUsageScopeMgtServerException;
+import org.wso2.carbon.identity.oauth2.config.models.IssuerDetails;
+import org.wso2.carbon.identity.oauth2.config.utils.OAuth2OIDCConfigOrgUsageScopeUtils;
 import org.wso2.carbon.identity.oauth2.token.bindings.TokenBinder;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 import org.wso2.carbon.identity.oidc.session.OIDCSessionConstants;
@@ -80,6 +83,8 @@ import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.security.interfaces.RSAPublicKey;
 import java.text.ParseException;
 import java.util.Enumeration;
@@ -91,6 +96,8 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import javax.servlet.Servlet;
 import javax.servlet.ServletException;
@@ -121,6 +128,10 @@ import static org.wso2.carbon.identity.oidc.session.util.OIDCSessionManagementUt
 public class OIDCLogoutServlet extends HttpServlet {
 
     private static final Log log = LogFactory.getLog(OIDCLogoutServlet.class);
+    private static final Pattern TENANT_QUALIFIED_ISSUER_PATTERN =
+            Pattern.compile("/t/([^/]+)/oauth2/token$");
+    private static final Pattern ORGANIZATION_QUALIFIED_ISSUER_PATTERN =
+            Pattern.compile("/o/([^/]+)/oauth2/token$");
     private static final String REQUEST_PARAM_SP = "sp";
     private static final String UTF_8 = "UTF-8";
     private static final long serialVersionUID = -9203934217770142011L;
@@ -453,21 +464,24 @@ public class OIDCLogoutServlet extends HttpServlet {
      */
     private boolean validateIdToken(String idToken) {
 
-        String tenantDomain = getTenantDomainForSignatureValidation(idToken);
+        String tenantDomain = resolveSigningTenantDomain(idToken);
         if (StringUtils.isEmpty(tenantDomain)) {
             return false;
         }
-
         try {
-            RSAPublicKey publicKey = (RSAPublicKey) IdentityKeyStoreResolver.getInstance().getCertificate(tenantDomain,
-                    IdentityKeyStoreResolverConstants.InboundProtocol.OAUTH).getPublicKey();
+            RSAPublicKey publicKey = (RSAPublicKey) IdentityKeyStoreResolver.getInstance()
+                    .getCertificate(tenantDomain, IdentityKeyStoreResolverConstants.InboundProtocol.OAUTH)
+                    .getPublicKey();
             SignedJWT signedJWT = SignedJWT.parse(idToken);
             JWSVerifier verifier = new RSASSAVerifier(publicKey);
-
+            if (log.isDebugEnabled()) {
+                log.debug("Validating the id token signature with the tenant domain: " + tenantDomain);
+            }
             return signedJWT.verify(verifier);
         } catch (JOSEException | ParseException e) {
             if (log.isDebugEnabled()) {
-                log.debug("Error occurred while validating id token signature for the id token: " + idToken);
+                log.debug("Error occurred while validating the id token signature with the tenant domain: "
+                        + tenantDomain, e);
             }
             return false;
         } catch (Exception e) {
@@ -477,52 +491,167 @@ public class OIDCLogoutServlet extends HttpServlet {
     }
 
     /**
-     * Get tenant domain for signature validation.
-     * There is a problem If Id token signed using SP's tenant and there is no direct way to get the tenant domain
-     * using client id. So have iterate all the Tenants until get the right client id.
+     * Resolve the single tenant domain whose key signed the id token.
+     * <p>
+     * The signing tenant is decided at issuance time by the endpoint form used by the relying party and by
+     * the token issuer configured on the application, so it cannot be derived from the application
+     * configuration alone. It is however recorded in the token: the issuer claim identifies exactly one
+     * issuing context. This method therefore matches the issuer claim against the issuers of the tenants
+     * that may legitimately issue for this application, and returns only the tenant that owns that issuer.
+     * A token is never validated against a key whose issuer does not match the token's own issuer claim.
+     * This mirrors the check already done for access tokens in
+     * {@code JWTUtils#getResidentIDPForIssuer}.
      *
      * @param idToken id token
-     * @return Tenant domain
+     * @return the tenant domain to validate the signature against, or null if the issuer is not recognised
      */
-    private String getTenantDomainForSignatureValidation(String idToken) {
+    private String resolveSigningTenantDomain(String idToken) {
 
         boolean isJWTSignedWithSPKey = OAuthServerConfiguration.getInstance().isJWTSignedWithSPKey();
         if (log.isDebugEnabled()) {
             log.debug("'SignJWTWithSPKey' property is set to : " + isJWTSignedWithSPKey);
         }
-        String tenantDomain;
-
         try {
-            String clientId = extractClientFromIdToken(idToken);
-            if (isJWTSignedWithSPKey) {
-                OAuthAppDO oAuthAppDO = OAuth2Util.getAppInformationByClientId(clientId);
-                tenantDomain = OAuth2Util.getTenantDomainOfOauthApp(oAuthAppDO);
-                if (log.isDebugEnabled()) {
-                    log.debug("JWT signature will be validated with the service provider's tenant domain : " +
-                            tenantDomain);
-                }
-            } else {
+            if (!isJWTSignedWithSPKey) {
                 if (log.isDebugEnabled()) {
                     log.debug("JWT signature will be validated with user tenant domain.");
                 }
-                tenantDomain = extractTenantDomainFromIdToken(idToken);
+                return extractTenantDomainFromIdToken(idToken);
             }
+            String clientId = extractClientFromIdToken(idToken);
+            String tokenIssuer = extractIssuerFromIdToken(idToken);
+            if (StringUtils.isBlank(tokenIssuer)) {
+                if (log.isDebugEnabled()) {
+                    log.debug("The id token does not carry an issuer claim. Client id: " + clientId);
+                }
+                return null;
+            }
+            String accessingOrgId = PrivilegedCarbonContext.getThreadLocalCarbonContext()
+                    .getApplicationResidentOrganizationId();
+            /*
+             The tenant qualified organization endpoints are served in the root tenant, where a lookup by
+             client id alone cannot find an application registered in a sub organization, so the application
+             is resolved through the organization hierarchy when an accessing organization is present.
+            */
+            OAuthAppDO oAuthAppDO = StringUtils.isNotEmpty(accessingOrgId)
+                    ? OAuth2Util.getAppInformationFromOrgHierarchy(clientId, accessingOrgId)
+                    : OAuth2Util.getAppInformationByClientId(clientId);
+            String appTenantDomain = OAuth2Util.getTenantDomainOfOauthApp(oAuthAppDO);
+
+            // The application owner tenant, which issues when the request is served in that tenant.
+            if (tokenIssuer.equals(OAuth2OIDCConfigOrgUsageScopeUtils.getIssuerLocation(appTenantDomain))) {
+                return appTenantDomain;
+            }
+            // The tenant of the token issuer configured on the application.
+            IssuerDetails issuerDetails = oAuthAppDO.getIssuerDetails();
+            if (issuerDetails != null && StringUtils.isNotEmpty(issuerDetails.getIssuerTenantDomain())
+                    && tokenIssuer.equals(OAuth2OIDCConfigOrgUsageScopeUtils
+                            .getIssuerLocation(issuerDetails.getIssuerTenantDomain()))) {
+                return issuerDetails.getIssuerTenantDomain();
+            }
+            /*
+             The qualified issuer forms, /t/<tenant-domain>/oauth2/token and /o/<organization-id>/oauth2/token,
+             which are used when the relying party obtains the token through those endpoints. Both name a
+             tenant in the path. That tenant must be one of the two tenants that may issue for this
+             application, so that an issuer naming an unrelated tenant is not accepted, and the issuer must
+             have an origin this server builds.
+            */
+            String issuerTenant = tenantNamedByIssuer(tokenIssuer);
+            if (StringUtils.isNotEmpty(issuerTenant)
+                    && hasSameOrigin(tokenIssuer, OAuth2OIDCConfigOrgUsageScopeUtils
+                            .getIssuerLocation(appTenantDomain))) {
+                if (StringUtils.equals(appTenantDomain, issuerTenant)) {
+                    return appTenantDomain;
+                }
+                if (issuerDetails != null
+                        && StringUtils.equals(issuerDetails.getIssuerTenantDomain(), issuerTenant)) {
+                    return issuerTenant;
+                }
+            }
+            if (log.isDebugEnabled()) {
+                log.debug("The issuer of the id token does not match any issuer of the application. Client id: "
+                        + clientId + ", issuer: " + tokenIssuer);
+            }
+            return null;
         } catch (ParseException e) {
             if (log.isDebugEnabled()) {
-                log.debug("Error occurred while extracting client id from id token: " + idToken, e);
+                log.debug("Error occurred while reading the id token.", e);
             }
             return null;
-        } catch (IdentityOAuth2Exception e) {
-            log.error("Error occurred while getting oauth application information.", e);
-            return null;
-        } catch (InvalidOAuthClientException e) {
+        } catch (IdentityOAuth2Exception | InvalidOAuthClientException
+                 | OAuth2OIDCConfigOrgUsageScopeMgtServerException | OrganizationManagementException e) {
             if (log.isDebugEnabled()) {
-                log.debug("Error occurred while getting tenant domain for signature validation with id token: "
-                        + idToken, e);
+                log.debug("Error occurred while resolving the tenant domain to validate the id token signature.", e);
             }
+            return null;
+        } catch (RuntimeException e) {
+            /*
+             Issuer resolution reaches services that may be unavailable, for example when organization
+             management is not active, and those fail with unchecked exceptions. Treat that as an
+             unresolved tenant so that the request is denied rather than failing with a server error.
+            */
+            log.error("Error occurred while resolving the tenant domain to validate the id token signature.", e);
             return null;
         }
-        return tenantDomain;
+    }
+
+    /**
+     * Read the issuer claim of the id token.
+     *
+     * @param idToken id token
+     * @return issuer claim, or null if it is not present
+     * @throws ParseException if the id token cannot be parsed
+     */
+    private String extractIssuerFromIdToken(String idToken) throws ParseException {
+
+        return SignedJWT.parse(idToken).getJWTClaimsSet().getIssuer();
+    }
+
+    /**
+     * Compare the origin, that is the scheme and the authority, of two issuer values. The organization
+     * qualified issuer is matched on its organization segment, so the origin is checked separately to keep
+     * the key from being selected on the strength of a host this server did not issue for.
+     *
+     * @param issuer         issuer claim of the id token
+     * @param expectedIssuer an issuer built by this server
+     * @return true if both have the same origin
+     */
+    private boolean hasSameOrigin(String issuer, String expectedIssuer) {
+
+        try {
+            URI issuerUri = new URI(issuer);
+            URI expectedUri = new URI(expectedIssuer);
+            return StringUtils.equalsIgnoreCase(issuerUri.getScheme(), expectedUri.getScheme())
+                    && StringUtils.equalsIgnoreCase(issuerUri.getAuthority(), expectedUri.getAuthority());
+        } catch (URISyntaxException e) {
+            if (log.isDebugEnabled()) {
+                log.debug("Could not compare the origin of the issuer: " + issuer, e);
+            }
+            return false;
+        }
+    }
+
+    /**
+     * Read the tenant named by the path of a qualified issuer. A tenant is addressable in two ways, and each
+     * way names it differently while the signing key stays the same: /t/&lt;tenant-domain&gt;/oauth2/token names
+     * the tenant directly, and /o/&lt;organization-id&gt;/oauth2/token names the organization that owns it.
+     *
+     * @param issuer issuer claim of the id token
+     * @return the tenant domain named in the issuer, or null if the issuer names no tenant
+     * @throws OrganizationManagementException if the organization in the issuer cannot be resolved
+     */
+    private String tenantNamedByIssuer(String issuer) throws OrganizationManagementException {
+
+        Matcher tenantMatcher = TENANT_QUALIFIED_ISSUER_PATTERN.matcher(issuer);
+        if (tenantMatcher.find()) {
+            return tenantMatcher.group(1);
+        }
+        Matcher organizationMatcher = ORGANIZATION_QUALIFIED_ISSUER_PATTERN.matcher(issuer);
+        if (organizationMatcher.find()) {
+            return OIDCSessionManagementComponentServiceHolder.getInstance().getOrganizationManager()
+                    .resolveTenantDomain(organizationMatcher.group(1));
+        }
+        return null;
     }
 
     /**
@@ -1110,9 +1239,20 @@ public class OIDCLogoutServlet extends HttpServlet {
                 response.sendRedirect(getRedirectURL(redirectURL, request));
                 return;
             } catch (IdentityOAuth2Exception e) {
-                String msg = "Error occurred while decrypting the id token (JWE).";
+                /*
+                 getClientIdFromIdToken fails with this exception in exactly two cases. An encrypted id
+                 token that cannot be decrypted, and a non encrypted id token whose signature does not
+                 validate. Only the second carries the INVALID_ID_TOKEN sub error code, so report the
+                 reason that actually applies instead of labelling every case a JWE decryption failure.
+                */
+                String msg;
+                if (OAuth2ErrorCodes.OAuth2SubErrorCodes.INVALID_ID_TOKEN.equals(e.getErrorCode())) {
+                    msg = "ID token signature validation failed.";
+                } else {
+                    msg = "Error occurred while decrypting the id token (JWE).";
+                }
                 if (log.isDebugEnabled()) {
-                    log.debug("Error occurred while decrypting the id token (JWE).", e);
+                    log.debug(msg, e);
                 }
                 redirectURL = OIDCSessionManagementUtil.getErrorPageURL(OAuth2ErrorCodes.ACCESS_DENIED, msg);
                 response.sendRedirect(getRedirectURL(redirectURL, request));

--- a/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/servlet/OIDCLogoutServlet.java
+++ b/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/servlet/OIDCLogoutServlet.java
@@ -59,9 +59,7 @@ import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
 import org.wso2.carbon.identity.oauth.dao.OAuthAppDO;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2ClientException;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
-import org.wso2.carbon.identity.oauth2.config.exceptions.OAuth2OIDCConfigOrgUsageScopeMgtServerException;
 import org.wso2.carbon.identity.oauth2.config.models.IssuerDetails;
-import org.wso2.carbon.identity.oauth2.config.utils.OAuth2OIDCConfigOrgUsageScopeUtils;
 import org.wso2.carbon.identity.oauth2.token.bindings.TokenBinder;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 import org.wso2.carbon.identity.oidc.session.OIDCSessionConstants;
@@ -512,59 +510,35 @@ public class OIDCLogoutServlet extends HttpServlet {
                 return extractTenantDomainFromIdToken(idToken);
             }
             String clientId = extractClientFromIdToken(idToken);
-            String tokenIssuer = extractIssuerFromIdToken(idToken);
-            if (StringUtils.isBlank(tokenIssuer)) {
-                if (log.isDebugEnabled()) {
-                    log.debug("The id token does not carry an issuer claim. Client id: " + clientId);
-                }
-                return null;
-            }
             String accessingOrgId = PrivilegedCarbonContext.getThreadLocalCarbonContext()
                     .getApplicationResidentOrganizationId();
             /*
+             No accessing organization means the request is already served in the tenant that owns the
+             application, which is the case for the organization qualified and tenant qualified endpoints of
+             the organization itself and for the root organization. The token was issued in that same tenant,
+             so the key to validate it with is the application owner tenant key.
+            */
+            if (StringUtils.isEmpty(accessingOrgId)) {
+                return OAuth2Util.getTenantDomainOfOauthApp(OAuth2Util.getAppInformationByClientId(clientId));
+            }
+            /*
              The tenant qualified organization endpoints are served in the root tenant, so a lookup by client
              id alone resolves against the root tenant and cannot find an application registered in a sub
-             organization. When an accessing organization is present the request is on one of those
-             endpoints, so the application is looked up in that organization's own tenant instead. Without
-             an accessing organization the request is already served in the tenant that owns the
-             application, and the existing lookup is used.
+             organization. The application is therefore looked up in the accessing organization's own tenant,
+             and validated with the key of the tenant that issues id tokens for it. The relying party is
+             expected to use the same endpoint form for login and for logout, so a token reaching here was
+             issued by that tenant.
             */
-            OAuthAppDO oAuthAppDO;
-            if (StringUtils.isNotEmpty(accessingOrgId)) {
-                String accessingTenantDomain = OIDCSessionManagementComponentServiceHolder.getInstance()
-                        .getOrganizationManager().resolveTenantDomain(accessingOrgId);
-                oAuthAppDO = OAuth2Util.getAppInformationByClientId(clientId, accessingTenantDomain);
-            } else {
-                /*
-                 No accessing organization means the request is already served in the tenant that owns the
-                 application, which is the case for the organization qualified and tenant qualified
-                 endpoints of the organization itself and for the root organization. The token was issued
-                 in that same tenant, so the key to validate it with is the application owner tenant key
-                 and the issuer claim does not need to be consulted.
-                */
-                oAuthAppDO = OAuth2Util.getAppInformationByClientId(clientId);
-                return OAuth2Util.getTenantDomainOfOauthApp(oAuthAppDO);
-            }
-            String appTenantDomain = OAuth2Util.getTenantDomainOfOauthApp(oAuthAppDO);
-
-            // The tenant that issues id tokens for this application. Its own issuer location is accepted
-            // as the issuer of the token.
-            String issuingTenantDomain = resolveIssuingTenantDomain(oAuthAppDO, appTenantDomain);
-            if (tokenIssuer.equals(OAuth2OIDCConfigOrgUsageScopeUtils.getIssuerLocation(issuingTenantDomain))) {
-                return issuingTenantDomain;
-            }
-            if (log.isDebugEnabled()) {
-                log.debug("The issuer of the id token does not match any issuer of the application. Client id: "
-                        + clientId + ", issuer: " + tokenIssuer);
-            }
-            return null;
+            String accessingTenantDomain = OIDCSessionManagementComponentServiceHolder.getInstance()
+                    .getOrganizationManager().resolveTenantDomain(accessingOrgId);
+            OAuthAppDO oAuthAppDO = OAuth2Util.getAppInformationByClientId(clientId, accessingTenantDomain);
+            return resolveIssuingTenantDomain(oAuthAppDO, OAuth2Util.getTenantDomainOfOauthApp(oAuthAppDO));
         } catch (ParseException e) {
             if (log.isDebugEnabled()) {
                 log.debug("Error occurred while reading the id token.", e);
             }
             return null;
-        } catch (IdentityOAuth2Exception | InvalidOAuthClientException
-                 | OAuth2OIDCConfigOrgUsageScopeMgtServerException | OrganizationManagementException e) {
+        } catch (IdentityOAuth2Exception | InvalidOAuthClientException | OrganizationManagementException e) {
             if (log.isDebugEnabled()) {
                 log.debug("Error occurred while resolving the tenant domain to validate the id token signature.", e);
             }
@@ -578,18 +552,6 @@ public class OIDCLogoutServlet extends HttpServlet {
             log.error("Error occurred while resolving the tenant domain to validate the id token signature.", e);
             return null;
         }
-    }
-
-    /**
-     * Read the issuer claim of the id token.
-     *
-     * @param idToken id token
-     * @return issuer claim, or null if it is not present
-     * @throws ParseException if the id token cannot be parsed
-     */
-    private String extractIssuerFromIdToken(String idToken) throws ParseException {
-
-        return SignedJWT.parse(idToken).getJWTClaimsSet().getIssuer();
     }
 
     /**

--- a/components/org.wso2.carbon.identity.oidc.session/src/test/java/org/wso2/carbon/identity/oidc/session/servlet/OIDCLogoutServletTest.java
+++ b/components/org.wso2.carbon.identity.oidc.session/src/test/java/org/wso2/carbon/identity/oidc/session/servlet/OIDCLogoutServletTest.java
@@ -652,6 +652,7 @@ public class OIDCLogoutServletTest extends TestOIDCSessionBase {
 
     private static final String SUB_ORG_TENANT = "sub-org-tenant";
     private static final String SUB_ORG_ID = "9476b110-131d-4c74-89b6-b2a8f1a877d0";
+    private static final String ROOT_ORG_ID = "10084a8d-113f-4211-a0d5-efe36b082211";
     private static final String ROOT_ISSUER = "https://localhost:9443/oauth2/token";
     private static final String SUB_ORG_ISSUER =
             "https://localhost:9443/t/carbon.super/o/9476b110-131d-4c74-89b6-b2a8f1a877d0/oauth2/token";
@@ -746,6 +747,18 @@ public class OIDCLogoutServletTest extends TestOIDCSessionBase {
                 {"http://localhost:9443/t/sub-org-tenant/oauth2/token", SUB_ORG_TENANT, null},
                 // A different port must not select a key.
                 {"https://localhost:9999/t/sub-org-tenant/oauth2/token", SUB_ORG_TENANT, null},
+                /*
+                 An application with no token issuer configured, the state of one migrated from before the
+                 setting existed. Issuance falls back to the tenant serving the request, so the root
+                 organization of the application's own organization is a legitimate issuer for it.
+                */
+                {ROOT_ISSUER, null, SUPER_TENANT_DOMAIN_NAME},
+                // The application's own tenant still selects its own key when it has no issuer configured.
+                {SUB_ORG_ISSUER, null, SUB_ORG_TENANT},
+                // An unrelated issuer is still refused when the application has no issuer configured.
+                {"https://localhost:9443/t/another-tenant/oauth2/token", null, null},
+                // A foreign origin is still refused when the application has no issuer configured.
+                {"https://evil.example.com/o/" + SUB_ORG_ID + "/oauth2/token", null, null},
         };
     }
 
@@ -763,6 +776,15 @@ public class OIDCLogoutServletTest extends TestOIDCSessionBase {
             */
             OrganizationManager organizationManager = mock(OrganizationManager.class);
             lenient().when(organizationManager.resolveTenantDomain(SUB_ORG_ID)).thenReturn(SUB_ORG_TENANT);
+            /*
+             The application's own organization and the root of its hierarchy, used when the application has
+             no token issuer configured, which is the state of an application migrated from before the
+             setting existed.
+            */
+            lenient().when(organizationManager.resolveOrganizationId(SUB_ORG_TENANT)).thenReturn(SUB_ORG_ID);
+            lenient().when(organizationManager.getPrimaryOrganizationId(SUB_ORG_ID)).thenReturn(ROOT_ORG_ID);
+            lenient().when(organizationManager.resolveTenantDomain(ROOT_ORG_ID))
+                    .thenReturn(SUPER_TENANT_DOMAIN_NAME);
             OIDCSessionManagementComponentServiceHolder.getInstance().setOrganizationManager(organizationManager);
             try {
                 Object resolved = invokePrivateMethod(logoutServlet, "resolveSigningTenantDomain",

--- a/components/org.wso2.carbon.identity.oidc.session/src/test/java/org/wso2/carbon/identity/oidc/session/servlet/OIDCLogoutServletTest.java
+++ b/components/org.wso2.carbon.identity.oidc.session/src/test/java/org/wso2/carbon/identity/oidc/session/servlet/OIDCLogoutServletTest.java
@@ -881,15 +881,14 @@ public class OIDCLogoutServletTest extends TestOIDCSessionBase {
     }
 
     @Test
-    public void testResolveSigningTenantDomainDeniesWhenResolutionFailsUnchecked() throws Exception {
+    public void testResolveSigningTenantDomainDeniesWhenOrganizationServiceUnavailable() throws Exception {
 
-        // Resolution reaches services that may be unavailable and fail with unchecked exceptions. The
+        // Organization management may not be active, in which case the service holder returns nothing. The
         // request must be denied rather than failing with a server error.
         mockApplication(SUPER_TENANT_DOMAIN_NAME);
-        OrganizationManager organizationManager = mockAccessingOrganization();
+        mockAccessingOrganization();
         try {
-            when(organizationManager.resolveTenantDomain(SUB_ORG_ID))
-                    .thenThrow(new NullPointerException("organization manager is not available"));
+            OIDCSessionManagementComponentServiceHolder.getInstance().setOrganizationManager(null);
             Object resolved = invokePrivateMethod(logoutServlet, "resolveSigningTenantDomain",
                     idTokenWithIssuer(SUB_ORG_ISSUER));
             assertEquals(resolved, null);

--- a/components/org.wso2.carbon.identity.oidc.session/src/test/java/org/wso2/carbon/identity/oidc/session/servlet/OIDCLogoutServletTest.java
+++ b/components/org.wso2.carbon.identity.oidc.session/src/test/java/org/wso2/carbon/identity/oidc/session/servlet/OIDCLogoutServletTest.java
@@ -755,22 +755,30 @@ public class OIDCLogoutServletTest extends TestOIDCSessionBase {
                 {"http://localhost:9443/o/" + SUB_ORG_ID + "/oauth2/token", SUB_ORG_TENANT, null},
                 // A different port must not select a key.
                 {"https://localhost:9999/o/" + SUB_ORG_ID + "/oauth2/token", SUB_ORG_TENANT, null},
-                // The organization qualified issuer resolves to the owning organization's tenant.
-                {ORG_QUALIFIED_ISSUER, SUB_ORG_TENANT, SUB_ORG_TENANT},
+                /*
+                 The organization qualified form is not accepted. The relying party is expected to use the
+                 same endpoint form for login and for logout, so a token obtained through
+                 /o/<organization-id>/oauth2/token is logged out through that same form, where the request
+                 carries no accessing organization and never reaches this comparison.
+                */
+                {ORG_QUALIFIED_ISSUER, SUB_ORG_TENANT, null},
                 // An unrecognised issuer is rejected.
                 {"https://localhost:9443/some/other/path", SUB_ORG_TENANT, null},
                 // A token with no issuer claim is rejected.
                 {null, SUB_ORG_TENANT, null},
                 /*
-                 The tenant qualified issuer form, /t/<tenant-domain>/oauth2/token, which is produced when
-                 the relying party obtains the token through the tenant's own endpoints. The organization
-                 qualified form of the same tenant is a different string, so both must be recognised.
+                 The tenant qualified issuer form, /t/<tenant-domain>/oauth2/token, is not accepted either,
+                 for the same reason. It is produced when the relying party obtains the token through the
+                 tenant's own endpoints, and logout through those same endpoints does not reach here.
                 */
-                {TENANT_QUALIFIED_ISSUER, SUB_ORG_TENANT, SUB_ORG_TENANT},
-                // The application owner tenant is accepted regardless of the configured token issuer.
-                {TENANT_QUALIFIED_ISSUER, SUPER_TENANT_DOMAIN_NAME, SUB_ORG_TENANT},
-                // The configured token issuer tenant is accepted in the tenant qualified form.
-                {ROOT_TENANT_QUALIFIED_ISSUER, SUPER_TENANT_DOMAIN_NAME, SUPER_TENANT_DOMAIN_NAME},
+                {TENANT_QUALIFIED_ISSUER, SUB_ORG_TENANT, null},
+                {TENANT_QUALIFIED_ISSUER, SUPER_TENANT_DOMAIN_NAME, null},
+                /*
+                 A path qualified form of the configured token issuer tenant is not accepted. When that
+                 tenant issues, the issuer claim is its own issuer location, which the configured token
+                 issuer check matches directly, so the server never produces this form.
+                */
+                {ROOT_TENANT_QUALIFIED_ISSUER, SUPER_TENANT_DOMAIN_NAME, null},
                 // The root tenant must not be selected when the application issues from the sub organization.
                 {ROOT_TENANT_QUALIFIED_ISSUER, SUB_ORG_TENANT, null},
                 // A tenant qualified issuer naming an unrelated tenant is not accepted.
@@ -787,8 +795,12 @@ public class OIDCLogoutServletTest extends TestOIDCSessionBase {
                  organization of the application's own organization is a legitimate issuer for it.
                 */
                 {ROOT_ISSUER, null, SUPER_TENANT_DOMAIN_NAME},
-                // The application's own tenant still selects its own key when it has no issuer configured.
-                {SUB_ORG_ISSUER, null, SUB_ORG_TENANT},
+                /*
+                 An application with no issuer configured issues from its root organization, so only that
+                 issuer is accepted. A token carrying the organization's own issuer was obtained through a
+                 different endpoint form and is logged out through that same form.
+                */
+                {SUB_ORG_ISSUER, null, null},
                 // An unrelated issuer is still refused when the application has no issuer configured.
                 {"https://localhost:9443/t/another-tenant/oauth2/token", null, null},
                 // A foreign origin is still refused when the application has no issuer configured.
@@ -855,8 +867,9 @@ public class OIDCLogoutServletTest extends TestOIDCSessionBase {
     @Test
     public void testResolveSigningTenantDomainWithOrganizationQualifiedIssuer() throws Exception {
 
-        // The organization qualified issuer resolves to the tenant of the organization that owns the
-        // application, which is how a token obtained through /o/<org-id>/oauth2/token is validated.
+        // A token obtained through /o/<org-id>/oauth2/token is logged out through that same endpoint form,
+        // where no accessing organization is set. Reaching this comparison with that issuer means the
+        // relying party crossed endpoint forms, which is not supported, so no key is selected.
         try (MockedStatic<OAuth2OIDCConfigOrgUsageScopeUtils> issuerUtils =
                      mockStatic(OAuth2OIDCConfigOrgUsageScopeUtils.class)) {
             mockApplicationWithIssuer(issuerUtils, SUB_ORG_TENANT);
@@ -864,7 +877,7 @@ public class OIDCLogoutServletTest extends TestOIDCSessionBase {
             try {
                 Object resolved = invokePrivateMethod(logoutServlet, "resolveSigningTenantDomain",
                         idTokenWithIssuer(ORG_QUALIFIED_ISSUER));
-                assertEquals(resolved, SUB_ORG_TENANT);
+                assertEquals(resolved, null);
             } finally {
                 clearAccessingOrganization();
             }
@@ -874,9 +887,9 @@ public class OIDCLogoutServletTest extends TestOIDCSessionBase {
     @Test
     public void testResolveSigningTenantDomainWithTenantQualifiedIssuer() throws Exception {
 
-        // A token obtained through /t/<tenant-domain>/oauth2/token carries an issuer that names the tenant
-        // directly. It is signed by the same key as the organization qualified form of that tenant, so it
-        // must resolve to the same tenant.
+        // A token obtained through /t/<tenant-domain>/oauth2/token is logged out through that same endpoint
+        // form, where no accessing organization is set. Reaching this comparison with that issuer means the
+        // relying party crossed endpoint forms, which is not supported, so no key is selected.
         try (MockedStatic<OAuth2OIDCConfigOrgUsageScopeUtils> issuerUtils =
                      mockStatic(OAuth2OIDCConfigOrgUsageScopeUtils.class)) {
             mockApplicationWithIssuer(issuerUtils, SUPER_TENANT_DOMAIN_NAME);
@@ -884,7 +897,7 @@ public class OIDCLogoutServletTest extends TestOIDCSessionBase {
             try {
                 Object resolved = invokePrivateMethod(logoutServlet, "resolveSigningTenantDomain",
                         idTokenWithIssuer(TENANT_QUALIFIED_ISSUER));
-                assertEquals(resolved, SUB_ORG_TENANT);
+                assertEquals(resolved, null);
             } finally {
                 clearAccessingOrganization();
             }

--- a/components/org.wso2.carbon.identity.oidc.session/src/test/java/org/wso2/carbon/identity/oidc/session/servlet/OIDCLogoutServletTest.java
+++ b/components/org.wso2.carbon.identity.oidc.session/src/test/java/org/wso2/carbon/identity/oidc/session/servlet/OIDCLogoutServletTest.java
@@ -48,6 +48,8 @@ import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
 import org.wso2.carbon.identity.oauth.dao.OAuthAppDO;
 import org.wso2.carbon.identity.oauth.tokenprocessor.TokenPersistenceProcessor;
+import org.wso2.carbon.identity.oauth2.config.models.IssuerDetails;
+import org.wso2.carbon.identity.oauth2.config.utils.OAuth2OIDCConfigOrgUsageScopeUtils;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 import org.wso2.carbon.identity.oidc.session.OIDCSessionConstants;
 import org.wso2.carbon.identity.oidc.session.OIDCSessionManager;
@@ -56,11 +58,14 @@ import org.wso2.carbon.identity.oidc.session.cache.OIDCSessionDataCacheEntry;
 import org.wso2.carbon.identity.oidc.session.cache.OIDCSessionDataCacheKey;
 import org.wso2.carbon.identity.oidc.session.internal.OIDCSessionManagementComponentServiceHolder;
 import org.wso2.carbon.identity.oidc.session.util.OIDCSessionManagementUtil;
+import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
 
 import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -642,6 +647,202 @@ public class OIDCLogoutServletTest extends TestOIDCSessionBase {
         Object expected = invokePrivateMethod(logoutServlet, "appendStateQueryParam",
                 postLogoutUrl, stateParam);
         assertEquals(expected, outputRedirectUrl);
+    }
+
+
+    private static final String SUB_ORG_TENANT = "sub-org-tenant";
+    private static final String SUB_ORG_ID = "9476b110-131d-4c74-89b6-b2a8f1a877d0";
+    private static final String ROOT_ISSUER = "https://localhost:9443/oauth2/token";
+    private static final String SUB_ORG_ISSUER =
+            "https://localhost:9443/t/carbon.super/o/9476b110-131d-4c74-89b6-b2a8f1a877d0/oauth2/token";
+    private static final String ORG_QUALIFIED_ISSUER =
+            "https://localhost:9443/o/9476b110-131d-4c74-89b6-b2a8f1a877d0/oauth2/token";
+    private static final String TENANT_QUALIFIED_ISSUER =
+            "https://localhost:9443/t/sub-org-tenant/oauth2/token";
+    private static final String ROOT_TENANT_QUALIFIED_ISSUER =
+            "https://localhost:9443/t/carbon.super/oauth2/token";
+
+    /**
+     * Build an unsigned id token carrying the given issuer and azp. Only the claims are read by the
+     * tenant resolution, so the signature is irrelevant here.
+     */
+    private String idTokenWithIssuer(String issuer) {
+
+        String header = Base64.getUrlEncoder().withoutPadding()
+                .encodeToString("{\"alg\":\"RS256\"}".getBytes(StandardCharsets.UTF_8));
+        String claims = issuer == null
+                ? "{\"azp\":\"" + CLIENT_ID_VALUE + "\",\"aud\":[\"" + CLIENT_ID_VALUE + "\"]}"
+                : "{\"azp\":\"" + CLIENT_ID_VALUE + "\",\"aud\":[\"" + CLIENT_ID_VALUE
+                        + "\"],\"iss\":\"" + issuer + "\"}";
+        String payload = Base64.getUrlEncoder().withoutPadding()
+                .encodeToString(claims.getBytes(StandardCharsets.UTF_8));
+        return header + "." + payload + ".c2ln";
+    }
+
+    /**
+     * Wire an application owned by the sub organization whose configured token issuer is the given
+     * tenant, and make the issuer of each tenant resolvable.
+     */
+    private void mockApplicationWithIssuer(MockedStatic<OAuth2OIDCConfigOrgUsageScopeUtils> issuerUtils,
+                                           String issuerTenantDomain) throws Exception {
+
+        OAuthAppDO oAuthAppDO = new OAuthAppDO();
+        if (issuerTenantDomain != null) {
+            IssuerDetails issuerDetails = new IssuerDetails();
+            issuerDetails.setIssuerTenantDomain(issuerTenantDomain);
+            oAuthAppDO.setIssuerDetails(issuerDetails);
+        }
+        oAuth2Util.when(() -> OAuth2Util.getAppInformationByClientId(CLIENT_ID_VALUE)).thenReturn(oAuthAppDO);
+        oAuth2Util.when(() -> OAuth2Util.getTenantDomainOfOauthApp(oAuthAppDO)).thenReturn(SUB_ORG_TENANT);
+        lenient().when(mockOAuthServerConfiguration.isJWTSignedWithSPKey()).thenReturn(true);
+        issuerUtils.when(() -> OAuth2OIDCConfigOrgUsageScopeUtils.getIssuerLocation(SUB_ORG_TENANT))
+                .thenReturn(SUB_ORG_ISSUER);
+        issuerUtils.when(() -> OAuth2OIDCConfigOrgUsageScopeUtils.getIssuerLocation(SUPER_TENANT_DOMAIN_NAME))
+                .thenReturn(ROOT_ISSUER);
+    }
+
+    @DataProvider(name = "signingTenantResolutionDataProvider")
+    public Object[][] signingTenantResolutionDataProvider() {
+
+        return new Object[][]{
+                // issuer claim, application token issuer tenant, expected tenant used for validation.
+                // The application owner tenant issued the token.
+                {SUB_ORG_ISSUER, SUB_ORG_TENANT, SUB_ORG_TENANT},
+                // The application is configured to issue from the root organization, so the root key signed it.
+                {ROOT_ISSUER, SUPER_TENANT_DOMAIN_NAME, SUPER_TENANT_DOMAIN_NAME},
+                // The root issuer must not be selected when the application issues from the sub organization.
+                {ROOT_ISSUER, SUB_ORG_TENANT, null},
+                // An issuer naming an unrelated organization is not accepted.
+                {"https://localhost:9443/o/11111111-2222-3333-4444-555555555555/oauth2/token", SUB_ORG_TENANT, null},
+                // A foreign origin must not select a key even when the organization segment is correct.
+                {"https://evil.example.com/o/" + SUB_ORG_ID + "/oauth2/token", SUB_ORG_TENANT, null},
+                // A scheme downgrade must not select a key.
+                {"http://localhost:9443/o/" + SUB_ORG_ID + "/oauth2/token", SUB_ORG_TENANT, null},
+                // A different port must not select a key.
+                {"https://localhost:9999/o/" + SUB_ORG_ID + "/oauth2/token", SUB_ORG_TENANT, null},
+                // The organization qualified issuer resolves to the owning organization's tenant.
+                {ORG_QUALIFIED_ISSUER, SUB_ORG_TENANT, SUB_ORG_TENANT},
+                // An unrecognised issuer is rejected.
+                {"https://localhost:9443/some/other/path", SUB_ORG_TENANT, null},
+                // A token with no issuer claim is rejected.
+                {null, SUB_ORG_TENANT, null},
+                /*
+                 The tenant qualified issuer form, /t/<tenant-domain>/oauth2/token, which is produced when
+                 the relying party obtains the token through the tenant's own endpoints. The organization
+                 qualified form of the same tenant is a different string, so both must be recognised.
+                */
+                {TENANT_QUALIFIED_ISSUER, SUB_ORG_TENANT, SUB_ORG_TENANT},
+                // The application owner tenant is accepted regardless of the configured token issuer.
+                {TENANT_QUALIFIED_ISSUER, SUPER_TENANT_DOMAIN_NAME, SUB_ORG_TENANT},
+                // The configured token issuer tenant is accepted in the tenant qualified form.
+                {ROOT_TENANT_QUALIFIED_ISSUER, SUPER_TENANT_DOMAIN_NAME, SUPER_TENANT_DOMAIN_NAME},
+                // The root tenant must not be selected when the application issues from the sub organization.
+                {ROOT_TENANT_QUALIFIED_ISSUER, SUB_ORG_TENANT, null},
+                // A tenant qualified issuer naming an unrelated tenant is not accepted.
+                {"https://localhost:9443/t/unrelated-tenant/oauth2/token", SUB_ORG_TENANT, null},
+                // A foreign origin must not select a key even when the tenant segment is correct.
+                {"https://evil.example.com/t/sub-org-tenant/oauth2/token", SUB_ORG_TENANT, null},
+                // A scheme downgrade must not select a key.
+                {"http://localhost:9443/t/sub-org-tenant/oauth2/token", SUB_ORG_TENANT, null},
+                // A different port must not select a key.
+                {"https://localhost:9999/t/sub-org-tenant/oauth2/token", SUB_ORG_TENANT, null},
+        };
+    }
+
+    @Test(dataProvider = "signingTenantResolutionDataProvider")
+    public void testResolveSigningTenantDomain(String issuerClaim, String appIssuerTenant, String expectedTenant)
+            throws Exception {
+
+        try (MockedStatic<OAuth2OIDCConfigOrgUsageScopeUtils> issuerUtils =
+                     mockStatic(OAuth2OIDCConfigOrgUsageScopeUtils.class)) {
+            mockApplicationWithIssuer(issuerUtils, appIssuerTenant);
+            /*
+             The organization manager must resolve the organization in the issuer to the application owner
+             tenant. Without it the organization qualified branch fails for an unrelated reason and the
+             assertions on the origin of the issuer would pass whether or not the origin is checked.
+            */
+            OrganizationManager organizationManager = mock(OrganizationManager.class);
+            lenient().when(organizationManager.resolveTenantDomain(SUB_ORG_ID)).thenReturn(SUB_ORG_TENANT);
+            OIDCSessionManagementComponentServiceHolder.getInstance().setOrganizationManager(organizationManager);
+            try {
+                Object resolved = invokePrivateMethod(logoutServlet, "resolveSigningTenantDomain",
+                        idTokenWithIssuer(issuerClaim));
+                assertEquals(resolved, expectedTenant);
+            } finally {
+                OIDCSessionManagementComponentServiceHolder.getInstance().setOrganizationManager(null);
+            }
+        }
+    }
+
+    @Test
+    public void testResolveSigningTenantDomainWithOrganizationQualifiedIssuer() throws Exception {
+
+        // The organization qualified issuer resolves to the tenant of the organization that owns the
+        // application, which is how a token obtained through /o/<org-id>/oauth2/token is validated.
+        try (MockedStatic<OAuth2OIDCConfigOrgUsageScopeUtils> issuerUtils =
+                     mockStatic(OAuth2OIDCConfigOrgUsageScopeUtils.class)) {
+            mockApplicationWithIssuer(issuerUtils, SUB_ORG_TENANT);
+            OrganizationManager organizationManager = mock(OrganizationManager.class);
+            when(organizationManager.resolveTenantDomain(SUB_ORG_ID)).thenReturn(SUB_ORG_TENANT);
+            OIDCSessionManagementComponentServiceHolder.getInstance()
+                    .setOrganizationManager(organizationManager);
+            try {
+                Object resolved = invokePrivateMethod(logoutServlet, "resolveSigningTenantDomain",
+                        idTokenWithIssuer(ORG_QUALIFIED_ISSUER));
+                assertEquals(resolved, SUB_ORG_TENANT);
+            } finally {
+                OIDCSessionManagementComponentServiceHolder.getInstance().setOrganizationManager(null);
+            }
+        }
+    }
+
+    @Test
+    public void testResolveSigningTenantDomainWithTenantQualifiedIssuer() throws Exception {
+
+        // A token obtained through /t/<tenant-domain>/oauth2/token carries an issuer that names the tenant
+        // directly. It is signed by the same key as the organization qualified form of that tenant, so it
+        // must resolve to the same tenant.
+        try (MockedStatic<OAuth2OIDCConfigOrgUsageScopeUtils> issuerUtils =
+                     mockStatic(OAuth2OIDCConfigOrgUsageScopeUtils.class)) {
+            mockApplicationWithIssuer(issuerUtils, SUPER_TENANT_DOMAIN_NAME);
+            /*
+             The organization manager is deliberately left unset. The tenant qualified form names the tenant
+             in the path, so it must resolve without reaching organization management at all.
+            */
+            Object resolved = invokePrivateMethod(logoutServlet, "resolveSigningTenantDomain",
+                    idTokenWithIssuer(TENANT_QUALIFIED_ISSUER));
+            assertEquals(resolved, SUB_ORG_TENANT);
+        }
+    }
+
+    @Test
+    public void testResolveSigningTenantDomainRejectsUnrelatedTenantInIssuer() throws Exception {
+
+        // The tenant named in a tenant qualified issuer must be one of the two tenants that may issue for
+        // the application. An issuer naming any other tenant must not select a key.
+        try (MockedStatic<OAuth2OIDCConfigOrgUsageScopeUtils> issuerUtils =
+                     mockStatic(OAuth2OIDCConfigOrgUsageScopeUtils.class)) {
+            mockApplicationWithIssuer(issuerUtils, SUB_ORG_TENANT);
+            Object resolved = invokePrivateMethod(logoutServlet, "resolveSigningTenantDomain",
+                    idTokenWithIssuer("https://localhost:9443/t/another-tenant/oauth2/token"));
+            assertEquals(resolved, null);
+        }
+    }
+
+    @Test
+    public void testResolveSigningTenantDomainDeniesWhenIssuerResolutionFails() throws Exception {
+
+        // Issuer resolution reaches services that may be unavailable and fail with unchecked exceptions.
+        // The request must be denied rather than failing with a server error.
+        try (MockedStatic<OAuth2OIDCConfigOrgUsageScopeUtils> issuerUtils =
+                     mockStatic(OAuth2OIDCConfigOrgUsageScopeUtils.class)) {
+            mockApplicationWithIssuer(issuerUtils, SUB_ORG_TENANT);
+            issuerUtils.when(() -> OAuth2OIDCConfigOrgUsageScopeUtils.getIssuerLocation(SUB_ORG_TENANT))
+                    .thenThrow(new NullPointerException("organization manager is not available"));
+            Object resolved = invokePrivateMethod(logoutServlet, "resolveSigningTenantDomain",
+                    idTokenWithIssuer(SUB_ORG_ISSUER));
+            assertEquals(resolved, null);
+        }
     }
 
     private void mockServiceURLBuilder(String context, MockedStatic<ServiceURLBuilder> serviceURLBuilder)

--- a/components/org.wso2.carbon.identity.oidc.session/src/test/java/org/wso2/carbon/identity/oidc/session/servlet/OIDCLogoutServletTest.java
+++ b/components/org.wso2.carbon.identity.oidc.session/src/test/java/org/wso2/carbon/identity/oidc/session/servlet/OIDCLogoutServletTest.java
@@ -45,11 +45,11 @@ import org.wso2.carbon.identity.core.util.IdentityDatabaseUtil;
 import org.wso2.carbon.identity.core.util.IdentityKeyStoreResolverConstants;
 import org.wso2.carbon.identity.core.util.IdentityKeyStoreResolverException;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.oauth.common.exception.InvalidOAuthClientException;
 import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
 import org.wso2.carbon.identity.oauth.dao.OAuthAppDO;
 import org.wso2.carbon.identity.oauth.tokenprocessor.TokenPersistenceProcessor;
 import org.wso2.carbon.identity.oauth2.config.models.IssuerDetails;
-import org.wso2.carbon.identity.oauth2.config.utils.OAuth2OIDCConfigOrgUsageScopeUtils;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 import org.wso2.carbon.identity.oidc.session.OIDCSessionConstants;
 import org.wso2.carbon.identity.oidc.session.OIDCSessionManager;
@@ -59,6 +59,7 @@ import org.wso2.carbon.identity.oidc.session.cache.OIDCSessionDataCacheKey;
 import org.wso2.carbon.identity.oidc.session.internal.OIDCSessionManagementComponentServiceHolder;
 import org.wso2.carbon.identity.oidc.session.util.OIDCSessionManagementUtil;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
+import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
 
 import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
@@ -685,8 +686,12 @@ public class OIDCLogoutServletTest extends TestOIDCSessionBase {
      * tenant, and make the issuer of each tenant resolvable. The application is resolvable both by
      * client id alone and within its own tenant, which are the two lookups the servlet uses.
      */
-    private void mockApplicationWithIssuer(MockedStatic<OAuth2OIDCConfigOrgUsageScopeUtils> issuerUtils,
-                                           String issuerTenantDomain) throws Exception {
+    /**
+     * Register an application owned by the sub organization tenant, optionally carrying a configured
+     * token issuer. A null issuer tenant domain leaves the application without one, which is the state of
+     * an application migrated from before the setting existed.
+     */
+    private void mockApplication(String issuerTenantDomain) throws Exception {
 
         OAuthAppDO oAuthAppDO = new OAuthAppDO();
         if (issuerTenantDomain != null) {
@@ -699,10 +704,6 @@ public class OIDCLogoutServletTest extends TestOIDCSessionBase {
                 .thenReturn(oAuthAppDO);
         oAuth2Util.when(() -> OAuth2Util.getTenantDomainOfOauthApp(oAuthAppDO)).thenReturn(SUB_ORG_TENANT);
         lenient().when(mockOAuthServerConfiguration.isJWTSignedWithSPKey()).thenReturn(true);
-        issuerUtils.when(() -> OAuth2OIDCConfigOrgUsageScopeUtils.getIssuerLocation(SUB_ORG_TENANT))
-                .thenReturn(SUB_ORG_ISSUER);
-        issuerUtils.when(() -> OAuth2OIDCConfigOrgUsageScopeUtils.getIssuerLocation(SUPER_TENANT_DOMAIN_NAME))
-                .thenReturn(ROOT_ISSUER);
     }
 
     /**
@@ -739,90 +740,71 @@ public class OIDCLogoutServletTest extends TestOIDCSessionBase {
     @DataProvider(name = "signingTenantResolutionDataProvider")
     public Object[][] signingTenantResolutionDataProvider() {
 
+        /*
+         The tenant that issues id tokens for the application, and the tenant its signature is validated
+         against, when the request carries an accessing organization. That is the tenant qualified
+         organization endpoint form, /t/<tenant-domain>/o/<organization-id>/.
+        */
         return new Object[][]{
-                // issuer claim, application token issuer tenant, expected tenant used for validation.
-                // The application owner tenant issued the token.
-                {SUB_ORG_ISSUER, SUB_ORG_TENANT, SUB_ORG_TENANT},
-                // The application is configured to issue from the root organization, so the root key signed it.
-                {ROOT_ISSUER, SUPER_TENANT_DOMAIN_NAME, SUPER_TENANT_DOMAIN_NAME},
-                // The root issuer must not be selected when the application issues from the sub organization.
-                {ROOT_ISSUER, SUB_ORG_TENANT, null},
-                // An issuer naming an unrelated organization is not accepted.
-                {"https://localhost:9443/o/11111111-2222-3333-4444-555555555555/oauth2/token", SUB_ORG_TENANT, null},
-                // A foreign origin must not select a key even when the organization segment is correct.
-                {"https://evil.example.com/o/" + SUB_ORG_ID + "/oauth2/token", SUB_ORG_TENANT, null},
-                // A scheme downgrade must not select a key.
-                {"http://localhost:9443/o/" + SUB_ORG_ID + "/oauth2/token", SUB_ORG_TENANT, null},
-                // A different port must not select a key.
-                {"https://localhost:9999/o/" + SUB_ORG_ID + "/oauth2/token", SUB_ORG_TENANT, null},
-                /*
-                 The organization qualified form is not accepted. The relying party is expected to use the
-                 same endpoint form for login and for logout, so a token obtained through
-                 /o/<organization-id>/oauth2/token is logged out through that same form, where the request
-                 carries no accessing organization and never reaches this comparison.
-                */
-                {ORG_QUALIFIED_ISSUER, SUB_ORG_TENANT, null},
-                // An unrecognised issuer is rejected.
-                {"https://localhost:9443/some/other/path", SUB_ORG_TENANT, null},
-                // A token with no issuer claim is rejected.
-                {null, SUB_ORG_TENANT, null},
-                /*
-                 The tenant qualified issuer form, /t/<tenant-domain>/oauth2/token, is not accepted either,
-                 for the same reason. It is produced when the relying party obtains the token through the
-                 tenant's own endpoints, and logout through those same endpoints does not reach here.
-                */
-                {TENANT_QUALIFIED_ISSUER, SUB_ORG_TENANT, null},
-                {TENANT_QUALIFIED_ISSUER, SUPER_TENANT_DOMAIN_NAME, null},
-                /*
-                 A path qualified form of the configured token issuer tenant is not accepted. When that
-                 tenant issues, the issuer claim is its own issuer location, which the configured token
-                 issuer check matches directly, so the server never produces this form.
-                */
-                {ROOT_TENANT_QUALIFIED_ISSUER, SUPER_TENANT_DOMAIN_NAME, null},
-                // The root tenant must not be selected when the application issues from the sub organization.
-                {ROOT_TENANT_QUALIFIED_ISSUER, SUB_ORG_TENANT, null},
-                // A tenant qualified issuer naming an unrelated tenant is not accepted.
-                {"https://localhost:9443/t/unrelated-tenant/oauth2/token", SUB_ORG_TENANT, null},
-                // A foreign origin must not select a key even when the tenant segment is correct.
-                {"https://evil.example.com/t/sub-org-tenant/oauth2/token", SUB_ORG_TENANT, null},
-                // A scheme downgrade must not select a key.
-                {"http://localhost:9443/t/sub-org-tenant/oauth2/token", SUB_ORG_TENANT, null},
-                // A different port must not select a key.
-                {"https://localhost:9999/t/sub-org-tenant/oauth2/token", SUB_ORG_TENANT, null},
+                // The configured token issuer is the root organization, the default for a new application.
+                {SUPER_TENANT_DOMAIN_NAME, SUPER_TENANT_DOMAIN_NAME},
+                // The configured token issuer is the application's own organization.
+                {SUB_ORG_TENANT, SUB_ORG_TENANT},
                 /*
                  An application with no token issuer configured, the state of one migrated from before the
                  setting existed. Issuance falls back to the tenant serving the request, so the root
-                 organization of the application's own organization is a legitimate issuer for it.
+                 organization of the application's own organization issues for it.
                 */
-                {ROOT_ISSUER, null, SUPER_TENANT_DOMAIN_NAME},
-                /*
-                 An application with no issuer configured issues from its root organization, so only that
-                 issuer is accepted. A token carrying the organization's own issuer was obtained through a
-                 different endpoint form and is logged out through that same form.
-                */
-                {SUB_ORG_ISSUER, null, null},
-                // An unrelated issuer is still refused when the application has no issuer configured.
-                {"https://localhost:9443/t/another-tenant/oauth2/token", null, null},
-                // A foreign origin is still refused when the application has no issuer configured.
-                {"https://evil.example.com/o/" + SUB_ORG_ID + "/oauth2/token", null, null},
+                {null, SUPER_TENANT_DOMAIN_NAME},
         };
     }
 
     @Test(dataProvider = "signingTenantResolutionDataProvider")
-    public void testResolveSigningTenantDomain(String issuerClaim, String appIssuerTenant, String expectedTenant)
+    public void testResolveSigningTenantDomain(String configuredIssuerTenant, String expectedTenant)
             throws Exception {
 
-        try (MockedStatic<OAuth2OIDCConfigOrgUsageScopeUtils> issuerUtils =
-                     mockStatic(OAuth2OIDCConfigOrgUsageScopeUtils.class)) {
-            mockApplicationWithIssuer(issuerUtils, appIssuerTenant);
-            mockAccessingOrganization();
-            try {
-                Object resolved = invokePrivateMethod(logoutServlet, "resolveSigningTenantDomain",
-                        idTokenWithIssuer(issuerClaim));
-                assertEquals(resolved, expectedTenant);
-            } finally {
-                clearAccessingOrganization();
-            }
+        mockApplication(configuredIssuerTenant);
+        mockAccessingOrganization();
+        try {
+            Object resolved = invokePrivateMethod(logoutServlet, "resolveSigningTenantDomain",
+                    idTokenWithIssuer(SUB_ORG_ISSUER));
+            assertEquals(resolved, expectedTenant);
+        } finally {
+            clearAccessingOrganization();
+        }
+    }
+
+    @DataProvider(name = "issuerClaimDataProvider")
+    public Object[][] issuerClaimDataProvider() {
+
+        /*
+         The relying party is expected to use the same endpoint form for login and for logout, so a token
+         reaching this path was issued by the tenant the application is configured to issue from. The
+         issuer claim is therefore not consulted, and the signature check is what refuses a token that
+         this server did not issue.
+        */
+        return new Object[][]{
+                {SUB_ORG_ISSUER},
+                {ROOT_ISSUER},
+                {ORG_QUALIFIED_ISSUER},
+                {TENANT_QUALIFIED_ISSUER},
+                {"https://evil.example.com/o/" + SUB_ORG_ID + "/oauth2/token"},
+                {"https://localhost:9443/some/other/path"},
+                {null},
+        };
+    }
+
+    @Test(dataProvider = "issuerClaimDataProvider")
+    public void testResolveSigningTenantDomainIgnoresIssuerClaim(String issuerClaim) throws Exception {
+
+        mockApplication(SUPER_TENANT_DOMAIN_NAME);
+        mockAccessingOrganization();
+        try {
+            Object resolved = invokePrivateMethod(logoutServlet, "resolveSigningTenantDomain",
+                    idTokenWithIssuer(issuerClaim));
+            assertEquals(resolved, SUPER_TENANT_DOMAIN_NAME);
+        } finally {
+            clearAccessingOrganization();
         }
     }
 
@@ -830,117 +812,89 @@ public class OIDCLogoutServletTest extends TestOIDCSessionBase {
     public Object[][] ownTenantRequestDataProvider() {
 
         /*
-         Issuer claims and the tenant each must resolve to when there is no accessing organization. The
-         request is then served in the tenant that owns the application, so any issuer resolves to that
-         tenant. A token carrying no issuer claim at all is still rejected, by the check that runs before
-         the application is looked up.
+         Without an accessing organization the request is already served in the tenant that owns the
+         application, which is the case for the root organization and for the organization qualified and
+         tenant qualified endpoints of the organization itself. The application owner tenant is used
+         whatever the issuer claim carries.
         */
         return new Object[][]{
-                {SUB_ORG_ISSUER, SUB_ORG_TENANT},
-                {ORG_QUALIFIED_ISSUER, SUB_ORG_TENANT},
-                {TENANT_QUALIFIED_ISSUER, SUB_ORG_TENANT},
-                {ROOT_ISSUER, SUB_ORG_TENANT},
-                {"https://evil.example.com/t/sub-org-tenant/oauth2/token", SUB_ORG_TENANT},
-                {null, null},
+                {SUB_ORG_ISSUER},
+                {ORG_QUALIFIED_ISSUER},
+                {TENANT_QUALIFIED_ISSUER},
+                {ROOT_ISSUER},
+                {"https://evil.example.com/t/sub-org-tenant/oauth2/token"},
+                {null},
         };
     }
 
     @Test(dataProvider = "ownTenantRequestDataProvider")
-    public void testResolveSigningTenantDomainWithoutAccessingOrganization(String issuerClaim,
-                                                                            String expectedTenant)
+    public void testResolveSigningTenantDomainWithoutAccessingOrganization(String issuerClaim)
             throws Exception {
 
-        /*
-         Without an accessing organization the request is already served in the tenant that owns the
-         application, so the token was issued in that same tenant and its key is the application owner
-         tenant key. The issuer claim is not consulted on this path.
-        */
-        try (MockedStatic<OAuth2OIDCConfigOrgUsageScopeUtils> issuerUtils =
-                     mockStatic(OAuth2OIDCConfigOrgUsageScopeUtils.class)) {
-            mockApplicationWithIssuer(issuerUtils, SUB_ORG_TENANT);
+        mockApplication(SUPER_TENANT_DOMAIN_NAME);
+        Object resolved = invokePrivateMethod(logoutServlet, "resolveSigningTenantDomain",
+                idTokenWithIssuer(issuerClaim));
+        assertEquals(resolved, SUB_ORG_TENANT);
+    }
+
+    @Test
+    public void testResolveSigningTenantDomainDeniesUnparseableToken() throws Exception {
+
+        // The id token hint is a request parameter, so it is not necessarily a token this server issued.
+        mockApplication(SUPER_TENANT_DOMAIN_NAME);
+        Object resolved = invokePrivateMethod(logoutServlet, "resolveSigningTenantDomain", "not.a.jwt");
+        assertEquals(resolved, null);
+    }
+
+    @Test
+    public void testResolveSigningTenantDomainDeniesUnknownClient() throws Exception {
+
+        // The client id carried by the token is not registered here, so no tenant can be resolved.
+        oAuth2Util.when(() -> OAuth2Util.getAppInformationByClientId(CLIENT_ID_VALUE, SUB_ORG_TENANT))
+                .thenThrow(new InvalidOAuthClientException("Cannot find an application for the client id."));
+        lenient().when(mockOAuthServerConfiguration.isJWTSignedWithSPKey()).thenReturn(true);
+        mockAccessingOrganization();
+        try {
             Object resolved = invokePrivateMethod(logoutServlet, "resolveSigningTenantDomain",
-                    idTokenWithIssuer(issuerClaim));
-            assertEquals(resolved, expectedTenant);
+                    idTokenWithIssuer(SUB_ORG_ISSUER));
+            assertEquals(resolved, null);
+        } finally {
+            clearAccessingOrganization();
         }
     }
 
     @Test
-    public void testResolveSigningTenantDomainWithOrganizationQualifiedIssuer() throws Exception {
+    public void testResolveSigningTenantDomainDeniesWhenOrganizationResolutionFails() throws Exception {
 
-        // A token obtained through /o/<org-id>/oauth2/token is logged out through that same endpoint form,
-        // where no accessing organization is set. Reaching this comparison with that issuer means the
-        // relying party crossed endpoint forms, which is not supported, so no key is selected.
-        try (MockedStatic<OAuth2OIDCConfigOrgUsageScopeUtils> issuerUtils =
-                     mockStatic(OAuth2OIDCConfigOrgUsageScopeUtils.class)) {
-            mockApplicationWithIssuer(issuerUtils, SUB_ORG_TENANT);
-            mockAccessingOrganization();
-            try {
-                Object resolved = invokePrivateMethod(logoutServlet, "resolveSigningTenantDomain",
-                        idTokenWithIssuer(ORG_QUALIFIED_ISSUER));
-                assertEquals(resolved, null);
-            } finally {
-                clearAccessingOrganization();
-            }
+        // The accessing organization cannot be resolved to a tenant, so no key can be selected.
+        mockApplication(SUPER_TENANT_DOMAIN_NAME);
+        OrganizationManager organizationManager = mockAccessingOrganization();
+        try {
+            when(organizationManager.resolveTenantDomain(SUB_ORG_ID))
+                    .thenThrow(new OrganizationManagementException("organization not found"));
+            Object resolved = invokePrivateMethod(logoutServlet, "resolveSigningTenantDomain",
+                    idTokenWithIssuer(SUB_ORG_ISSUER));
+            assertEquals(resolved, null);
+        } finally {
+            clearAccessingOrganization();
         }
     }
 
     @Test
-    public void testResolveSigningTenantDomainWithTenantQualifiedIssuer() throws Exception {
+    public void testResolveSigningTenantDomainDeniesWhenResolutionFailsUnchecked() throws Exception {
 
-        // A token obtained through /t/<tenant-domain>/oauth2/token is logged out through that same endpoint
-        // form, where no accessing organization is set. Reaching this comparison with that issuer means the
-        // relying party crossed endpoint forms, which is not supported, so no key is selected.
-        try (MockedStatic<OAuth2OIDCConfigOrgUsageScopeUtils> issuerUtils =
-                     mockStatic(OAuth2OIDCConfigOrgUsageScopeUtils.class)) {
-            mockApplicationWithIssuer(issuerUtils, SUPER_TENANT_DOMAIN_NAME);
-            mockAccessingOrganization();
-            try {
-                Object resolved = invokePrivateMethod(logoutServlet, "resolveSigningTenantDomain",
-                        idTokenWithIssuer(TENANT_QUALIFIED_ISSUER));
-                assertEquals(resolved, null);
-            } finally {
-                clearAccessingOrganization();
-            }
-        }
-    }
-
-    @Test
-    public void testResolveSigningTenantDomainRejectsUnrelatedTenantInIssuer() throws Exception {
-
-        // The tenant named in a tenant qualified issuer must be one of the two tenants that may issue for
-        // the application. An issuer naming any other tenant must not select a key.
-        try (MockedStatic<OAuth2OIDCConfigOrgUsageScopeUtils> issuerUtils =
-                     mockStatic(OAuth2OIDCConfigOrgUsageScopeUtils.class)) {
-            mockApplicationWithIssuer(issuerUtils, SUB_ORG_TENANT);
-            mockAccessingOrganization();
-            try {
-                Object resolved = invokePrivateMethod(logoutServlet, "resolveSigningTenantDomain",
-                        idTokenWithIssuer("https://localhost:9443/t/another-tenant/oauth2/token"));
-                assertEquals(resolved, null);
-            } finally {
-                clearAccessingOrganization();
-            }
-        }
-    }
-
-    @Test
-    public void testResolveSigningTenantDomainDeniesWhenIssuerResolutionFails() throws Exception {
-
-        // Issuer resolution reaches services that may be unavailable and fail with unchecked exceptions.
-        // The request must be denied rather than failing with a server error.
-        try (MockedStatic<OAuth2OIDCConfigOrgUsageScopeUtils> issuerUtils =
-                     mockStatic(OAuth2OIDCConfigOrgUsageScopeUtils.class)) {
-            mockApplicationWithIssuer(issuerUtils, SUB_ORG_TENANT);
-            mockAccessingOrganization();
-            try {
-                issuerUtils.when(() -> OAuth2OIDCConfigOrgUsageScopeUtils.getIssuerLocation(SUB_ORG_TENANT))
-                        .thenThrow(new NullPointerException("organization manager is not available"));
-                Object resolved = invokePrivateMethod(logoutServlet, "resolveSigningTenantDomain",
-                        idTokenWithIssuer(SUB_ORG_ISSUER));
-                assertEquals(resolved, null);
-            } finally {
-                clearAccessingOrganization();
-            }
+        // Resolution reaches services that may be unavailable and fail with unchecked exceptions. The
+        // request must be denied rather than failing with a server error.
+        mockApplication(SUPER_TENANT_DOMAIN_NAME);
+        OrganizationManager organizationManager = mockAccessingOrganization();
+        try {
+            when(organizationManager.resolveTenantDomain(SUB_ORG_ID))
+                    .thenThrow(new NullPointerException("organization manager is not available"));
+            Object resolved = invokePrivateMethod(logoutServlet, "resolveSigningTenantDomain",
+                    idTokenWithIssuer(SUB_ORG_ISSUER));
+            assertEquals(resolved, null);
+        } finally {
+            clearAccessingOrganization();
         }
     }
 

--- a/components/org.wso2.carbon.identity.oidc.session/src/test/java/org/wso2/carbon/identity/oidc/session/servlet/OIDCLogoutServletTest.java
+++ b/components/org.wso2.carbon.identity.oidc.session/src/test/java/org/wso2/carbon/identity/oidc/session/servlet/OIDCLogoutServletTest.java
@@ -682,7 +682,8 @@ public class OIDCLogoutServletTest extends TestOIDCSessionBase {
 
     /**
      * Wire an application owned by the sub organization whose configured token issuer is the given
-     * tenant, and make the issuer of each tenant resolvable.
+     * tenant, and make the issuer of each tenant resolvable. The application is resolvable both by
+     * client id alone and within its own tenant, which are the two lookups the servlet uses.
      */
     private void mockApplicationWithIssuer(MockedStatic<OAuth2OIDCConfigOrgUsageScopeUtils> issuerUtils,
                                            String issuerTenantDomain) throws Exception {
@@ -694,12 +695,45 @@ public class OIDCLogoutServletTest extends TestOIDCSessionBase {
             oAuthAppDO.setIssuerDetails(issuerDetails);
         }
         oAuth2Util.when(() -> OAuth2Util.getAppInformationByClientId(CLIENT_ID_VALUE)).thenReturn(oAuthAppDO);
+        oAuth2Util.when(() -> OAuth2Util.getAppInformationByClientId(CLIENT_ID_VALUE, SUB_ORG_TENANT))
+                .thenReturn(oAuthAppDO);
         oAuth2Util.when(() -> OAuth2Util.getTenantDomainOfOauthApp(oAuthAppDO)).thenReturn(SUB_ORG_TENANT);
         lenient().when(mockOAuthServerConfiguration.isJWTSignedWithSPKey()).thenReturn(true);
         issuerUtils.when(() -> OAuth2OIDCConfigOrgUsageScopeUtils.getIssuerLocation(SUB_ORG_TENANT))
                 .thenReturn(SUB_ORG_ISSUER);
         issuerUtils.when(() -> OAuth2OIDCConfigOrgUsageScopeUtils.getIssuerLocation(SUPER_TENANT_DOMAIN_NAME))
                 .thenReturn(ROOT_ISSUER);
+    }
+
+    /**
+     * Wire the organization manager used while resolving the signing tenant, and put the request in the
+     * tenant qualified organization context, which is where the issuer of the token is consulted. Without
+     * an accessing organization the request is served in the tenant that owns the application and the
+     * issuer is not consulted at all, which is covered separately.
+     */
+    private OrganizationManager mockAccessingOrganization() throws Exception {
+
+        OrganizationManager organizationManager = mock(OrganizationManager.class);
+        lenient().when(organizationManager.resolveTenantDomain(SUB_ORG_ID)).thenReturn(SUB_ORG_TENANT);
+        /*
+         The application's own organization and the root of its hierarchy, used when the application has
+         no token issuer configured, which is the state of an application migrated from before the
+         setting existed.
+        */
+        lenient().when(organizationManager.resolveOrganizationId(SUB_ORG_TENANT)).thenReturn(SUB_ORG_ID);
+        lenient().when(organizationManager.getPrimaryOrganizationId(SUB_ORG_ID)).thenReturn(ROOT_ORG_ID);
+        lenient().when(organizationManager.resolveTenantDomain(ROOT_ORG_ID))
+                .thenReturn(SUPER_TENANT_DOMAIN_NAME);
+        OIDCSessionManagementComponentServiceHolder.getInstance().setOrganizationManager(organizationManager);
+        PrivilegedCarbonContext.startTenantFlow();
+        PrivilegedCarbonContext.getThreadLocalCarbonContext().setApplicationResidentOrganizationId(SUB_ORG_ID);
+        return organizationManager;
+    }
+
+    private void clearAccessingOrganization() {
+
+        PrivilegedCarbonContext.endTenantFlow();
+        OIDCSessionManagementComponentServiceHolder.getInstance().setOrganizationManager(null);
     }
 
     @DataProvider(name = "signingTenantResolutionDataProvider")
@@ -769,30 +803,52 @@ public class OIDCLogoutServletTest extends TestOIDCSessionBase {
         try (MockedStatic<OAuth2OIDCConfigOrgUsageScopeUtils> issuerUtils =
                      mockStatic(OAuth2OIDCConfigOrgUsageScopeUtils.class)) {
             mockApplicationWithIssuer(issuerUtils, appIssuerTenant);
-            /*
-             The organization manager must resolve the organization in the issuer to the application owner
-             tenant. Without it the organization qualified branch fails for an unrelated reason and the
-             assertions on the origin of the issuer would pass whether or not the origin is checked.
-            */
-            OrganizationManager organizationManager = mock(OrganizationManager.class);
-            lenient().when(organizationManager.resolveTenantDomain(SUB_ORG_ID)).thenReturn(SUB_ORG_TENANT);
-            /*
-             The application's own organization and the root of its hierarchy, used when the application has
-             no token issuer configured, which is the state of an application migrated from before the
-             setting existed.
-            */
-            lenient().when(organizationManager.resolveOrganizationId(SUB_ORG_TENANT)).thenReturn(SUB_ORG_ID);
-            lenient().when(organizationManager.getPrimaryOrganizationId(SUB_ORG_ID)).thenReturn(ROOT_ORG_ID);
-            lenient().when(organizationManager.resolveTenantDomain(ROOT_ORG_ID))
-                    .thenReturn(SUPER_TENANT_DOMAIN_NAME);
-            OIDCSessionManagementComponentServiceHolder.getInstance().setOrganizationManager(organizationManager);
+            mockAccessingOrganization();
             try {
                 Object resolved = invokePrivateMethod(logoutServlet, "resolveSigningTenantDomain",
                         idTokenWithIssuer(issuerClaim));
                 assertEquals(resolved, expectedTenant);
             } finally {
-                OIDCSessionManagementComponentServiceHolder.getInstance().setOrganizationManager(null);
+                clearAccessingOrganization();
             }
+        }
+    }
+
+    @DataProvider(name = "ownTenantRequestDataProvider")
+    public Object[][] ownTenantRequestDataProvider() {
+
+        /*
+         Issuer claims and the tenant each must resolve to when there is no accessing organization. The
+         request is then served in the tenant that owns the application, so any issuer resolves to that
+         tenant. A token carrying no issuer claim at all is still rejected, by the check that runs before
+         the application is looked up.
+        */
+        return new Object[][]{
+                {SUB_ORG_ISSUER, SUB_ORG_TENANT},
+                {ORG_QUALIFIED_ISSUER, SUB_ORG_TENANT},
+                {TENANT_QUALIFIED_ISSUER, SUB_ORG_TENANT},
+                {ROOT_ISSUER, SUB_ORG_TENANT},
+                {"https://evil.example.com/t/sub-org-tenant/oauth2/token", SUB_ORG_TENANT},
+                {null, null},
+        };
+    }
+
+    @Test(dataProvider = "ownTenantRequestDataProvider")
+    public void testResolveSigningTenantDomainWithoutAccessingOrganization(String issuerClaim,
+                                                                            String expectedTenant)
+            throws Exception {
+
+        /*
+         Without an accessing organization the request is already served in the tenant that owns the
+         application, so the token was issued in that same tenant and its key is the application owner
+         tenant key. The issuer claim is not consulted on this path.
+        */
+        try (MockedStatic<OAuth2OIDCConfigOrgUsageScopeUtils> issuerUtils =
+                     mockStatic(OAuth2OIDCConfigOrgUsageScopeUtils.class)) {
+            mockApplicationWithIssuer(issuerUtils, SUB_ORG_TENANT);
+            Object resolved = invokePrivateMethod(logoutServlet, "resolveSigningTenantDomain",
+                    idTokenWithIssuer(issuerClaim));
+            assertEquals(resolved, expectedTenant);
         }
     }
 
@@ -804,16 +860,13 @@ public class OIDCLogoutServletTest extends TestOIDCSessionBase {
         try (MockedStatic<OAuth2OIDCConfigOrgUsageScopeUtils> issuerUtils =
                      mockStatic(OAuth2OIDCConfigOrgUsageScopeUtils.class)) {
             mockApplicationWithIssuer(issuerUtils, SUB_ORG_TENANT);
-            OrganizationManager organizationManager = mock(OrganizationManager.class);
-            when(organizationManager.resolveTenantDomain(SUB_ORG_ID)).thenReturn(SUB_ORG_TENANT);
-            OIDCSessionManagementComponentServiceHolder.getInstance()
-                    .setOrganizationManager(organizationManager);
+            mockAccessingOrganization();
             try {
                 Object resolved = invokePrivateMethod(logoutServlet, "resolveSigningTenantDomain",
                         idTokenWithIssuer(ORG_QUALIFIED_ISSUER));
                 assertEquals(resolved, SUB_ORG_TENANT);
             } finally {
-                OIDCSessionManagementComponentServiceHolder.getInstance().setOrganizationManager(null);
+                clearAccessingOrganization();
             }
         }
     }
@@ -827,13 +880,14 @@ public class OIDCLogoutServletTest extends TestOIDCSessionBase {
         try (MockedStatic<OAuth2OIDCConfigOrgUsageScopeUtils> issuerUtils =
                      mockStatic(OAuth2OIDCConfigOrgUsageScopeUtils.class)) {
             mockApplicationWithIssuer(issuerUtils, SUPER_TENANT_DOMAIN_NAME);
-            /*
-             The organization manager is deliberately left unset. The tenant qualified form names the tenant
-             in the path, so it must resolve without reaching organization management at all.
-            */
-            Object resolved = invokePrivateMethod(logoutServlet, "resolveSigningTenantDomain",
-                    idTokenWithIssuer(TENANT_QUALIFIED_ISSUER));
-            assertEquals(resolved, SUB_ORG_TENANT);
+            mockAccessingOrganization();
+            try {
+                Object resolved = invokePrivateMethod(logoutServlet, "resolveSigningTenantDomain",
+                        idTokenWithIssuer(TENANT_QUALIFIED_ISSUER));
+                assertEquals(resolved, SUB_ORG_TENANT);
+            } finally {
+                clearAccessingOrganization();
+            }
         }
     }
 
@@ -845,9 +899,14 @@ public class OIDCLogoutServletTest extends TestOIDCSessionBase {
         try (MockedStatic<OAuth2OIDCConfigOrgUsageScopeUtils> issuerUtils =
                      mockStatic(OAuth2OIDCConfigOrgUsageScopeUtils.class)) {
             mockApplicationWithIssuer(issuerUtils, SUB_ORG_TENANT);
-            Object resolved = invokePrivateMethod(logoutServlet, "resolveSigningTenantDomain",
-                    idTokenWithIssuer("https://localhost:9443/t/another-tenant/oauth2/token"));
-            assertEquals(resolved, null);
+            mockAccessingOrganization();
+            try {
+                Object resolved = invokePrivateMethod(logoutServlet, "resolveSigningTenantDomain",
+                        idTokenWithIssuer("https://localhost:9443/t/another-tenant/oauth2/token"));
+                assertEquals(resolved, null);
+            } finally {
+                clearAccessingOrganization();
+            }
         }
     }
 
@@ -859,11 +918,16 @@ public class OIDCLogoutServletTest extends TestOIDCSessionBase {
         try (MockedStatic<OAuth2OIDCConfigOrgUsageScopeUtils> issuerUtils =
                      mockStatic(OAuth2OIDCConfigOrgUsageScopeUtils.class)) {
             mockApplicationWithIssuer(issuerUtils, SUB_ORG_TENANT);
-            issuerUtils.when(() -> OAuth2OIDCConfigOrgUsageScopeUtils.getIssuerLocation(SUB_ORG_TENANT))
-                    .thenThrow(new NullPointerException("organization manager is not available"));
-            Object resolved = invokePrivateMethod(logoutServlet, "resolveSigningTenantDomain",
-                    idTokenWithIssuer(SUB_ORG_ISSUER));
-            assertEquals(resolved, null);
+            mockAccessingOrganization();
+            try {
+                issuerUtils.when(() -> OAuth2OIDCConfigOrgUsageScopeUtils.getIssuerLocation(SUB_ORG_TENANT))
+                        .thenThrow(new NullPointerException("organization manager is not available"));
+                Object resolved = invokePrivateMethod(logoutServlet, "resolveSigningTenantDomain",
+                        idTokenWithIssuer(SUB_ORG_ISSUER));
+                assertEquals(resolved, null);
+            } finally {
+                clearAccessingOrganization();
+            }
         }
     }
 


### PR DESCRIPTION
## Purpose

Resolves https://github.com/wso2/product-is/issues/28231

OIDC RP initiated logout fails with `access_denied` for an application in a sub organization, and the server log reports it as a JWE decryption failure, which is a misdiagnosis. The real failure is id token signature validation.

This is the out of the box configuration: a newly created sub organization application defaults its token issuer to the root organization.

## Goals

Validate the `id_token_hint` with the key that actually signed it when logout is called on `/t/<tenant-domain>/o/<organization-id>/`, and find the application reliably rather than only when a cache happens to be warm.

## Approach

Two separate causes.

**The wrong key.** The tenant qualified organization endpoints are served in the **root** tenant, so the id token is root signed. Validation resolved the **application owner** tenant, the sub organization, and used its key.

**The application was often not found at all.** The lookup used the deprecated `getAppInformationByClientId(clientId)`, which reads a tenant unscoped cache and otherwise falls back to the tenant in the thread local context. In the root tenant a sub organization application does not exist there, so the lookup succeeded only while the application happened to be in `AppInfoCache`, and failed with `application.not.found` otherwise. That is why one request produced two different errors, and why the failure depended on whether the cache was warm.

Two measured facts shape the fix.

Only one endpoint form sets an accessing organization:

| logout called at | accessing organization set |
|---|---|
| `/oauth2/...` | no |
| `/t/<tenant-domain>/oauth2/...` | no |
| `/o/<organization-id>/oauth2/...` | no |
| `/t/<tenant-domain>/o/<organization-id>/oauth2/...` | **yes** |

And the token issuer configured on an application only takes effect for tokens obtained through `/t/<tenant-domain>/o/<organization-id>/`. On the other forms it is ignored and the sub organization key signs. So the application configuration alone does not determine which key signed a given token.

`resolveSigningTenantDomain` therefore has two paths, decided by the accessing organization.

**No accessing organization.** The request is already served in the tenant that owns the application, and the token was issued in that same tenant, so the application owner tenant key is used.

**Accessing organization present.** The application is looked up with `getAppInformationByClientId(clientId, accessingTenantDomain)`, so it is found regardless of cache state. The signature is then validated with the key of the tenant that issues id tokens for that application: its configured token issuer, or, for an application created before that setting existed, the root organization of its own organization.

Two smaller fixes: the complete id token is no longer written to the logs, since it comes from a request parameter and is credential like (CWE-532); and the error now tells a JWE decryption failure apart from a signature failure using the `INVALID_ID_TOKEN` sub error code, rather than labelling every case a JWE failure.

## Behaviour change

**A relying party must use the same endpoint form for login and for logout.** A token obtained through `/o/<organization-id>/` or `/t/<org-handle>/` and then logged out through `/t/<tenant-domain>/o/<organization-id>/` is denied. Four such combinations work on the unpatched product.

Measured over every login form crossed with every logout form, for both token issuer values:

| application | token obtained at | logout called at | unpatched | with this change |
|---|---|---|---|---|
| sub organization, issuer = root organization | `/t/<tenant>/o/<org-id>/` | `/t/<tenant>/o/<org-id>/` | fails | **works** |
| no token issuer configured | `/t/<tenant>/o/<org-id>/` | `/t/<tenant>/o/<org-id>/` | fails | **works** |
| sub organization, issuer = root organization | `/t/<org-handle>/` | `/t/<tenant>/o/<org-id>/` | works | **fails** |
| sub organization, issuer = root organization | `/o/<org-id>/` | `/t/<tenant>/o/<org-id>/` | works | **fails** |
| no token issuer configured | `/t/<org-handle>/` | `/t/<tenant>/o/<org-id>/` | works | **fails** |
| no token issuer configured | `/o/<org-id>/` | `/t/<tenant>/o/<org-id>/` | works | **fails** |

The two that begin working are the reported defect and its equivalent for an application with no token issuer configured. The four that stop working all obtain the token on one endpoint form and call logout on another. Applications owned by the root organization are unaffected.

One qualification worth stating plainly: cross form logout is not refused uniformly. It still succeeds where the tenant the application issues from also owns the signing key, and fails otherwise. The same form expectation is a convention, not something the code enforces.

This behaviour change was agreed with the B2B team.

## Release note

Fixed OIDC RP initiated logout failing with "ID token signature validation failed" for a sub organization application accessed through the tenant qualified endpoint form. Relying parties must use the same endpoint form for login and for logout.

## Automation tests

**Unit tests.** Cases on `resolveSigningTenantDomain` cover the configured token issuer tenant, an application with no token issuer configured falling back to its root organization, requests with no accessing organization, the issuer claim not being consulted, and the cases that resolve to no tenant at all: an unparseable token, a client id that is not registered, a failure resolving the accessing organization, and organization management not being available.

On a recent JDK the suite needs `-Djacoco.skip=true -DargLine="-Dnet.bytebuddy.experimental=true"`. JaCoCo cannot instrument class file major version 69 and Mockito needs the ByteBuddy flag. This is a pre existing environment issue.

**Functional matrix, IS 7.3.0.** 39 cells: every login form crossed with every logout form, for both token issuer values, over a sub organization application, a root owned application with the root organization as the accessing organization, and an application with no token issuer stored. **33 of 39 pass unpatched, 31 of 39 with this change**: 2 fixed, 4 dropped by the behaviour change above.

**Behavioural suite, IS 7.3.0.** 92 assertions over two sub organizations, a root owned application, an application shared from the root organization, an organization addressed by a named handle, and a second application per organization. **12 assertions differ from the unpatched product: 6 fixed, 4 dropped by the behaviour change, and 2 that stay denied with a clearer reason.**

**Cold start, IS 7.3.0.** Logout as the first request after a restart, so the application lookup cannot be served from cache. This is where the `application.not.found` half of the defect appears. A configured application goes from 3 of 4 to 3 of 4, one same form case fixed and one cross form case dropped. An application with no token issuer stored goes from **2 of 5 to 3 of 5**.

**Public branch build.** The same behavioural suite (48 assertions) and cold suite (12 cells) run on a build of the public branch, with the cross form assertions differing as above. On that build a newly created sub organization application also defaults to the root organization as its token issuer, so the failure occurs without changing any setting.

**Negatives, all unchanged:** tampered signature, `alg=none`, an unparseable token, tokens signed by another organization in both directions, an issuer rewritten to name another tenant, an issuer origin swapped to a foreign host, another application's redirect uri, and an unregistered redirect uri. Adjacent endpoints are unchanged too: introspection, the refresh token grant, revocation, discovery and jwks.

## Security checks

- Followed secure coding standards? yes
- Ran FindSecurityBugs plugin and verified report? no. SpotBugs runs in the build; the report was not separately reviewed.
- Confirmed no keys, passwords, tokens, usernames or secrets committed? yes

The key used is always the one belonging to the tenant the application is configured to issue from, bounded to the application's own organization or its root. That is the same bound the product already enforces when the token issuer is selected (`getAllowedIssuerDetails` returns `Arrays.asList(primaryOrgId, orgId)`). A token this server did not issue is refused by the signature check.

## Test environment

WSO2 Identity Server 7.3.0 and a build of the public branch, Temurin JDK 25, macOS 15 arm64, H2.

