### PR TITLE
Fix object casting issue

### DIFF
--- a/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/JWTUtils.java
+++ b/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/JWTUtils.java
@@ -61,7 +61,6 @@ import java.security.cert.X509Certificate;
 import java.security.interfaces.RSAPublicKey;
 import java.text.ParseException;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -432,18 +431,21 @@ public class JWTUtils {
     public static String getSigningTenantDomain(JWTClaimsSet claimsSet, AccessTokenDO accessTokenDO)
             throws ParseException, IdentityOAuth2Exception {
 
-        Map<String, String> realm = (HashMap) claimsSet.getClaim(OAuthConstants.OIDCClaims.REALM);
+        Map realm = getRealmClaim(claimsSet);
         if (MapUtils.isNotEmpty(realm)) {
-            if (realm.get(OAuthConstants.OIDCClaims.SIGNING_TENANT) != null) {
+            String signingTenant = getClaimWithinRealmAsString(realm, OAuthConstants.OIDCClaims.SIGNING_TENANT);
+            if (signingTenant != null) {
                 if (log.isDebugEnabled()) {
                     log.debug("Getting signing tenant domain from JWT's 'signing_tenant' claim.");
                 }
-                return realm.get(OAuthConstants.OIDCClaims.SIGNING_TENANT);
-            } else if (realm.get(OAuthConstants.OIDCClaims.TENANT) != null) {
+                return signingTenant;
+            }
+            String tenant = getClaimWithinRealmAsString(realm, OAuthConstants.OIDCClaims.TENANT);
+            if (tenant != null) {
                 if (log.isDebugEnabled()) {
                     log.debug("Getting signing tenant domain from JWT's 'tenant' claim.");
                 }
-                return realm.get(OAuthConstants.OIDCClaims.TENANT);
+                return tenant;
             }
         }
         if (accessTokenDO == null) {
@@ -490,6 +492,37 @@ public class JWTUtils {
             }
             return accessTokenDO.getAuthzUser().getTenantDomain();
         }
+    }
+
+    /**
+     * Retrieves the 'realm' claim of the given JWT as a Map. The claim is returned only when it is a JSON object;
+     * a 'realm' claim of any other type is treated as absent.
+     *
+     * Note that the concrete Map implementation depends on the JSON parser behind Nimbus, so the value must only
+     * ever be handled through the Map interface and never cast to a concrete type such as HashMap.
+     *
+     * @param claimsSet The JWTClaimsSet to read the 'realm' claim from.
+     * @return The 'realm' claim as a Map, or null if it is missing or not a JSON object.
+     */
+    private static Map getRealmClaim(JWTClaimsSet claimsSet) {
+
+        Object realm = claimsSet.getClaim(OAuthConstants.OIDCClaims.REALM);
+        return realm instanceof Map ? (Map) realm : null;
+    }
+
+    /**
+     * Retrieves a claim nested within the 'realm' claim as a String value. A nested claim holding any other JSON
+     * type is treated as absent, so that a malformed token falls back to the other tenant resolution paths instead
+     * of failing the whole validation flow.
+     *
+     * @param realm     The 'realm' claim of the JWT.
+     * @param claimName The name of the claim within 'realm' to read.
+     * @return The nested claim value as a String, or null if it is missing or not a String.
+     */
+    private static String getClaimWithinRealmAsString(Map realm, String claimName) {
+
+        Object value = realm.get(claimName);
+        return value instanceof String ? (String) value : null;
     }
 
     /**
@@ -561,15 +594,13 @@ public class JWTUtils {
             throws IdentityOAuth2Exception {
 
         X509Certificate x509Certificate = null;
-        Map<String, String> realm = (HashMap) jwtClaimsSet.getClaim(OAuthConstants.OIDCClaims.REALM);
+        Map realm = getRealmClaim(jwtClaimsSet);
         // Get certificate from tenant if available in claims.
         if (MapUtils.isNotEmpty(realm)) {
-            String tenantDomain = null;
             // Get signed key tenant from JWT token or ID token based on claim key.
-            if (realm.get(OAuthConstants.OIDCClaims.SIGNING_TENANT) != null) {
-                tenantDomain = realm.get(OAuthConstants.OIDCClaims.SIGNING_TENANT);
-            } else if (realm.get(OAuthConstants.OIDCClaims.TENANT) != null) {
-                tenantDomain = realm.get(OAuthConstants.OIDCClaims.TENANT);
+            String tenantDomain = getClaimWithinRealmAsString(realm, OAuthConstants.OIDCClaims.SIGNING_TENANT);
+            if (tenantDomain == null) {
+                tenantDomain = getClaimWithinRealmAsString(realm, OAuthConstants.OIDCClaims.TENANT);
             }
             if (tenantDomain != null) {
                 int tenantId = IdentityTenantUtil.getTenantId(tenantDomain);

--- a/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/util/JWTUtilsTest.java
+++ b/components/org.wso2.carbon.identity.oauth/src/test/java/org/wso2/carbon/identity/oauth2/util/JWTUtilsTest.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.oauth2.util;
 
+import com.nimbusds.jwt.JWTClaimsSet;
 import org.mockito.MockedStatic;
 import org.mockito.testng.MockitoTestNGListener;
 import org.testng.annotations.AfterClass;
@@ -46,14 +47,20 @@ import java.io.FileInputStream;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.KeyStore;
+import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 import static org.wso2.carbon.base.MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
 
 @Listeners(MockitoTestNGListener.class)
@@ -90,6 +97,32 @@ public class JWTUtilsTest {
             "3pDI4B+vQipcfTjJqgPAWvUz903z61lRuAlJFPPD69l+IQ15z1Mfc7rgl0wmZLBU\n" +
             "HjVlGsFGQX6e10Rx/msN+NWxKJGf7Z6vxS8Qoc4nddUBnndCOvCVvgI9BThNv0cG\n" +
             "e3hB2nvCQvUJ/wfuj6i1PNfoM81nA2qEQfjY/QWuF4Ex/RYWBfASNU35TBRVc26R";
+
+    private static final String SIGNING_TENANT_DOMAIN = "signing.tenant.com";
+    private static final String USER_TENANT_DOMAIN = "user.tenant.com";
+
+    /*
+     These claim sets are deliberately built by parsing raw JSON rather than by JWTClaimsSet.Builder.
+     Nimbus deserializes a nested JSON object into com.nimbusds.jose.shaded.gson.internal.LinkedTreeMap,
+     which implements Map but does NOT extend HashMap. A Builder-constructed claim set would keep whatever
+     Map implementation the test handed it and would therefore not exercise the cast at all.
+    */
+    private static final String CLAIMS_WITH_SIGNING_TENANT =
+            "{\"sub\":\"user1\",\"realm\":{\"signing_tenant\":\"" + SIGNING_TENANT_DOMAIN + "\"}}";
+    private static final String CLAIMS_WITH_TENANT =
+            "{\"sub\":\"user1\",\"realm\":{\"tenant\":\"" + USER_TENANT_DOMAIN + "\"}}";
+    private static final String CLAIMS_WITH_BOTH_TENANTS =
+            "{\"sub\":\"user1\",\"realm\":{\"tenant\":\"" + USER_TENANT_DOMAIN + "\","
+                    + "\"signing_tenant\":\"" + SIGNING_TENANT_DOMAIN + "\"}}";
+    private static final String CLAIMS_WITH_NON_STRING_SIGNING_TENANT =
+            "{\"sub\":\"user1\",\"realm\":{\"signing_tenant\":{\"name\":\"" + SIGNING_TENANT_DOMAIN + "\"}}}";
+    private static final String CLAIMS_WITH_NON_STRING_TENANT = "{\"sub\":\"user1\",\"realm\":{\"tenant\":42}}";
+    private static final String CLAIMS_WITH_NON_STRING_SIGNING_TENANT_AND_VALID_TENANT =
+            "{\"sub\":\"user1\",\"realm\":{\"signing_tenant\":true,"
+                    + "\"tenant\":\"" + USER_TENANT_DOMAIN + "\"}}";
+    private static final String CLAIMS_WITH_STRING_REALM = "{\"sub\":\"user1\",\"realm\":\"/alpha\"}";
+    private static final String CLAIMS_WITH_EMPTY_REALM = "{\"sub\":\"user1\",\"realm\":{}}";
+    private static final String CLAIMS_WITHOUT_REALM = "{\"sub\":\"user1\"}";
 
     private static final String MUTUAL_TLS_ALIASES_ENABLED = "OAuth.MutualTLSAliases.Enabled";
     private static final String OAUTH_BUILD_ISSUER_WITH_HOSTNAME = "OAuth.BuildIssuerWithHostname";
@@ -227,6 +260,153 @@ public class JWTUtilsTest {
             JWTUtils.getResidentIDPIssuer("https://some-issuer", "client-id", SUPER_TENANT_DOMAIN_NAME,
                     "switched-org-id");
         }
+    }
+
+    /**
+     * Canary for the ClassCastException fixed in getSigningTenantDomain()/getCertificateFromClaims().
+     *
+     * Nimbus 10.x replaced json-smart with a shaded Gson parser, so a nested JSON object is no longer a
+     * net.minidev.json.JSONObject (which extends HashMap) but a LinkedTreeMap (which does not). Any code
+     * casting the 'realm' claim to a concrete HashMap therefore throws at runtime. If this assertion ever
+     * fails, the JSON parser behind JWTClaimsSet has changed again and every 'realm' consumer needs review.
+     */
+    @Test(description = "The parsed 'realm' claim is a Map but not a HashMap")
+    public void testRealmClaimIsNotDeserializedAsHashMap() throws Exception {
+
+        Object realm = JWTClaimsSet.parse(CLAIMS_WITH_SIGNING_TENANT).getClaim("realm");
+        assertTrue(realm instanceof Map, "The 'realm' claim must be readable as a java.util.Map. Actual type: "
+                + realm.getClass().getName());
+        assertFalse(realm instanceof HashMap, "The 'realm' claim is no longer a HashMap subtype, so it must only "
+                + "ever be cast to the Map interface. Actual type: " + realm.getClass().getName());
+    }
+
+    @Test(description = "getSigningTenantDomain resolves the tenant from the 'signing_tenant' claim")
+    public void testGetSigningTenantDomainFromSigningTenantClaim() throws Exception {
+
+        assertEquals(JWTUtils.getSigningTenantDomain(JWTClaimsSet.parse(CLAIMS_WITH_SIGNING_TENANT), null),
+                SIGNING_TENANT_DOMAIN);
+    }
+
+    @Test(description = "getSigningTenantDomain resolves the tenant from the 'tenant' claim")
+    public void testGetSigningTenantDomainFromTenantClaim() throws Exception {
+
+        assertEquals(JWTUtils.getSigningTenantDomain(JWTClaimsSet.parse(CLAIMS_WITH_TENANT), null),
+                USER_TENANT_DOMAIN);
+    }
+
+    @Test(description = "getSigningTenantDomain prefers 'signing_tenant' over 'tenant'")
+    public void testGetSigningTenantDomainPrefersSigningTenantClaim() throws Exception {
+
+        assertEquals(JWTUtils.getSigningTenantDomain(JWTClaimsSet.parse(CLAIMS_WITH_BOTH_TENANTS), null),
+                SIGNING_TENANT_DOMAIN);
+    }
+
+    /**
+     * A 'realm' claim carrying a plain string (an organization path, for instance) must be ignored rather
+     * than blowing up the token validation flow.
+     */
+    @Test(description = "getSigningTenantDomain falls back when the 'realm' claim is not a JSON object")
+    public void testGetSigningTenantDomainWithNonObjectRealmClaim() throws Exception {
+
+        when(privilegedCarbonContext.getTenantDomain()).thenReturn(SUPER_TENANT_DOMAIN_NAME);
+        assertEquals(JWTUtils.getSigningTenantDomain(JWTClaimsSet.parse(CLAIMS_WITH_STRING_REALM), null),
+                SUPER_TENANT_DOMAIN_NAME);
+    }
+
+    @Test(description = "getSigningTenantDomain falls back when the 'realm' claim is an empty object")
+    public void testGetSigningTenantDomainWithEmptyRealmClaim() throws Exception {
+
+        when(privilegedCarbonContext.getTenantDomain()).thenReturn(SUPER_TENANT_DOMAIN_NAME);
+        assertEquals(JWTUtils.getSigningTenantDomain(JWTClaimsSet.parse(CLAIMS_WITH_EMPTY_REALM), null),
+                SUPER_TENANT_DOMAIN_NAME);
+    }
+
+    @Test(description = "getSigningTenantDomain falls back when there is no 'realm' claim")
+    public void testGetSigningTenantDomainWithoutRealmClaim() throws Exception {
+
+        when(privilegedCarbonContext.getTenantDomain()).thenReturn(SUPER_TENANT_DOMAIN_NAME);
+        assertEquals(JWTUtils.getSigningTenantDomain(JWTClaimsSet.parse(CLAIMS_WITHOUT_REALM), null),
+                SUPER_TENANT_DOMAIN_NAME);
+    }
+
+    @Test(description = "getSigningTenantDomain ignores a 'signing_tenant' claim that is not a String")
+    public void testGetSigningTenantDomainWithNonStringSigningTenantClaim() throws Exception {
+
+        when(privilegedCarbonContext.getTenantDomain()).thenReturn(SUPER_TENANT_DOMAIN_NAME);
+        assertEquals(
+                JWTUtils.getSigningTenantDomain(JWTClaimsSet.parse(CLAIMS_WITH_NON_STRING_SIGNING_TENANT), null),
+                SUPER_TENANT_DOMAIN_NAME);
+    }
+
+    @Test(description = "getSigningTenantDomain ignores a 'tenant' claim that is not a String")
+    public void testGetSigningTenantDomainWithNonStringTenantClaim() throws Exception {
+
+        when(privilegedCarbonContext.getTenantDomain()).thenReturn(SUPER_TENANT_DOMAIN_NAME);
+        assertEquals(JWTUtils.getSigningTenantDomain(JWTClaimsSet.parse(CLAIMS_WITH_NON_STRING_TENANT), null),
+                SUPER_TENANT_DOMAIN_NAME);
+    }
+
+    @Test(description = "getSigningTenantDomain falls back to 'tenant' when 'signing_tenant' is not a String")
+    public void testGetSigningTenantDomainFallsBackToTenantClaimOnNonStringSigningTenant() throws Exception {
+
+        assertEquals(JWTUtils.getSigningTenantDomain(
+                JWTClaimsSet.parse(CLAIMS_WITH_NON_STRING_SIGNING_TENANT_AND_VALID_TENANT), null),
+                USER_TENANT_DOMAIN);
+    }
+
+    @Test(description = "getCertificateFromClaims resolves the certificate of the 'signing_tenant' claim")
+    public void testGetCertificateFromClaimsWithSigningTenantClaim() throws Exception {
+
+        Certificate expectedCertificate = getKeyStoreFromFile("wso2carbon.jks", "wso2carbon",
+                System.getProperty(CarbonBaseConstants.CARBON_HOME)).getCertificate("wso2carbon");
+        try (MockedStatic<IdentityTenantUtil> identityTenantUtil = mockStatic(IdentityTenantUtil.class);
+             MockedStatic<OAuth2Util> oAuth2Util = mockStatic(OAuth2Util.class)) {
+            identityTenantUtil.when(() -> IdentityTenantUtil.getTenantId(SIGNING_TENANT_DOMAIN)).thenReturn(1);
+            oAuth2Util.when(() -> OAuth2Util.getCertificate(SIGNING_TENANT_DOMAIN, 1)).thenReturn(expectedCertificate);
+
+            Optional<X509Certificate> certificate =
+                    JWTUtils.getCertificateFromClaims(JWTClaimsSet.parse(CLAIMS_WITH_SIGNING_TENANT));
+            assertTrue(certificate.isPresent());
+            assertEquals(certificate.get(), expectedCertificate);
+        }
+    }
+
+    @Test(description = "getCertificateFromClaims returns empty when the 'realm' claim is not a JSON object")
+    public void testGetCertificateFromClaimsWithNonObjectRealmClaim() throws Exception {
+
+        assertFalse(JWTUtils.getCertificateFromClaims(JWTClaimsSet.parse(CLAIMS_WITH_STRING_REALM)).isPresent());
+    }
+
+    @Test(description = "getCertificateFromClaims returns empty when the tenant claims are not Strings")
+    public void testGetCertificateFromClaimsWithNonStringTenantClaims() throws Exception {
+
+        assertFalse(JWTUtils.getCertificateFromClaims(
+                JWTClaimsSet.parse(CLAIMS_WITH_NON_STRING_SIGNING_TENANT)).isPresent());
+        assertFalse(JWTUtils.getCertificateFromClaims(
+                JWTClaimsSet.parse(CLAIMS_WITH_NON_STRING_TENANT)).isPresent());
+    }
+
+    @Test(description = "getCertificateFromClaims falls back to 'tenant' when 'signing_tenant' is not a String")
+    public void testGetCertificateFromClaimsFallsBackToTenantClaimOnNonStringSigningTenant() throws Exception {
+
+        Certificate expectedCertificate = getKeyStoreFromFile("wso2carbon.jks", "wso2carbon",
+                System.getProperty(CarbonBaseConstants.CARBON_HOME)).getCertificate("wso2carbon");
+        try (MockedStatic<IdentityTenantUtil> identityTenantUtil = mockStatic(IdentityTenantUtil.class);
+             MockedStatic<OAuth2Util> oAuth2Util = mockStatic(OAuth2Util.class)) {
+            identityTenantUtil.when(() -> IdentityTenantUtil.getTenantId(USER_TENANT_DOMAIN)).thenReturn(2);
+            oAuth2Util.when(() -> OAuth2Util.getCertificate(USER_TENANT_DOMAIN, 2)).thenReturn(expectedCertificate);
+
+            Optional<X509Certificate> certificate = JWTUtils.getCertificateFromClaims(
+                    JWTClaimsSet.parse(CLAIMS_WITH_NON_STRING_SIGNING_TENANT_AND_VALID_TENANT));
+            assertTrue(certificate.isPresent());
+            assertEquals(certificate.get(), expectedCertificate);
+        }
+    }
+
+    @Test(description = "getCertificateFromClaims returns empty when there is no 'realm' claim")
+    public void testGetCertificateFromClaimsWithoutRealmClaim() throws Exception {
+
+        assertFalse(JWTUtils.getCertificateFromClaims(JWTClaimsSet.parse(CLAIMS_WITHOUT_REALM)).isPresent());
     }
 
     private void mockResidentIdP(MockedStatic<IdentityProviderManager> identityProviderManager,


### PR DESCRIPTION
### Proposed Changes in This Pull Request

#### Root Cause

The failure occurs at [1], where the `realm` claim is cast directly to a concrete `HashMap`:

```java
Map<String, String> realm = (HashMap) claimsSet.getClaim(OAuthConstants.OIDCClaims.REALM);
```

With Nimbus 10, an object-valued claim may be represented as a `LinkedTreeMap` rather than a `HashMap`. As a result, the concrete cast can throw a `ClassCastException`.

Additionally, the `realm` claim is not always an object. For example, it may be a string such as `"/alpha"`. Attempting to cast such a value to a map will also result in an exception.

#### Fix

Cast the claim to the `Map` interface and verify its type using `instanceof` before processing it. This follows the same pattern already used in `OIDCLogoutServlet.extractTenantDomainFromIdToken`:

```java
Map realm = null;

if (claimsSet.getClaim(OAuthConstants.OIDCClaims.REALM) instanceof Map) {
    realm = (Map) claimsSet.getClaim(OAuthConstants.OIDCClaims.REALM);
}
```

This approach handles both scenarios:

* **Map-valued realm claims:** The `Map` interface supports implementations such as Nimbus 10's `LinkedTreeMap`.
* **Non-object realm claims:** Values such as `"/alpha"` are ignored instead of causing a `ClassCastException`. This comes as a use case where we set the "realm" value via Pre Issue Access Token Action.

[1] https://github.com/wso2-extensions/identity-inbound-auth-oauth/blob/9a7817571ce29646ce3e0e2bdaeaea4c287489c4/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/JWTUtils.java#L435
