### PR TITLE
Reject disabled applications at the device authorization endpoint

### DIFF
--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/device/DeviceEndpoint.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/device/DeviceEndpoint.java
@@ -33,6 +33,7 @@ import org.wso2.carbon.identity.oauth.common.OAuth2ErrorCodes;
 import org.wso2.carbon.identity.oauth.common.OAuthConstants;
 import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
 import org.wso2.carbon.identity.oauth.endpoint.OAuthRequestWrapper;
+import org.wso2.carbon.identity.oauth.endpoint.exception.InvalidApplicationClientException;
 import org.wso2.carbon.identity.oauth.endpoint.exception.TokenEndpointBadRequestException;
 import org.wso2.carbon.identity.oauth.endpoint.util.EndpointUtil;
 import org.wso2.carbon.identity.oauth.endpoint.util.factory.DeviceServiceFactory;
@@ -68,13 +69,15 @@ public class DeviceEndpoint {
     @Produces("application/json")
     public Response authorize(@Context HttpServletRequest request, MultivaluedMap<String, String> paramMap,
                               @Context HttpServletResponse response)
-            throws IdentityOAuth2Exception, OAuthSystemException {
+            throws IdentityOAuth2Exception, OAuthSystemException, InvalidApplicationClientException {
 
         OAuthClientAuthnContext oAuthClientAuthnContext =  getValidationObject(request);
 
         if (!oAuthClientAuthnContext.isAuthenticated()) {
             return handleErrorResponse(oAuthClientAuthnContext);
         }
+
+        validateIfApplicationAccessEnabled(oAuthClientAuthnContext);
 
         // Wrap the request to avoid missing of request attributes.
         request = new OAuthRequestWrapper(request, paramMap);
@@ -111,6 +114,23 @@ public class DeviceEndpoint {
 
         if (!EndpointUtil.validateParams(request, paramMap)) {
             throw new TokenEndpointBadRequestException("Invalid request with repeated parameters.");
+        }
+    }
+
+    /**
+     * Validate whether the application is in the enabled state before issuing a device code. This mirrors the
+     * validation done by the token endpoint, so that a disabled application is rejected up front instead of being
+     * handed a device code that can never be exchanged.
+     *
+     * @param oAuthClientAuthnContext OAuth client authentication context.
+     * @throws InvalidApplicationClientException If the application is disabled.
+     * @throws OAuthSystemException              If an error occurred while retrieving the service provider.
+     */
+    private void validateIfApplicationAccessEnabled(OAuthClientAuthnContext oAuthClientAuthnContext)
+            throws InvalidApplicationClientException, OAuthSystemException {
+
+        if (StringUtils.isNotBlank(oAuthClientAuthnContext.getClientId())) {
+            EndpointUtil.validateAppAccess(oAuthClientAuthnContext.getClientId());
         }
     }
 

--- a/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/device/DeviceEndpointTest.java
+++ b/components/org.wso2.carbon.identity.oauth.endpoint/src/test/java/org/wso2/carbon/identity/oauth/endpoint/device/DeviceEndpointTest.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.oauth.endpoint.device;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.oltu.oauth2.common.OAuth;
 import org.apache.oltu.oauth2.common.exception.OAuthSystemException;
 import org.mockito.ArgumentCaptor;
@@ -43,12 +44,16 @@ import org.wso2.carbon.context.internal.OSGiDataHolder;
 import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
 import org.wso2.carbon.identity.core.ServiceURL;
 import org.wso2.carbon.identity.core.ServiceURLBuilder;
+import org.wso2.carbon.identity.core.URLBuilderException;
 import org.wso2.carbon.identity.core.util.IdentityDatabaseUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.oauth.common.OAuth2ErrorCodes;
 import org.wso2.carbon.identity.oauth.common.OAuthConstants;
 import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
+import org.wso2.carbon.identity.oauth.endpoint.exception.InvalidApplicationClientException;
+import org.wso2.carbon.identity.oauth.endpoint.util.EndpointUtil;
 import org.wso2.carbon.identity.oauth.endpoint.util.TestOAuthEndpointBase;
+import org.wso2.carbon.identity.oauth.endpoint.util.factory.DeviceServiceFactory;
 import org.wso2.carbon.identity.oauth.tokenprocessor.TokenPersistenceProcessor;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.bean.OAuthClientAuthnContext;
@@ -70,17 +75,23 @@ import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
 
 /**
  * Use for unit tests in device end-point.
@@ -119,6 +130,7 @@ public class DeviceEndpointTest extends TestOAuthEndpointBase {
 
     private static final String CLIENT_ID_VALUE = "ca19a540f544777860e44e75f605d927";
     private static final String TEST_URL = "testURL";
+    private static final String APPLICATION_DISABLED_MESSAGE = "Application is disabled.";
 
     private MockedStatic<LoggerUtils> loggerUtils;
     MockedStatic<IdentityDatabaseUtil> identityDatabaseUtil;
@@ -229,9 +241,11 @@ public class DeviceEndpointTest extends TestOAuthEndpointBase {
              MockedStatic<DeviceFlowPersistenceFactory> deviceFlowPersistenceFactory =
                      mockStatic(DeviceFlowPersistenceFactory.class);
              MockedStatic<OAuthServerConfiguration> oAuthServerConfiguration =
-                     mockStatic(OAuthServerConfiguration.class)) {
+                     mockStatic(OAuthServerConfiguration.class);
+             MockedStatic<EndpointUtil> endpointUtil = mockStatic(EndpointUtil.class)) {
             DeviceEndpoint deviceEndpoint = spy(new DeviceEndpoint());
             mockOAuthServerConfiguration(oAuthServerConfiguration);
+            mockEndpointUtil(endpointUtil);
 
             ServiceURLBuilder mockServiceURLBuilder = Mockito.mock(ServiceURLBuilder.class);
             serviceURLBuilder.when(ServiceURLBuilder::create).thenReturn(mockServiceURLBuilder);
@@ -275,6 +289,249 @@ public class DeviceEndpointTest extends TestOAuthEndpointBase {
                     httpServletResponse);
             Assert.assertEquals(response.getStatus(), expectedStatus);
         }
+    }
+
+    /**
+     * A disabled application must be rejected before any device code is issued. Previously the endpoint replied
+     * HTTP 200 with a device_code/user_code pair that could never be exchanged, and the rejection only surfaced
+     * later, at the token endpoint.
+     *
+     * <p>The thrown {@link InvalidApplicationClientException} is rendered by the webapp-wide
+     * InvalidRequestExceptionMapper as HTTP 401 invalid_client, matching the token endpoint's response.</p>
+     */
+    @Test(description = "Device authorization endpoint rejects a disabled application before issuing a device code")
+    public void testDeviceAuthorizeForDisabledApplication() throws Exception {
+
+        try (MockedStatic<ServiceURLBuilder> serviceURLBuilder = mockStatic(ServiceURLBuilder.class);
+             MockedStatic<IdentityUtil> identityUtil = mockStatic(IdentityUtil.class);
+             MockedStatic<DeviceFlowPersistenceFactory> deviceFlowPersistenceFactory =
+                     mockStatic(DeviceFlowPersistenceFactory.class);
+             MockedStatic<OAuthServerConfiguration> oAuthServerConfiguration =
+                     mockStatic(OAuthServerConfiguration.class);
+             MockedStatic<EndpointUtil> endpointUtil = mockStatic(EndpointUtil.class);
+             MockedStatic<DeviceServiceFactory> deviceServiceFactory =
+                     mockStatic(DeviceServiceFactory.class)) {
+
+            DeviceEndpoint deviceEndpoint = spy(new DeviceEndpoint());
+            mockOAuthServerConfiguration(oAuthServerConfiguration);
+            mockEndpointUtil(endpointUtil);
+            // DeviceServiceFactory holds its service in a static final field, so stub the accessor
+            // to make sure the assertions below observe this test's mock.
+            deviceServiceFactory.when(DeviceServiceFactory::getDeviceAuthService)
+                    .thenReturn(deviceAuthService);
+            mockServiceURLBuilder(serviceURLBuilder);
+            mockDeviceFlowPersistence(deviceFlowPersistenceFactory, identityUtil, true);
+            mockDeviceAuthorizeRequest(CLIENT_ID_VALUE, true);
+            endpointUtil.when(() -> EndpointUtil.validateAppAccess(anyString()))
+                    .thenThrow(new InvalidApplicationClientException(APPLICATION_DISABLED_MESSAGE));
+
+            InvalidApplicationClientException exception = expectThrows(InvalidApplicationClientException.class,
+                    () -> deviceEndpoint.authorize(httpServletRequest, new MultivaluedHashMap<>(),
+                            httpServletResponse));
+
+            assertEquals(exception.getMessage(), APPLICATION_DISABLED_MESSAGE,
+                    "Expected the same error the token endpoint returns for a disabled application.");
+
+            // No device or user code may be generated or persisted for a disabled application.
+            verify(deviceAuthService, never())
+                    .generateDeviceResponse(any(), any(), anyLong(), any(), any());
+        }
+    }
+
+    /**
+     * Regression guard for the happy path: an enabled application must still receive a device code, and the
+     * application access check must actually be performed for it.
+     */
+    @Test(description = "Device authorization endpoint still issues a device code for an enabled application")
+    public void testDeviceAuthorizeForEnabledApplication() throws Exception {
+
+        try (MockedStatic<ServiceURLBuilder> serviceURLBuilder = mockStatic(ServiceURLBuilder.class);
+             MockedStatic<IdentityUtil> identityUtil = mockStatic(IdentityUtil.class);
+             MockedStatic<DeviceFlowPersistenceFactory> deviceFlowPersistenceFactory =
+                     mockStatic(DeviceFlowPersistenceFactory.class);
+             MockedStatic<OAuthServerConfiguration> oAuthServerConfiguration =
+                     mockStatic(OAuthServerConfiguration.class);
+             MockedStatic<EndpointUtil> endpointUtil = mockStatic(EndpointUtil.class);
+             MockedStatic<DeviceServiceFactory> deviceServiceFactory =
+                     mockStatic(DeviceServiceFactory.class)) {
+
+            DeviceEndpoint deviceEndpoint = spy(new DeviceEndpoint());
+            mockOAuthServerConfiguration(oAuthServerConfiguration);
+            mockEndpointUtil(endpointUtil);
+            // DeviceServiceFactory holds its service in a static final field, so stub the accessor
+            // to make sure the assertions below observe this test's mock.
+            deviceServiceFactory.when(DeviceServiceFactory::getDeviceAuthService)
+                    .thenReturn(deviceAuthService);
+            mockServiceURLBuilder(serviceURLBuilder);
+            mockDeviceFlowPersistence(deviceFlowPersistenceFactory, identityUtil, true);
+            mockDeviceAuthorizeRequest(CLIENT_ID_VALUE, true);
+
+            Response response = deviceEndpoint.authorize(httpServletRequest, new MultivaluedHashMap<>(),
+                    httpServletResponse);
+
+            assertEquals(response.getStatus(), HttpServletResponse.SC_OK,
+                    "An enabled application should still receive a device authorization response.");
+            endpointUtil.verify(() -> EndpointUtil.validateAppAccess(CLIENT_ID_VALUE));
+            verify(deviceAuthService).generateDeviceResponse(any(), any(), anyLong(), any(), any());
+        }
+    }
+
+    /**
+     * The application access check is guarded on a non-blank client id, mirroring the token endpoint, so a blank
+     * client id must skip it rather than fail.
+     */
+    @Test(description = "Blank client id skips the application access validation without failing")
+    public void testDeviceAuthorizeWithBlankClientId() throws Exception {
+
+        try (MockedStatic<ServiceURLBuilder> serviceURLBuilder = mockStatic(ServiceURLBuilder.class);
+             MockedStatic<IdentityUtil> identityUtil = mockStatic(IdentityUtil.class);
+             MockedStatic<DeviceFlowPersistenceFactory> deviceFlowPersistenceFactory =
+                     mockStatic(DeviceFlowPersistenceFactory.class);
+             MockedStatic<OAuthServerConfiguration> oAuthServerConfiguration =
+                     mockStatic(OAuthServerConfiguration.class);
+             MockedStatic<EndpointUtil> endpointUtil = mockStatic(EndpointUtil.class)) {
+
+            DeviceEndpoint deviceEndpoint = spy(new DeviceEndpoint());
+            mockOAuthServerConfiguration(oAuthServerConfiguration);
+            mockEndpointUtil(endpointUtil);
+            mockServiceURLBuilder(serviceURLBuilder);
+            mockDeviceFlowPersistence(deviceFlowPersistenceFactory, identityUtil, true);
+            mockDeviceAuthorizeRequest(StringUtils.EMPTY, true);
+
+            Response response = deviceEndpoint.authorize(httpServletRequest, new MultivaluedHashMap<>(),
+                    httpServletResponse);
+
+            assertEquals(response.getStatus(), HttpServletResponse.SC_OK,
+                    "A blank client id should fall through to the existing behaviour.");
+            endpointUtil.verify(() -> EndpointUtil.validateAppAccess(anyString()), never());
+        }
+    }
+
+    /**
+     * A failure while resolving the application must surface as an error rather than silently issuing a
+     * device code.
+     */
+    @Test(description = "Application access validation failure surfaces as an error, not a device code")
+    public void testDeviceAuthorizeWhenApplicationAccessValidationFails() throws Exception {
+
+        try (MockedStatic<ServiceURLBuilder> serviceURLBuilder = mockStatic(ServiceURLBuilder.class);
+             MockedStatic<IdentityUtil> identityUtil = mockStatic(IdentityUtil.class);
+             MockedStatic<DeviceFlowPersistenceFactory> deviceFlowPersistenceFactory =
+                     mockStatic(DeviceFlowPersistenceFactory.class);
+             MockedStatic<OAuthServerConfiguration> oAuthServerConfiguration =
+                     mockStatic(OAuthServerConfiguration.class);
+             MockedStatic<EndpointUtil> endpointUtil = mockStatic(EndpointUtil.class)) {
+
+            DeviceEndpoint deviceEndpoint = spy(new DeviceEndpoint());
+            mockOAuthServerConfiguration(oAuthServerConfiguration);
+            mockEndpointUtil(endpointUtil);
+            mockServiceURLBuilder(serviceURLBuilder);
+            mockDeviceFlowPersistence(deviceFlowPersistenceFactory, identityUtil, true);
+            mockDeviceAuthorizeRequest(CLIENT_ID_VALUE, true);
+            endpointUtil.when(() -> EndpointUtil.validateAppAccess(anyString()))
+                    .thenThrow(new OAuthSystemException("Error while retrieving service provider."));
+
+            assertThrows(OAuthSystemException.class,
+                    () -> deviceEndpoint.authorize(httpServletRequest, new MultivaluedHashMap<>(),
+                            httpServletResponse));
+
+            verify(deviceAuthService, never())
+                    .generateDeviceResponse(any(), any(), anyLong(), any(), any());
+        }
+    }
+
+    /**
+     * The application access check must not mask a client authentication failure: the credential error still
+     * wins, and the application is never looked up.
+     */
+    @Test(description = "Client authentication failure is still reported ahead of the application access check")
+    public void testDeviceAuthorizeWhenClientAuthenticationFails() throws Exception {
+
+        try (MockedStatic<ServiceURLBuilder> serviceURLBuilder = mockStatic(ServiceURLBuilder.class);
+             MockedStatic<IdentityUtil> identityUtil = mockStatic(IdentityUtil.class);
+             MockedStatic<DeviceFlowPersistenceFactory> deviceFlowPersistenceFactory =
+                     mockStatic(DeviceFlowPersistenceFactory.class);
+             MockedStatic<OAuthServerConfiguration> oAuthServerConfiguration =
+                     mockStatic(OAuthServerConfiguration.class);
+             MockedStatic<EndpointUtil> endpointUtil = mockStatic(EndpointUtil.class)) {
+
+            DeviceEndpoint deviceEndpoint = spy(new DeviceEndpoint());
+            mockOAuthServerConfiguration(oAuthServerConfiguration);
+            mockEndpointUtil(endpointUtil);
+            mockServiceURLBuilder(serviceURLBuilder);
+            mockDeviceFlowPersistence(deviceFlowPersistenceFactory, identityUtil, false);
+            mockDeviceAuthorizeRequest(CLIENT_ID_VALUE, false);
+
+            Response response = deviceEndpoint.authorize(httpServletRequest, new MultivaluedHashMap<>(),
+                    httpServletResponse);
+
+            assertEquals(response.getStatus(), HttpServletResponse.SC_BAD_REQUEST,
+                    "Client authentication failure should still be reported to the client.");
+            endpointUtil.verify(() -> EndpointUtil.validateAppAccess(anyString()), never());
+        }
+    }
+
+    /**
+     * By default the endpoint utilities behave as they do for a valid, enabled application. Individual tests
+     * override {@code validateAppAccess} to exercise the failure paths.
+     */
+    private void mockEndpointUtil(MockedStatic<EndpointUtil> endpointUtil) {
+
+        endpointUtil.when(() -> EndpointUtil.validateParams(any(HttpServletRequest.class),
+                any(MultivaluedMap.class))).thenReturn(true);
+        endpointUtil.when(EndpointUtil::getRealmInfo).thenReturn("Basic realm=localhost");
+    }
+
+    /**
+     * Stub the OAuth client authentication context carried on the request.
+     */
+    private void mockDeviceAuthorizeRequest(String clientId, boolean clientAuthenticated) {
+
+        OAuthClientAuthnContext oAuthClientAuthnContext = new OAuthClientAuthnContext();
+        oAuthClientAuthnContext.setClientId(clientId);
+        oAuthClientAuthnContext.setAuthenticated(clientAuthenticated);
+        lenient().when(request.getAttribute(anyString())).thenReturn(oAuthClientAuthnContext);
+        lenient().when(httpServletRequest.getParameter(anyString())).thenReturn(clientId);
+        lenient().when(httpServletRequest.getAttribute(OAuthConstants.CLIENT_AUTHN_CONTEXT))
+                .thenReturn(oAuthClientAuthnContext);
+        lenient().when(httpServletRequest.getParameterNames()).thenReturn(new Enumeration<String>() {
+            @Override
+            public boolean hasMoreElements() {
+
+                return false;
+            }
+
+            @Override
+            public String nextElement() {
+
+                return null;
+            }
+        });
+    }
+
+    private void mockServiceURLBuilder(MockedStatic<ServiceURLBuilder> serviceURLBuilder)
+            throws URLBuilderException {
+
+        ServiceURLBuilder mockServiceURLBuilder = Mockito.mock(ServiceURLBuilder.class);
+        serviceURLBuilder.when(ServiceURLBuilder::create).thenReturn(mockServiceURLBuilder);
+        ServiceURL mockServiceURL = Mockito.mock(ServiceURL.class);
+        lenient().when(mockServiceURLBuilder.addPath(anyString())).thenReturn(mockServiceURLBuilder);
+        lenient().when(mockServiceURLBuilder.addParameter(anyString(), isNull())).thenReturn(mockServiceURLBuilder);
+        lenient().when(mockServiceURLBuilder.build()).thenReturn(mockServiceURL);
+        lenient().when(mockServiceURL.getAbsolutePublicURL())
+                .thenReturn("http://localhost:9443/authenticationendpoint/device.do");
+    }
+
+    private void mockDeviceFlowPersistence(MockedStatic<DeviceFlowPersistenceFactory> deviceFlowPersistenceFactoryMock,
+                                           MockedStatic<IdentityUtil> identityUtil, boolean clientIdExists)
+            throws IdentityOAuth2Exception {
+
+        identityUtil.when(() -> IdentityUtil.getServerURL(anyString(), anyBoolean(), anyBoolean()))
+                .thenReturn(TEST_URL);
+        deviceFlowPersistenceFactoryMock.when(DeviceFlowPersistenceFactory::getInstance)
+                .thenReturn(this.deviceFlowPersistenceFactory);
+        lenient().when(this.deviceFlowPersistenceFactory.getDeviceFlowDAO()).thenReturn(deviceFlowDAO);
+        lenient().when(deviceFlowDAO.checkClientIdExist(anyString())).thenReturn(clientIdExists);
     }
 
     private void mockOAuthServerConfiguration(MockedStatic<OAuthServerConfiguration> oAuthServerConfiguration)


### PR DESCRIPTION
## Purpose

`POST /oauth2/device_authorize` issues a device code for an application that is disabled (`applicationEnabled = false`).

The endpoint replies `200` with a full device authorization response — `device_code`, `user_code`, `verification_uri`, `verification_uri_complete` — that can never be exchanged. The rejection only surfaces afterwards: `/oauth2/device` redirects to `retry.do?status=authentication.flow.app.disabled`, and `/oauth2/token` returns `401 invalid_client` "Application is disabled.". The client is handed credentials for a flow that was never going to complete.

Every other OAuth2 entry point enforces the disabled-application state. The device authorization endpoint is the only one that does not.

## Root cause

The check lives in `EndpointUtil.validateAppAccess(String consumerKey)`, which resolves the `ServiceProvider` and throws `InvalidApplicationClientException("Application is disabled.")` when `isApplicationEnabled()` is false.

Before this change that helper had exactly **one** production caller in the repo — `OAuth2TokenEndpoint` (via `validateIfApplicationAccessEnabled`). `DeviceEndpoint.authorize()` gated only on `oAuthClientAuthnContext.isAuthenticated()`, which the `OAuthClientAuthenticatorProxy` interceptor sets after validating client *credentials*. That carries no notion of application state, so an authenticated client fell straight through to `getUniqueUserCode(...)` → `DeviceAuthServiceImpl.generateDeviceResponse(...)`, which generates and persists the code.

`OAuth2AuthzEndpoint` is covered without calling `validateAppAccess` because the authentication framework enforces the flag downstream. The device authorization endpoint never enters that framework, so it has no equivalent safety net.

## Approach

Call `EndpointUtil.validateAppAccess(...)` immediately after the client authentication check and **before** the device code is minted, guarded on a non-blank client id — mirroring `OAuth2TokenEndpoint.validateIfApplicationAccessEnabled(...)`.

No new error-handling code was needed. `InvalidRequestExceptionMapper` is already registered as a `jaxrs.providers` entry for the whole `OAuth2Endpoints` CXF servlet, and `DeviceEndpoint` is one of its service classes, so letting the exception propagate produces a response identical to the token endpoint's:

```
HTTP/1.1 401
WWW-Authenticate: Basic realm=localhost
{"error_description":"Application is disabled.","error":"invalid_client"}
```

This is spec-conformant: RFC 8628 §3.2 defers to RFC 6749 §5.2, where `invalid_client` with 401 is the correct response for a client not permitted to use the grant.

**Deliberately out of scope:** `EndpointUtil.validateOauthApplication(...)` (the ACTIVE/REVOKED app-state check the token endpoint also runs) is not added here, since this issue concerns `applicationEnabled` specifically and adding it would change behaviour for revoked applications. `OAuth2CibaEndpoint` and `OAuth2ParEndpoint` appear to have the same gap and are worth a separate issue; they are untouched here.

## Behaviour change

A call that previously returned `200` now returns `401`. No working integration can regress, because the device code returned in that case was always unusable — the change moves an existing failure earlier and makes it legible. Enabled applications are unaffected. One extra cached `ServiceProvider` lookup per `device_authorize` call, a cost `/oauth2/token` already pays.

## Verification

Verified at runtime against a built server with the patched webapp deployed (WSO2 IS 7.4.0-SNAPSHOT, oauth endpoint 7.5.84), not by code inspection.

| Check | Before | After |
|---|---|---|
| `device_authorize`, application **disabled** | `200` + `device_code`/`user_code` | `401 invalid_client` "Application is disabled.", **no device code** |
| `device_authorize`, application **enabled** | `200` + device code | unchanged |
| `device_authorize`, unknown `client_id` | `401 invalid_request` | unchanged |
| `GET /oauth2/authorize`, disabled | `302 → retry.do` app.disabled | unchanged |
| `/oauth2/token` device_code grant, disabled | `401 invalid_client` | unchanged |
| Full device flow on an enabled app | reaches `login.do` | unchanged |

Server logs show no new exceptions — the rejection is a clean 401, not a leaked stack trace.

## Tests

`DeviceEndpointTest` had no application-state coverage: its data provider varied only client authentication and never stubbed the application lookup. Adding the validation therefore **broke the existing `testDevice[testClientId, 200, true]`** case (6/6 passed before the change, 5/6 after), since `authorize()` now resolves the application. That is fixed here, and the gap is closed with five new cases:

- **`testDeviceAuthorizeForDisabledApplication`** — the regression test: `InvalidApplicationClientException("Application is disabled.")` is raised, and `generateDeviceResponse(...)` is **never** invoked, so no code is generated or persisted.
- `testDeviceAuthorizeForEnabledApplication` — happy-path guard: still `200`, the check *is* performed, the code is still generated.
- `testDeviceAuthorizeWithBlankClientId` — the `isNotBlank` guard skips validation without failing.
- `testDeviceAuthorizeWhenApplicationAccessValidationFails` — a validation failure surfaces as an error rather than silently issuing a code.
- `testDeviceAuthorizeWhenClientAuthenticationFails` — the new check does not mask a credential failure.

Results:

| Run | Result |
|---|---|
| `DeviceEndpointTest` with this change | **11/11 pass** |
| `DeviceEndpointTest` with the fix reverted | **3 failures** (the three bug-facing cases) |
| Full `org.wso2.carbon.identity.oauth.endpoint` suite | **1108/1108 pass** |

The middle row is the point: the new tests genuinely fail without the fix, so they lock in the regression.

**Note on test design:** the tests stub `EndpointUtil` rather than `OAuth2Util`. `mockStatic(OAuth2Util.class)` cannot be instrumented from `DeviceEndpointTest` — its static initialiser needs a carbon config directory the class does not establish (`EndpointUtilTest` only succeeds because another test class initialises `OAuth2Util` earlier in a full-module run). Stubbing `EndpointUtil` keeps these tests hermetic and order-independent; `validateAppAccess` itself remains covered by `EndpointUtilTest.testValidateAppAccess`, so the two suites compose without overlap. `DeviceServiceFactory` is also stubbed where device-code generation is asserted, because it caches its service in a `static final` field — without that, the `never()` verification would pass vacuously.
