### PR TITLE
Apply proxy_context_path to tenant qualified opbs cookie paths

### DIFF
--- a/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/DefaultOIDCSessionStateManager.java
+++ b/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/DefaultOIDCSessionStateManager.java
@@ -26,6 +26,7 @@ import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.core.SameSiteCookie;
 import org.wso2.carbon.core.ServletCookie;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
@@ -120,18 +121,21 @@ public class DefaultOIDCSessionStateManager implements OIDCSessionStateManager {
                         MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equals(loginTenantDomain)) {
                     cookie.setPath("/");
                 } else {
-                    cookie.setPath(FrameworkConstants.TENANT_CONTEXT_PREFIX + loginTenantDomain + "/");
+                    cookie.setPath(FrameworkUtils.prependProxyContextPath(
+                            FrameworkConstants.TENANT_CONTEXT_PREFIX + loginTenantDomain + "/"));
                 }
             } else if (isOrganizationQualifiedRequest()) {
                 // Handling the cookie path for request coming with the path `/o/<org-id>`.
                 String organizationId = PrivilegedCarbonContext.getThreadLocalCarbonContext().getOrganizationId();
-                cookie.setPath(FrameworkConstants.ORGANIZATION_CONTEXT_PREFIX + organizationId + "/");
+                cookie.setPath(FrameworkUtils.prependProxyContextPath(
+                        FrameworkConstants.ORGANIZATION_CONTEXT_PREFIX + organizationId + "/"));
             } else {
                 if (!IdentityTenantUtil.isSuperTenantAppendInCookiePath() &&
                         MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equals(loginTenantDomain)) {
                     cookie.setPath("/");
                 } else {
-                    cookie.setPath(FrameworkConstants.TENANT_CONTEXT_PREFIX + loginTenantDomain + "/");
+                    cookie.setPath(FrameworkUtils.prependProxyContextPath(
+                            FrameworkConstants.TENANT_CONTEXT_PREFIX + loginTenantDomain + "/"));
                 }
 
             }

--- a/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/util/OIDCSessionManagementUtil.java
+++ b/components/org.wso2.carbon.identity.oidc.session/src/main/java/org/wso2/carbon/identity/oidc/session/util/OIDCSessionManagementUtil.java
@@ -272,11 +272,13 @@ public class OIDCSessionManagementUtil {
                                 String organizationId = PrivilegedCarbonContext.getThreadLocalCarbonContext()
                                         .getOrganizationId();
                                 if (StringUtils.isNotEmpty(organizationId)) {
-                                    servletCookie.setPath(FrameworkConstants.ORGANIZATION_CONTEXT_PREFIX +
-                                            organizationId + "/");
+                                    servletCookie.setPath(FrameworkUtils.prependProxyContextPath(
+                                            FrameworkConstants.ORGANIZATION_CONTEXT_PREFIX +
+                                                    organizationId + "/"));
                                 } else {
-                                    servletCookie.setPath(FrameworkConstants.TENANT_CONTEXT_PREFIX +
-                                            tenantDomain + "/");
+                                    servletCookie.setPath(FrameworkUtils.prependProxyContextPath(
+                                            FrameworkConstants.TENANT_CONTEXT_PREFIX +
+                                                    tenantDomain + "/"));
                                 }
                             }
                         } else {

--- a/components/org.wso2.carbon.identity.oidc.session/src/test/java/org/wso2/carbon/identity/oidc/session/DefaultOIDCSessionStateManagerTest.java
+++ b/components/org.wso2.carbon.identity.oidc.session/src/test/java/org/wso2/carbon/identity/oidc/session/DefaultOIDCSessionStateManagerTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.oidc.session;
+
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+import org.wso2.carbon.base.ServerConfiguration;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.identity.common.testng.WithCarbonHome;
+import org.wso2.carbon.identity.core.util.IdentityCoreConstants;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.testng.Assert.assertEquals;
+
+/**
+ * Unit tests for the opbs cookie path resolution in {@link DefaultOIDCSessionStateManager}.
+ */
+@Listeners(MockitoTestNGListener.class)
+@WithCarbonHome
+public class DefaultOIDCSessionStateManagerTest {
+
+    private static final String OPBS_VALUE = "090907ce-eab0-40d2-a46d-acd4bb33f0d0";
+    private static final String TENANT_DOMAIN = "foo.com";
+    private static final String SUPER_TENANT_DOMAIN = "carbon.super";
+
+    @DataProvider(name = "opbsCookiePathDataProvider")
+    public Object[][] provideOpbsCookiePathData() {
+
+        return new Object[][]{
+                // loginTenantDomain, proxyContextPath, superTenantAppendInCookiePath, expectedCookiePath
+
+                // A tenanted cookie path carries the proxy context path.
+                {TENANT_DOMAIN, "auth", false, "/auth/t/" + TENANT_DOMAIN + "/"},
+
+                // The configured value is normalized before it is applied.
+                {TENANT_DOMAIN, "/auth/", false, "/auth/t/" + TENANT_DOMAIN + "/"},
+
+                // Without a proxy context path the tenanted path is unchanged.
+                {TENANT_DOMAIN, "", false, "/t/" + TENANT_DOMAIN + "/"},
+
+                // The super tenant keeps the root cookie path, which already covers any prefix.
+                {SUPER_TENANT_DOMAIN, "auth", false, "/"},
+
+                // When the super tenant is appended, its path is prefixed like any other tenant.
+                {SUPER_TENANT_DOMAIN, "auth", true, "/auth/t/" + SUPER_TENANT_DOMAIN + "/"},
+        };
+    }
+
+    @Test(dataProvider = "opbsCookiePathDataProvider")
+    public void testAddOPBrowserStateCookieAppliesProxyContextPath(String loginTenantDomain, String proxyContextPath,
+                                                                  boolean superTenantAppendInCookiePath,
+                                                                  String expectedCookiePath) {
+
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        lenient().when(request.getCookies()).thenReturn(null);
+
+        ServerConfiguration serverConfiguration = mock(ServerConfiguration.class);
+        lenient().when(serverConfiguration.getFirstProperty(IdentityCoreConstants.PROXY_CONTEXT_PATH))
+                .thenReturn(proxyContextPath);
+
+        PrivilegedCarbonContext.startTenantFlow();
+        try (MockedStatic<IdentityTenantUtil> identityTenantUtil = mockStatic(IdentityTenantUtil.class);
+             MockedStatic<ServerConfiguration> serverConfigurationStatic = mockStatic(ServerConfiguration.class)) {
+
+            identityTenantUtil.when(IdentityTenantUtil::isTenantedSessionsEnabled).thenReturn(true);
+            identityTenantUtil.when(IdentityTenantUtil::isSuperTenantAppendInCookiePath)
+                    .thenReturn(superTenantAppendInCookiePath);
+            serverConfigurationStatic.when(ServerConfiguration::getInstance).thenReturn(serverConfiguration);
+
+            new DefaultOIDCSessionStateManager()
+                    .addOPBrowserStateCookie(response, request, loginTenantDomain, OPBS_VALUE);
+        } finally {
+            PrivilegedCarbonContext.endTenantFlow();
+        }
+
+        ArgumentCaptor<Cookie> cookieCaptor = ArgumentCaptor.forClass(Cookie.class);
+        verify(response).addCookie(cookieCaptor.capture());
+        assertEquals(cookieCaptor.getValue().getPath(), expectedCookiePath,
+                "Unexpected opbs cookie path for login tenant domain: " + loginTenantDomain);
+    }
+
+    @Test
+    public void testAddOPBrowserStateCookieWithoutTenantedSessions() {
+
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+
+        try (MockedStatic<IdentityTenantUtil> identityTenantUtil = mockStatic(IdentityTenantUtil.class)) {
+            identityTenantUtil.when(IdentityTenantUtil::isTenantedSessionsEnabled).thenReturn(false);
+
+            new DefaultOIDCSessionStateManager()
+                    .addOPBrowserStateCookie(response, request, TENANT_DOMAIN, OPBS_VALUE);
+        }
+
+        ArgumentCaptor<Cookie> cookieCaptor = ArgumentCaptor.forClass(Cookie.class);
+        verify(response).addCookie(cookieCaptor.capture());
+        assertEquals(cookieCaptor.getValue().getPath(), "/",
+                "The cookie path should stay at the root path when tenanted sessions are disabled");
+    }
+}

--- a/components/org.wso2.carbon.identity.oidc.session/src/test/java/org/wso2/carbon/identity/oidc/session/util/OIDCSessionManagementUtilTest.java
+++ b/components/org.wso2.carbon.identity.oidc.session/src/test/java/org/wso2/carbon/identity/oidc/session/util/OIDCSessionManagementUtilTest.java
@@ -33,12 +33,17 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
+import org.wso2.carbon.base.ServerConfiguration;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.identity.common.testng.WithCarbonHome;
 import org.wso2.carbon.identity.core.IdentityKeyStoreResolver;
 import org.wso2.carbon.identity.core.ServiceURL;
 import org.wso2.carbon.identity.core.ServiceURLBuilder;
 import org.wso2.carbon.identity.core.URLBuilderException;
+import org.wso2.carbon.identity.core.util.IdentityCoreConstants;
 import org.wso2.carbon.identity.core.util.IdentityKeyStoreResolverConstants;
 import org.wso2.carbon.identity.core.util.IdentityKeyStoreResolverException;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.oauth.common.OAuthConstants;
 import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
 import org.wso2.carbon.identity.oidc.session.OIDCSessionConstants;
@@ -59,6 +64,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertThrows;
@@ -67,6 +73,7 @@ import static org.testng.Assert.assertThrows;
  Unit test coverage for OIDCSessionManagementUtil class
  */
 @Listeners(MockitoTestNGListener.class)
+@WithCarbonHome
 public class OIDCSessionManagementUtilTest {
 
     @Mock
@@ -84,6 +91,7 @@ public class OIDCSessionManagementUtilTest {
     private static final String CLIENT_ID = "u5FIfG5xzLvBGiamoAYzzcqpBqga";
     private static final String CALLBACK_URL = "http://localhost:8080/playground2/oauth2client";
     private static final String OPBROWSER_STATE = "090907ce-eab0-40d2-a46d-acd4bb33f0d0";
+    private static final String TENANT_DOMAIN = "foo.com";
     private static final String SESSION_STATE = "18b2343e6edaec1c8b1208169ffa141d158156518135350be60dfbf6f41d340f" +
             ".W2Gf-RAzLUFy2xq_8tuM6A";
     String responseType[] = new String[]{"id_token", "token", "code"};
@@ -515,4 +523,38 @@ public class OIDCSessionManagementUtilTest {
         String clientId = OIDCSessionManagementUtil.extractClientIDFromDecryptedIDToken(idtoken);
         Assert.assertEquals(clientId, CLIENT_ID, "Client ID is not as expected");
     }
+
+    @Test
+    public void testRemoveOPBrowserStateCookieAppliesProxyContextPath() {
+
+        Cookie opbsCookie = new Cookie(OIDCSessionConstants.OPBS_COOKIE_ID,
+                OPBROWSER_STATE + OIDCSessionConstants.TENANT_QUALIFIED_OPBS_COOKIE_SUFFIX);
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getCookies()).thenReturn(new Cookie[]{opbsCookie});
+        HttpServletResponse response = mock(HttpServletResponse.class);
+
+        ServerConfiguration serverConfiguration = mock(ServerConfiguration.class);
+        when(serverConfiguration.getFirstProperty(IdentityCoreConstants.PROXY_CONTEXT_PATH)).thenReturn("auth");
+
+        PrivilegedCarbonContext.startTenantFlow();
+        try (MockedStatic<IdentityTenantUtil> identityTenantUtil = mockStatic(IdentityTenantUtil.class);
+             MockedStatic<ServerConfiguration> serverConfigurationStatic = mockStatic(ServerConfiguration.class)) {
+
+            identityTenantUtil.when(IdentityTenantUtil::isTenantedSessionsEnabled).thenReturn(true);
+            identityTenantUtil.when(IdentityTenantUtil::isTenantQualifiedUrlsEnabled).thenReturn(true);
+            identityTenantUtil.when(IdentityTenantUtil::resolveTenantDomain).thenReturn(TENANT_DOMAIN);
+            identityTenantUtil.when(IdentityTenantUtil::isSuperTenantAppendInCookiePath).thenReturn(false);
+            serverConfigurationStatic.when(ServerConfiguration::getInstance).thenReturn(serverConfiguration);
+
+            OIDCSessionManagementUtil.removeOPBrowserStateCookie(request, response);
+        } finally {
+            PrivilegedCarbonContext.endTenantFlow();
+        }
+
+        ArgumentCaptor<Cookie> cookieCaptor = ArgumentCaptor.forClass(Cookie.class);
+        verify(response).addCookie(cookieCaptor.capture());
+        Assert.assertEquals(cookieCaptor.getValue().getPath(), "/auth/t/" + TENANT_DOMAIN + "/",
+                "The proxy context path is not applied to the tenanted opbs cookie path");
+    }
+
 }

--- a/components/org.wso2.carbon.identity.oidc.session/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.identity.oidc.session/src/test/resources/testng.xml
@@ -25,6 +25,7 @@
         <class name="org.wso2.carbon.identity.oidc.session.servlet.OIDCLogoutServletTest" />
         <class name="org.wso2.carbon.identity.oidc.session.servlet.OIDCSessionIFrameServletTest" />
         <class name="org.wso2.carbon.identity.oidc.session.OIDCSessionManagerTest"/>
+        <class name="org.wso2.carbon.identity.oidc.session.DefaultOIDCSessionStateManagerTest"/>
         <class name="org.wso2.carbon.identity.oidc.session.OIDCSessionStateTest"/>
         <class name="org.wso2.carbon.identity.oidc.session.cache.OIDCSessionParticipantCacheTest"/>
         <class name="org.wso2.carbon.identity.oidc.session.cache.OIDCSessionDataCacheTest"/>
@@ -40,6 +41,7 @@
             <class name="org.wso2.carbon.identity.oidc.session.servlet.OIDCLogoutServletTest" />
             <class name="org.wso2.carbon.identity.oidc.session.servlet.OIDCSessionIFrameServletTest" />
             <class name="org.wso2.carbon.identity.oidc.session.OIDCSessionManagerTest"/>
+        <class name="org.wso2.carbon.identity.oidc.session.DefaultOIDCSessionStateManagerTest"/>
             <class name="org.wso2.carbon.identity.oidc.session.OIDCSessionStateTest"/>
             <class name="org.wso2.carbon.identity.oidc.session.cache.OIDCSessionParticipantCacheTest"/>
             <class name="org.wso2.carbon.identity.oidc.session.cache.OIDCSessionDataCacheTest"/>

--- a/pom.xml
+++ b/pom.xml
@@ -998,7 +998,7 @@
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!-- Carbon Identity Framework version -->
-        <carbon.identity.framework.version>7.11.176</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.11.195</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.25.234, 8.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
         <identity.oauth.xacml.version.range>[2.0.0, 3.0.0)</identity.oauth.xacml.version.range>


### PR DESCRIPTION
## Summary

Applies the configured `proxy_context_path` to the tenant qualified `opbs` cookie path, so the OIDC session state cookie is scoped to the path the browser actually requests when the server sits behind a reverse-proxy prefix.

- **Cookie path fix** — with `EnableTenantedSessions` enabled, the `opbs` cookie path is built by hand as `/t/<tenant-domain>/` (or `/o/<org-id>/`), bypassing `ServiceURLBuilder` and therefore omitting the proxy context path. Behind a prefix the browser sits at `/<prefix>/t/<tenant-domain>/...` and never returns the cookie, so OIDC session management and RP initiated logout cannot resolve the session. The prefix is now applied at both the write site (`DefaultOIDCSessionStateManager#addOPBrowserStateCookie`) and the remove site (`OIDCSessionManagementUtil#removeOPBrowserStateCookie`), so the cookie is cleared at the path it was set on.
- **Super tenant unchanged** — where the cookie path resolves to the root path it is left as `/`, which already covers any prefix.
- **Shared helper** — the prefix is applied through `FrameworkUtils.prependProxyContextPath`, which is a no-op when the path is already prefixed, when it is absolute or blank, when `proxy_context_path` is not configured, and when the configured value normalizes to the root path.
- **Unit test** — `OIDCSessionManagementUtilTest#testRemoveOPBrowserStateCookieAppliesProxyContextPath` asserts the tenanted `opbs` removal path carries the prefix.

Depends on https://github.com/wso2/carbon-identity-framework/pull/8267, which adds `prependProxyContextPath`. `carbon.identity.framework.version` is bumped to 7.11.195, the released version that carries `prependProxyContextPath`.

Fixes: https://github.com/wso2/product-is/issues/18904
