### PR TITLE
Use defensive clone of AccessTokenDO before filtering scopes during token validation

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/TokenValidationHandler.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/TokenValidationHandler.java
@@ -601,6 +601,10 @@ public class TokenValidationHandler {
                             scopesToBeValidated.add(scope);
                         }
                     }
+                    // Work on a clone so the shared cached AccessTokenDO is never mutated. OAuthCache returns the
+                    // same instance to all callers (no defensive copy); filtering its scopes in place would corrupt
+                    // the cached entry, breaking subsequent introspections and revocation cache-key matching.
+                    accessTokenDO = AccessTokenDO.clone(accessTokenDO);
                     accessTokenDO.setScope(scopesToBeValidated.toArray(new String[0]));
                 }
             } catch (IllegalArgumentException e) {

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/validators/TokenValidationHandlerTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/validators/TokenValidationHandlerTest.java
@@ -98,6 +98,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.lenient;
@@ -918,10 +919,104 @@ public class TokenValidationHandlerTest {
 
             if ((!isLegacySessionBoundTokenBehaviourEnabled || !isSessionBoundTokensAllowedAfterSessionExpiry &&
                     isAppLevelTokenRevocationEnabled) && !isSessionActive) {
-                oAuthUtil.verify(() -> OAuthUtil.clearOAuthCache(accessTokenDO));
-                verify(revocationProcessor, times(1)).revokeAccessToken(
-                        any(), eq(accessTokenDO));
+                // Introspection defensively clones the AccessTokenDO before filtering scopes so the shared cached
+                // object is never mutated. The SSO-bound token revocation therefore operates on the clone, which
+                // carries the same token identity. Match on the token id instead of the exact instance.
+                oAuthUtil.verify(() -> OAuthUtil.clearOAuthCache(
+                        argThat((AccessTokenDO tokenDO) -> tokenDO != null
+                                && "sso-session-token-id".equals(tokenDO.getTokenId()))));
+                verify(revocationProcessor, times(1)).revokeAccessToken(any(),
+                        argThat((AccessTokenDO tokenDO) -> tokenDO != null
+                                && "sso-session-token-id".equals(tokenDO.getTokenId())));
             }
+        }
+    }
+
+    @Test
+    public void testCachedTokenScopesNotMutatedByIntrospection() throws Exception {
+
+        try (MockedStatic<IdentityDatabaseUtil> identityDatabaseUtil = mockStatic(IdentityDatabaseUtil.class);
+             MockedStatic<OAuthServerConfiguration> oAuthServerConfiguration =
+                     mockStatic(OAuthServerConfiguration.class);
+             MockedStatic<OAuth2ServiceComponentHolder> oAuth2ServiceComponentHolder =
+                     mockStatic(OAuth2ServiceComponentHolder.class);
+             MockedStatic<OAuth2Util> oAuth2Util = mockStatic(OAuth2Util.class);
+             MockedStatic<IdentityUtil> identityUtil = mockStatic(IdentityUtil.class);
+             MockedStatic<OrganizationManagementUtil> organizationManagementUtil =
+                     mockStatic(OrganizationManagementUtil.class);
+             MockedStatic<FrameworkUtils> frameworkUtils = mockStatic(FrameworkUtils.class);
+             MockedStatic<OAuthUtil> oAuthUtil = mockStatic(OAuthUtil.class)) {
+
+            organizationManagementUtil.when(() -> OrganizationManagementUtil.isOrganization(anyString()))
+                    .thenReturn(false);
+            mockRequiredObjects(oAuthServerConfiguration, identityDatabaseUtil);
+
+            oAuthServerConfiguration.when(
+                            () -> OAuthServerConfiguration.getInstance().isCrossTenantTokenIntrospectionAllowed())
+                    .thenReturn(true);
+            oAuthServerConfiguration.when(
+                            () -> OAuthServerConfiguration.getInstance().allowCrossTenantIntrospectionForSubOrgTokens())
+                    .thenReturn(true);
+            // Configure allowed scopes — this triggers the scope filtering logic in validateAccessToken.
+            List<String> allowedScopes = new ArrayList<>();
+            allowedScopes.add("openid");
+            oAuthServerConfiguration.when(() -> OAuthServerConfiguration.getInstance().getAllowedScopes())
+                    .thenReturn(allowedScopes);
+
+            OAuth2ServiceComponentHolder oAuth2ServiceComponentHolderInstance =
+                    Mockito.mock(OAuth2ServiceComponentHolder.class);
+            oAuth2ServiceComponentHolder.when(OAuth2ServiceComponentHolder::getInstance)
+                    .thenReturn(oAuth2ServiceComponentHolderInstance);
+
+            OAuthComponentServiceHolder.getInstance().setRealmService(realmService);
+            IdentityTenantUtil.setRealmService(realmService);
+            lenient().when(realmService.getBootstrapRealmConfiguration()).thenReturn(realmConfiguration);
+            identityUtil.when(IdentityUtil::getPrimaryDomainName).thenReturn("PRIMARY");
+
+            PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain("carbon.super");
+            PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantId(MultitenantConstants.SUPER_TENANT_ID);
+
+            OAuth2TokenValidationRequestDTO validationRequest = new OAuth2TokenValidationRequestDTO();
+            OAuth2TokenValidationRequestDTO.OAuth2AccessToken accessToken = validationRequest.new OAuth2AccessToken();
+            accessToken.setIdentifier("test-access-token-scope-restore");
+            accessToken.setTokenType("bearer");
+            validationRequest.setAccessToken(accessToken);
+
+            // Create token with scopes including an allowed scope ("openid") that will be filtered.
+            String[] originalScopes = new String[]{"openid", "scope1", "scope2"};
+            AccessTokenDO accessTokenDO = new AccessTokenDO(clientId, authzUser, originalScopes, issuedTime,
+                    refreshTokenIssuedTime, validityPeriodInMillis, refreshTokenValidityPeriodInMillis, tokenType,
+                    authorizationCode);
+            accessTokenDO.setTokenId("test-token-id-scope-not-mutated");
+
+            TokenProvider tokenProvider = Mockito.mock(TokenProvider.class);
+            when(oAuth2ServiceComponentHolderInstance.getTokenProvider()).thenReturn(tokenProvider);
+            when(tokenProvider.getVerifiedAccessToken(anyString(), anyBoolean())).thenReturn(accessTokenDO);
+            oAuth2Util.when(() -> OAuth2Util.getAppInformationByAccessTokenDO(any())).thenReturn(new OAuthAppDO());
+
+            ServiceProvider serviceProvider = new ServiceProvider();
+            serviceProvider.setApplicationVersion("v1.0.0");
+            oAuth2Util.when(() -> OAuth2Util.getServiceProvider(anyString(), any()))
+                    .thenReturn(serviceProvider);
+            oAuth2Util.when(() -> OAuth2Util.getAccessTokenExpireMillis(any(), anyBoolean())).thenReturn(1000L);
+            oAuth2Util.when(() -> OAuth2Util.getTenantDomain(anyInt())).thenReturn(StringUtils.EMPTY);
+            oAuth2Util.when(() -> OAuth2Util.buildScopeString(any(String[].class))).thenCallRealMethod();
+            oAuth2Util.when(() -> OAuth2Util.isAllowedScope(any(), anyString())).thenCallRealMethod();
+
+            OAuth2IntrospectionResponseDTO introspectionResponse = tokenValidationHandler
+                    .buildIntrospectionResponse(validationRequest);
+
+            assertNotNull(introspectionResponse, "Introspection response should not be null");
+
+            // Verify that the cached AccessTokenDO is never mutated by introspection. The validation logic filters
+            // out allowed scopes on a clone, so the original (cache-referenced) object retains its full scopes.
+            // Before the fix, this object was mutated in place to only contain non-allowed scopes (e.g., "openid"
+            // would be stripped), causing cache key mismatches during subsequent operations like revocation.
+            String[] scopesAfterIntrospection = accessTokenDO.getScope();
+            assertEquals(scopesAfterIntrospection.length, originalScopes.length,
+                    "Scope count on the cached AccessTokenDO should be unchanged after introspection");
+            assertEquals(scopesAfterIntrospection, originalScopes,
+                    "Scopes on the cached AccessTokenDO should not be mutated by introspection");
         }
     }
 }


### PR DESCRIPTION
## Root cause and fix

- During introspection, `TokenValidationHandler.validateAccessToken()` calls `accessTokenDO.setScope(scopesToBeValidated)` to strip allowed scopes before validation. `OAuthCache` hands out the same `AccessTokenDO` instance to every caller (no defensive copy), so this filtering mutates the shared cached entry permanently.
- Subsequent operations (e.g. token revocation) then see incomplete scopes, build incorrect cache keys, and fail to clear stale cache entries — causing the same token to be returned after revocation.
- Fix: clone the `AccessTokenDO` (via the existing `AccessTokenDO.clone()`) before the `setScope` call, so the cached object is never written to. Behaviour is unchanged for in-flight readers (scope validators and the introspection response still see the filtered scopes via the clone held in the message context), and it avoids the lost-update race a mutate-then-restore approach would introduce under concurrent introspection.
- The SSO-bound token revocation path now operates on the clone, which carries the same token identity; the related test asserts on token id instead of instance identity.

## Source fix

Ported from https://github.com/wso2-support/identity-inbound-auth-oauth/pull/2393 (IS 7.3).

Supersedes the earlier approach in #3071, which was reverted by #3177.

## Tests

- New `testCachedTokenScopesNotMutatedByIntrospection` asserts the cached `AccessTokenDO` retains its full scopes after introspection.
- All 41 `TokenValidationHandlerTest` tests pass.