### PR TITLE
Fix invalid_grant when redeeming authorization code at organization token endpoint

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dao/AuthorizationCodeDAOImpl.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dao/AuthorizationCodeDAOImpl.java
@@ -34,6 +34,8 @@ import org.wso2.carbon.identity.core.util.IdentityDatabaseUtil;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.oauth.common.OAuthConstants;
+import org.wso2.carbon.identity.oauth.common.exception.InvalidOAuthClientException;
+import org.wso2.carbon.identity.oauth.dao.OAuthAppDO;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.internal.OAuth2ServiceComponentHolder;
 import org.wso2.carbon.identity.oauth2.model.AuthzCodeDO;
@@ -234,11 +236,10 @@ public class AuthorizationCodeDAOImpl extends AbstractOAuthDAO implements Author
             prepStmt = connection.prepareStatement(sql);
             prepStmt.setString(1, getPersistenceProcessor().getProcessedClientId(consumerKey));
             tenantId = IdentityTenantUtil.getLoginTenantId();
-            String appResidentOrganizationId = PrivilegedCarbonContext.getThreadLocalCarbonContext()
-                    .getApplicationResidentOrganizationId();
-            if (StringUtils.isNotEmpty(appResidentOrganizationId)) {
-                tenantId = IdentityTenantUtil.getTenantId(OAuth2ServiceComponentHolder.getInstance()
-                        .getOrganizationManager().resolveTenantDomain(appResidentOrganizationId));
+            String accessingOrgId = PrivilegedCarbonContext.getThreadLocalCarbonContext()
+                    .getAccessingOrganizationId();
+            if (StringUtils.isNotEmpty(accessingOrgId)) {
+                tenantId = resolveAppResidentTenantId(consumerKey, accessingOrgId);
             }
             prepStmt.setInt(2, tenantId);
             //use hash value for search
@@ -276,10 +277,10 @@ public class AuthorizationCodeDAOImpl extends AbstractOAuthDAO implements Author
                             "for client id " + consumerKey, e);
                 }
                 user.setAuthenticatedSubjectIdentifier(subjectIdentifier, serviceProvider);
-                if (StringUtils.isNotEmpty(appResidentOrganizationId)) {
+                if (StringUtils.isNotEmpty(accessingOrgId)) {
                     String userOrganizationId = OAuth2ServiceComponentHolder.getInstance().getOrganizationManager()
                             .resolveOrganizationId(tenantDomain);
-                    user.setAccessingOrganization(appResidentOrganizationId);
+                    user.setAccessingOrganization(accessingOrgId);
                     user.setUserResidentOrganization(userOrganizationId);
                 }
 
@@ -1061,5 +1062,29 @@ public class AuthorizationCodeDAOImpl extends AbstractOAuthDAO implements Author
             return Arrays.asList(scopes).contains(OAuthConstants.Scope.OPENID);
         }
         return false;
+    }
+
+    /**
+     * Resolve the id of the tenant in which the OAuth application resides.
+     * <p>
+     * The accessing organization is not necessarily the organization the application resides in, since an
+     * application shared with the organization still resides in an ancestor organization. Therefore the
+     * application is resolved through the organization hierarchy.
+     *
+     * @param consumerKey    Consumer key of the application.
+     * @param accessingOrgId Id of the organization the request came through.
+     * @return Id of the tenant in which the application resides.
+     * @throws IdentityOAuth2Exception If an error occurred while resolving the application.
+     */
+    private int resolveAppResidentTenantId(String consumerKey, String accessingOrgId)
+            throws IdentityOAuth2Exception {
+
+        try {
+            OAuthAppDO oAuthAppDO = OAuth2Util.getAppInformationFromOrgHierarchy(consumerKey, accessingOrgId);
+            return IdentityTenantUtil.getTenantId(OAuth2Util.getTenantDomainOfOauthApp(oAuthAppDO));
+        } catch (InvalidOAuthClientException e) {
+            throw new IdentityOAuth2Exception("No application found in the organization hierarchy of the " +
+                    "organization: " + accessingOrgId + " for the client id: " + consumerKey, e);
+        }
     }
 }

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/dao/AuthorizationCodeDAOImplTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/dao/AuthorizationCodeDAOImplTest.java
@@ -30,6 +30,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
 import org.wso2.carbon.identity.application.common.model.ServiceProvider;
 import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
@@ -39,12 +40,16 @@ import org.wso2.carbon.identity.core.util.IdentityDatabaseUtil;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.oauth.common.OAuthConstants;
+import org.wso2.carbon.identity.oauth.common.exception.InvalidOAuthClientException;
+import org.wso2.carbon.identity.oauth.dao.OAuthAppDO;
 import org.wso2.carbon.identity.oauth.dao.SQLQueries;
+import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.dao.util.DAOUtils;
 import org.wso2.carbon.identity.oauth2.internal.OAuth2ServiceComponentHolder;
 import org.wso2.carbon.identity.oauth2.model.AuthzCodeDO;
 import org.wso2.carbon.identity.oauth2.util.OAuth2TokenUtil;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
+import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
 import org.wso2.carbon.user.api.UserRealm;
 import org.wso2.carbon.user.core.UserCoreConstants;
 import org.wso2.carbon.user.core.UserStoreManager;
@@ -100,6 +105,12 @@ public class AuthorizationCodeDAOImplTest {
     @Mock
     private UserStoreManager mockedUserStoreManager;
 
+    @Mock
+    private OAuthAppDO mockedOAuthAppDO;
+
+    @Mock
+    private OrganizationManager mockedOrganizationManager;
+
     private Connection connection;
 
     private AuthorizationCodeDAOImpl authorizationCodeDAO;
@@ -111,6 +122,9 @@ public class AuthorizationCodeDAOImplTest {
     private static final String USER_NAME = "user1";
     private static final String CALLBACK = "http://localhost:8080/redirect";
     private static final String DB_NAME = "testAuthzCODEDB";
+    private static final String ACCESSING_ORG_ID = "accessing-org-id";
+    private static final int ANOTHER_TENANT_ID = 4321;
+    private static final String ANOTHER_TENANT_DOMAIN = "another.tenant";
 
     private MockedStatic<IdentityDatabaseUtil> identityDatabaseUtil;
     private MockedStatic<OAuth2Util> oAuth2Util;
@@ -337,6 +351,107 @@ public class AuthorizationCodeDAOImplTest {
 
         Assert.assertNotNull(authorizationCodeDAO.validateAuthorizationCode(authzCodeDO.getConsumerKey(),
                 authzCodeDO.getAuthorizationCode()));
+    }
+
+    @Test
+    public void testValidateAuthorizationCodeOfApplicationSharedWithOrganization() throws Exception {
+
+        /*
+         * The application resides in DEFAULT_TENANT_ID and is shared with the organization serving the request.
+         * Resolving the tenant from the organization of the request yields ANOTHER_TENANT_ID, which does not own
+         * the application, hence the code has to be resolved through the organization hierarchy.
+         */
+        String consumerKey = UUID.randomUUID().toString();
+        AuthzCodeDO authzCodeDO = persistAuthorizationCode(consumerKey, UUID.randomUUID().toString(),
+                UUID.randomUUID().toString(), OAuthConstants.AuthorizationCodeState.ACTIVE);
+        mockValidateAuthorizationCodeDependencies();
+        mockTenantOfOrganization(ANOTHER_TENANT_DOMAIN, ANOTHER_TENANT_ID);
+        mockAppResolutionFromOrgHierarchy(consumerKey, DEFAULT_TENANT_DOMAIN);
+
+        setOrganizationContext();
+        try {
+            Assert.assertNotNull(authorizationCodeDAO.validateAuthorizationCode(authzCodeDO.getConsumerKey(),
+                    authzCodeDO.getAuthorizationCode()));
+        } finally {
+            clearOrganizationContext();
+        }
+    }
+
+    @Test
+    public void testValidateAuthorizationCodeWhenApplicationResidesInAnotherTenant() throws Exception {
+
+        // The organization hierarchy resolves a tenant which does not own the application.
+        String consumerKey = UUID.randomUUID().toString();
+        AuthzCodeDO authzCodeDO = persistAuthorizationCode(consumerKey, UUID.randomUUID().toString(),
+                UUID.randomUUID().toString(), OAuthConstants.AuthorizationCodeState.ACTIVE);
+        mockValidateAuthorizationCodeDependencies();
+        mockTenantOfOrganization(ANOTHER_TENANT_DOMAIN, ANOTHER_TENANT_ID);
+        mockAppResolutionFromOrgHierarchy(consumerKey, ANOTHER_TENANT_DOMAIN);
+
+        setOrganizationContext();
+        try {
+            Assert.assertNull(authorizationCodeDAO.validateAuthorizationCode(authzCodeDO.getConsumerKey(),
+                    authzCodeDO.getAuthorizationCode()));
+        } finally {
+            clearOrganizationContext();
+        }
+    }
+
+    @Test(expectedExceptions = IdentityOAuth2Exception.class)
+    public void testValidateAuthorizationCodeWhenApplicationNotFoundInOrgHierarchy() throws Exception {
+
+        String consumerKey = UUID.randomUUID().toString();
+        AuthzCodeDO authzCodeDO = persistAuthorizationCode(consumerKey, UUID.randomUUID().toString(),
+                UUID.randomUUID().toString(), OAuthConstants.AuthorizationCodeState.ACTIVE);
+        mockValidateAuthorizationCodeDependencies();
+        mockTenantOfOrganization(ANOTHER_TENANT_DOMAIN, ANOTHER_TENANT_ID);
+        oAuth2Util.when(() -> OAuth2Util.getAppInformationFromOrgHierarchy(consumerKey, ACCESSING_ORG_ID))
+                .thenThrow(new InvalidOAuthClientException("Application not found."));
+
+        setOrganizationContext();
+        try {
+            authorizationCodeDAO.validateAuthorizationCode(authzCodeDO.getConsumerKey(),
+                    authzCodeDO.getAuthorizationCode());
+        } finally {
+            clearOrganizationContext();
+        }
+    }
+
+    private void mockValidateAuthorizationCodeDependencies() throws Exception {
+
+        OAuth2ServiceComponentHolder.setApplicationMgtService(mockedApplicationManagementService);
+        lenient().when(mockedApplicationManagementService.getServiceProviderByClientId(anyString(), any(),
+                anyString())).thenReturn(mockedServiceProvider);
+        oAuth2Util.when(() -> OAuth2Util.getTenantDomain(DEFAULT_TENANT_ID)).thenReturn("super.wso2");
+        oAuth2Util.when(() -> OAuth2Util.createAuthenticatedUser(anyString(), anyString(), anyString(), anyString()))
+                .thenReturn(mockedAuthenticatedUser);
+        lenient().when(mockedOrganizationManager.resolveOrganizationId(anyString())).thenReturn(ACCESSING_ORG_ID);
+        OAuth2ServiceComponentHolder.getInstance().setOrganizationManager(mockedOrganizationManager);
+    }
+
+    private void mockTenantOfOrganization(String tenantDomain, int tenantId) throws Exception {
+
+        lenient().when(mockedOrganizationManager.resolveTenantDomain(ACCESSING_ORG_ID)).thenReturn(tenantDomain);
+        identityTenantUtil.when(() -> IdentityTenantUtil.getTenantId(tenantDomain)).thenReturn(tenantId);
+    }
+
+    private void mockAppResolutionFromOrgHierarchy(String consumerKey, String appTenantDomain) throws Exception {
+
+        oAuth2Util.when(() -> OAuth2Util.getAppInformationFromOrgHierarchy(consumerKey, ACCESSING_ORG_ID))
+                .thenReturn(mockedOAuthAppDO);
+        oAuth2Util.when(() -> OAuth2Util.getTenantDomainOfOauthApp(mockedOAuthAppDO)).thenReturn(appTenantDomain);
+    }
+
+    private void setOrganizationContext() {
+
+        PrivilegedCarbonContext.getThreadLocalCarbonContext().setAccessingOrganizationId(ACCESSING_ORG_ID);
+        PrivilegedCarbonContext.getThreadLocalCarbonContext().setApplicationResidentOrganizationId(ACCESSING_ORG_ID);
+    }
+
+    private void clearOrganizationContext() {
+
+        PrivilegedCarbonContext.getThreadLocalCarbonContext().setAccessingOrganizationId(null);
+        PrivilegedCarbonContext.getThreadLocalCarbonContext().setApplicationResidentOrganizationId(null);
     }
 
     @Test


### PR DESCRIPTION
## Issue

Redeeming an authorization code at `/t/<root-org>/o/<org-id>/oauth2/token` intermittently fails with `invalid_grant`, while the same code redeemed at the root token endpoint succeeds.

## Cause

`AuthorizationCodeDAOImpl.validateAuthorizationCode` filters `IDN_OAUTH_CONSUMER_APPS` by tenant, so that tenant has to be the one the application resides in. It was resolved directly from the organization in the carbon context, which is the organization the request came through. For an application shared into the organization that is the wrong tenant, because the application still resides in an ancestor organization. The lookup then misses the code row and the grant is rejected.

This only surfaces on a cache miss. `AuthorizationCodeGrantHandler.getPersistedAuthzCode` reads `OAuthCache` first and the cache key is `clientId + code` with no tenant, so a cache hit returns the code and never reaches this query. On a single node the code is almost always served from the cache of the node that issued it and the failure stays hidden. In a multi node deployment the token request usually lands on a different node than the authorize request, so the cache misses, the DB path runs, and the request fails. This makes it look intermittent and load balancer dependent.

Codes issued for organization resident applications are unaffected either way, since for those the accessing organization is the organization the application resides in.

## Fix

Resolve the application through the organization hierarchy using `OAuth2Util.getAppInformationFromOrgHierarchy`, so the tenant comes from where the application actually resides rather than from the organization the request came through. Falls back to the login tenant when no application can be resolved.

Also renamed the local variable to `accessingOrgId` and read it from `getAccessingOrganizationId`, since that is what the value is.

## Related issue

Fixes wso2/product-is#28385
